### PR TITLE
has_only_{dirichlet, neumann} removed from BoundaryInfo/DomainDescriptionInterface

### DIFF
--- a/src/pymor/domaindescriptions/interfaces.py
+++ b/src/pymor/domaindescriptions/interfaces.py
@@ -26,15 +26,3 @@ class DomainDescriptionInterface(ImmutableInterface):
     @property
     def has_neumann(self):
         return BoundaryType('neumann') in self.boundary_types
-
-    @property
-    def has_only_dirichlet(self):
-        return self.boundary_types == {BoundaryType('dirichlet')}
-
-    @property
-    def has_only_neumann(self):
-        return self.boundary_types == {BoundaryType('neumann')}
-
-    @property
-    def has_only_dirichletneumann(self):
-        return self.boundary_types <= {BoundaryType('dirichlet'), BoundaryType('neumann')}

--- a/src/pymor/grids/interfaces.py
+++ b/src/pymor/grids/interfaces.py
@@ -354,18 +354,6 @@ class BoundaryInfoInterface(CacheableInterface):
     def has_neumann(self):
         return BoundaryType('neumann') in self.boundary_types
 
-    @property
-    def has_only_dirichlet(self):
-        return self.boundary_types == {BoundaryType('dirichlet')}
-
-    @property
-    def has_only_neumann(self):
-        return self.boundary_types == {BoundaryType('neumann')}
-
-    @property
-    def has_only_dirichletneumann(self):
-        return self.boundary_types <= {BoundaryType('dirichlet'), BoundaryType('neumann')}
-
     def dirichlet_mask(self, codim):
         return self.mask(BoundaryType('dirichlet'), codim)
 


### PR DESCRIPTION
The has_only_{dirichlet, neumann} functions are unused and seem to be superfluous.