### PR TITLE
[gui.qt] fix vtk export for tuples

### DIFF
--- a/src/pymor/gui/qt.py
+++ b/src/pymor/gui/qt.py
@@ -443,7 +443,7 @@ class PatchVisualizer(BasicInterface):
             if not isinstance(U, tuple):
                 write_vtk(self.grid, U, filename, codim=self.codim)
             else:
-                for i, u in enumerate(self.U):
+                for i, u in enumerate(U):
                     write_vtk(self.grid, u, '{}-{}'.format(filename, i), codim=self.codim)
         else:
             block = self.block if block is None else block


### PR DESCRIPTION
When experimenting with the VTK exporter I notices that the export does not work in case of the given argument `U` being a tuple. This is because the function erroneously tries to access `self.U` which does not exists and must be replaced by `U` itself.