### PR TITLE
[operators.basic] add sanity check to apply_inverse of NumpyMatrixOperator

### DIFF
--- a/src/pymor/operators/basic.py
+++ b/src/pymor/operators/basic.py
@@ -334,7 +334,9 @@ class NumpyMatrixOperator(NumpyMatrixBasedOperator):
         U = U._array[:U._len] if ind is None else U._array[ind]
         if U.shape[1] == 0:
             return NumpyVectorArray(U)
-        return NumpyVectorArray(numpysolvers.apply_inverse(self._matrix, U, options=options), copy=False)
+        solution = numpysolvers.apply_inverse(self._matrix, U, options=options)
+        assert (not np.isnan(np.sum(solution))) and (not np.isinf(np.sum(solution)))
+        return NumpyVectorArray(solution, copy=False)
 
     def projected_to_subbasis(self, dim_source=None, dim_range=None, name=None):
         """Project the operator to a subbasis.


### PR DESCRIPTION
I ran across a problem where the reduced system matrix contained NaNs and thus the reduced solution contained NaNs. The cause for this was some memory corruprion in an external library and since the reduced matrices were projections of external matrices (that were not available, just applyable) this resulted in hard to trace back NaNs in the reduced matrices. The attached commit checks the solution of a call to `numpysolvers` for NaNs and infs using an assert. Do we want to have something like this?

* this could lead to slow code when asserts are enabled (as they are most of the time)
* if we want this, should it be moved to `numpysolvers`?
* if we want this, do we want to have this in all solvers?