### PR TITLE
Two bugfixes

### DIFF
--- a/src/pymor/core/cache.py
+++ b/src/pymor/core/cache.py
@@ -271,7 +271,7 @@ _setup_default_regions(disk_path=os.environ.get('PYMOR_CACHE_PATH', None),
 
 _caching_disabled = int(os.environ.get('PYMOR_CACHE_DISABLE', 0)) == 1
 if _caching_disabled:
-    from pymor.core import getLogger
+    from pymor.core.logger import getLogger
     getLogger('pymor.core.cache').warn('caching globally disabled by environment')
 
 

--- a/src/pymor/playground/functions/bitmap.py
+++ b/src/pymor/playground/functions/bitmap.py
@@ -30,8 +30,11 @@ class BitmapFunction(FunctionBase):
             from PIL import Image
         except ImportError:
             raise ImportError("PIL is needed for loading images. Try 'pip install pillow'")
-        self.bitmap = np.array(Image.open(filename)).T[:, ::-1]
-        assert self.bitmap.ndim == 2, 'A grayscale image is needed.'
+        img = Image.open(filename)
+        rawdata = np.array(img.getdata())
+        assert rawdata.ndim == 1, 'A grayscale image is needed. Problem with ' + filename
+        assert rawdata.shape[0] == img.size[0]*img.size[1]
+        self.bitmap = rawdata.reshape(img.size[0],img.size[1]).T[:, ::-1]
         self.bounding_box = bounding_box
         self.lower_left = np.array(bounding_box[0])
         self.size = np.array(bounding_box[1] - self.lower_left)


### PR DESCRIPTION
1. Fix logger import in case of disabled caching. Sorry, Stephan, I think your fix is wrong, or do I miss something?
2. In older versions of PIL (for example the version shipped with Ubuntu 14.04), the "Image" does not support the array-Interface. Therefore it is not possible to put an "Image" directly into the numpy-array constructor. You end up with a 1x1 array of type "object". This is fixed here.