### PR TITLE
Add support for persistent cache regions

### DIFF
--- a/src/pymor/core/cache.py
+++ b/src/pymor/core/cache.py
@@ -362,20 +362,9 @@ class CacheableInterface(ImmutableInterface):
         is disabled.
     """
 
-    sid_ignore = ImmutableInterface.sid_ignore | {'_CacheableInterface__cache_region'}
+    sid_ignore = ImmutableInterface.sid_ignore | {'cache_region'}
 
-    __cache_region = 'memory'
-
-    @property
-    def cache_region(self):
-        return self.__cache_region
-
-    @cache_region.setter
-    def cache_region(self, region):
-        if region in (None, 'none'):
-            self.__cache_region = None
-        else:
-            self.__cache_region = region
+    cache_region = None
 
     def disable_caching(self):
         """Disable caching for this instance."""
@@ -391,4 +380,10 @@ class CacheableInterface(ImmutableInterface):
             `pymor.core.cache.cache_regions`. If `None` or `'none'`, caching
             is disabled.
         """
-        self.__cache_region = region
+        if region in (None, 'none'):
+            self.__dict__['cache_region'] = None
+        else:
+            self.__dict__['cache_region'] = region
+            r = cache_regions.get(region, None)
+            if r and r.persistent:
+                self.generate_sid()

--- a/src/pymor/core/cache.py
+++ b/src/pymor/core/cache.py
@@ -66,6 +66,7 @@ A cache region can be emptied using :meth:`CacheRegion.clear`. The function
 from __future__ import absolute_import, division, print_function
 # cannot use unicode_literals here, or else dbm backend fails
 
+import atexit
 from collections import OrderedDict
 import datetime
 from functools import partial
@@ -79,6 +80,13 @@ from types import MethodType
 from pymor.core.defaults import defaults, defaults_sid
 from pymor.core.interfaces import ImmutableInterface, generate_sid
 from pymor.core.pickle import dump, load
+
+
+@atexit.register
+def cleanup_non_persisten_regions():
+    for region in cache_regions.values():
+        if not region.persistent:
+            region.clear()
 
 
 class CacheRegion(object):

--- a/src/pymor/core/cache.py
+++ b/src/pymor/core/cache.py
@@ -318,6 +318,15 @@ class cached(object):
         except KeyError:
             raise KeyError('No cache region "{}" found'.format(im_self.cache_region))
 
+        # compute id for self
+        if region.persistent:
+            self_id = getattr(im_self, 'sid')
+            if not self_id:     # this can happen when cache_region is already set by the class to
+                                # a persistent region
+                self_id = im_self.generate_sid()
+        else:
+            self_id = im_self.uid
+
         # ensure that passing a value as positional or keyword argument does not matter
         kwargs.update(zip(self.argnames, args))
 
@@ -326,9 +335,7 @@ class cached(object):
         if defaults:
             kwargs = dict(defaults, **kwargs)
 
-        key = generate_sid((self.decorated_function.__name__, getattr(im_self, 'sid', im_self.uid),
-                            kwargs,
-                            defaults_sid()))
+        key = generate_sid((self.decorated_function.__name__, self_id, kwargs, defaults_sid()))
         found, value = region.get(key)
         if found:
             return value

--- a/src/pymor/core/cache.py
+++ b/src/pymor/core/cache.py
@@ -82,7 +82,16 @@ from pymor.core.pickle import dump, load
 
 
 class CacheRegion(object):
-    """Base class for all pyMOR cache regions."""
+    """Base class for all pyMOR cache regions.
+
+    Attributes
+    ----------
+    persistent
+        If `True`, cache entries are kept between multiple
+        program runs.
+    """
+
+    persistent = False
 
     def get(self, key):
         raise NotImplementedError
@@ -121,9 +130,10 @@ class MemoryRegion(CacheRegion):
 
 class SQLiteRegion(CacheRegion):
 
-    def __init__(self, path, max_size):
+    def __init__(self, path, max_size, persistent):
         self.path = path
         self.max_size = max_size
+        self.persistent = persistent
         self.bytes_written = 0
         if not os.path.exists(path):
             os.mkdir(path)
@@ -134,7 +144,10 @@ class SQLiteRegion(CacheRegion):
             conn.commit()
         else:
             self.conn = sqlite3.connect(os.path.join(path, 'pymor_cache.db'))
-            self.housekeeping()
+            if persistent:
+                self.housekeeping()
+            else:
+                self.clear()
 
     def get(self, key):
         c = self.conn.cursor()
@@ -227,9 +240,12 @@ class SQLiteRegion(CacheRegion):
             getLogger('pymor.core.cache.SQLiteRegion').info('Removed {} old cache entries'.format(len(ids_to_delete)))
 
 
-@defaults('disk_path', 'disk_max_size', 'memory_max_keys', sid_ignore=('disk_path', 'disk_max_size', 'memory_max_keys'))
+@defaults('disk_path', 'disk_max_size', 'persistent_path', 'persistent_max_size', 'memory_max_keys',
+          sid_ignore=('disk_path', 'disk_max_size', 'persistent_path', 'persistent_max_size', 'memory_max_keys'))
 def default_regions(disk_path=os.path.join(tempfile.gettempdir(), 'pymor.cache.' + getpass.getuser()),
                     disk_max_size=1024 ** 3,
+                    persistent_path=os.path.join(tempfile.gettempdir(), 'pymor.persistent.cache.' + getpass.getuser()),
+                    persistent_max_size=1024 ** 3,
                     memory_max_keys=1000):
 
     parse_size_string = lambda size: \
@@ -241,7 +257,8 @@ def default_regions(disk_path=os.path.join(tempfile.gettempdir(), 'pymor.cache.'
     if isinstance(disk_max_size, str):
         disk_max_size = parse_size_string(disk_max_size)
 
-    cache_regions['disk'] = SQLiteRegion(path=disk_path, max_size=disk_max_size)
+    cache_regions['disk'] = SQLiteRegion(path=disk_path, max_size=disk_max_size, persistent=False)
+    cache_regions['persistent'] = SQLiteRegion(path=persistent_path, max_size=persistent_max_size, persistent=True)
     cache_regions['memory'] = MemoryRegion(memory_max_keys)
 
 cache_regions = {}

--- a/src/pymor/discretizations/basic.py
+++ b/src/pymor/discretizations/basic.py
@@ -31,7 +31,7 @@ class DiscretizationBase(DiscretizationInterface):
         self.products = products
         self.estimator = estimator
         self.visualizer = visualizer
-        self.cache_region = cache_region
+        self.enable_caching(cache_region)
         self.name = name
 
         if products:

--- a/src/pymor/grids/interfaces.py
+++ b/src/pymor/grids/interfaces.py
@@ -32,6 +32,8 @@ class ConformalTopologicalGridInterface(ConformalTopologicalGridDefaultImplement
         The dimension of the grid.
     """
 
+    cache_region = 'memory'
+
     @abstractmethod
     def size(self, codim):
         """The number of entities of codimension `codim`."""
@@ -116,6 +118,7 @@ class ReferenceElementInterface(ReferenceElementDefaultImplementations, Cacheabl
 
     dim = None
     volume = None
+    cache_region = 'memory'
 
     @abstractmethod
     def size(self, codim):
@@ -324,6 +327,7 @@ class BoundaryInfoInterface(CacheableInterface):
     """
 
     boundary_types = frozenset()
+    cache_region = 'memory'
 
     def mask(self, boundary_type, codim):
         """retval[i] is `True` if the codim-`codim` entity of global index `i` is

--- a/src/pymordemos/burgers.py
+++ b/src/pymordemos/burgers.py
@@ -84,7 +84,6 @@ def burgers_demo(args):
     discretization, data = discretizer(problem, diameter=1. / args['--grid'],
                                        num_flux=args['--num-flux'], lxf_lambda=args['--lxf-lambda'],
                                        nt=args['--nt'], domain_discretizer=domain_discretizer)
-    discretization.generate_sid()
     print(discretization.operator.grid)
 
     print('The parameter type is {}'.format(discretization.parameter_type))

--- a/src/pymordemos/burgers_ei.py
+++ b/src/pymordemos/burgers_ei.py
@@ -30,6 +30,10 @@ Arguments:
 
 
 Options:
+  --cache-region=REGION           Name of cache region to use for caching solution snapshots
+                                  (NONE, MEMORY, DISK, PERSISTENT)
+                                  [default: DISK]
+
   --grid=NI                       Use grid with (2*NI)*NI elements [default: 60].
 
   --grid-type=TYPE                Type of grid to use (rect, tria) [default: rect].
@@ -91,6 +95,7 @@ from pymor.vectorarrays.numpy import NumpyVectorArray
 
 
 def burgers_demo(args):
+    args['--cache-region'] = args['--cache-region'].lower()
     args['--grid'] = int(args['--grid'])
     args['--grid-type'] = args['--grid-type'].lower()
     assert args['--grid-type'] in ('rect', 'tria')
@@ -126,6 +131,9 @@ def burgers_demo(args):
     discretization, _ = discretizer(problem, diameter=1. / args['--grid'],
                                     num_flux=args['--num-flux'], lxf_lambda=args['--lxf-lambda'],
                                     nt=args['--nt'], domain_discretizer=domain_discretizer)
+
+    if args['--cache-region'] != 'none':
+        discretization.enable_caching(args['--cache-region'])
 
     print(discretization.operator.grid)
 

--- a/src/pymordemos/thermalblock.py
+++ b/src/pymordemos/thermalblock.py
@@ -55,6 +55,10 @@ Options:
 
   --profile=PROFILE      IPython profile to use for parallelization.
 
+  --cache-region=REGION  Name of cache region to use for caching solution snapshots
+                         (NONE, MEMORY, DISK, PERSISTENT)
+                         [default: NONE]
+
   --list-vector-array    Solve using ListVectorArray[NumpyVector] instead of NumpyVectorArray.
 """
 
@@ -95,6 +99,7 @@ def thermalblock_demo(args):
     assert args['--extension-alg'] in {'trivial', 'gram_schmidt', 'h1_gram_schmidt'}
     args['--reductor'] = args['--reductor'].lower()
     assert args['--reductor'] in {'traditional', 'residual_basis'}
+    args['--cache-region'] = args['--cache-region'].lower()
 
     print('Solving on TriaGrid(({0},{0}))'.format(args['--grid']))
 
@@ -108,7 +113,8 @@ def thermalblock_demo(args):
         from pymor.playground.discretizers.numpylistvectorarray import convert_to_numpy_list_vector_array
         discretization = convert_to_numpy_list_vector_array(discretization)
 
-    discretization.generate_sid()
+    if args['--cache-region'] != 'none':
+        discretization.enable_caching(args['--cache-region'])
 
     print('The parameter type is {}'.format(discretization.parameter_type))
 

--- a/src/pymordemos/thermalblock_fenics.py
+++ b/src/pymordemos/thermalblock_fenics.py
@@ -131,7 +131,7 @@ def discretize(args):
     parameter_space = CubicParameterSpace(op.parameter_type, 0.1, 1.)
     d = StationaryDiscretization(op, rhs, products={'h1': h1_product},
                                  parameter_space=parameter_space,
-                                 visualizer=visualizer, cache_region=None)
+                                 visualizer=visualizer)
 
     return d
 

--- a/src/pymortests/cache.py
+++ b/src/pymortests/cache.py
@@ -85,7 +85,7 @@ class TestCache(TestInterface):
     def test_region_api(self):
         tempdir = gettempdir()
         backends = [cache.MemoryRegion(100), cache.SQLiteRegion(path=os.path.join(tempdir, str(uuid4())),
-                                                                max_size=1024 ** 2)]
+                                                                max_size=1024 ** 2, persistent=False)]
         for backend in backends:
             assert not backend.get('mykey')[0]
             backend.set('mykey', 1)


### PR DESCRIPTION
Cache regions are marked as persistent or not. Non-persistent cache regions are cleared at program exit. State ids are automatically generated when persistent cache regions are selected.

This addresses #121, #180.