### PR TITLE
Add parallelization framework

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ before_install:
  - pip install --upgrade numpy
  - pip install --upgrade pytest
  - pip install --upgrade pytest pytest-cov
+ - pip install --upgrade ipython
+ - pip install ipyparallel
 
 # command to install dependencies
 install:

--- a/docs/source/substitutions.py
+++ b/docs/source/substitutions.py
@@ -26,6 +26,8 @@ interfaces = '''
 .. |Grid| replace:: :class:`Grid <pymor.grids.interfaces.AffineGridInterface>`
 .. |Grids| replace:: :class:`Grids <pymor.grids.interfaces.AffineGridInterface>`
 .. |ImmutableInterface| replace:: :class:`~pymor.core.interfaces.ImmutableInterface`
+.. |immutable| replace:: :class:`immutable <pymor.core.interfaces.ImmutableInterface>`
+.. |Immutable| replace:: :class:`Immutable <pymor.core.interfaces.ImmutableInterface>`
 .. |LincombOperators| replace:: :class:`LincombOperators <pymor.operators.constructions.LincombOperator>`
 .. |LincombOperator| replace:: :class:`LincombOperator <pymor.operators.constructions.LincombOperator>`
 .. |Operators| replace:: :class:`Operators <pymor.operators.interfaces.OperatorInterface>`
@@ -35,8 +37,12 @@ interfaces = '''
 .. |ParameterSpace| replace:: :class:`ParameterSpace <pymor.parameters.interfaces.ParameterSpaceInterface>`
 .. |ReferenceElements| replace:: :class:`ReferenceElements <pymor.grids.interfaces.ReferenceElementInterface>`
 .. |ReferenceElement| replace:: :class:`ReferenceElement <pymor.grids.interfaces.ReferenceElementInterface>`
+.. |RemoteObject| replace:: :class:`RemoteObject <pymor.parallel.interfaces.RemoteObjectInterface>`
+.. |RemoteObjects| replace:: :class:`RemoteObjects <pymor.parallel.interfaces.RemoteObjectInterface>`
 .. |VectorArrays| replace:: :class:`VectorArrays <pymor.vectorarrays.interfaces.VectorArrayInterface>`
 .. |VectorArray| replace:: :class:`VectorArray <pymor.vectorarrays.interfaces.VectorArrayInterface>`
+.. |WorkerPool| replace:: :class:`WorkerPool <pymor.parallel.interfaces.WorkerPoolInterface>`
+.. |WorkerPools| replace:: :class:`WorkerPools <pymor.parallel.interfaces.WorkerPoolInterface>`
 
 '''
 

--- a/src/pymor/core/pickle.py
+++ b/src/pymor/core/pickle.py
@@ -122,3 +122,26 @@ def loads_function(s):
     r = FunctionType(code, globals_, name, defaults, closure)
     r.func_dict = func_dict
     return r
+
+
+class FunctionPicklingWrapper(object):
+    """Serializable function container, using :func:`dumps_function` if necessary."""
+
+    def __init__(self, f):
+        self.function = f
+
+    def __getstate__(self):
+        f = self.function
+        if f.__module__ != '__main__':
+            try:
+                return dumps(f)
+            except PicklingError:
+                return (dumps_function(f),)
+        else:
+            return (dumps_function(f),)
+
+    def __setstate__(self, f):
+        if type(f) == tuple:
+            self.function = loads_function(f[0])
+        else:
+            self.function = loads(f)

--- a/src/pymor/parallel/__init__.py
+++ b/src/pymor/parallel/__init__.py
@@ -1,0 +1,4 @@
+# This file is part of the pyMOR project (http://www.pymor.org).
+# Copyright Holders: Rene Milk, Stephan Rave, Felix Schindler
+# License: BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+

--- a/src/pymor/parallel/defaultimpl.py
+++ b/src/pymor/parallel/defaultimpl.py
@@ -61,4 +61,4 @@ def _append_array_slice(s, U=None):
 
 
 def _append_list_slice(s, l=None):
-    l.append(s)
+    l.extend(s)

--- a/src/pymor/parallel/defaultimpl.py
+++ b/src/pymor/parallel/defaultimpl.py
@@ -1,0 +1,64 @@
+# This file is part of the pyMOR project (http://www.pymor.org).
+# Copyright Holders: Rene Milk, Stephan Rave, Felix Schindler
+# License: BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+
+from __future__ import absolute_import, division, print_function
+
+from contextlib import contextmanager
+import weakref
+
+
+class WorkerPoolDefaultImplementations(object):
+
+    @contextmanager
+    def distribute_array(self, U, copy=True):
+
+        def impl(U, copy):
+            U = U()
+            UR = U.empty()
+            slice_len = len(U) // len(self) + (1 if len(U) % len(self) else 0)
+            if copy:
+                slices = []
+                for i in range(len(self)):
+                    slices.append(U.copy(ind=range(i*slice_len, min((i+1)*slice_len, len(U)))))
+            else:
+                slices = [U.empty() for _ in range(len(self))]
+                for s in slices:
+                    s.append(U, o_ind=range(0, min(slice_len, len(U))), remove_from_other=True)
+            del U
+
+            with self.distribute(UR) as remote_U:
+                self.map(_append_array_slice, slices, U=remote_U)
+                del slices
+                yield remote_U
+
+        # pass weakref to impl to make sure that no reference to U is kept while inside the context
+        return impl(weakref.ref(U), copy)
+
+    @contextmanager
+    def distribute_list(self, l):
+
+        def impl(l):
+            slice_len = len(l) // len(self) + (1 if len(l) % len(self) else 0)
+            slices = []
+            for i in range(len(self)):
+                slices.append(l[i*slice_len:(i+1)*slice_len])
+            del l[:]
+
+            with self.distribute([]) as remote_l:
+                self.map(_append_list_slice, slices, l=remote_l)
+                del slices
+                yield remote_l
+
+        # always pass a copy of l which we can empty inside impl so that we do not hold refs to the data
+        # note that the weakref trick from 'distribute_array' does not work here since lists cannot be
+        # weakrefed
+        return impl(list(l))
+
+
+def _append_array_slice(s, U=None):
+    U.append(s, remove_from_other=True)
+
+
+def _append_list_slice(s, l=None):
+    l.append(s)

--- a/src/pymor/parallel/dummy.py
+++ b/src/pymor/parallel/dummy.py
@@ -1,0 +1,63 @@
+# This file is part of the pyMOR project (http://www.pymor.org).
+# Copyright Holders: Rene Milk, Stephan Rave, Felix Schindler
+# License: BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+
+from __future__ import absolute_import, division, print_function
+
+from itertools import izip
+
+from pymor.core.interfaces import ImmutableInterface
+from pymor.core.pickle import dumps, loads
+from pymor.parallel.interfaces import WorkerPoolInterface, RemoteObjectInterface
+
+
+class DummyPool(WorkerPoolInterface):
+
+    def __len__(self):
+        return 1
+
+    def push(self, obj):
+        if isinstance(obj, ImmutableInterface):
+            return DummyRemoteObject(obj)
+        else:
+            return DummyRemoteObject(loads(dumps(obj)))  # ensure we make a deep copy of the data
+
+    def scatter_array(self, U, copy=True):
+        if copy:
+            U = U.copy()
+        return DummyRemoteObject(U)
+
+    def scatter_list(self, l):
+        l = list(l)
+        return DummyRemoteObject(l)
+
+    def _map_kwargs(self, kwargs):
+        return {k: (v.obj if isinstance(v, DummyRemoteObject) else v) for k, v in kwargs.iteritems()}
+
+    def apply(self, function, *args, **kwargs):
+        kwargs = self._map_kwargs(kwargs)
+        return [function(*args, **kwargs)]
+
+    def apply_only(self, function, worker, *args, **kwargs):
+        kwargs = self._map_kwargs(kwargs)
+        return function(*args, **kwargs)
+
+    def map(self, function, *args, **kwargs):
+        kwargs = self._map_kwargs(kwargs)
+        result = [function(*a, **kwargs) for a in izip(*args)]
+        if isinstance(result[0], tuple):
+            return zip(*result)
+        else:
+            return result
+
+
+dummy_pool = DummyPool()
+
+
+class DummyRemoteObject(RemoteObjectInterface):
+
+    def __init__(self, obj):
+        self.obj = obj
+
+    def _remove(self):
+        del self.obj

--- a/src/pymor/parallel/interfaces.py
+++ b/src/pymor/parallel/interfaces.py
@@ -1,0 +1,28 @@
+# This file is part of the pyMOR project (http://www.pymor.org).
+# Copyright Holders: Rene Milk, Stephan Rave, Felix Schindler
+# License: BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+
+from pymor.core.interfaces import BasicInterface, abstractmethod
+
+
+class WorkerPoolInterface(BasicInterface):
+
+    @abstractmethod
+    def __len__(self):
+        pass
+
+    @abstractmethod
+    def distribute(self, *args):
+        pass
+
+    @abstractmethod
+    def apply(self, function, *args, **kwargs):
+        pass
+
+    @abstractmethod
+    def apply_only(self, function, worker, *args, **kwargs):
+        pass
+
+    @abstractmethod
+    def map(self, function, zip_return_values=True, *args, **kwargs):
+        pass

--- a/src/pymor/parallel/interfaces.py
+++ b/src/pymor/parallel/interfaces.py
@@ -6,29 +6,154 @@ from pymor.core.interfaces import BasicInterface, abstractmethod
 
 
 class WorkerPoolInterface(BasicInterface):
+    """Interface for parallel worker pools.
+
+    |WorkerPools| allow to easily parallelize algorithms which involve
+    no or little communication between the workers at runtime. The interface
+    methods give the user simple means to distribute data to
+    workers (:meth:`~WorkerPoolInterface.push`, :meth:`~WorkerPoolInterface.scatter_array`,
+    :meth:`~WorkerPoolInterface.scatter_list`) and execute functions on
+    the distributed data in parallel (:meth:`~WorkerPoolInterface.apply`),
+    collecting the return values from each function call. Moreover, a
+    single worker can be instructed to execute a function
+    (:meth:`WorkerPoolInterface.apply_only`). Finally, a parallelized
+    (:math:`~WorkerPoolInterface.map`) function is available, which
+    automatically scatters the data among the workers.
+
+    All operations are performed synchronously.
+    """
 
     @abstractmethod
     def __len__(self):
+        """The number of workers in the pool."""
         pass
 
     @abstractmethod
     def push(self, obj):
+        """Push a copy of 'obj' to  all workers of the pool.
+
+        A |RemoteObject| is returned as a handle to the pushed objects.
+        This object can be used as an argument to :meth:`~WorkerPoolInterface.apply`,
+        :meth:`~WorkerPoolInterface.apply_only`, :meth:`~WorkerPoolInterface.map`
+        and will then be transparently mapped to the respective copy
+        of the pushed object on the worker.
+
+        |Immutable| objects will be pushed only once. If the same |immutable| object
+        is pushed a second time, the returned |RemoteObject| will refer to the
+        already transfered copy. It is therefore safe to use `push` to ensure
+        that a given |immutable| object is available on the worker. No unnecessary
+        copies will be created.
+
+        Parameters
+        ----------
+        obj
+            The object to push to all workers.
+
+        Returns
+        -------
+        A |RemoteObject| referring to the pushed data.
+        """
         pass
 
     @abstractmethod
     def scatter_array(self, U, copy=True):
+        """Distribute |VectorArray| evenly among the workers.
+
+        On each worker a |VectorArray| is created holding an (up to rounding) equal
+        amount of vectors of `U`. The returned |RemoteObject| therefore refers
+        to different data on each of the workers.
+
+        Parameters
+        ----------
+        U
+            The |VectorArray| to distribute.
+        copy
+            If `False`, `U` will be emptied during distribution of the vectors.
+
+        Returns
+        -------
+        A |RemoteObject| referring to the scattered data.
+        """
         pass
 
     @abstractmethod
     def scatter_list(self, l):
+        """Distribute list of objects evenly among the workers.
+
+        On each worker a `list` is created holding an (up to rounding) equal
+        amount of objects of `l`. The returned |RemoteObject| therefore refers
+        to different data on each of the workers.
+
+        Parameters
+        ----------
+        l
+            The list (sequence) of objects to distribute.
+
+        Returns
+        -------
+        A |RemoteObject| referring to the scattered data.
+        """
         pass
 
     @abstractmethod
     def apply(self, function, *args, **kwargs):
+        """Apply function in parallel on each worker.
+
+        This calls `function` on each worker in parallel, passing `args` as
+        positional and `kwargs` as keyword arguments. Keyword arguments
+        which are |RemoteObjects| are automatically mapped to the
+        respective object on the worker. Moreover, keyword arguments which
+        are |immutable| objects that have already been pushed to the workers
+        will not be transmitted again. (|Immutable| objects which have not
+        been pushed before will be transmitted and the remote copy will be
+        destroyed after function execution.)
+
+        Parameters
+        ----------
+        function
+            The function to execute on each worker.
+        args
+            The positional arguments for `function`.
+        kwargs
+            The keyword arguments for `function`.
+
+        Returns
+        -------
+        List of return values of the function executions, ordered by
+        worker number (from `0` to `len(pool)`). If `function` returns
+        a (tuple) of n values, n lists of return values are returned.
+        """
         pass
 
     @abstractmethod
     def apply_only(self, function, worker, *args, **kwargs):
+        """Apply function on a single worker.
+
+        This calls `function` on on the worker with number `worker`, passing
+        `args` as positional and `kwargs` as keyword arguments. Keyword arguments
+        which are |RemoteObjects| are automatically mapped to the
+        respective object on the worker. Moreover, keyword arguments which
+        are |immutable| objects that have already been pushed to the workers
+        will not be transmitted again. (|Immutable| objects which have not
+        been pushed before will be transmitted and the remote copy will be
+        destroyed after function execution.)
+
+        Parameters
+        ----------
+        function
+            The function to execute.
+        worker
+            The worker on which to execute the function. (Number between
+            `0` and `len(pool)`.)
+        args
+            The positional arguments for `function`.
+        kwargs
+            The keyword arguments for `function`.
+
+        Returns
+        -------
+        Return value of the function execution.
+        """
         pass
 
     @abstractmethod
@@ -64,14 +189,40 @@ class WorkerPoolInterface(BasicInterface):
 
 
 class RemoteObjectInterface(object):
+    """Handle to data on workers of a |WorkerPool|.
+
+    See documentation of :class:`WorkerPoolInterface` for usage
+    of these handles in conjunction with :meth:`~WorkerPoolInterface.apply`,
+    :meth:`~WorkerPoolInterface.scatter_array`,
+    :meth:`~WorkerPoolInterface.scatter_list`.
+
+    Remote objects can be used as a context manager: when leaving the
+    context, the remote object's :meth:`~RemoteObjectInterface.remove`
+    method is called to ensure proper cleanup of remote resources.
+
+    Attributes
+    ----------
+    removed
+        `True`, if :meth:`RemoteObjectInterface.remove` has been called.
+    """
 
     removed = False
 
     @abstractmethod
     def _remove(self):
+        """Actual implementation of 'remove'."""
         pass
 
     def remove(self):
+        """Remove the remote object from the workers.
+
+        Remove the object to which this handle refers from all workers.
+        Note that the object will only be destroyed if no other
+        object on the worker holds a reference to the object.
+        Moreover, |immutable| objects will only be destroyed, if
+        `remove` has been called on _all_ |RemoteObjects| which refer
+        to the object (also see :meth:`~WorkerPoolInterface.push`).
+        """
         if self.removed:
             return
         self._remove()

--- a/src/pymor/parallel/interfaces.py
+++ b/src/pymor/parallel/interfaces.py
@@ -12,15 +12,15 @@ class WorkerPoolInterface(BasicInterface):
         pass
 
     @abstractmethod
-    def distribute(self, *args):
+    def push(self, *args):
         pass
 
     @abstractmethod
-    def distribute_array(self, U, copy=True):
+    def scatter_array(self, U, copy=True):
         pass
 
     @abstractmethod
-    def distribute_list(self, l):
+    def scatter_list(self, l):
         pass
 
     @abstractmethod

--- a/src/pymor/parallel/interfaces.py
+++ b/src/pymor/parallel/interfaces.py
@@ -17,7 +17,7 @@ class WorkerPoolInterface(BasicInterface):
     collecting the return values from each function call. Moreover, a
     single worker can be instructed to execute a function
     (:meth:`WorkerPoolInterface.apply_only`). Finally, a parallelized
-    (:math:`~WorkerPoolInterface.map`) function is available, which
+    :meth:`~WorkerPoolInterface.map` function is available, which
     automatically scatters the data among the workers.
 
     All operations are performed synchronously.
@@ -120,7 +120,7 @@ class WorkerPoolInterface(BasicInterface):
         Returns
         -------
         List of return values of the function executions, ordered by
-        worker number (from `0` to `len(pool)`). If `function` returns
+        worker number (from `0` to `len(pool) - 1`). If `function` returns
         a (tuple) of n values, n lists of return values are returned.
         """
         pass
@@ -144,7 +144,7 @@ class WorkerPoolInterface(BasicInterface):
             The function to execute.
         worker
             The worker on which to execute the function. (Number between
-            `0` and `len(pool)`.)
+            `0` and `len(pool) - 1`.)
         args
             The positional arguments for `function`.
         kwargs
@@ -216,7 +216,7 @@ class RemoteObjectInterface(object):
     def remove(self):
         """Remove the remote object from the workers.
 
-        Remove the object to which this handle refers from all workers.
+        Remove the object to which this handle refers to from all workers.
         Note that the object will only be destroyed if no other
         object on the worker holds a reference to the object.
         Moreover, |immutable| objects will only be destroyed, if

--- a/src/pymor/parallel/interfaces.py
+++ b/src/pymor/parallel/interfaces.py
@@ -32,7 +32,34 @@ class WorkerPoolInterface(BasicInterface):
         pass
 
     @abstractmethod
-    def map(self, function, zip_return_values=True, *args, **kwargs):
+    def map(self, function, *args, **kwargs):
+        """Parallel version of the builtin map function.
+
+        Each positional argument (after `function`) must be a sequence
+        of same length n. `map` calls `function` in parallel on each of these n
+        positional argument combinations, always passing `kwargs` as keyword
+        arguments.  Keyword arguments which are |RemoteObjects| are automatically
+        mapped to the respective object on the worker. Moreover, keyword arguments
+        which are |immutable| objects that have already been pushed to the workers
+        will not be transmitted again. (|Immutable| objects which have not
+        been pushed before will be transmitted and the remote copy will be
+        destroyed after function execution.)
+
+        Parameters
+        ----------
+        function
+            The function to execute on each worker.
+        args
+            The sequences of positional arguments for `function`.
+        kwargs
+            The keyword arguments for `function`.
+
+        Returns
+        -------
+        List of return values of the function executions, ordered by
+        the sequence of positional arguments.  If `function` returns
+        a (tuple) of k values, k lists of return values are returned.
+        """
         pass
 
 

--- a/src/pymor/parallel/interfaces.py
+++ b/src/pymor/parallel/interfaces.py
@@ -16,6 +16,14 @@ class WorkerPoolInterface(BasicInterface):
         pass
 
     @abstractmethod
+    def distribute_array(self, U, copy=True):
+        pass
+
+    @abstractmethod
+    def distribute_list(self, l):
+        pass
+
+    @abstractmethod
     def apply(self, function, *args, **kwargs):
         pass
 

--- a/src/pymor/parallel/interfaces.py
+++ b/src/pymor/parallel/interfaces.py
@@ -34,3 +34,7 @@ class WorkerPoolInterface(BasicInterface):
     @abstractmethod
     def map(self, function, zip_return_values=True, *args, **kwargs):
         pass
+
+
+class RemoteObjectInterface(object):
+    pass

--- a/src/pymor/parallel/interfaces.py
+++ b/src/pymor/parallel/interfaces.py
@@ -12,7 +12,7 @@ class WorkerPoolInterface(BasicInterface):
         pass
 
     @abstractmethod
-    def push(self, *args):
+    def push(self, obj):
         pass
 
     @abstractmethod
@@ -37,4 +37,24 @@ class WorkerPoolInterface(BasicInterface):
 
 
 class RemoteObjectInterface(object):
-    pass
+
+    removed = False
+
+    @abstractmethod
+    def _remove(self):
+        pass
+
+    def remove(self):
+        if self.removed:
+            return
+        self._remove()
+        self.removed = True
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.remove()
+
+    def __del__(self):
+        self.remove()

--- a/src/pymor/parallel/ipython.py
+++ b/src/pymor/parallel/ipython.py
@@ -1,0 +1,166 @@
+# This file is part of the pyMOR project (http://www.pymor.org).
+# Copyright Holders: Rene Milk, Stephan Rave, Felix Schindler
+# License: BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+
+from __future__ import absolute_import, division, print_function
+
+from itertools import izip, chain
+import weakref
+
+from IPython.parallel import Client
+
+from pymor.core.interfaces import ImmutableInterface
+from pymor.core.pickle import dumps, dumps_function, PicklingError
+from pymor.parallel.interfaces import WorkerPoolInterface
+from pymor.tools.counter import Counter
+
+
+def _worker_call_function(function, loop, args, kwargs):
+    from pymor.core.pickle import loads, loads_function
+    global remote_objects
+    if isinstance(function, tuple):
+        function = loads_function(function[0])
+    else:
+        function = loads(function)
+    kwargs = {k: remote_objects[v.key] if isinstance(v, RemoteObject) else v
+              for k, v in kwargs.iteritems()}
+    if loop:
+        return [function(*a, **kwargs) for a in izip(*args)]
+    else:
+        return function(*args, **kwargs)
+
+
+def _split_into_chunks(count, *args):
+    lens = map(len, args)
+    min_len = min(lens)
+    max_len = max(lens)
+    assert min_len == max_len
+    chunk_size = max_len // count + (1 if max_len % count > 0 else 0)
+
+    def split_arg(arg):
+        while arg:
+            chunk, arg = arg[:chunk_size], arg[chunk_size:]
+            yield chunk
+    chunks = tuple(list(split_arg(arg)) for arg in args)
+    return chunks
+
+
+remote_objects = {}
+
+
+def _setup_worker():
+    global remote_objects
+    remote_objects.clear()
+
+
+def _distribute_objects(objs):
+    global remote_objects
+    remote_objects.update(objs)
+
+
+def _remove_objects(ids):
+    global remote_objects
+    for i in ids:
+        del remote_objects[i]
+
+
+class RemoteObject(object):
+
+    def __init__(self, key):
+        self.key = key
+
+
+class IPythonPool(WorkerPoolInterface):
+
+    def __init__(self):
+        self.client = Client()
+        self.view = self.client[:]
+        self.view.apply(_setup_worker, block=True)
+        self._distributed_immutable_objects = {}
+        self._remote_objects_created = Counter()
+
+    def __len__(self):
+        return len(self.client)
+
+    def distribute(self, *args):
+        return IPythonPool.DistributedObjectManager(self, *args)
+
+    def _pickle_function(self, function):
+        if hasattr(function, '__file__'):
+            try:
+                function = dumps(function)
+            except PicklingError:
+                function = (dumps_function(function),)
+        else:
+            function = (dumps_function(function),)
+        return function
+
+    def _map_kwargs(self, kwargs):
+        distributed_immutable_objects = self._distributed_immutable_objects
+        return {k: distributed_immutable_objects.get(v.uid, v) if isinstance(v, ImmutableInterface) else v
+                for k, v in kwargs.iteritems()}
+
+    def apply(self, function, *args, **kwargs):
+        function = self._pickle_function(function)
+        kwargs = self._map_kwargs(kwargs)
+        return self.view.apply_sync(_worker_call_function, function, False, args, kwargs)
+
+    def apply_only(self, function, worker, *args, **kwargs):
+        view = self.client[worker]
+        function = self._pickle_function(function)
+        kwargs = self._map_kwargs(kwargs)
+        return view.apply_sync(_worker_call_function, function, False, args, kwargs)
+
+    def map(self, function, *args, **kwargs):
+        function = self._pickle_function(function)
+        kwargs = self._map_kwargs(kwargs)
+        num_workers = len(self.view)
+        chunks = _split_into_chunks(num_workers, *args)
+        result = self.view.map_sync(_worker_call_function,
+                                    *zip(*((function, True, a, kwargs) for a in izip(*chunks))))
+        if isinstance(result[0][0], tuple):
+            return tuple(list(x) for x in zip(*chain(*result)))
+        else:
+            return list(chain(*result))
+
+    class DistributedObjectManager(object):
+
+        def __init__(self, pool, *args):
+            self.pool = weakref.ref(pool)
+            self.objs = args
+
+        def __enter__(self):
+            pool = self.pool()
+            objects_to_distribute = {}
+            self.remote_objects_to_remove = []
+            self.distributed_immutable_objects_to_remove = []
+
+            def process_obj(o):
+                if isinstance(o, ImmutableInterface):
+                    if o.uid not in pool._distributed_immutable_objects:
+                        remote_id = pool._remote_objects_created.inc()
+                        objects_to_distribute[remote_id] = o
+                        pool._distributed_immutable_objects[o.uid] = RemoteObject(remote_id)
+                        self.remote_objects_to_remove.append(remote_id)
+                        self.distributed_immutable_objects_to_remove.append(o.uid)
+                    return pool._distributed_immutable_objects[o.uid]
+                else:
+                    remote_id = pool._remote_objects_created.inc()
+                    objects_to_distribute[remote_id] = o
+                    self.remote_objects_to_remove.append(remote_id)
+                    return RemoteObject(remote_id)
+
+            remote_objects = tuple(process_obj(o) for o in self.objs)
+            pool.view.apply_sync(_distribute_objects, objects_to_distribute)
+
+            # release local refecrences to distributed objects
+            del self.objs
+
+            return remote_objects
+
+        def __exit__(self, exc_type, exc_val, exc_tb):
+            pool = self.pool()
+            pool.view.apply(_remove_objects, self.remote_objects_to_remove)
+            for uid in self.distributed_immutable_objects_to_remove:
+                del pool._distributed_immutable_objects[uid]
+            return False

--- a/src/pymor/parallel/ipython.py
+++ b/src/pymor/parallel/ipython.py
@@ -126,7 +126,7 @@ class IPythonPool(WorkerPoolInterface):
         return IPythonPool.DistributedObjectManager(self, *args)
 
     def _pickle_function(self, function):
-        if hasattr(function, '__file__'):
+        if function.__module__ != '__main__':
             try:
                 function = dumps(function)
             except PicklingError:

--- a/src/pymor/parallel/ipython.py
+++ b/src/pymor/parallel/ipython.py
@@ -19,6 +19,7 @@ except ImportError:
 
 from pymor.core.interfaces import BasicInterface, ImmutableInterface
 from pymor.core.pickle import dumps, dumps_function, PicklingError
+from pymor.parallel.defaultimpl import WorkerPoolDefaultImplementations
 from pymor.parallel.interfaces import WorkerPoolInterface
 from pymor.tools.counter import Counter
 
@@ -106,7 +107,7 @@ class new_ipcluster_pool(BasicInterface):
         os.system(cmd)
 
 
-class IPythonPool(WorkerPoolInterface):
+class IPythonPool(WorkerPoolDefaultImplementations, WorkerPoolInterface):
 
     def __init__(self, num_engines=None, **kwargs):
         self.client = Client(**kwargs)

--- a/src/pymor/parallel/ipython.py
+++ b/src/pymor/parallel/ipython.py
@@ -120,7 +120,7 @@ class IPythonPool(WorkerPoolInterface):
         self._remote_objects_created = Counter()
 
     def __len__(self):
-        return len(self.client)
+        return len(self.view)
 
     def distribute(self, *args):
         return IPythonPool.DistributedObjectManager(self, *args)

--- a/src/pymor/parallel/ipython.py
+++ b/src/pymor/parallel/ipython.py
@@ -9,7 +9,13 @@ import os
 import time
 import weakref
 
-from IPython.parallel import Client, TimeoutError
+
+try:
+    from IPython.parallel import Client, TimeoutError
+    HAVE_IPYTHON = True
+except ImportError:
+    HAVE_IPYTHON = False
+
 
 from pymor.core.interfaces import BasicInterface, ImmutableInterface
 from pymor.core.pickle import dumps, dumps_function, PicklingError

--- a/src/pymor/parallel/ipython.py
+++ b/src/pymor/parallel/ipython.py
@@ -191,6 +191,8 @@ class IPythonPool(WorkerPoolInterface):
                     return RemoteObject(remote_id)
 
             remote_objects = tuple(process_obj(o) for o in self.objs)
+            if len(remote_objects) == 1:
+                remote_objects = remote_objects[0]
             pool.view.apply_sync(_distribute_objects, objects_to_distribute)
 
             # release local refecrences to distributed objects

--- a/src/pymor/parallel/ipython.py
+++ b/src/pymor/parallel/ipython.py
@@ -11,10 +11,14 @@ import weakref
 
 
 try:
-    from IPython.parallel import Client, TimeoutError
+    from ipyparallel import Client, TimeoutError
     HAVE_IPYTHON = True
 except ImportError:
-    HAVE_IPYTHON = False
+    try:
+        from IPython.parallel import Client, TimeoutError
+        HAVE_IPYTHON = True
+    except ImportError:
+        HAVE_IPYTHON = False
 
 
 from pymor.core.interfaces import BasicInterface, ImmutableInterface

--- a/src/pymor/parallel/manager.py
+++ b/src/pymor/parallel/manager.py
@@ -1,0 +1,31 @@
+# This file is part of the pyMOR project (http://www.pymor.org).
+# Copyright Holders: Rene Milk, Stephan Rave, Felix Schindler
+# License: BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+
+from __future__ import absolute_import, division, print_function
+
+from pymor.core.interfaces import BasicInterface
+
+
+class RemoteObjectManager(BasicInterface):
+
+    def __init__(self):
+        self.remote_objects = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.remove_objects()
+
+    def __del__(self):
+        self.remove_objects()
+
+    def remove_objects(self):
+        for obj in self.remote_objects:
+            obj.remove()
+        del self.remote_objects[:]
+
+    def manage(self, remote_object):
+        self.remote_objects.append(remote_object)
+        return remote_object

--- a/src/pymor/tools/counter.py
+++ b/src/pymor/tools/counter.py
@@ -1,0 +1,15 @@
+# This file is part of the pyMOR project (http://www.pymor.org).
+# Copyright Holders: Rene Milk, Stephan Rave, Felix Schindler
+# License: BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+
+from __future__ import absolute_import, division, print_function
+
+
+class Counter(object):
+
+    def __init__(self, start=0):
+        self.value = start
+
+    def inc(self):
+        self.value += 1
+        return self.value

--- a/src/pymortests/core/interface.py
+++ b/src/pymortests/core/interface.py
@@ -119,7 +119,7 @@ class WithcopyInterface(TestInterface):
         self_type = self.Type
         try:
             obj = self_type()
-        except TypeError as e:
+        except Exception as e:
             self.logger.debug('WithcopyInterface: Not testing {} because its init failed: {}'.format(self_type, str(e)))
             return
 


### PR DESCRIPTION
The pull request contains pyMOR's parallelization framework from the pymor-paper branch (only the framework, not the parallelized algorithms).

Before we merge to master, we should double-check if we are satisfied with the interfaces. (A bit of documentation would also be nice, I guess.)

As a first commit I would propose to rename some methods as follows:
- distribute -> push
- distribute_array -> scatter_array
- distribute_list -> scatter_list

Any comments?