### PR TITLE
Repace 'invert_options' by 'solver_options'

### DIFF
--- a/docs/source/substitutions.py
+++ b/docs/source/substitutions.py
@@ -112,7 +112,7 @@ common = '''
 
 .. |OrderedDict| replace:: :class:`~collections.OrderedDict`
 
-.. |invert_options| replace:: :meth:`invert options <pymor.operators.interfaces.OperatorInterface.invert_options>`
+.. |solver_options| replace:: :attr:`~pymor.operators.interfaces.OperatorInterface.solver_options`
 
 '''
 

--- a/src/pymor/algorithms/genericsolvers.py
+++ b/src/pymor/algorithms/genericsolvers.py
@@ -27,25 +27,25 @@ _options_sid = None
           'least_squares_generic_lsqr_atol', 'least_squares_generic_lsqr_btol', 'least_squares_generic_lsqr_conlim',
           'least_squares_generic_lsqr_iter_lim', 'least_squares_generic_lsqr_show',
           sid_ignore=('least_squares_generic_lsmr_show', 'least_squares_generic_lsqr_show'))
-def invert_options(default_solver='generic_lgmres',
-                   default_least_squares_solver='least_squares_generic_lsmr',
-                   generic_lgmres_tol=1e-5,
-                   generic_lgmres_maxiter=1000,
-                   generic_lgmres_inner_m=39,
-                   generic_lgmres_outer_k=3,
-                   least_squares_generic_lsmr_damp=0.0,
-                   least_squares_generic_lsmr_atol=1e-6,
-                   least_squares_generic_lsmr_btol=1e-6,
-                   least_squares_generic_lsmr_conlim=1e8,
-                   least_squares_generic_lsmr_maxiter=None,
-                   least_squares_generic_lsmr_show=False,
-                   least_squares_generic_lsqr_damp=0.0,
-                   least_squares_generic_lsqr_atol=1e-6,
-                   least_squares_generic_lsqr_btol=1e-6,
-                   least_squares_generic_lsqr_conlim=1e8,
-                   least_squares_generic_lsqr_iter_lim=None,
-                   least_squares_generic_lsqr_show=False):
-    """Returns |invert_options| (with default values) for arbitrary linear |Operators|.
+def options(default_solver='generic_lgmres',
+            default_least_squares_solver='least_squares_generic_lsmr',
+            generic_lgmres_tol=1e-5,
+            generic_lgmres_maxiter=1000,
+            generic_lgmres_inner_m=39,
+            generic_lgmres_outer_k=3,
+            least_squares_generic_lsmr_damp=0.0,
+            least_squares_generic_lsmr_atol=1e-6,
+            least_squares_generic_lsmr_btol=1e-6,
+            least_squares_generic_lsmr_conlim=1e8,
+            least_squares_generic_lsmr_maxiter=None,
+            least_squares_generic_lsmr_show=False,
+            least_squares_generic_lsqr_damp=0.0,
+            least_squares_generic_lsqr_atol=1e-6,
+            least_squares_generic_lsqr_btol=1e-6,
+            least_squares_generic_lsqr_conlim=1e8,
+            least_squares_generic_lsqr_iter_lim=None,
+            least_squares_generic_lsqr_show=False):
+    """Returns |solver_options| (with default values) for arbitrary linear |Operators|.
 
     Parameters
     ----------
@@ -89,7 +89,7 @@ def invert_options(default_solver='generic_lgmres',
 
     Returns
     -------
-    A tuple of all possible |invert_options|.
+    A tuple of possible values for |solver_options| (key `'generic'`).
     """
 
     assert default_least_squares_solver.startswith('least_squares')
@@ -121,7 +121,7 @@ def invert_options(default_solver='generic_lgmres',
     if default_least_squares_solver != default_solver:
         def_ls_opt = opts.pop(default_least_squares_solver)
         _options = OrderedDict(((default_solver, def_opt),
-                                (default_least_squares_solver, def_ls_opt)))
+                               (default_least_squares_solver, def_ls_opt)))
     else:
         _options = OrderedDict(((default_solver, def_opt),))
     _options.update(opts)
@@ -148,24 +148,24 @@ def apply_inverse(op, rhs, options=None):
     |VectorArray| of the solution vectors.
     """
 
-    default_options = invert_options()
+    def_opts = globals()['options']()
 
     if options is None:
-        options = default_options.values()[0]
+        options = def_opts.values()[0]
     elif isinstance(options, str):
         if options == 'least_squares':
-            for k, v in default_options.iteritems():
+            for k, v in def_opts.iteritems():
                 if k.startswith('least_squares'):
                     options = v
                     break
             assert not isinstance(options, str)
         else:
-            options = default_options[options]
+            options = def_opts[options]
     else:
-        assert 'type' in options and options['type'] in default_options \
-            and options.viewkeys() <= default_options[options['type']].viewkeys()
+        assert 'type' in options and options['type'] in def_opts \
+            and options.viewkeys() <= def_opts[options['type']].viewkeys()
         user_options = options
-        options = default_options[user_options['type']]
+        options = def_opts[user_options['type']]
         options.update(user_options)
 
     R = op.source.empty(reserve=len(rhs))

--- a/src/pymor/algorithms/genericsolvers.py
+++ b/src/pymor/algorithms/genericsolvers.py
@@ -141,7 +141,7 @@ def apply_inverse(op, rhs, options=None):
     rhs
         |VectorArray| of right-hand sides for the equation system.
     options
-        |invert_options| to use. (See :func:`invert_options`.)
+        The solver options to use. (See :func:`options`.)
 
     Returns
     -------

--- a/src/pymor/algorithms/newton.py
+++ b/src/pymor/algorithms/newton.py
@@ -111,7 +111,10 @@ def newton(operator, rhs, initial_guess=None, mu=None, error_norm=None, least_sq
         iteration += 1
         jacobian = operator.jacobian(U, mu=mu)
         try:
-            correction = jacobian.apply_inverse(residual, options='least_squares' if least_squares else None)
+            if least_squares:
+                correction = jacobian.solve_least_squares(residual)
+            else:
+                correction = jacobian.apply_inverse(residual)
         except InversionError:
             raise NewtonError('Could not invert jacobian')
         U += correction

--- a/src/pymor/algorithms/timestepping.py
+++ b/src/pymor/algorithms/timestepping.py
@@ -83,18 +83,13 @@ class ImplicitEulerTimeStepper(TimeStepperInterface):
     ----------
     nt
         The number of time-steps the time-stepper will perform.
-    invert_options
-        The :attr:`~pymor.operators.interfaces.OperatorInterface.invert_options` used
-        to invert `M + dt*A`.
     """
 
-    def __init__(self, nt, invert_options=None):
+    def __init__(self, nt):
         self.nt = nt
-        self.invert_options = invert_options
 
     def solve(self, initial_time, end_time, initial_data, operator, rhs=None, mass=None, mu=None, num_values=None):
-        return implicit_euler(operator, rhs, mass, initial_data, initial_time, end_time, self.nt, mu,
-                              self.invert_options, num_values)
+        return implicit_euler(operator, rhs, mass, initial_data, initial_time, end_time, self.nt, mu, num_values)
 
 
 class ExplicitEulerTimeStepper(TimeStepperInterface):
@@ -119,7 +114,7 @@ class ExplicitEulerTimeStepper(TimeStepperInterface):
         return explicit_euler(operator, rhs, initial_data, initial_time, end_time, self.nt, mu, num_values)
 
 
-def implicit_euler(A, F, M, U0, t0, t1, nt, mu=None, invert_options=None, num_values=None):
+def implicit_euler(A, F, M, U0, t0, t1, nt, mu=None, num_values=None):
     assert isinstance(A, OperatorInterface)
     assert isinstance(F, (OperatorInterface, VectorArrayInterface))
     assert isinstance(M, OperatorInterface)
@@ -161,7 +156,7 @@ def implicit_euler(A, F, M, U0, t0, t1, nt, mu=None, invert_options=None, num_va
         mu['_t'] = t
         if F_time_dep:
             dt_F = F.as_vector(mu) * dt
-        U = M_dt_A.apply_inverse(M.apply(U) + dt_F, mu=mu, options=invert_options)
+        U = M_dt_A.apply_inverse(M.apply(U) + dt_F, mu=mu)
         while t - t0 + (min(dt, DT) * 0.5) >= len(R) * DT:
             R.append(U)
 

--- a/src/pymor/operators/basic.py
+++ b/src/pymor/operators/basic.py
@@ -107,6 +107,16 @@ class OperatorBase(OperatorInterface):
             options = self.solver_options.get('generic') if self.solver_options else None
             return genericsolvers.apply_inverse(assembled_op, V.copy(ind), options=options)
 
+    def solve_least_squares(self, V, ind=None, mu=None):
+        from pymor.operators.constructions import FixedParameterOperator
+        assembled_op = self.assemble(mu)
+        if assembled_op != self and not isinstance(assembled_op, FixedParameterOperator):
+            return assembled_op.solve_least_squares(V, ind=ind)
+        else:
+            options = (self.solver_options.get('generic_least_squares', 'least_squares') if self.solver_options
+                       else 'least_squares')
+            return genericsolvers.apply_inverse(assembled_op, V.copy(ind), options=options)
+
     def as_vector(self, mu=None):
         if not self.linear:
             raise TypeError('This nonlinear operator does not represent a vector or linear functional.')

--- a/src/pymor/operators/cg.py
+++ b/src/pymor/operators/cg.py
@@ -58,7 +58,7 @@ class L2ProductFunctionalP1(NumpyMatrixBasedOperator):
     range = NumpyVectorSpace(1)
 
     def __init__(self, grid, function, boundary_info=None, dirichlet_data=None, neumann_data=None, robin_data=None,
-                 order=2, name=None):
+                 order=2, solver_options=None, name=None):
         assert grid.reference_element(0) in {line, triangle}
         assert function.shape_range == tuple()
         self.source = NumpyVectorSpace(grid.size(grid.dim))
@@ -69,6 +69,7 @@ class L2ProductFunctionalP1(NumpyMatrixBasedOperator):
         self.neumann_data = neumann_data
         self.robin_data = robin_data
         self.order = order
+        self.solver_options = solver_options
         self.name = name
         self.build_parameter_type(inherits=(function, dirichlet_data, neumann_data))
 
@@ -284,7 +285,7 @@ class L2ProductP1(NumpyMatrixBasedOperator):
     sparse = True
 
     def __init__(self, grid, boundary_info, dirichlet_clear_rows=True, dirichlet_clear_columns=False,
-                 dirichlet_clear_diag=False, name=None):
+                 dirichlet_clear_diag=False, solver_options=None, name=None):
         assert grid.reference_element in (line, triangle)
         self.source = self.range = NumpyVectorSpace(grid.size(grid.dim))
         self.grid = grid
@@ -292,6 +293,7 @@ class L2ProductP1(NumpyMatrixBasedOperator):
         self.dirichlet_clear_rows = dirichlet_clear_rows
         self.dirichlet_clear_columns = dirichlet_clear_columns
         self.dirichlet_clear_diag = dirichlet_clear_diag
+        self.solver_options = solver_options
         self.name = name
 
     def _assemble(self, mu=None):
@@ -375,7 +377,7 @@ class L2ProductQ1(NumpyMatrixBasedOperator):
     sparse = True
 
     def __init__(self, grid, boundary_info, dirichlet_clear_rows=True, dirichlet_clear_columns=False,
-                 dirichlet_clear_diag=False, name=None):
+                 dirichlet_clear_diag=False, solver_options=None, name=None):
         assert grid.reference_element in {square}
         self.source = self.range = NumpyVectorSpace(grid.size(grid.dim))
         self.grid = grid
@@ -383,6 +385,7 @@ class L2ProductQ1(NumpyMatrixBasedOperator):
         self.dirichlet_clear_rows = dirichlet_clear_rows
         self.dirichlet_clear_columns = dirichlet_clear_columns
         self.dirichlet_clear_diag = dirichlet_clear_diag
+        self.solver_options = solver_options
         self.name = name
 
     def _assemble(self, mu=None):
@@ -469,7 +472,8 @@ class DiffusionOperatorP1(NumpyMatrixBasedOperator):
     sparse = True
 
     def __init__(self, grid, boundary_info, diffusion_function=None, diffusion_constant=None,
-                 dirichlet_clear_columns=False, dirichlet_clear_diag=False, name=None):
+                 dirichlet_clear_columns=False, dirichlet_clear_diag=False,
+                 solver_options=None, name=None):
         assert grid.reference_element(0) in {triangle, line}, 'A simplicial grid is expected!'
         assert diffusion_function is None \
             or (isinstance(diffusion_function, FunctionInterface) and
@@ -482,6 +486,7 @@ class DiffusionOperatorP1(NumpyMatrixBasedOperator):
         self.diffusion_function = diffusion_function
         self.dirichlet_clear_columns = dirichlet_clear_columns
         self.dirichlet_clear_diag = dirichlet_clear_diag
+        self.solver_options = solver_options
         self.name = name
         if diffusion_function is not None:
             self.build_parameter_type(inherits=(diffusion_function,))
@@ -587,7 +592,8 @@ class DiffusionOperatorQ1(NumpyMatrixBasedOperator):
     sparse = True
 
     def __init__(self, grid, boundary_info, diffusion_function=None, diffusion_constant=None,
-                 dirichlet_clear_columns=False, dirichlet_clear_diag=False, name=None):
+                 dirichlet_clear_columns=False, dirichlet_clear_diag=False,
+                 solver_options=None, name=None):
         assert grid.reference_element(0) in {square}, 'A square grid is expected!'
         assert diffusion_function is None \
             or (isinstance(diffusion_function, FunctionInterface) and
@@ -600,6 +606,7 @@ class DiffusionOperatorQ1(NumpyMatrixBasedOperator):
         self.diffusion_function = diffusion_function
         self.dirichlet_clear_columns = dirichlet_clear_columns
         self.dirichlet_clear_diag = dirichlet_clear_diag
+        self.solver_options = solver_options
         self.name = name
         if diffusion_function is not None:
             self.build_parameter_type(inherits=(diffusion_function,))
@@ -696,7 +703,7 @@ class RobinBoundaryOperator(NumpyMatrixBasedOperator):
 
     sparse = True
 
-    def __init__(self, grid, boundary_info, robin_data=None, order=2, name=None):
+    def __init__(self, grid, boundary_info, robin_data=None, order=2, solver_options=None, name=None):
         assert robin_data is None or (isinstance(robin_data, tuple) and len(robin_data) == 2)
         assert robin_data is None or all([isinstance(f, FunctionInterface)
                                           and f.dim_domain == grid.dim_outer
@@ -705,6 +712,7 @@ class RobinBoundaryOperator(NumpyMatrixBasedOperator):
         self.grid = grid
         self.boundary_info = boundary_info
         self.robin_data = robin_data
+        self.solver_options = solver_options
         self.name = name
         self.order = order
 

--- a/src/pymor/operators/constructions.py
+++ b/src/pymor/operators/constructions.py
@@ -679,6 +679,13 @@ class FixedParameterOperator(OperatorBase):
             op = self.operator
         return op.apply_inverse(V, ind=ind, mu=self.mu)
 
+    def solve_least_squares(self, V, ind=None, mu=None):
+        if self.solver_options is not None and self.solver_options != self.operator.solver_options:
+            op = self.operator.with_(solver_options=self.solver_options)
+        else:
+            op = self.operator
+        return op.solve_least_squares(V, ind=ind, mu=self.mu)
+
 
 class AdjointOperator(OperatorBase):
     """Represents the adjoint of a given |Operator|.

--- a/src/pymor/operators/fenics.py
+++ b/src/pymor/operators/fenics.py
@@ -25,11 +25,12 @@ if HAVE_FENICS:
 
         linear = True
 
-        def __init__(self, matrix, name=None):
+        def __init__(self, matrix, solver_options=None, name=None):
             assert matrix.rank() == 2
             comm = matrix.mpi_comm()
             self.source = FenicsVectorSpace(matrix.size(1), mpi_comm=comm)
             self.range = FenicsVectorSpace(matrix.size(0), mpi_comm=comm)
+            self.solver_options = solver_options
             self.name = name
             self.matrix = matrix
 
@@ -69,7 +70,7 @@ if HAVE_FENICS:
                 df.solve(self.matrix, r.impl, v.impl)
             return R
 
-        def assemble_lincomb(self, operators, coefficients, name=None):
+        def assemble_lincomb(self, operators, coefficients, solver_options=None, name=None):
             if not all(isinstance(op, (FenicsMatrixOperator, ZeroOperator)) for op in operators):
                 return None
 
@@ -83,4 +84,4 @@ if HAVE_FENICS:
                 matrix.axpy(c, op.matrix, False)  # in general, we cannot assume the same nonzero pattern for
                                                   # all matrices. how to improve this?
 
-            return FenicsMatrixOperator(matrix, name=name)
+            return FenicsMatrixOperator(matrix, solver_options=solver_options, name=name)

--- a/src/pymor/operators/fenics.py
+++ b/src/pymor/operators/fenics.py
@@ -70,6 +70,10 @@ if HAVE_FENICS:
                 df.solve(self.matrix, r.impl, v.impl)
             return R
 
+        def solve_least_squares(self, V, ind=None, mu=None):
+            self.logger.warn('solve_least_squares not implemented, falling back to generic solver')
+            super(FenicsMatrixOperator, self).solve_least_squares(V, ind=ind, mu=mu)
+
         def assemble_lincomb(self, operators, coefficients, solver_options=None, name=None):
             if not all(isinstance(op, (FenicsMatrixOperator, ZeroOperator)) for op in operators):
                 return None

--- a/src/pymor/operators/fv.py
+++ b/src/pymor/operators/fv.py
@@ -215,13 +215,14 @@ class NonlinearAdvectionOperator(OperatorBase):
 
     linear = False
 
-    def __init__(self, grid, boundary_info, numerical_flux, dirichlet_data=None, name=None):
+    def __init__(self, grid, boundary_info, numerical_flux, dirichlet_data=None, solver_options=None, name=None):
         assert dirichlet_data is None or isinstance(dirichlet_data, FunctionInterface)
 
         self.grid = grid
         self.boundary_info = boundary_info
         self.numerical_flux = numerical_flux
         self.dirichlet_data = dirichlet_data
+        self.solver_options = solver_options
         self.name = name
         if (isinstance(dirichlet_data, FunctionInterface) and boundary_info.has_dirichlet
                 and not dirichlet_data.parametric):
@@ -250,7 +251,7 @@ class NonlinearAdvectionOperator(OperatorBase):
         op = self.with_(grid=sub_grid, boundary_info=sub_boundary_info, name='{}_restricted'.format(self.name))
         sub_grid_indices = sub_grid.indices_from_parent_indices(dofs, codim=0)
         proj = ComponentProjection(sub_grid_indices, op.range)
-        return Concatenation(proj, op), sub_grid.parent_indices(0)
+        return Concatenation(proj, op, solver_options=self.solver_options), sub_grid.parent_indices(0)
 
     def _fetch_grid_data(self):
         # pre-fetch all grid-associated data to avoid searching the cache for each operator application
@@ -326,24 +327,24 @@ class NonlinearAdvectionOperator(OperatorBase):
 
 
 def nonlinear_advection_lax_friedrichs_operator(grid, boundary_info, flux, lxf_lambda=1.0,
-                                                dirichlet_data=None, name=None):
+                                                dirichlet_data=None, solver_options=None, name=None):
     """Instantiate a :class:`NonlinearAdvectionOperator` using :class:`LaxFriedrichsFlux`."""
     num_flux = LaxFriedrichsFlux(flux, lxf_lambda)
-    return NonlinearAdvectionOperator(grid, boundary_info, num_flux, dirichlet_data, name)
+    return NonlinearAdvectionOperator(grid, boundary_info, num_flux, dirichlet_data, solver_options, name)
 
 
 def nonlinear_advection_simplified_engquist_osher_operator(grid, boundary_info, flux, flux_derivative,
-                                                           dirichlet_data=None, name=None):
+                                                           dirichlet_data=None, solver_options=None, name=None):
     """Instantiate a :class:`NonlinearAdvectionOperator` using :class:`SimplifiedEngquistOsherFlux`."""
     num_flux = SimplifiedEngquistOsherFlux(flux, flux_derivative)
-    return NonlinearAdvectionOperator(grid, boundary_info, num_flux, dirichlet_data, name)
+    return NonlinearAdvectionOperator(grid, boundary_info, num_flux, dirichlet_data, solver_options, name)
 
 
 def nonlinear_advection_engquist_osher_operator(grid, boundary_info, flux, flux_derivative, gausspoints=5, intervals=1,
-                                                dirichlet_data=None, name=None):
+                                                dirichlet_data=None, solver_options=None, name=None):
     """Instantiate a :class:`NonlinearAdvectionOperator` using :class:`EngquistOsherFlux`."""
     num_flux = EngquistOsherFlux(flux, flux_derivative, gausspoints=gausspoints, intervals=intervals)
-    return NonlinearAdvectionOperator(grid, boundary_info, num_flux, dirichlet_data, name)
+    return NonlinearAdvectionOperator(grid, boundary_info, num_flux, dirichlet_data, solver_options, name)
 
 
 class LinearAdvectionLaxFriedrichs(NumpyMatrixBasedOperator):
@@ -369,11 +370,12 @@ class LinearAdvectionLaxFriedrichs(NumpyMatrixBasedOperator):
         The name of the operator.
     """
 
-    def __init__(self, grid, boundary_info, velocity_field, lxf_lambda=1.0, name=None):
+    def __init__(self, grid, boundary_info, velocity_field, lxf_lambda=1.0, solver_options=None, name=None):
         self.grid = grid
         self.boundary_info = boundary_info
         self.velocity_field = velocity_field
         self.lxf_lambda = lxf_lambda
+        self.solver_options = solver_options
         self.name = name
         self.build_parameter_type(inherits=(velocity_field,))
         self.source = self.range = NumpyVectorSpace(grid.size(0))
@@ -435,9 +437,10 @@ class L2Product(NumpyMatrixBasedOperator):
 
     sparse = True
 
-    def __init__(self, grid, name=None):
+    def __init__(self, grid, solver_options=None, name=None):
         self.source = self.range = NumpyVectorSpace(grid.size(0))
         self.grid = grid
+        self.solver_options = solver_options
         self.name = name
 
     def _assemble(self, mu=None):
@@ -570,7 +573,8 @@ class DiffusionOperator(NumpyMatrixBasedOperator):
 
     sparse = True
 
-    def __init__(self, grid, boundary_info, diffusion_function=None, diffusion_constant=None, name=None):
+    def __init__(self, grid, boundary_info, diffusion_function=None, diffusion_constant=None, solver_options=None,
+                 name=None):
         super(DiffusionOperator, self).__init__()
         assert isinstance(grid, AffineGridWithOrthogonalCentersInterface)
         assert diffusion_function is None \
@@ -581,6 +585,7 @@ class DiffusionOperator(NumpyMatrixBasedOperator):
         self.boundary_info = boundary_info
         self.diffusion_function = diffusion_function
         self.diffusion_constant = diffusion_constant
+        self.solver_options = solver_options
         self.name = name
         self.source = self.range = NumpyVectorSpace(grid.size(0))
         if diffusion_function is not None:

--- a/src/pymor/operators/interfaces.py
+++ b/src/pymor/operators/interfaces.py
@@ -5,7 +5,7 @@
 
 from __future__ import absolute_import, division, print_function
 
-from pymor.core.interfaces import ImmutableInterface, abstractmethod, abstractstaticmethod
+from pymor.core.interfaces import ImmutableInterface, abstractmethod
 from pymor.parameters.base import Parametric
 
 
@@ -22,13 +22,9 @@ class OperatorInterface(ImmutableInterface, Parametric):
 
     Attributes
     ----------
-    invert_options
-        |OrderedDict| of possible options for :meth:`~OperatorInterface.apply_inverse`.
-        Each key is a type of inversion algorithm which can be used to invert the
-        operator. `invert_options[k]` is a dict containing all options along with
-        their default values which can be set for algorithm `k`. We always have
-        `invert_options[k]['type'] == k` such that `invert_options[k]` can be passed
-        directly to :meth:`~OperatorInterface.apply_inverse()`.
+    solver_options
+        Solver options used for :meth:`~OperatorInterface.apply_inverse`.
+        If `None`, default options are used.
     linear
         `True` if the operator is linear.
     source
@@ -36,6 +32,8 @@ class OperatorInterface(ImmutableInterface, Parametric):
     range
         The range |VectorSpace|.
     """
+
+    solver_options = None
 
     @abstractmethod
     def apply(self, U, ind=None, mu=None):
@@ -164,7 +162,7 @@ class OperatorInterface(ImmutableInterface, Parametric):
         pass
 
     @abstractmethod
-    def apply_inverse(self, V, ind=None, mu=None, options=None):
+    def apply_inverse(self, V, ind=None, mu=None):
         """Apply the inverse operator.
 
         Parameters
@@ -176,15 +174,6 @@ class OperatorInterface(ImmutableInterface, Parametric):
             applied. (See the |VectorArray| documentation for further details.)
         mu
             The |Parameter| for which to evaluate the inverse operator.
-        options
-            Dictionary of options for the inversion algorithm. The dictionary
-            has to contain the key `'type'` whose value determines which inversion
-            algorithm is to be used. All other items represent options specific to
-            this algorithm.  `options` can also be given as a string, which is then
-            interpreted as the type of inversion algorithm. If `options` is `None`,
-            a default algorithm with default options is chosen.  Available algorithms
-            and their default options are provided by
-            :attr:`~OperatorInterface.invert_options`.
 
         Returns
         -------
@@ -268,7 +257,7 @@ class OperatorInterface(ImmutableInterface, Parametric):
         """
         pass
 
-    def assemble_lincomb(self, operators, coefficients, name=None):
+    def assemble_lincomb(self, operators, coefficients, solver_options=None, name=None):
         """Try to assemble a linear combination of the given operators.
 
         This method is called in the `assemble` method of |LincombOperator| on
@@ -283,6 +272,9 @@ class OperatorInterface(ImmutableInterface, Parametric):
             List of |Operators| whose linear combination is formed.
         coefficients
             List of the corresponding linear coefficients.
+        solver_options
+            The :attr:`~OperatorInterface.solver_options` for the assembled
+            operator.
         name
             Name of the assembled operator.
 

--- a/src/pymor/operators/interfaces.py
+++ b/src/pymor/operators/interfaces.py
@@ -23,12 +23,15 @@ class OperatorInterface(ImmutableInterface, Parametric):
     Attributes
     ----------
     solver_options
-        Solver options used for :meth:`~OperatorInterface.apply_inverse`.
+        Solver options used for :meth:`~OperatorInterface.apply_inverse`
+        and :meth:`~OperatorInterface.solve_least_squares`.
         If `None`, default options are used. If not `None`, a dict of
         options for different operator backends.
-        (In pyMOR itself, the keys `'numpy_dense'`, `'numpy_sparse'` for
-        |NumpyMatrixBasedOperators| and `'generic'` for the generic
-        fallback solvers in :mod:`pymor.algorithms.genericsolvers` are
+        (In pyMOR itself, the keys `'numpy_dense'`, `'numpy_sparse'`,
+        `'numpy_dense_least_squares'`, `'numpy_sparse_least_squares'`
+        for |NumpyMatrixBasedOperators| and `'generic'`,
+        `'generic_least_squares'` for the generic fallback solvers
+        in :mod:`pymor.algorithms.genericsolvers` are
         recognized. Arbitrary other entries may be added to customize
         external linear solvers.)
         Note that `solver_options` is usually inherited by derived

--- a/src/pymor/operators/interfaces.py
+++ b/src/pymor/operators/interfaces.py
@@ -198,6 +198,37 @@ class OperatorInterface(ImmutableInterface, Parametric):
         pass
 
     @abstractmethod
+    def solve_least_squares(self, V, ind=None, mu=None):
+        """Solve least squares problem.
+
+        If we denote `self` by A, then this method finds
+        for each vector v contained in `V` vectors u s.t. ::
+
+            u = argmin ||Au - v||_2
+                  u'
+
+        Parameters
+        ----------
+        V
+            |VectorArray| of vectors for which the least squares problem is solved.
+        ind
+            The indices of the vectors in `V` for which the least squares problem
+            shall be solved. (See the |VectorArray| documentation for further details.)
+        mu
+            The |Parameter| for which to solve the least squares problem.
+
+        Returns
+        -------
+        |VectorArray| of the least squares problem solutions.
+
+        Raises
+        ------
+        InversionError
+            The the least squares problems could not be solved.
+        """
+        pass
+
+    @abstractmethod
     def jacobian(self, U, mu=None):
         """Return the operator's Jacobian.
 

--- a/src/pymor/operators/interfaces.py
+++ b/src/pymor/operators/interfaces.py
@@ -24,7 +24,18 @@ class OperatorInterface(ImmutableInterface, Parametric):
     ----------
     solver_options
         Solver options used for :meth:`~OperatorInterface.apply_inverse`.
-        If `None`, default options are used.
+        If `None`, default options are used. If not `None`, a dict of
+        options for different operator backends.
+        (In pyMOR itself, the keys `'numpy_dense'`, `'numpy_sparse'` for
+        |NumpyMatrixBasedOperators| and `'generic'` for the generic
+        fallback solvers in :mod:`pymor.algorithms.genericsolvers` are
+        recognized. Arbitrary other entries may be added to customize
+        external linear solvers.)
+        Note that `solver_options` is usually inherited by derived
+        operators (e.g. via :meth:`~OperatorInterface.projected`,
+        :meth:`~OperatorInterface.assemble_lincomb`). Thus, it can make
+        sense to add entries to `solver_options` which are not directly
+        relevant for the given operator itself.
     linear
         `True` if the operator is linear.
     source
@@ -273,8 +284,11 @@ class OperatorInterface(ImmutableInterface, Parametric):
         coefficients
             List of the corresponding linear coefficients.
         solver_options
-            The :attr:`~OperatorInterface.solver_options` for the assembled
-            operator.
+            |solver_options| for the assembled operator. When called by
+            |LincombOperator| and no |solver_options| have been specified
+            during instantiation the |LincombOperator|, this parameter will
+            be set to the first non-`None` |solver_options| of the given
+            `operators`.
         name
             Name of the assembled operator.
 

--- a/src/pymor/operators/interfaces.py
+++ b/src/pymor/operators/interfaces.py
@@ -181,7 +181,7 @@ class OperatorInterface(ImmutableInterface, Parametric):
         V
             |VectorArray| of vectors to which the inverse operator is applied.
         ind
-            The indices of the vectors in `U` to which the inverse operator shall be
+            The indices of the vectors in `V` to which the inverse operator shall be
             applied. (See the |VectorArray| documentation for further details.)
         mu
             The |Parameter| for which to evaluate the inverse operator.

--- a/src/pymor/operators/mpi.py
+++ b/src/pymor/operators/mpi.py
@@ -162,6 +162,16 @@ class MPIOperator(OperatorBase):
                           mpi.call(mpi.method_call_manage, self.obj_id, 'apply_inverse',
                                    U.obj_id, ind=ind, mu=mu, options=options))
 
+    def solve_least_squares(self, V, ind=None, mu=None):
+        if self.vector or self.functional:
+            raise NotImplementedError
+        assert V in self.range
+        mu = self.parse_parameter(mu)
+        space = self.source
+        return space.type(space.subtype[0], space.subtype[1],
+                          mpi.call(mpi.method_call_manage, self.obj_id, 'solve_least_squares',
+                                   V.obj_id, ind=ind, mu=mu))
+
     def jacobian(self, U, mu=None):
         assert U in self.source
         mu = self.parse_parameter(mu)

--- a/src/pymor/operators/mpi.py
+++ b/src/pymor/operators/mpi.py
@@ -152,15 +152,15 @@ class MPIOperator(OperatorBase):
                               mpi.call(mpi.method_call_manage, self.obj_id, 'apply_adjoint',
                                        U, ind=ind, mu=mu, source_product=source_product, range_product=range_product))
 
-    def apply_inverse(self, U, ind=None, mu=None, options=None):
+    def apply_inverse(self, V, ind=None, mu=None):
         if self.vector or self.functional:
             raise NotImplementedError
-        assert U in self.range
+        assert V in self.range
         mu = self.parse_parameter(mu)
         space = self.source
         return space.type(space.subtype[0], space.subtype[1],
                           mpi.call(mpi.method_call_manage, self.obj_id, 'apply_inverse',
-                                   U.obj_id, ind=ind, mu=mu, options=options))
+                                   V.obj_id, ind=ind, mu=mu))
 
     def solve_least_squares(self, V, ind=None, mu=None):
         if self.vector or self.functional:

--- a/src/pymor/operators/numpy.py
+++ b/src/pymor/operators/numpy.py
@@ -641,7 +641,7 @@ def sparse_options(default_solver='spsolve',
     return ordered_opts
 
 
-def _invert_options(matrix=None, sparse=None):
+def _options(matrix=None, sparse=None):
     """Returns |invert_options| (with default values) for a given |NumPy| matrix.
 
     See :func:`sparse_options` for documentation of all possible options for
@@ -706,7 +706,7 @@ def _apply_inverse(matrix, V, options=None):
     |NumPy array| of the solution vectors.
     """
 
-    default_options = _invert_options(matrix)
+    default_options = _options(matrix)
 
     if options is None:
         options = default_options.values()[0]

--- a/src/pymor/operators/numpy.py
+++ b/src/pymor/operators/numpy.py
@@ -407,7 +407,7 @@ def dense_options(default_solver='solve',
           'pyamg_sa_accel', 'pyamg_sa_tol', 'pyamg_sa_maxiter',
           sid_ignore=('least_squares_lsmr_show', 'least_squares_lsqr_show', 'pyamg_verb'))
 def sparse_options(default_solver='spsolve',
-                   default_least_squares_solver='least_squares_generic_lsmr',
+                   default_least_squares_solver='least_squares_lsmr',
                    bicgstab_tol=1e-15,
                    bicgstab_maxiter=None,
                    spilu_drop_tol=1e-4,

--- a/src/pymor/operators/numpy.py
+++ b/src/pymor/operators/numpy.py
@@ -356,7 +356,7 @@ def dense_options(default_solver='solve',
             ('least_squares_lstsq', {'type': 'least_squares_lstsq',
                                      'rcond': least_squares_lstsq_rcond}))
     opts = OrderedDict(opts)
-    opts.update(genericsolvers.invert_options())
+    opts.update(genericsolvers.options())
     def_opt = opts.pop(default_solver)
     if default_least_squares_solver != default_solver:
         def_ls_opt = opts.pop(default_least_squares_solver)
@@ -629,7 +629,7 @@ def sparse_options(default_solver='spsolve',
                                'tol': pyamg_sa_tol,
                                'maxiter': pyamg_sa_maxiter}))
     opts = OrderedDict(opts)
-    opts.update(genericsolvers.invert_options())
+    opts.update(genericsolvers.options())
     def_opt = opts.pop(default_solver)
     if default_least_squares_solver != default_solver:
         def_ls_opt = opts.pop(default_least_squares_solver)

--- a/src/pymor/operators/numpy.py
+++ b/src/pymor/operators/numpy.py
@@ -332,7 +332,7 @@ _sparse_options_sid = None
 def dense_options(default_solver='solve',
                   default_least_squares_solver='least_squares_lstsq',
                   least_squares_lstsq_rcond=-1.):
-    """Returns |invert_options| (with default values) for dense |NumPy| matricies.
+    """Returns |solver_options| (with default values) for dense |NumPy| matricies.
 
     Parameters
     ----------
@@ -347,7 +347,7 @@ def dense_options(default_solver='solve',
 
     Returns
     -------
-    A tuple of all possible |invert_options|.
+    A tuple of possible values for |solver_options| (key `'numpy_dense'`).
     """
 
     assert default_least_squares_solver.startswith('least_squares')
@@ -438,7 +438,7 @@ def sparse_options(default_solver='spsolve',
                    pyamg_sa_accel=None,
                    pyamg_sa_tol=1e-5,
                    pyamg_sa_maxiter=100):
-    """Returns |invert_options| (with default values) for sparse |NumPy| matricies.
+    """Returns |solver_options| (with default values) for sparse |NumPy| matricies.
 
     Parameters
     ----------
@@ -556,7 +556,7 @@ def sparse_options(default_solver='spsolve',
 
     Returns
     -------
-    A tuple of all possible |invert_options|.
+    A tuple of all possible |solver_options| (key `'numpy_sparse'`).
     """
 
     assert default_least_squares_solver.startswith('least_squares')
@@ -642,7 +642,10 @@ def sparse_options(default_solver='spsolve',
 
 
 def _options(matrix=None, sparse=None):
-    """Returns |invert_options| (with default values) for a given |NumPy| matrix.
+    """Returns |solver_options| (with default values) for a given |NumPy| matrix.
+
+    See :func:`dense_options` for documentation of all possible options for
+    dense matrices.
 
     See :func:`sparse_options` for documentation of all possible options for
     sparse matrices.
@@ -658,7 +661,8 @@ def _options(matrix=None, sparse=None):
 
     Returns
     -------
-    A tuple of all possible |invert_options|.
+    A tuple of all possible |solver_options| (key `'numpy_dense'` or `'numpy_sparse'`
+    depending on sparsity).
     """
     global _dense_options, _dense_options_sid, _sparse_options, _sparse_options_sid
     assert (matrix is None) != (sparse is None)
@@ -684,6 +688,9 @@ def _apply_inverse(matrix, V, options=None):
 
     Applies the inverse of `matrix` to the row vectors in `V`.
 
+    See :func:`dense_options` for documentation of all possible options for
+    sparse matrices.
+
     See :func:`sparse_options` for documentation of all possible options for
     sparse matrices.
 
@@ -699,7 +706,7 @@ def _apply_inverse(matrix, V, options=None):
         the right-hand sides of the linear equation systems to
         solve.
     options
-        |invert_options| to use. (See :func:`invert_options`.)
+        The solver options to use. (See :func:`_options`.)
 
     Returns
     -------

--- a/src/pymor/operators/numpy.py
+++ b/src/pymor/operators/numpy.py
@@ -136,6 +136,9 @@ class NumpyMatrixBasedOperator(OperatorBase):
     def apply_inverse(self, V, ind=None, mu=None):
         return self.assemble(mu).apply_inverse(V, ind=ind)
 
+    def solve_least_squares(self, V, ind=None, mu=None):
+        return self.assemble(mu).solve_least_squares(V, ind=ind)
+
     def export_matrix(self, filename, matrix_name=None, output_format='matlab', mu=None):
         """Save the matrix of the operator to a file.
 
@@ -235,6 +238,26 @@ class NumpyMatrixOperator(NumpyMatrixBasedOperator):
             options = self.solver_options.get('numpy_sparse' if self.sparse else 'numpy_dense')
         else:
             options = None
+
+        return NumpyVectorArray(_apply_inverse(self._matrix, V, options=options), copy=False)
+
+    def solve_least_squares(self, V, ind=None, mu=None):
+        assert V in self.range
+        assert V.check_ind(ind)
+        if V.dim == 0:
+            if self.source.dim == 0:
+                return NumpyVectorArray(np.zeros((V.len_ind(ind), self.source.dim)))
+            else:
+                raise InversionError
+        V = V.data if ind is None else \
+            V.data[ind] if hasattr(ind, '__len__') else V.data[ind:ind + 1]
+
+        if self.solver_options:
+            options = self.solver_options.get(('numpy_sparse_least_squares' if self.sparse
+                                               else 'numpy_dense_least_squares'),
+                                              'least_squares')
+        else:
+            options = 'least_squares'
 
         return NumpyVectorArray(_apply_inverse(self._matrix, V, options=options), copy=False)
 

--- a/src/pymor/playground/operators/numpy.py
+++ b/src/pymor/playground/operators/numpy.py
@@ -51,24 +51,24 @@ class NumpyListVectorArrayMatrixOperator(NumpyMatrixOperator):
     def apply_adjoint(self, U, ind=None, mu=None, source_product=None, range_product=None):
         raise NotImplementedError
 
-    def apply_inverse(self, U, ind=None, mu=None):
-        assert U in self.range
-        assert U.check_ind(ind)
+    def apply_inverse(self, V, ind=None, mu=None):
+        assert V in self.range
+        assert V.check_ind(ind)
         assert not self.functional and not self.vector
 
-        if U.dim == 0:
+        if V.dim == 0:
             if self.source.dim == 0:
-                return ListVectorArray([NumpyVector(np.zeros(0), copy=False) for _ in range(U.len_ind(ind))],
+                return ListVectorArray([NumpyVector(np.zeros(0), copy=False) for _ in range(V.len_ind(ind))],
                                        subtype=self.source.subtype)
             else:
                 raise InversionError
 
         if ind is None:
-            vectors = U._list
+            vectors = V._list
         elif isinstance(ind, Number):
-            vectors = [U._list[ind]]
+            vectors = [V._list[ind]]
         else:
-            vectors = (U._list[i] for i in ind)
+            vectors = (V._list[i] for i in ind)
 
         if self.solver_options:
             options = self.solver_options.get('numpy_sparse' if self.sparse else 'numpy_dense')

--- a/src/pymor/playground/operators/numpy.py
+++ b/src/pymor/playground/operators/numpy.py
@@ -70,7 +70,13 @@ class NumpyListVectorArrayMatrixOperator(NumpyMatrixOperator):
         else:
             vectors = (U._list[i] for i in ind)
 
-        return ListVectorArray([NumpyVector(_apply_inverse(self._matrix, v._array, options=self.solver_options),
+        if self.solver_options:
+            options = self.solver_options.get('numpy_sparse' if self.sparse else 'numpy_dense')
+        else:
+            options = None
+
+        return ListVectorArray([NumpyVector(_apply_inverse(self._matrix, v._array.reshape((1, -1)),
+                                                           options=options).ravel(),
                                             copy=False)
                                 for v in vectors],
                                subtype=self.source.subtype)
@@ -85,4 +91,4 @@ class NumpyListVectorArrayMatrixOperator(NumpyMatrixOperator):
         if lincomb is None:
             return None
         else:
-            return NumpyListVectorArrayMatrixOperator(lincomb._matrix, solver_options=self.solver_options, name=name)
+            return NumpyListVectorArrayMatrixOperator(lincomb._matrix, solver_options=solver_options, name=name)

--- a/src/pymortests/base.py
+++ b/src/pymortests/base.py
@@ -100,5 +100,5 @@ class MonomOperator(OperatorBase):
     def jacobian(self, U, mu=None):
         return MonomOperator(self.order - 1, self.derivative)
 
-    def apply_inverse(self, V, ind=None, mu=None, options=None):
+    def apply_inverse(self, V, ind=None, mu=None):
         return NumpyVectorArray(1. / V.data)

--- a/src/pymortests/operators.py
+++ b/src/pymortests/operators.py
@@ -169,19 +169,15 @@ def test_apply_adjoint_2_with_products(operator_with_arrays_and_products):
 
 def test_apply_inverse(operator_with_arrays):
     op, mu, _, V = operator_with_arrays
-    for options in chain([None], op.invert_options, op.invert_options.itervalues()):
-        for ind in valid_inds(V):
-            try:
-                U = op.apply_inverse(V, mu=mu, ind=ind, options=options)
-            except InversionError:
-                return
-            assert U in op.source
-            assert len(U) == V.len_ind(ind)
-            VV = op.apply(U, mu=mu)
-            if (isinstance(options, str) and options.startswith('least_squares')
-                    or not isinstance(options, (str, type(None))) and options['type'].startswith('least_squares')):
-                continue
-            assert float_cmp_all(VV.l2_norm(), V.l2_norm(ind=ind), atol=1e-10, rtol=0.5)
+    for ind in valid_inds(V):
+        try:
+            U = op.apply_inverse(V, mu=mu, ind=ind)
+        except InversionError:
+            return
+        assert U in op.source
+        assert len(U) == V.len_ind(ind)
+        VV = op.apply(U, mu=mu)
+        assert float_cmp_all(VV.l2_norm(), V.l2_norm(ind=ind), atol=1e-10, rtol=0.5)
 
 
 def test_projected(operator_with_arrays):

--- a/src/pymortests/solver.py
+++ b/src/pymortests/solver.py
@@ -30,7 +30,7 @@ class GenericOperator(OperatorBase):
         return self.op.apply_adjoint(U, ind=ind, mu=mu)
 
 
-@pytest.fixture(params=pymor.algorithms.genericsolvers.invert_options().keys())
+@pytest.fixture(params=pymor.algorithms.genericsolvers.options().keys())
 def generic_solver(request):
     return {'generic': request.param}
 

--- a/src/pymortests/solver.py
+++ b/src/pymortests/solver.py
@@ -8,8 +8,9 @@ import numpy as np
 from scipy.sparse import diags
 import pytest
 
+import pymor.algorithms.genericsolvers
 from pymor.operators.basic import OperatorBase
-from pymor.operators.numpy import NumpyMatrixOperator
+from pymor.operators.numpy import NumpyMatrixOperator, sparse_options, dense_options
 from pymor.vectorarrays.numpy import NumpyVectorSpace, NumpyVectorArray
 
 
@@ -19,6 +20,9 @@ class GenericOperator(OperatorBase):
     op = NumpyMatrixOperator(np.eye(10) * np.arange(1, 11))
     linear = True
 
+    def __init__(self, solver_options=None):
+        self.solver_options = solver_options
+
     def apply(self, U, ind=None, mu=None):
         return self.op.apply(U, ind=ind, mu=mu)
 
@@ -26,37 +30,37 @@ class GenericOperator(OperatorBase):
         return self.op.apply_adjoint(U, ind=ind, mu=mu)
 
 
-@pytest.fixture(params=GenericOperator().invert_options.keys())
+@pytest.fixture(params=pymor.algorithms.genericsolvers.invert_options().keys())
 def generic_solver(request):
-    return request.param
+    return {'generic': request.param}
 
 
-@pytest.fixture(params=NumpyMatrixOperator(np.eye(10)).invert_options.keys())
+@pytest.fixture(params=dense_options().keys())
 def numpy_dense_solver(request):
-    return request.param
+    return {'numpy_dense': request.param}
 
 
-@pytest.fixture(params=NumpyMatrixOperator(diags([np.ones(10)], [0])).invert_options.keys())
+@pytest.fixture(params=sparse_options().keys())
 def numpy_sparse_solver(request):
-    return request.param
+    return {'numpy_sparse': request.param}
 
 
 def test_generic_solvers(generic_solver):
-    op = GenericOperator()
+    op = GenericOperator(generic_solver)
     rhs = NumpyVectorArray(np.ones(10))
-    solution = op.apply_inverse(rhs, options=generic_solver)
+    solution = op.apply_inverse(rhs)
     assert ((op.apply(solution) - rhs).l2_norm() / rhs.l2_norm())[0] < 1e-8
 
 
 def test_numpy_dense_solvers(numpy_dense_solver):
-    op = NumpyMatrixOperator(np.eye(10) * np.arange(1, 11))
+    op = NumpyMatrixOperator(np.eye(10) * np.arange(1, 11), solver_options=numpy_dense_solver)
     rhs = NumpyVectorArray(np.ones(10))
-    solution = op.apply_inverse(rhs, options=numpy_dense_solver)
+    solution = op.apply_inverse(rhs)
     assert ((op.apply(solution) - rhs).l2_norm() / rhs.l2_norm())[0] < 1e-8
 
 
 def test_numpy_sparse_solvers(numpy_sparse_solver):
-    op = NumpyMatrixOperator(diags([np.arange(1., 11.)], [0]))
+    op = NumpyMatrixOperator(diags([np.arange(1., 11.)], [0]), solver_options=numpy_sparse_solver)
     rhs = NumpyVectorArray(np.ones(10))
-    solution = op.apply_inverse(rhs, options=numpy_sparse_solver)
+    solution = op.apply_inverse(rhs)
     assert ((op.apply(solution) - rhs).l2_norm() / rhs.l2_norm())[0] < 1e-8


### PR DESCRIPTION
This pull request contains the following changes:

- `options` is removed from OperatorInterface.apply_inverse
- `invert_options` is removed from OperatorInterface
- `solver_options` is added to OperatorInterface
- `solve_least_squares` is added to OperatorInterface

If not `None`, `solver_options` is a dict with configurations for the
linear and least-squares (in future also nonlinear) solvers of the various
operator types in pyMOR. In pyMOR itself, the keys `'numpy_dense'`,
`'numpy_sparse'`, `'numpy_dense_least_squares'`,
`'numpy_sparse_least_squares'`, `'generic'` and `'generic_least_squares'`
are recognized.

As a rule of thumb, new operators obtained from a given operator
(projection, Jacobian, linear combination) inherit its solver_options.
Each Operator implementation should take `solver_options` as an
 `__init__` argument in order to being able to customize the solver 
options for different operators.

As a next step, we should also expose our newton algorithm via 
`'generic_nonlinear'` and call it as a default implementation for 
`OperatorBase.apply_inverse` when `self.linear` is `False`.

This PR addresses #122.