### PR TITLE
Support for Robin boundary conditions

### DIFF
--- a/src/pymor/domaindescriptions/interfaces.py
+++ b/src/pymor/domaindescriptions/interfaces.py
@@ -26,3 +26,7 @@ class DomainDescriptionInterface(ImmutableInterface):
     @property
     def has_neumann(self):
         return BoundaryType('neumann') in self.boundary_types
+
+    @property
+    def has_robin(self):
+        return BoundaryType('robin') in self.boundary_types

--- a/src/pymor/grids/interfaces.py
+++ b/src/pymor/grids/interfaces.py
@@ -354,11 +354,18 @@ class BoundaryInfoInterface(CacheableInterface):
     def has_neumann(self):
         return BoundaryType('neumann') in self.boundary_types
 
+    @property
+    def has_robin(self):
+        return BoundaryType('robin') in self.boundary_types
+
     def dirichlet_mask(self, codim):
         return self.mask(BoundaryType('dirichlet'), codim)
 
     def neumann_mask(self, codim):
         return self.mask(BoundaryType('neumann'), codim)
+
+    def robin_mask(self, codim):
+        return self.mask(BoundaryType('robin'), codim)
 
     @cached
     def _dirichlet_boundaries(self, codim):
@@ -373,3 +380,10 @@ class BoundaryInfoInterface(CacheableInterface):
 
     def neumann_boundaries(self, codim):
         return self._neumann_boundaries(codim)
+
+    @cached
+    def _robin_boundaries(self, codim):
+        return np.where(self.robin_mask(codim))[0].astype('int32')
+
+    def robin_boundaries(self, codim):
+        return self._robin_boundaries(codim)

--- a/src/pymor/operators/cg.py
+++ b/src/pymor/operators/cg.py
@@ -45,7 +45,7 @@ class L2ProductFunctionalP1(NumpyMatrixBasedOperator):
         |Function| providing the Neumann boundary values. If `None`,
         constant-zero is assumed.
     robin_data
-        Tuple of two |Functions| providing the Robin parameter and boundary values, see `RobinOperatorP1`.
+        Tuple of two |Functions| providing the Robin parameter and boundary values, see `RobinBoundaryOperator`.
         If `None`, constant-zero for both functions is assumed.
     order
         Order of the Gauss quadrature to use for numerical integration.
@@ -650,10 +650,12 @@ class DiffusionOperatorQ1(NumpyMatrixBasedOperator):
         return A
 
 
-class RobinOperatorP1(NumpyMatrixBasedOperator):
-    """Robin |Operator| for linear finite elements.
+class RobinBoundaryOperator(NumpyMatrixBasedOperator):
+    """Robin boundary |Operator| for linear finite elements.
 
-    The Robin boundary condition is supposed to be of the form ::
+    The operator represents the contribution of Robin boundary conditions to the
+    stiffness matrix, where the boundary condition is supposed to be given in the
+    form ::
 
         -d(x) ⋅ ∇u(x) = c(x) (u(x) - g(x))
 
@@ -692,6 +694,9 @@ class RobinOperatorP1(NumpyMatrixBasedOperator):
     def _assemble(self, mu=None):
         g = self.grid
         bi = self.boundary_info
+
+        if g.dim > 2:
+            raise NotImplementedError
 
         if bi is None or not bi.has_robin or self.robin_data is None:
             return coo_matrix((g.size(g.dim), g.size(g.dim))).tocsc()

--- a/src/pymor/operators/cg.py
+++ b/src/pymor/operators/cg.py
@@ -24,7 +24,7 @@ class L2ProductFunctionalP1(NumpyMatrixBasedOperator):
     Boundary treatment can be performed by providing `boundary_info` and `dirichlet_data`,
     in which case the DOFs corresponding to Dirichlet boundaries are set to the values
     provided by `dirichlet_data`. Neumann boundaries are handled by providing a
-    `neumann_data` function.
+    `neumann_data` function, Robin boundaries by providing a `robin_data` tuple
 
     The current implementation works in one and two dimensions, but can be trivially
     extended to arbitrary dimensions.
@@ -44,6 +44,9 @@ class L2ProductFunctionalP1(NumpyMatrixBasedOperator):
     neumann_data
         |Function| providing the Neumann boundary values. If `None`,
         constant-zero is assumed.
+    robin_data
+        Tuple of two |Functions| providing the Robin parameter and boundary values, cf. |RobinOperatorP1|.
+         If `None`, constant-zero for both functions is assumed.
     order
         Order of the Gauss quadrature to use for numerical integration.
     name
@@ -53,7 +56,8 @@ class L2ProductFunctionalP1(NumpyMatrixBasedOperator):
     sparse = False
     range = NumpyVectorSpace(1)
 
-    def __init__(self, grid, function, boundary_info=None, dirichlet_data=None, neumann_data=None, order=2, name=None):
+    def __init__(self, grid, function, boundary_info=None, dirichlet_data=None, neumann_data=None, robin_data=None,
+                 order=2, name=None):
         assert grid.reference_element(0) in {line, triangle}
         assert function.shape_range == tuple()
         self.source = NumpyVectorSpace(grid.size(grid.dim))
@@ -62,6 +66,7 @@ class L2ProductFunctionalP1(NumpyMatrixBasedOperator):
         self.function = function
         self.dirichlet_data = dirichlet_data
         self.neumann_data = neumann_data
+        self.robin_data = robin_data
         self.order = order
         self.name = name
         self.build_parameter_type(inherits=(function, dirichlet_data, neumann_data))

--- a/src/pymor/operators/cg.py
+++ b/src/pymor/operators/cg.py
@@ -24,7 +24,7 @@ class L2ProductFunctionalP1(NumpyMatrixBasedOperator):
     Boundary treatment can be performed by providing `boundary_info` and `dirichlet_data`,
     in which case the DOFs corresponding to Dirichlet boundaries are set to the values
     provided by `dirichlet_data`. Neumann boundaries are handled by providing a
-    `neumann_data` function, Robin boundaries by providing a `robin_data` tuple
+    `neumann_data` function, Robin boundaries by providing a `robin_data` tuple.
 
     The current implementation works in one and two dimensions, but can be trivially
     extended to arbitrary dimensions.
@@ -145,7 +145,7 @@ class L2ProductFunctionalQ1(NumpyMatrixBasedOperator):
     Boundary treatment can be performed by providing `boundary_info` and `dirichlet_data`,
     in which case the DOFs corresponding to Dirichlet boundaries are set to the values
     provided by `dirichlet_data`. Neumann boundaries are handled by providing a
-    `neumann_data` function, Robin boundaries by providing a `robin_data` tuple
+    `neumann_data` function, Robin boundaries by providing a `robin_data` tuple.
 
     The current implementation works in two dimensions, but can be trivially
     extended to arbitrary dimensions.
@@ -674,11 +674,11 @@ class RobinBoundaryOperator(NumpyMatrixBasedOperator):
     stiffness matrix, where the boundary condition is supposed to be given in the
     form ::
 
-        -d(x) ⋅ ∇u(x) = c(x) (u(x) - g(x))
+        -[ d(x) ∇u(x) ] ⋅ n(x) = c(x) (u(x) - g(x))
 
-    The function `d` is the diffusion function (see `DiffusionOperatorP1`), while
-    `c` is the (scalar) Robin parameter function and `g` is the (also scalar)
-    Robin boundary value function.
+    `d` and `n` are the diffusion function (see `DiffusionOperatorP1`) and the
+    unit outer normal in `x`, while `c` is the (scalar) Robin parameter
+    function and `g` is the (also scalar) Robin boundary value function.
 
     Parameters
     ----------

--- a/src/pymor/operators/cg.py
+++ b/src/pymor/operators/cg.py
@@ -45,8 +45,8 @@ class L2ProductFunctionalP1(NumpyMatrixBasedOperator):
         |Function| providing the Neumann boundary values. If `None`,
         constant-zero is assumed.
     robin_data
-        Tuple of two |Functions| providing the Robin parameter and boundary values, cf. |RobinOperatorP1|.
-         If `None`, constant-zero for both functions is assumed.
+        Tuple of two |Functions| providing the Robin parameter and boundary values, see `RobinOperatorP1`.
+        If `None`, constant-zero for both functions is assumed.
     order
         Order of the Gauss quadrature to use for numerical integration.
     name
@@ -657,7 +657,7 @@ class RobinOperatorP1(NumpyMatrixBasedOperator):
 
         -d(x) ⋅ ∇u(x) = c(x) (u(x) - g(x))
 
-    The function `d` is the diffusion function (cf. |DiffusionOperatorP1|), while
+    The function `d` is the diffusion function (see `DiffusionOperatorP1`), while
     `c` is the (scalar) Robin parameter function and `g` is the (also scalar)
     Robin boundary value function.
 


### PR DESCRIPTION
To support Robin boundary conditions the following modifications were made:
- `DomainDescriptionInterface` and `BoundaryInfoInterface` extended so that the Robin condition can be handled just like Dirichlet and Neumann conditions
- `L2ProductFunctional{P|Q}1` can be supplied with `robin_data` to assemble the rhs part of the Robin BC
- `RobinBoundaryOperator` introduced to supply Robin BC contribution to the stiffness matrix