### PR TITLE
[blocks]

### DIFF
--- a/src/pymor/playground/algorithms/__init__.py
+++ b/src/pymor/playground/algorithms/__init__.py
@@ -1,0 +1,5 @@
+# This file is part of the pyMOR project (http://www.pymor.org).
+# Copyright Holders: Rene Milk, Stephan Rave, Felix Schindler
+# License: BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+
+from blockbasisextension import trivial_block_basis_extension, gram_schmidt_block_basis_extension

--- a/src/pymor/playground/algorithms/blockbasisextension.py
+++ b/src/pymor/playground/algorithms/blockbasisextension.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import, division, print_function
 import numpy as np
 
 from pymor.algorithms import trivial_basis_extension, gram_schmidt_basis_extension
+from pymor.core import getLogger
 from pymor.core.exceptions import ExtensionError
 from pymor.playground.la import BlockVectorArray
 from pymor.playground.operators import BlockOperator
@@ -15,9 +16,12 @@ from pymor.playground.operators import BlockOperator
 def trivial_block_basis_extension(basis, U, copy_basis=True, copy_U=True, require_all=False):
     """Block variant of |trivial_basis_extension|
     """
+
+    logger = getLogger('pymor.algorithms.blockbasisextension.trivial_block_basis_extension')
+
     assert isinstance(U, BlockVectorArray)
     if not copy_U:
-        raise ValueError('The option copy_U==False is not supported for BlockVectorArrays!')
+        logger.warn('The option copy_U==False is not supported for BlockVectorArrays!')
     num_blocks = U.num_blocks
     if basis is None:
         basis = [None for ii in np.arange(num_blocks)]
@@ -33,7 +37,7 @@ def trivial_block_basis_extension(basis, U, copy_basis=True, copy_U=True, requir
             nb, ed = trivial_basis_extension(basis[ii],
                                              U._blocks[ii],
                                              copy_basis=copy_basis,
-                                             copy_U=copy_U)
+                                             copy_U=True)
             failure[ii] = False
             new_basis[ii] = nb
             assert ed.keys() == ['hierarchic']
@@ -53,8 +57,11 @@ def trivial_block_basis_extension(basis, U, copy_basis=True, copy_U=True, requir
 def gram_schmidt_block_basis_extension(basis, U, product=None, copy_basis=True, copy_U=True, require_all=False):
     """Block variant of |gram_schmidt_basis_extension|.
     """
+
+    logger = getLogger('pymor.algorithms.blockbasisextension.gram_schmidt_block_basis_extension')
+
     if not copy_U:
-        raise ValueError('The option copy_U==False is not supported for BlockVectorArrays!')
+        logger.warn('The option copy_U==False is not supported for BlockVectorArrays!')
     num_blocks = U.num_blocks
     if basis is None:
         basis = [None for ii in np.arange(num_blocks)]
@@ -80,7 +87,7 @@ def gram_schmidt_block_basis_extension(basis, U, product=None, copy_basis=True, 
                                                   U._blocks[ii],
                                                   product=product[ii],
                                                   copy_basis=copy_basis,
-                                                  copy_U=copy_U)
+                                                  copy_U=True)
             failure[ii] = False
             new_basis[ii] = nb
             assert ed.keys() == ['hierarchic']

--- a/src/pymor/playground/algorithms/blockbasisextension.py
+++ b/src/pymor/playground/algorithms/blockbasisextension.py
@@ -46,10 +46,15 @@ def trivial_block_basis_extension(basis, U, copy_basis=True, copy_U=True, requir
             new_basis[ii] = basis[ii]
             hierarchic[ii] = True
 
+    num_failures = sum(1 if ff else 0 for ff in failure)
     if require_all and any(failure):
         raise ExtensionError
     elif not require_all and all(failure):
         raise ExtensionError
+    elif num_failures > 0:
+        logger.warn('Extension failed for {} out of {} block{}!'.format(num_failures,
+                                                                        num_blocks,
+                                                                        's' if num_blocks > 1 else ''))
 
     return new_basis, {'hierarchic': all(hierarchic)}
 
@@ -96,10 +101,15 @@ def gram_schmidt_block_basis_extension(basis, U, product=None, copy_basis=True, 
             new_basis[ii] = basis[ii]
             hierarchic[ii] = True
 
+    num_failures = sum(1 if ff else 0 for ff in failure)
     if require_all and any(failure):
         raise ExtensionError
     elif not require_all and all(failure):
         raise ExtensionError
+    elif num_failures > 0:
+        logger.warn('Extension failed for {} out of {} block{}!'.format(num_failures,
+                                                                        num_blocks,
+                                                                        's' if num_blocks > 1 else ''))
 
     return new_basis, {'hierarchic': all(hierarchic)}
 

--- a/src/pymor/playground/algorithms/blockbasisextension.py
+++ b/src/pymor/playground/algorithms/blockbasisextension.py
@@ -65,9 +65,16 @@ def gram_schmidt_block_basis_extension(basis, U, product=None, copy_basis=True, 
 
     logger = getLogger('pymor.algorithms.blockbasisextension.gram_schmidt_block_basis_extension')
 
-    if not copy_U:
+    if isinstance(U, BlockVectorArray):
+        blocks = U._blocks
+    elif isinstance(U, list):
+        blocks = U
+    else:
+        raise ExtensionError('U of unknown type given: {}'.format(type(U)))
+    if isinstance(U, BlockVectorArray) and not copy_U:
         logger.warn('The option copy_U==False is not supported for BlockVectorArrays!')
-    num_blocks = U.num_blocks
+    num_blocks = len(blocks)
+
     if basis is None:
         basis = [None for ii in np.arange(num_blocks)]
     assert isinstance(basis, list)
@@ -89,7 +96,7 @@ def gram_schmidt_block_basis_extension(basis, U, product=None, copy_basis=True, 
     for ii in np.arange(num_blocks):
         try:
             nb, ed = gram_schmidt_basis_extension(basis[ii],
-                                                  U._blocks[ii],
+                                                  blocks[ii],
                                                   product=product[ii],
                                                   copy_basis=copy_basis,
                                                   copy_U=True)

--- a/src/pymor/playground/algorithms/blockbasisextension.py
+++ b/src/pymor/playground/algorithms/blockbasisextension.py
@@ -24,7 +24,7 @@ def trivial_block_basis_extension(basis, U, copy_basis=True, copy_U=True, requir
         logger.warn('The option copy_U==False is not supported for BlockVectorArrays!')
     num_blocks = U.num_blocks
     if basis is None:
-        basis = [None for ii in np.arange(num_blocks)]
+        basis = tuple(None for ii in np.arange(num_blocks))
     assert isinstance(basis, list)
     assert len(basis) == num_blocks
 
@@ -56,7 +56,7 @@ def trivial_block_basis_extension(basis, U, copy_basis=True, copy_U=True, requir
                                                                         num_blocks,
                                                                         's' if num_blocks > 1 else ''))
 
-    return new_basis, {'hierarchic': all(hierarchic)}
+    return tuple(new_basis), {'hierarchic': all(hierarchic)}
 
 
 def gram_schmidt_block_basis_extension(basis, U, product=None, copy_basis=True, copy_U=True, require_all=False):
@@ -68,6 +68,8 @@ def gram_schmidt_block_basis_extension(basis, U, product=None, copy_basis=True, 
     if isinstance(U, BlockVectorArray):
         blocks = U._blocks
     elif isinstance(U, list):
+        blocks = tuple(U)
+    elif isinstance(U, tuple):
         blocks = U
     else:
         raise ExtensionError('U of unknown type given: {}'.format(type(U)))
@@ -76,8 +78,10 @@ def gram_schmidt_block_basis_extension(basis, U, product=None, copy_basis=True, 
     num_blocks = len(blocks)
 
     if basis is None:
-        basis = [None for ii in np.arange(num_blocks)]
-    assert isinstance(basis, list)
+        basis = tuple(None for ii in np.arange(num_blocks))
+    elif isinstance(basis, list):
+        basis = tuple(basis)
+    assert isinstance(basis, tuple)
     assert len(basis) == num_blocks
     if product is None:
         product = [None for ii in np.arange(num_blocks)]
@@ -118,5 +122,5 @@ def gram_schmidt_block_basis_extension(basis, U, product=None, copy_basis=True, 
                                                                         num_blocks,
                                                                         's' if num_blocks > 1 else ''))
 
-    return new_basis, {'hierarchic': all(hierarchic)}
+    return tuple(new_basis), {'hierarchic': all(hierarchic)}
 

--- a/src/pymor/playground/operators/__init__.py
+++ b/src/pymor/playground/operators/__init__.py
@@ -1,0 +1,5 @@
+# This file is part of the pyMOR project (http://www.pymor.org).
+# Copyright Holders: Rene Milk, Stephan Rave, Felix Schindler
+# License: BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+
+from block import BlockOperator

--- a/src/pymor/playground/operators/block.py
+++ b/src/pymor/playground/operators/block.py
@@ -50,10 +50,11 @@ class BlockOperator(OperatorBase):
         source_types = [None for ii in np.arange(len(self._blocks[0]))]
         range_types  = [None for jj in np.arange(len(self._blocks))]
         for ii, jj, op in self._enumerated_operators():
-            assert source_types[jj] is None or op.source == source_types[jj]
-            source_types[jj] = op.source
-            assert range_types[ii] is None or op.range == range_types[ii]
-            range_types[ii] = op.range
+            if op is not None:
+                assert source_types[jj] is None or op.source == source_types[jj]
+                source_types[jj] = op.source
+                assert range_types[ii] is None or op.range == range_types[ii]
+                range_types[ii] = op.range
         # theere needs to be at least one operator for each combination of row and column
         assert all([ss is not None for ss in source_types])
         assert all([rr is not None for rr in range_types])

--- a/src/pymor/playground/operators/block.py
+++ b/src/pymor/playground/operators/block.py
@@ -1,0 +1,158 @@
+# -*- coding: utf-8 -*-
+# This file is part of the pyMOR project (http://www.pymor.org).
+# Copyright Holders: Rene Milk, Stephan Rave, Felix Schindler
+# License: BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+
+from __future__ import absolute_import, division, print_function
+
+import numpy as np
+from scipy.sparse import coo_matrix, bmat
+
+from pymor.operators.interfaces import OperatorInterface
+from pymor.la.interfaces import VectorSpace
+from pymor.la.numpyvectorarray import NumpyVectorArray
+from pymor.playground.la.blockvectorarray import BlockVectorArray
+from pymor.operators.basic import NumpyMatrixOperator, OperatorBase
+
+
+class BlockOperator(OperatorBase):
+    """A sparse matrix of arbitrary operators
+    """
+
+    def _operators(self):
+        for row in self._blocks:
+            for entry in row:
+                if entry is not None:
+                    yield entry
+
+    def _enumerated_operators(self):
+        for ii, row in enumerate(self._blocks):
+            for jj, entry in enumerate(row):
+                yield ii, jj, entry
+
+    def __init__(self, blocks, sources=None, ranges=None):
+        # check input
+        assert isinstance(blocks, list)
+        if isinstance(blocks[0], list):
+            self._blocks = blocks
+        else:
+            self._blocks = []
+            self._blocks.append(blocks)
+        # each block has to be an operator or None
+        assert all([isinstance(op, OperatorInterface) for op in self._operators()])
+        # all rows of blocks have to have the same lenght
+        assert all([len(row) == len(self._blocks[0]) for row in self._blocks])
+        # all rows need to have at least one operator
+        assert all([any([op is not None for op in row]) for row in self._blocks])
+        # all columns need to have at least one operator
+        assert all([any([row[ii] is not None for row in self._blocks]) for ii in np.arange(len(self._blocks[0]))])
+        # build source and range
+        source_types = [None for ii in np.arange(len(self._blocks[0]))]
+        range_types  = [None for jj in np.arange(len(self._blocks))]
+        for ii, jj, op in self._enumerated_operators():
+            assert source_types[jj] is None or op.source == source_types[jj]
+            source_types[jj] = op.source
+            assert range_types[ii] is None or op.range == range_types[ii]
+            range_types[ii] = op.range
+        # theere needs to be at least one operator for each combination of row and column
+        assert all([ss is not None for ss in source_types])
+        assert all([rr is not None for rr in range_types])
+        self.source = VectorSpace(BlockVectorArray, source_types)
+        self.range = VectorSpace(BlockVectorArray, range_types)
+        # some information
+        self.linear = all([op.linear for op in self._operators()])
+        self.num_source_blocks = len(source_types)
+        self.num_range_blocks  = len(range_types)
+        self._is_diagonal = (all([block is None if ii != jj else True for ii, jj, block in self._enumerated_operators()])
+                             and self.num_source_blocks == self.num_range_blocks)
+        # build parameter type
+        self.build_parameter_type(inherits=list(self._operators()))
+
+    def apply(self, U, ind=None, mu=None):
+        ind = [0] if ind is None else ind
+        if len(U) == 0:
+            return self.range.empty()
+        if len(U) != 1:
+            raise NotImplementedError
+        if len(ind) != 1 or ind[0] != 0:
+            raise NotImplementedError
+        V = [range_type.zeros(len(ind)) for range_type in self.range.subtype]
+        for ii, jj, op in self._enumerated_operators():
+            if op is not None:
+                V[ii] += op.apply(U._blocks[jj], ind=ind, mu=mu)
+        return BlockVectorArray(V)
+
+    def apply2(self, V, U, pairwise, U_ind=None, V_ind=None, mu=None, product=None):
+        assert U in self.source
+        assert V in self.range
+        if self._is_diagonal and product is None:
+            if len(U) != 1:
+                raise NotImplementedError
+            if len(V) != 1:
+                raise NotImplementedError
+            if U_ind is not None:
+                raise NotImplementedError
+            if V_ind is not None:
+                raise NotImplementedError
+            return sum([self._blocks[ii][ii].apply2(V._blocks[ii], U._blocks[ii], pairwise)
+                        for ii in np.arange(self.num_source_blocks)])
+        else:
+            return super(BlockOperator, self).apply2(V, U, pairwise, U_ind=U_ind, V_ind=V_ind, mu=mu, product=product)
+
+    def apply_inverse(self, U, ind=None, mu=None, options=None):
+        assembled = self.assemble(mu=mu)
+        if isinstance(assembled, NumpyMatrixOperator):
+            solution = assembled.apply_inverse(U, ind=ind, options=options)
+            return BlockVectorArray(solution, block_sizes=[sp.subtype for sp in self.source.subtype])
+        else:
+            # TODO: implement use of generic solver
+            raise NotImplementedError
+
+    def projected(self, source_basis, range_basis, product=None, name=None):
+        if product is not None:
+            raise NotImplementedError
+        assert source_basis is not None or range_basis is not None
+        assert isinstance(source_basis, list) or source_basis is None
+        assert isinstance(range_basis, list) or range_basis is None
+        source_basis = [None for ss in np.arange(self.num_source_blocks)] if source_basis is None else source_basis
+        range_basis  = [None for rr in np.arange(self.num_range_blocks)]  if range_basis  is None else range_basis
+        return BlockOperator([[self._blocks[ii][jj].projected(source_basis[jj], range_basis[ii], name=name)
+                               if self._blocks[ii][jj] is not None else None
+                               for jj in np.arange(self.num_source_blocks)]
+                              for ii in np.arange(self.num_range_blocks)])
+
+    def assemble(self, mu=None):
+        # TODO: convert mu to correct local mu for each block
+        assembled_blocks = [[self._blocks[ii][jj].assemble(mu) if self._blocks[ii][jj] is not None else None
+                             for jj in np.arange(self.num_source_blocks)]
+                            for ii in np.arange(self.num_range_blocks)]
+        if all(all([isinstance(op, NumpyMatrixOperator) if op is not None else True for op in row]) for row in assembled_blocks):
+            mat = bmat([[coo_matrix(assembled_blocks[ii][jj]._matrix)
+                         if assembled_blocks[ii][jj] is not None else coo_matrix((self._range_dims[ii], self._source_dims[jj]))
+                         for jj in np.arange(self.num_source_blocks)]
+                        for ii in np.arange(self.num_range_blocks)])
+            # TODO: decide (depending on the size of mat) if we want to call todense()?
+            return NumpyMatrixOperator(mat.todense())
+        else:
+            return BlockOperator(assembled_blocks)
+
+    def as_vector(self, mu=None):
+        if not self.linear:
+            raise TypeError('This nonlinear operator does not represent a vector or linear functional.')
+        elif self.source.dim == 1 and self.num_source_blocks == 1 and self.source.subtype[0].type is NumpyVectorArray:
+            # we are a vector
+            if not all(rr.type is NumpyVectorArray for rr in self.range.subtype):
+                raise NotImplementedError
+            return NumpyVectorArray(np.concatenate([self._blocks[ii][0].assemble(mu)._matrix
+                                                    for ii in np.arange(self.num_range_blocks)],
+                                                   axis=1))
+        elif self.range.dim == 1 and self.num_range_blocks == 1 and self.range.subtype[0].type is NumpyVectorArray:
+            # we are a functional
+            if not all(ss.type is NumpyVectorArray for ss in self.source.subtype):
+                raise NotImplementedError
+            return NumpyVectorArray(np.concatenate([self._blocks[0][jj].assemble(mu)._matrix
+                                                    for jj in np.arange(self.num_source_blocks)],
+                                                   axis=1))
+        else:
+            raise TypeError('This operator does not represent a vector or linear functional.')
+

--- a/src/pymor/playground/operators/block.py
+++ b/src/pymor/playground/operators/block.py
@@ -58,8 +58,8 @@ class BlockOperator(OperatorBase):
         # there needs to be at least one operator for each combination of row and column
         assert all([ss is not None for ss in source_types])
         assert all([rr is not None for rr in range_types])
-        self.source = VectorSpace(BlockVectorArray, source_types)
-        self.range = VectorSpace(BlockVectorArray, range_types)
+        self.source = VectorSpace(BlockVectorArray, tuple(source_types))
+        self.range = VectorSpace(BlockVectorArray, tuple(range_types))
         # some information
         self._source_dims = tuple(space.dim for space in self.source.subtype)
         self._range_dims  = tuple(space.dim for space in self.range.subtype)
@@ -120,10 +120,12 @@ class BlockOperator(OperatorBase):
         if product is not None:
             raise NotImplementedError
         assert source_basis is not None or range_basis is not None
-        assert isinstance(source_basis, list) or source_basis is None
-        assert isinstance(range_basis, list) or range_basis is None
-        source_basis = [None for ss in np.arange(self.num_source_blocks)] if source_basis is None else source_basis
-        range_basis  = [None for rr in np.arange(self.num_range_blocks)]  if range_basis  is None else range_basis
+        assert isinstance(source_basis, (tuple, list)) or source_basis is None
+        assert isinstance(range_basis, (tuple, list)) or range_basis is None
+        source_basis = tuple([None for ss in np.arange(self.num_source_blocks)]
+                             if source_basis is None else source_basis)
+        range_basis  = tuple([None for rr in np.arange(self.num_range_blocks)]
+                             if range_basis  is None else range_basis)
         return BlockOperator([[self._blocks[ii][jj].projected(source_basis[jj], range_basis[ii], name=name)
                                if self._blocks[ii][jj] is not None else None
                                for jj in np.arange(self.num_source_blocks)]

--- a/src/pymor/playground/operators/block.py
+++ b/src/pymor/playground/operators/block.py
@@ -61,9 +61,11 @@ class BlockOperator(OperatorBase):
         self.source = VectorSpace(BlockVectorArray, source_types)
         self.range = VectorSpace(BlockVectorArray, range_types)
         # some information
-        self.linear = all([op.linear for op in self._operators()])
+        self._source_dims = [space.dim for space in self.source.subtype]
+        self._range_dims  = [space.dim for space in self.range.subtype]
         self.num_source_blocks = len(source_types)
         self.num_range_blocks  = len(range_types)
+        self.linear = all([op.linear for op in self._operators()])
         self._is_diagonal = (all([block is None if ii != jj else True for ii, jj, block in self._enumerated_operators()])
                              and self.num_source_blocks == self.num_range_blocks)
         # build parameter type

--- a/src/pymor/playground/operators/block.py
+++ b/src/pymor/playground/operators/block.py
@@ -61,8 +61,8 @@ class BlockOperator(OperatorBase):
         self.source = VectorSpace(BlockVectorArray, source_types)
         self.range = VectorSpace(BlockVectorArray, range_types)
         # some information
-        self._source_dims = [space.dim for space in self.source.subtype]
-        self._range_dims  = [space.dim for space in self.range.subtype]
+        self._source_dims = tuple(space.dim for space in self.source.subtype)
+        self._range_dims  = tuple(space.dim for space in self.range.subtype)
         self.num_source_blocks = len(source_types)
         self.num_range_blocks  = len(range_types)
         self.linear = all([op.linear for op in self._operators()])

--- a/src/pymor/playground/operators/block.py
+++ b/src/pymor/playground/operators/block.py
@@ -126,6 +126,11 @@ class BlockOperator(OperatorBase):
                               for ii in np.arange(self.num_range_blocks)])
 
     def assemble(self, mu=None):
+        # handle empty case
+        dim_source = np.sum(self._source_dims)
+        dim_range  = np.sum(self._range_dims)
+        if dim_source == 0 or dim_range == 0:
+            return NumpyMatrixOperator(np.zeros((dim_range, dim_source)))
         # TODO: convert mu to correct local mu for each block
         assembled_blocks = [[self._blocks[ii][jj].assemble(mu) if self._blocks[ii][jj] is not None else None
                              for jj in np.arange(self.num_source_blocks)]

--- a/src/pymor/playground/operators/block.py
+++ b/src/pymor/playground/operators/block.py
@@ -106,8 +106,12 @@ class BlockOperator(OperatorBase):
         assembled = self.assemble(mu=mu)
         if isinstance(assembled, NumpyMatrixOperator):
             solution = assembled.apply_inverse(U, ind=ind, options=options)
+            assert len(solution) == 1
             assert (not np.isnan(np.sum(solution._array))) and (not np.isinf(np.sum(solution._array)))
-            return BlockVectorArray(solution, block_sizes=[sp.subtype for sp in self.source.subtype])
+            block_sizes = [sp.subtype for sp in self.source.subtype]
+            blocks = [NumpyVectorArray(solution._array[0][sum(block_sizes[:ss]):sum(block_sizes[:(ss + 1)])])
+                      for ss in np.arange(len(block_sizes))]
+            return BlockVectorArray(blocks)
         else:
             # TODO: implement use of generic solver
             raise NotImplementedError

--- a/src/pymor/playground/operators/block.py
+++ b/src/pymor/playground/operators/block.py
@@ -55,7 +55,7 @@ class BlockOperator(OperatorBase):
                 source_types[jj] = op.source
                 assert range_types[ii] is None or op.range == range_types[ii]
                 range_types[ii] = op.range
-        # theere needs to be at least one operator for each combination of row and column
+        # there needs to be at least one operator for each combination of row and column
         assert all([ss is not None for ss in source_types])
         assert all([rr is not None for rr in range_types])
         self.source = VectorSpace(BlockVectorArray, source_types)

--- a/src/pymor/playground/operators/block.py
+++ b/src/pymor/playground/operators/block.py
@@ -106,6 +106,7 @@ class BlockOperator(OperatorBase):
         assembled = self.assemble(mu=mu)
         if isinstance(assembled, NumpyMatrixOperator):
             solution = assembled.apply_inverse(U, ind=ind, options=options)
+            assert (not np.isnan(np.sum(solution._array))) and (not np.isinf(np.sum(solution._array)))
             return BlockVectorArray(solution, block_sizes=[sp.subtype for sp in self.source.subtype])
         else:
             # TODO: implement use of generic solver

--- a/src/pymor/playground/reductors/__init__.py
+++ b/src/pymor/playground/reductors/__init__.py
@@ -1,0 +1,5 @@
+# This file is part of the pyMOR project (http://www.pymor.org).
+# Copyright Holders: Rene Milk, Stephan Rave, Felix Schindler
+# License: BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+
+from block import GenericBlockRBReconstructor

--- a/src/pymor/playground/reductors/block.py
+++ b/src/pymor/playground/reductors/block.py
@@ -15,8 +15,8 @@ class GenericBlockRBReconstructor(core.BasicInterface):
     """Block variant of GenericRBReconstructor"""
 
     def __init__(self, RB):
-        assert isinstance(RB, list)
-        self.RB = RB
+        assert isinstance(RB, (tuple, list))
+        self.RB = tuple(RB)
 
     def reconstruct(self, U):
         assert isinstance(U, BlockVectorArray)
@@ -25,7 +25,7 @@ class GenericBlockRBReconstructor(core.BasicInterface):
                                  for rb, block in izip(self.RB, U._blocks)])
 
     def restricted_to_subbasis(self, dim):
-        if not isinstance(dim, list):
+        if not isinstance(dim, tuple):
             dim = len(self.RB)*[dim]
         assert all([dd <= len(rb) for dd, rb in izip(dim, self.RB)])
         return GenericBlockRBReconstructor([rb.copy(ind=range(dd)) for rb, dd in izip(self.RB, dim)])

--- a/src/pymor/playground/reductors/block.py
+++ b/src/pymor/playground/reductors/block.py
@@ -12,13 +12,13 @@ from pymor.reductors.basic import GenericRBReconstructor
 
 
 class GenericBlockRBReconstructor(core.BasicInterface):
+    """Block variant of GenericRBReconstructor"""
 
     def __init__(self, RB):
         assert isinstance(RB, list)
         self.RB = RB
 
     def reconstruct(self, U):
-        """Reconstruct high-dimensional vector from reduced vector `U`."""
         assert isinstance(U, BlockVectorArray)
         assert all(subspace.type == NumpyVectorArray for subspace in U.space.subtype)
         return BlockVectorArray([GenericRBReconstructor(rb).reconstruct(block)
@@ -26,7 +26,6 @@ class GenericBlockRBReconstructor(core.BasicInterface):
 
     def restricted_to_subbasis(self, dim):
         raise NotImplementedError
-        """Analog of :meth:`~pymor.operators.basic.NumpyMatrixOperator.projected_to_subbasis`."""
         assert dim <= len(self.RB)
         return GenericBlockRBReconstructor([rb.copy(ind=range(dim)) for rb in self.RB])
 

--- a/src/pymor/playground/reductors/block.py
+++ b/src/pymor/playground/reductors/block.py
@@ -1,0 +1,32 @@
+# This file is part of the pyMOR project (http://www.pymor.org).
+# Copyright Holders: Rene Milk, Stephan Rave, Felix Schindler
+# License: BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+
+from __future__ import absolute_import, division, print_function
+from itertools import izip
+
+import pymor.core as core
+from pymor.la import NumpyVectorArray
+from pymor.playground.la import BlockVectorArray
+from pymor.reductors.basic import GenericRBReconstructor
+
+
+class GenericBlockRBReconstructor(core.BasicInterface):
+
+    def __init__(self, RB):
+        assert isinstance(RB, list)
+        self.RB = RB
+
+    def reconstruct(self, U):
+        """Reconstruct high-dimensional vector from reduced vector `U`."""
+        assert isinstance(U, BlockVectorArray)
+        assert all(subspace.type == NumpyVectorArray for subspace in U.space.subtype)
+        return BlockVectorArray([GenericRBReconstructor(rb).reconstruct(block)
+                                 for rb, block in izip(self.RB, U._blocks)])
+
+    def restricted_to_subbasis(self, dim):
+        raise NotImplementedError
+        """Analog of :meth:`~pymor.operators.basic.NumpyMatrixOperator.projected_to_subbasis`."""
+        assert dim <= len(self.RB)
+        return GenericBlockRBReconstructor([rb.copy(ind=range(dim)) for rb in self.RB])
+

--- a/src/pymor/playground/reductors/block.py
+++ b/src/pymor/playground/reductors/block.py
@@ -25,7 +25,8 @@ class GenericBlockRBReconstructor(core.BasicInterface):
                                  for rb, block in izip(self.RB, U._blocks)])
 
     def restricted_to_subbasis(self, dim):
-        raise NotImplementedError
-        assert dim <= len(self.RB)
-        return GenericBlockRBReconstructor([rb.copy(ind=range(dim)) for rb in self.RB])
+        if not isinstance(dim, list):
+            dim = len(self.RB)*[dim]
+        assert all([dd <= len(rb) for dd, rb in izip(dim, self.RB)])
+        return GenericBlockRBReconstructor([rb.copy(ind=range(dd)) for rb, dd in izip(self.RB, dim)])
 


### PR DESCRIPTION
This pr adds support for spatially blocked discretizations (as used in the LRBMS) or systems of pdes. This is done by introducing `BlockVectorArray` and `BlockOperator` which are implementations of `VectorArrayInterface` and `OperatorInterface` that are composed of a collection of vector arrays or operators, respectively. In addition, this adds generalizations of some structures like extension algorithms or reductors. Everything is implemented in `playground/` and is supposed to merge cleanly to master.

Note that this pr is not yet intented to be merged, just to serve as an overview and to get automated builds.