### PR TITLE
Repace 'invert_options' by 'solver_options' (second try)

### DIFF
--- a/docs/source/substitutions.py
+++ b/docs/source/substitutions.py
@@ -112,7 +112,7 @@ common = '''
 
 .. |OrderedDict| replace:: :class:`~collections.OrderedDict`
 
-.. |invert_options| replace:: :meth:`invert options <pymor.operators.interfaces.OperatorInterface.invert_options>`
+.. |solver_options| replace:: :attr:`~pymor.operators.interfaces.OperatorInterface.solver_options`
 
 '''
 

--- a/src/pymor/algorithms/genericsolvers.py
+++ b/src/pymor/algorithms/genericsolvers.py
@@ -45,7 +45,7 @@ def options(default_solver='generic_lgmres',
             least_squares_generic_lsqr_conlim=1e8,
             least_squares_generic_lsqr_iter_lim=None,
             least_squares_generic_lsqr_show=False):
-    """Returns |invert_options| (with default values) for arbitrary linear |Operators|.
+    """Returns |solver_options| (with default values) for arbitrary linear |Operators|.
 
     Parameters
     ----------
@@ -89,7 +89,7 @@ def options(default_solver='generic_lgmres',
 
     Returns
     -------
-    A tuple of all possible |invert_options|.
+    A tuple of possible values for |solver_options|.
     """
 
     assert default_least_squares_solver.startswith('least_squares')
@@ -141,7 +141,7 @@ def apply_inverse(op, rhs, options=None):
     rhs
         |VectorArray| of right-hand sides for the equation system.
     options
-        |invert_options| to use. (See :func:`options`.)
+        The solver options to use. (See :func:`options`.)
 
     Returns
     -------

--- a/src/pymor/algorithms/genericsolvers.py
+++ b/src/pymor/algorithms/genericsolvers.py
@@ -27,24 +27,24 @@ _options_sid = None
           'least_squares_generic_lsqr_atol', 'least_squares_generic_lsqr_btol', 'least_squares_generic_lsqr_conlim',
           'least_squares_generic_lsqr_iter_lim', 'least_squares_generic_lsqr_show',
           sid_ignore=('least_squares_generic_lsmr_show', 'least_squares_generic_lsqr_show'))
-def invert_options(default_solver='generic_lgmres',
-                   default_least_squares_solver='least_squares_generic_lsmr',
-                   generic_lgmres_tol=1e-5,
-                   generic_lgmres_maxiter=1000,
-                   generic_lgmres_inner_m=39,
-                   generic_lgmres_outer_k=3,
-                   least_squares_generic_lsmr_damp=0.0,
-                   least_squares_generic_lsmr_atol=1e-6,
-                   least_squares_generic_lsmr_btol=1e-6,
-                   least_squares_generic_lsmr_conlim=1e8,
-                   least_squares_generic_lsmr_maxiter=None,
-                   least_squares_generic_lsmr_show=False,
-                   least_squares_generic_lsqr_damp=0.0,
-                   least_squares_generic_lsqr_atol=1e-6,
-                   least_squares_generic_lsqr_btol=1e-6,
-                   least_squares_generic_lsqr_conlim=1e8,
-                   least_squares_generic_lsqr_iter_lim=None,
-                   least_squares_generic_lsqr_show=False):
+def options(default_solver='generic_lgmres',
+            default_least_squares_solver='least_squares_generic_lsmr',
+            generic_lgmres_tol=1e-5,
+            generic_lgmres_maxiter=1000,
+            generic_lgmres_inner_m=39,
+            generic_lgmres_outer_k=3,
+            least_squares_generic_lsmr_damp=0.0,
+            least_squares_generic_lsmr_atol=1e-6,
+            least_squares_generic_lsmr_btol=1e-6,
+            least_squares_generic_lsmr_conlim=1e8,
+            least_squares_generic_lsmr_maxiter=None,
+            least_squares_generic_lsmr_show=False,
+            least_squares_generic_lsqr_damp=0.0,
+            least_squares_generic_lsqr_atol=1e-6,
+            least_squares_generic_lsqr_btol=1e-6,
+            least_squares_generic_lsqr_conlim=1e8,
+            least_squares_generic_lsqr_iter_lim=None,
+            least_squares_generic_lsqr_show=False):
     """Returns |invert_options| (with default values) for arbitrary linear |Operators|.
 
     Parameters
@@ -141,31 +141,31 @@ def apply_inverse(op, rhs, options=None):
     rhs
         |VectorArray| of right-hand sides for the equation system.
     options
-        |invert_options| to use. (See :func:`invert_options`.)
+        |invert_options| to use. (See :func:`options`.)
 
     Returns
     -------
     |VectorArray| of the solution vectors.
     """
 
-    default_options = invert_options()
+    def_opts = globals()['options']()
 
     if options is None:
-        options = default_options.values()[0]
+        options = def_opts.values()[0]
     elif isinstance(options, str):
         if options == 'least_squares':
-            for k, v in default_options.iteritems():
+            for k, v in def_opts.iteritems():
                 if k.startswith('least_squares'):
                     options = v
                     break
             assert not isinstance(options, str)
         else:
-            options = default_options[options]
+            options = def_opts[options]
     else:
-        assert 'type' in options and options['type'] in default_options \
-            and options.viewkeys() <= default_options[options['type']].viewkeys()
+        assert 'type' in options and options['type'] in def_opts \
+            and options.viewkeys() <= def_opts[options['type']].viewkeys()
         user_options = options
-        options = default_options[user_options['type']]
+        options = def_opts[user_options['type']]
         options.update(user_options)
 
     R = op.source.empty(reserve=len(rhs))

--- a/src/pymor/algorithms/newton.py
+++ b/src/pymor/algorithms/newton.py
@@ -111,7 +111,9 @@ def newton(operator, rhs, initial_guess=None, mu=None, error_norm=None, least_sq
         iteration += 1
         jacobian = operator.jacobian(U, mu=mu)
         try:
-            correction = jacobian.apply_inverse(residual, options='least_squares' if least_squares else None)
+            if least_squares:
+                raise NotImplementedError
+            correction = jacobian.apply_inverse(residual)
         except InversionError:
             raise NewtonError('Could not invert jacobian')
         U += correction

--- a/src/pymor/algorithms/timestepping.py
+++ b/src/pymor/algorithms/timestepping.py
@@ -83,18 +83,13 @@ class ImplicitEulerTimeStepper(TimeStepperInterface):
     ----------
     nt
         The number of time-steps the time-stepper will perform.
-    invert_options
-        The :attr:`~pymor.operators.interfaces.OperatorInterface.invert_options` used
-        to invert `M + dt*A`.
     """
 
-    def __init__(self, nt, invert_options=None):
+    def __init__(self, nt):
         self.nt = nt
-        self.invert_options = invert_options
 
     def solve(self, initial_time, end_time, initial_data, operator, rhs=None, mass=None, mu=None, num_values=None):
-        return implicit_euler(operator, rhs, mass, initial_data, initial_time, end_time, self.nt, mu,
-                              self.invert_options, num_values)
+        return implicit_euler(operator, rhs, mass, initial_data, initial_time, end_time, self.nt, mu, num_values)
 
 
 class ExplicitEulerTimeStepper(TimeStepperInterface):
@@ -119,7 +114,7 @@ class ExplicitEulerTimeStepper(TimeStepperInterface):
         return explicit_euler(operator, rhs, initial_data, initial_time, end_time, self.nt, mu, num_values)
 
 
-def implicit_euler(A, F, M, U0, t0, t1, nt, mu=None, invert_options=None, num_values=None):
+def implicit_euler(A, F, M, U0, t0, t1, nt, mu=None, num_values=None):
     assert isinstance(A, OperatorInterface)
     assert isinstance(F, (OperatorInterface, VectorArrayInterface))
     assert isinstance(M, OperatorInterface)
@@ -161,7 +156,7 @@ def implicit_euler(A, F, M, U0, t0, t1, nt, mu=None, invert_options=None, num_va
         mu['_t'] = t
         if F_time_dep:
             dt_F = F.as_vector(mu) * dt
-        U = M_dt_A.apply_inverse(M.apply(U) + dt_F, mu=mu, options=invert_options)
+        U = M_dt_A.apply_inverse(M.apply(U) + dt_F, mu=mu)
         while t - t0 + (min(dt, DT) * 0.5) >= len(R) * DT:
             R.append(U)
 

--- a/src/pymor/operators/basic.py
+++ b/src/pymor/operators/basic.py
@@ -101,7 +101,7 @@ class OperatorBase(OperatorInterface):
     @property
     def invert_options(self):
         if self.linear:
-            return genericsolvers.invert_options()
+            return genericsolvers.options()
         else:
             return {}
 

--- a/src/pymor/operators/basic.py
+++ b/src/pymor/operators/basic.py
@@ -98,19 +98,13 @@ class OperatorBase(OperatorInterface):
         else:
             raise ValueError('Trying to apply adjoint of nonlinear operator.')
 
-    @property
-    def invert_options(self):
-        if self.linear:
-            return genericsolvers.options()
-        else:
-            return {}
-
-    def apply_inverse(self, V, ind=None, mu=None, options=None):
+    def apply_inverse(self, V, ind=None, mu=None):
         from pymor.operators.constructions import FixedParameterOperator
         assembled_op = self.assemble(mu)
         if assembled_op != self and not isinstance(assembled_op, FixedParameterOperator):
-            return assembled_op.apply_inverse(V, ind=ind, options=options)
+            return assembled_op.apply_inverse(V, ind=ind)
         else:
+            options = self.solver_options.get('inverse') if self.solver_options else None
             return genericsolvers.apply_inverse(assembled_op, V.copy(ind), options=options)
 
     def as_vector(self, mu=None):
@@ -189,7 +183,7 @@ class ProjectedOperator(OperatorBase):
 
     linear = False
 
-    def __init__(self, operator, range_basis, source_basis, product=None, copy=True, name=None):
+    def __init__(self, operator, range_basis, source_basis, product=None, copy=True, solver_options=None, name=None):
         assert isinstance(operator, OperatorInterface)
         assert source_basis is None or source_basis in operator.source
         assert range_basis is None or range_basis in operator.range
@@ -201,6 +195,7 @@ class ProjectedOperator(OperatorBase):
         self.build_parameter_type(inherits=(operator,))
         self.source = NumpyVectorSpace(len(source_basis)) if source_basis is not None else operator.source
         self.range = NumpyVectorSpace(len(range_basis)) if range_basis is not None else operator.range
+        self.solver_options = solver_options
         self.name = name
         self.operator = operator
         self.source_basis = source_basis.copy() if source_basis is not None and copy else source_basis
@@ -240,19 +235,30 @@ class ProjectedOperator(OperatorBase):
             else self.source_basis.copy(ind=range(dim_source))
         range_basis = self.range_basis if dim_range is None \
             else self.range_basis.copy(ind=range(dim_range))
-        return ProjectedOperator(self.operator, range_basis, source_basis, product=None, copy=False, name=name)
+        return ProjectedOperator(self.operator, range_basis, source_basis, product=None, copy=False,
+                                 solver_options=self.solver_options, name=name)
 
     def jacobian(self, U, mu=None):
+        if self.linear:
+            return self.assemble(mu)
         assert len(U) == 1
         mu = self.parse_parameter(mu)
         if self.source_basis is None:
             J = self.operator.jacobian(U, mu=mu)
         else:
             J = self.operator.jacobian(self.source_basis.lincomb(U.data), mu=mu)
-        return J.projected(range_basis=self.range_basis, source_basis=self.source_basis,
-                           product=self.product, name=self.name + '_jacobian')
+        pop = J.projected(range_basis=self.range_basis, source_basis=self.source_basis,
+                          product=self.product, name=self.name + '_jacobian')
+        if self.solver_options:
+            options = self.solver_options.get('jacobian')
+            if options:
+                pop = pop.with_(solver_options=options)
+        return pop
 
     def assemble(self, mu=None):
         op = self.operator.assemble(mu=mu)
-        return op.projected(range_basis=self.range_basis, source_basis=self.source_basis,
-                            product=self.product, name=self.name + '_assembled')
+        pop = op.projected(range_basis=self.range_basis, source_basis=self.source_basis,
+                           product=self.product, name=self.name + '_assembled')
+        if self.solver_options:
+            pop = pop.with_(solver_options=self.solver_options)
+        return pop

--- a/src/pymor/operators/cg.py
+++ b/src/pymor/operators/cg.py
@@ -58,7 +58,7 @@ class L2ProductFunctionalP1(NumpyMatrixBasedOperator):
     range = NumpyVectorSpace(1)
 
     def __init__(self, grid, function, boundary_info=None, dirichlet_data=None, neumann_data=None, robin_data=None,
-                 order=2, name=None):
+                 order=2, solver_options=None, name=None):
         assert grid.reference_element(0) in {line, triangle}
         assert function.shape_range == tuple()
         self.source = NumpyVectorSpace(grid.size(grid.dim))
@@ -69,6 +69,7 @@ class L2ProductFunctionalP1(NumpyMatrixBasedOperator):
         self.neumann_data = neumann_data
         self.robin_data = robin_data
         self.order = order
+        self.solver_options = solver_options
         self.name = name
         self.build_parameter_type(inherits=(function, dirichlet_data, neumann_data))
 
@@ -284,7 +285,7 @@ class L2ProductP1(NumpyMatrixBasedOperator):
     sparse = True
 
     def __init__(self, grid, boundary_info, dirichlet_clear_rows=True, dirichlet_clear_columns=False,
-                 dirichlet_clear_diag=False, name=None):
+                 dirichlet_clear_diag=False, solver_options=None, name=None):
         assert grid.reference_element in (line, triangle)
         self.source = self.range = NumpyVectorSpace(grid.size(grid.dim))
         self.grid = grid
@@ -292,6 +293,7 @@ class L2ProductP1(NumpyMatrixBasedOperator):
         self.dirichlet_clear_rows = dirichlet_clear_rows
         self.dirichlet_clear_columns = dirichlet_clear_columns
         self.dirichlet_clear_diag = dirichlet_clear_diag
+        self.solver_options = solver_options
         self.name = name
 
     def _assemble(self, mu=None):
@@ -375,7 +377,7 @@ class L2ProductQ1(NumpyMatrixBasedOperator):
     sparse = True
 
     def __init__(self, grid, boundary_info, dirichlet_clear_rows=True, dirichlet_clear_columns=False,
-                 dirichlet_clear_diag=False, name=None):
+                 dirichlet_clear_diag=False, solver_options=None, name=None):
         assert grid.reference_element in {square}
         self.source = self.range = NumpyVectorSpace(grid.size(grid.dim))
         self.grid = grid
@@ -383,6 +385,7 @@ class L2ProductQ1(NumpyMatrixBasedOperator):
         self.dirichlet_clear_rows = dirichlet_clear_rows
         self.dirichlet_clear_columns = dirichlet_clear_columns
         self.dirichlet_clear_diag = dirichlet_clear_diag
+        self.solver_options = solver_options
         self.name = name
 
     def _assemble(self, mu=None):
@@ -469,7 +472,8 @@ class DiffusionOperatorP1(NumpyMatrixBasedOperator):
     sparse = True
 
     def __init__(self, grid, boundary_info, diffusion_function=None, diffusion_constant=None,
-                 dirichlet_clear_columns=False, dirichlet_clear_diag=False, name=None):
+                 dirichlet_clear_columns=False, dirichlet_clear_diag=False,
+                 solver_options=None, name=None):
         assert grid.reference_element(0) in {triangle, line}, 'A simplicial grid is expected!'
         assert diffusion_function is None \
             or (isinstance(diffusion_function, FunctionInterface) and
@@ -482,6 +486,7 @@ class DiffusionOperatorP1(NumpyMatrixBasedOperator):
         self.diffusion_function = diffusion_function
         self.dirichlet_clear_columns = dirichlet_clear_columns
         self.dirichlet_clear_diag = dirichlet_clear_diag
+        self.solver_options = solver_options
         self.name = name
         if diffusion_function is not None:
             self.build_parameter_type(inherits=(diffusion_function,))
@@ -587,7 +592,8 @@ class DiffusionOperatorQ1(NumpyMatrixBasedOperator):
     sparse = True
 
     def __init__(self, grid, boundary_info, diffusion_function=None, diffusion_constant=None,
-                 dirichlet_clear_columns=False, dirichlet_clear_diag=False, name=None):
+                 dirichlet_clear_columns=False, dirichlet_clear_diag=False,
+                 solver_options=None, name=None):
         assert grid.reference_element(0) in {square}, 'A square grid is expected!'
         assert diffusion_function is None \
             or (isinstance(diffusion_function, FunctionInterface) and
@@ -600,6 +606,7 @@ class DiffusionOperatorQ1(NumpyMatrixBasedOperator):
         self.diffusion_function = diffusion_function
         self.dirichlet_clear_columns = dirichlet_clear_columns
         self.dirichlet_clear_diag = dirichlet_clear_diag
+        self.solver_options = solver_options
         self.name = name
         if diffusion_function is not None:
             self.build_parameter_type(inherits=(diffusion_function,))
@@ -696,7 +703,7 @@ class RobinBoundaryOperator(NumpyMatrixBasedOperator):
 
     sparse = True
 
-    def __init__(self, grid, boundary_info, robin_data=None, order=2, name=None):
+    def __init__(self, grid, boundary_info, robin_data=None, order=2, solver_options=None, name=None):
         assert robin_data is None or (isinstance(robin_data, tuple) and len(robin_data) == 2)
         assert robin_data is None or all([isinstance(f, FunctionInterface)
                                           and f.dim_domain == grid.dim_outer
@@ -705,6 +712,7 @@ class RobinBoundaryOperator(NumpyMatrixBasedOperator):
         self.grid = grid
         self.boundary_info = boundary_info
         self.robin_data = robin_data
+        self.solver_options = solver_options
         self.name = name
         self.order = order
 

--- a/src/pymor/operators/fenics.py
+++ b/src/pymor/operators/fenics.py
@@ -69,9 +69,10 @@ if HAVE_FENICS:
                 df.solve(self.matrix, r.impl, v.impl)
             return R
 
-        def assemble_lincomb(self, operators, coefficients, name=None):
+        def assemble_lincomb(self, operators, coefficients, solver_options=None, name=None):
             if not all(isinstance(op, (FenicsMatrixOperator, ZeroOperator)) for op in operators):
                 return None
+            assert not solver_options
 
             if coefficients[0] == 1:
                 matrix = operators[0].matrix.copy()

--- a/src/pymor/operators/fv.py
+++ b/src/pymor/operators/fv.py
@@ -215,13 +215,14 @@ class NonlinearAdvectionOperator(OperatorBase):
 
     linear = False
 
-    def __init__(self, grid, boundary_info, numerical_flux, dirichlet_data=None, name=None):
+    def __init__(self, grid, boundary_info, numerical_flux, dirichlet_data=None, solver_options=None, name=None):
         assert dirichlet_data is None or isinstance(dirichlet_data, FunctionInterface)
 
         self.grid = grid
         self.boundary_info = boundary_info
         self.numerical_flux = numerical_flux
         self.dirichlet_data = dirichlet_data
+        self.solver_options = solver_options
         self.name = name
         if (isinstance(dirichlet_data, FunctionInterface) and boundary_info.has_dirichlet
                 and not dirichlet_data.parametric):
@@ -326,24 +327,24 @@ class NonlinearAdvectionOperator(OperatorBase):
 
 
 def nonlinear_advection_lax_friedrichs_operator(grid, boundary_info, flux, lxf_lambda=1.0,
-                                                dirichlet_data=None, name=None):
+                                                dirichlet_data=None, solver_options=None, name=None):
     """Instantiate a :class:`NonlinearAdvectionOperator` using :class:`LaxFriedrichsFlux`."""
     num_flux = LaxFriedrichsFlux(flux, lxf_lambda)
-    return NonlinearAdvectionOperator(grid, boundary_info, num_flux, dirichlet_data, name)
+    return NonlinearAdvectionOperator(grid, boundary_info, num_flux, dirichlet_data, solver_options, name)
 
 
 def nonlinear_advection_simplified_engquist_osher_operator(grid, boundary_info, flux, flux_derivative,
-                                                           dirichlet_data=None, name=None):
+                                                           dirichlet_data=None, solver_options=None, name=None):
     """Instantiate a :class:`NonlinearAdvectionOperator` using :class:`SimplifiedEngquistOsherFlux`."""
     num_flux = SimplifiedEngquistOsherFlux(flux, flux_derivative)
-    return NonlinearAdvectionOperator(grid, boundary_info, num_flux, dirichlet_data, name)
+    return NonlinearAdvectionOperator(grid, boundary_info, num_flux, dirichlet_data, solver_options, name)
 
 
 def nonlinear_advection_engquist_osher_operator(grid, boundary_info, flux, flux_derivative, gausspoints=5, intervals=1,
-                                                dirichlet_data=None, name=None):
+                                                dirichlet_data=None, solver_options=None, name=None):
     """Instantiate a :class:`NonlinearAdvectionOperator` using :class:`EngquistOsherFlux`."""
     num_flux = EngquistOsherFlux(flux, flux_derivative, gausspoints=gausspoints, intervals=intervals)
-    return NonlinearAdvectionOperator(grid, boundary_info, num_flux, dirichlet_data, name)
+    return NonlinearAdvectionOperator(grid, boundary_info, num_flux, dirichlet_data, solver_options, name)
 
 
 class LinearAdvectionLaxFriedrichs(NumpyMatrixBasedOperator):
@@ -369,11 +370,12 @@ class LinearAdvectionLaxFriedrichs(NumpyMatrixBasedOperator):
         The name of the operator.
     """
 
-    def __init__(self, grid, boundary_info, velocity_field, lxf_lambda=1.0, name=None):
+    def __init__(self, grid, boundary_info, velocity_field, lxf_lambda=1.0, solver_options=None, name=None):
         self.grid = grid
         self.boundary_info = boundary_info
         self.velocity_field = velocity_field
         self.lxf_lambda = lxf_lambda
+        self.solver_options = solver_options
         self.name = name
         self.build_parameter_type(inherits=(velocity_field,))
         self.source = self.range = NumpyVectorSpace(grid.size(0))
@@ -435,9 +437,10 @@ class L2Product(NumpyMatrixBasedOperator):
 
     sparse = True
 
-    def __init__(self, grid, name=None):
+    def __init__(self, grid, solver_options=None, name=None):
         self.source = self.range = NumpyVectorSpace(grid.size(0))
         self.grid = grid
+        self.solver_options = solver_options
         self.name = name
 
     def _assemble(self, mu=None):
@@ -570,7 +573,8 @@ class DiffusionOperator(NumpyMatrixBasedOperator):
 
     sparse = True
 
-    def __init__(self, grid, boundary_info, diffusion_function=None, diffusion_constant=None, name=None):
+    def __init__(self, grid, boundary_info, diffusion_function=None, diffusion_constant=None, solver_options=None,
+                 name=None):
         super(DiffusionOperator, self).__init__()
         assert isinstance(grid, AffineGridWithOrthogonalCentersInterface)
         assert diffusion_function is None \
@@ -581,6 +585,7 @@ class DiffusionOperator(NumpyMatrixBasedOperator):
         self.boundary_info = boundary_info
         self.diffusion_function = diffusion_function
         self.diffusion_constant = diffusion_constant
+        self.solver_options = solver_options
         self.name = name
         self.source = self.range = NumpyVectorSpace(grid.size(0))
         if diffusion_function is not None:

--- a/src/pymor/operators/interfaces.py
+++ b/src/pymor/operators/interfaces.py
@@ -5,7 +5,7 @@
 
 from __future__ import absolute_import, division, print_function
 
-from pymor.core.interfaces import ImmutableInterface, abstractmethod, abstractstaticmethod
+from pymor.core.interfaces import ImmutableInterface, abstractmethod
 from pymor.parameters.base import Parametric
 
 
@@ -22,13 +22,23 @@ class OperatorInterface(ImmutableInterface, Parametric):
 
     Attributes
     ----------
-    invert_options
-        |OrderedDict| of possible options for :meth:`~OperatorInterface.apply_inverse`.
-        Each key is a type of inversion algorithm which can be used to invert the
-        operator. `invert_options[k]` is a dict containing all options along with
-        their default values which can be set for algorithm `k`. We always have
-        `invert_options[k]['type'] == k` such that `invert_options[k]` can be passed
-        directly to :meth:`~OperatorInterface.apply_inverse()`.
+    solver_options
+        If not `None`, a dict which can contain the follwing keys:
+
+        :inverse:   solver options used for
+                    :meth:`~OperatorInterface.apply_inverse`
+        :jacobian:  solver options for the operators returned
+                    by :meth:`~OperatorInterface.jacobian`
+                    (has no effect for linear operators)
+
+        If `solver_options` is `None` or a dict entry is missing
+        or `None`, default options are used.
+        The interpretation of the given solver options is up to
+        the operator at hand. In general, a values in `solver_options`
+        should either be strings (indicating a solver type) or
+        dicts of options, usually with an entry `'type'` which
+        specifies the solver type to use and further items which
+        configure this solver.
     linear
         `True` if the operator is linear.
     source
@@ -36,6 +46,8 @@ class OperatorInterface(ImmutableInterface, Parametric):
     range
         The range |VectorSpace|.
     """
+
+    solver_options = None
 
     @abstractmethod
     def apply(self, U, ind=None, mu=None):
@@ -164,7 +176,7 @@ class OperatorInterface(ImmutableInterface, Parametric):
         pass
 
     @abstractmethod
-    def apply_inverse(self, V, ind=None, mu=None, options=None):
+    def apply_inverse(self, V, ind=None, mu=None):
         """Apply the inverse operator.
 
         Parameters
@@ -176,15 +188,6 @@ class OperatorInterface(ImmutableInterface, Parametric):
             applied. (See the |VectorArray| documentation for further details.)
         mu
             The |Parameter| for which to evaluate the inverse operator.
-        options
-            Dictionary of options for the inversion algorithm. The dictionary
-            has to contain the key `'type'` whose value determines which inversion
-            algorithm is to be used. All other items represent options specific to
-            this algorithm.  `options` can also be given as a string, which is then
-            interpreted as the type of inversion algorithm. If `options` is `None`,
-            a default algorithm with default options is chosen.  Available algorithms
-            and their default options are provided by
-            :attr:`~OperatorInterface.invert_options`.
 
         Returns
         -------
@@ -268,7 +271,7 @@ class OperatorInterface(ImmutableInterface, Parametric):
         """
         pass
 
-    def assemble_lincomb(self, operators, coefficients, name=None):
+    def assemble_lincomb(self, operators, coefficients, solver_options=None, name=None):
         """Try to assemble a linear combination of the given operators.
 
         This method is called in the `assemble` method of |LincombOperator| on
@@ -283,6 +286,8 @@ class OperatorInterface(ImmutableInterface, Parametric):
             List of |Operators| whose linear combination is formed.
         coefficients
             List of the corresponding linear coefficients.
+        solver_options
+            |solver_options| for the assembled operator.
         name
             Name of the assembled operator.
 

--- a/src/pymor/operators/numpy.py
+++ b/src/pymor/operators/numpy.py
@@ -138,7 +138,7 @@ class NumpyMatrixBasedOperator(OperatorBase):
         if self.sparse is None:
             raise ValueError('Sparsity unkown, assemble first.')
         else:
-            return _invert_options(sparse=self.sparse)
+            return _options(sparse=self.sparse)
 
     def export_matrix(self, filename, matrix_name=None, output_format='matlab', mu=None):
         """Save the matrix of the operator to a file.
@@ -639,7 +639,7 @@ def sparse_options(default_solver='spsolve',
     return ordered_opts
 
 
-def _invert_options(matrix=None, sparse=None):
+def _options(matrix=None, sparse=None):
     """Returns |invert_options| (with default values) for a given |NumPy| matrix.
 
     See :func:`sparse_options` for documentation of all possible options for
@@ -697,14 +697,14 @@ def _apply_inverse(matrix, V, options=None):
         the right-hand sides of the linear equation systems to
         solve.
     options
-        |invert_options| to use. (See :func:`invert_options`.)
+        |invert_options| to use. (See :func:`_options`.)
 
     Returns
     -------
     |NumPy array| of the solution vectors.
     """
 
-    default_options = _invert_options(matrix)
+    default_options = _options(matrix)
 
     if options is None:
         options = default_options.values()[0]

--- a/src/pymor/operators/numpy.py
+++ b/src/pymor/operators/numpy.py
@@ -354,7 +354,7 @@ def dense_options(default_solver='solve',
             ('least_squares_lstsq', {'type': 'least_squares_lstsq',
                                      'rcond': least_squares_lstsq_rcond}))
     opts = OrderedDict(opts)
-    opts.update(genericsolvers.invert_options())
+    opts.update(genericsolvers.options())
     def_opt = opts.pop(default_solver)
     if default_least_squares_solver != default_solver:
         def_ls_opt = opts.pop(default_least_squares_solver)
@@ -627,7 +627,7 @@ def sparse_options(default_solver='spsolve',
                                'tol': pyamg_sa_tol,
                                'maxiter': pyamg_sa_maxiter}))
     opts = OrderedDict(opts)
-    opts.update(genericsolvers.invert_options())
+    opts.update(genericsolvers.options())
     def_opt = opts.pop(default_solver)
     if default_least_squares_solver != default_solver:
         def_ls_opt = opts.pop(default_least_squares_solver)

--- a/src/pymor/operators/numpy.py
+++ b/src/pymor/operators/numpy.py
@@ -57,9 +57,11 @@ class NumpyGenericOperator(OperatorBase):
         Name of the operator.
     """
 
-    def __init__(self, mapping, dim_source=1, dim_range=1, linear=False, parameter_type=None, name=None):
+    def __init__(self, mapping, dim_source=1, dim_range=1, linear=False, parameter_type=None, solver_options=None,
+                 name=None):
         self.source = NumpyVectorSpace(dim_source)
         self.range = NumpyVectorSpace(dim_range)
+        self.solver_options = solver_options
         self.name = name
         self._mapping = mapping
         self.linear = linear
@@ -109,17 +111,18 @@ class NumpyMatrixBasedOperator(OperatorBase):
         if hasattr(self, '_assembled_operator'):
             if self._defaults_sid != defaults_sid():
                 self.logger.warn('Re-assembling since state of global defaults has changed.')
-                op = self._assembled_operator = NumpyMatrixOperator(self._assemble())
+                op = self._assembled_operator = NumpyMatrixOperator(self._assemble(),
+                                                                    solver_options=self.solver_options)
                 self._defaults_sid = defaults_sid()
                 return op
             else:
                 return self._assembled_operator
         elif not self.parameter_type:
-            op = self._assembled_operator = NumpyMatrixOperator(self._assemble())
+            op = self._assembled_operator = NumpyMatrixOperator(self._assemble(), solver_options=self.solver_options)
             self._defaults_sid = defaults_sid()
             return op
         else:
-            return NumpyMatrixOperator(self._assemble(self.parse_parameter(mu)))
+            return NumpyMatrixOperator(self._assemble(self.parse_parameter(mu)), solver_options=self.solver_options)
 
     def apply(self, U, ind=None, mu=None):
         return self.assemble(mu).apply(U, ind=ind)
@@ -130,15 +133,9 @@ class NumpyMatrixBasedOperator(OperatorBase):
     def as_vector(self, mu=None):
         return self.assemble(mu).as_vector()
 
-    def apply_inverse(self, V, ind=None, mu=None, options=None):
-        return self.assemble(mu).apply_inverse(V, ind=ind, options=options)
+    def apply_inverse(self, V, ind=None, mu=None):
+        return self.assemble(mu).apply_inverse(V, ind=ind)
 
-    @property
-    def invert_options(self):
-        if self.sparse is None:
-            raise ValueError('Sparsity unkown, assemble first.')
-        else:
-            return _options(sparse=self.sparse)
 
     def export_matrix(self, filename, matrix_name=None, output_format='matlab', mu=None):
         """Save the matrix of the operator to a file.
@@ -180,12 +177,13 @@ class NumpyMatrixOperator(NumpyMatrixBasedOperator):
         Name of the operator.
     """
 
-    def __init__(self, matrix, name=None):
+    def __init__(self, matrix, solver_options=None, name=None):
         assert matrix.ndim <= 2
         if matrix.ndim == 1:
             matrix = np.reshape(matrix, (1, -1))
         self.source = NumpyVectorSpace(matrix.shape[1])
         self.range = NumpyVectorSpace(matrix.shape[0])
+        self.solver_options = solver_options
         self.name = name
         self._matrix = matrix
         self.sparse = issparse(matrix)
@@ -223,9 +221,10 @@ class NumpyMatrixOperator(NumpyMatrixBasedOperator):
         else:
             return ATPrU
 
-    def apply_inverse(self, V, ind=None, mu=None, options=None):
+    def apply_inverse(self, V, ind=None, mu=None):
         assert V in self.range
         assert V.check_ind(ind)
+        options = self.solver_options.get('inverse') if self.solver_options else None
         if V.dim == 0:
             if (self.source.dim == 0
                     or isinstance(options, str) and options.startswith('least_squares')
@@ -268,9 +267,10 @@ class NumpyMatrixOperator(NumpyMatrixBasedOperator):
         assert dim_range is None or dim_range <= self.range.dim
         name = name or '{}_projected_to_subbasis'.format(self.name)
         # copy instead of just slicing the matrix to ensure contiguous memory
-        return NumpyMatrixOperator(self._matrix[:dim_range, :dim_source].copy(), name=name)
+        return NumpyMatrixOperator(self._matrix[:dim_range, :dim_source].copy(), solver_options=self.solver_options,
+                                   name=name)
 
-    def assemble_lincomb(self, operators, coefficients, name=None):
+    def assemble_lincomb(self, operators, coefficients, solver_options=None, name=None):
         if not all(isinstance(op, NumpyMatrixOperator) for op in operators):
             return None
 
@@ -294,7 +294,7 @@ class NumpyMatrixOperator(NumpyMatrixBasedOperator):
                     matrix += (op._matrix * c)
                 except NotImplementedError:
                     matrix = matrix + (op._matrix * c)
-        return NumpyMatrixOperator(matrix)
+        return NumpyMatrixOperator(matrix, solver_options=solver_options)
 
     def __getstate__(self):
         if hasattr(self._matrix, 'factorization'):  # remove unplicklable SuperLU factorization
@@ -330,7 +330,7 @@ _sparse_options_sid = None
 def dense_options(default_solver='solve',
                   default_least_squares_solver='least_squares_lstsq',
                   least_squares_lstsq_rcond=-1.):
-    """Returns |invert_options| (with default values) for dense |NumPy| matricies.
+    """Returns |solver_options| (with default values) for dense |NumPy| matricies.
 
     Parameters
     ----------
@@ -345,7 +345,7 @@ def dense_options(default_solver='solve',
 
     Returns
     -------
-    A tuple of all possible |invert_options|.
+    A tuple of possible values for |solver_options|.
     """
 
     assert default_least_squares_solver.startswith('least_squares')
@@ -382,7 +382,7 @@ def dense_options(default_solver='solve',
           'pyamg_sa_accel', 'pyamg_sa_tol', 'pyamg_sa_maxiter',
           sid_ignore=('least_squares_lsmr_show', 'least_squares_lsqr_show', 'pyamg_verb'))
 def sparse_options(default_solver='spsolve',
-                   default_least_squares_solver='least_squares_generic_lsmr',
+                   default_least_squares_solver='least_squares_lsmr',
                    bicgstab_tol=1e-15,
                    bicgstab_maxiter=None,
                    spilu_drop_tol=1e-4,
@@ -436,7 +436,7 @@ def sparse_options(default_solver='spsolve',
                    pyamg_sa_accel=None,
                    pyamg_sa_tol=1e-5,
                    pyamg_sa_maxiter=100):
-    """Returns |invert_options| (with default values) for sparse |NumPy| matricies.
+    """Returns |solver_options| (with default values) for sparse |NumPy| matricies.
 
     Parameters
     ----------
@@ -554,7 +554,7 @@ def sparse_options(default_solver='spsolve',
 
     Returns
     -------
-    A tuple of all possible |invert_options|.
+    A tuple of all possible |solver_options|.
     """
 
     assert default_least_squares_solver.startswith('least_squares')
@@ -640,7 +640,10 @@ def sparse_options(default_solver='spsolve',
 
 
 def _options(matrix=None, sparse=None):
-    """Returns |invert_options| (with default values) for a given |NumPy| matrix.
+    """Returns |solver_options| (with default values) for a given |NumPy| matrix.
+
+    See :func:`dense_options` for documentation of all possible options for
+    dense matrices.
 
     See :func:`sparse_options` for documentation of all possible options for
     sparse matrices.
@@ -656,7 +659,7 @@ def _options(matrix=None, sparse=None):
 
     Returns
     -------
-    A tuple of all possible |invert_options|.
+    A tuple of all possible |solver_options|.
     """
     global _dense_options, _dense_options_sid, _sparse_options, _sparse_options_sid
     assert (matrix is None) != (sparse is None)
@@ -682,6 +685,9 @@ def _apply_inverse(matrix, V, options=None):
 
     Applies the inverse of `matrix` to the row vectors in `V`.
 
+    See :func:`dense_options` for documentation of all possible options for
+    sparse matrices.
+
     See :func:`sparse_options` for documentation of all possible options for
     sparse matrices.
 
@@ -697,7 +703,7 @@ def _apply_inverse(matrix, V, options=None):
         the right-hand sides of the linear equation systems to
         solve.
     options
-        |invert_options| to use. (See :func:`_options`.)
+        The solver options to use. (See :func:`_options`.)
 
     Returns
     -------

--- a/src/pymor/playground/operators/numpy.py
+++ b/src/pymor/playground/operators/numpy.py
@@ -16,9 +16,9 @@ from pymor.vectorarrays.numpy import NumpyVectorArray
 class NumpyListVectorArrayMatrixOperator(NumpyMatrixOperator):
     """Variant of |NumpyMatrixOperator| using |ListVectorArray| instead of |NumpyVectorArray|."""
 
-    def __init__(self, matrix, functional=False, vector=False, name=None):
+    def __init__(self, matrix, functional=False, vector=False, solver_options=None, name=None):
         assert not (functional and vector)
-        super(NumpyListVectorArrayMatrixOperator, self).__init__(matrix, name)
+        super(NumpyListVectorArrayMatrixOperator, self).__init__(matrix, solver_options=solver_options, name=name)
         if not vector:
             self.source = VectorSpace(ListVectorArray, (NumpyVector, matrix.shape[1]))
         if not functional:
@@ -51,16 +51,17 @@ class NumpyListVectorArrayMatrixOperator(NumpyMatrixOperator):
     def apply_adjoint(self, U, ind=None, mu=None, source_product=None, range_product=None):
         raise NotImplementedError
 
-    def apply_inverse(self, V, ind=None, mu=None, options=None):
+    def apply_inverse(self, V, ind=None, mu=None):
         assert V in self.range
         assert V.check_ind(ind)
         assert not self.functional and not self.vector
+        options = self.solver_options.get('inverse') if self.solver_options else None
 
         if V.dim == 0:
             if (self.source.dim == 0
                     or isinstance(options, str) and options.startswith('least_squares')
                     or isinstance(options, dict) and options['type'].startswith('least_squares')):
-                return ListVectorArray([NumpyVector(np.zeros(0), copy=False) for _ in range(U.len_ind(ind))],
+                return ListVectorArray([NumpyVector(np.zeros(0), copy=False) for _ in range(V.len_ind(ind))],
                                        subtype=self.source.subtype)
             else:
                 raise InversionError
@@ -72,7 +73,9 @@ class NumpyListVectorArrayMatrixOperator(NumpyMatrixOperator):
         else:
             vectors = (V._list[i] for i in ind)
 
-        return ListVectorArray([NumpyVector(_apply_inverse(self._matrix, v._array, options=options), copy=False)
+        return ListVectorArray([NumpyVector(_apply_inverse(self._matrix, v._array.reshape((1, -1)),
+                                                           options=options).ravel(),
+                                            copy=False)
                                 for v in vectors],
                                subtype=self.source.subtype)
 
@@ -81,9 +84,9 @@ class NumpyListVectorArrayMatrixOperator(NumpyMatrixOperator):
             raise TypeError('This operator does not represent a vector or linear functional.')
         return ListVectorArray([NumpyVector(self._matrix.ravel(), copy=True)])
 
-    def assemble_lincomb(self, operators, coefficients, name=None):
+    def assemble_lincomb(self, operators, coefficients, solver_options=None, name=None):
         lincomb = super(NumpyListVectorArrayMatrixOperator, self).assemble_lincomb(operators, coefficients)
         if lincomb is None:
             return None
         else:
-            return NumpyListVectorArrayMatrixOperator(lincomb._matrix, name=name)
+            return NumpyListVectorArrayMatrixOperator(lincomb._matrix, solver_options=solver_options, name=name)

--- a/src/pymortests/base.py
+++ b/src/pymortests/base.py
@@ -100,5 +100,5 @@ class MonomOperator(OperatorBase):
     def jacobian(self, U, mu=None):
         return MonomOperator(self.order - 1, self.derivative)
 
-    def apply_inverse(self, V, ind=None, mu=None, options=None):
+    def apply_inverse(self, V, ind=None, mu=None):
         return NumpyVectorArray(1. / V.data)

--- a/src/pymortests/operators.py
+++ b/src/pymortests/operators.py
@@ -169,19 +169,15 @@ def test_apply_adjoint_2_with_products(operator_with_arrays_and_products):
 
 def test_apply_inverse(operator_with_arrays):
     op, mu, _, V = operator_with_arrays
-    for options in chain([None], op.invert_options, op.invert_options.itervalues()):
-        for ind in valid_inds(V):
-            try:
-                U = op.apply_inverse(V, mu=mu, ind=ind, options=options)
-            except InversionError:
-                return
-            assert U in op.source
-            assert len(U) == V.len_ind(ind)
-            VV = op.apply(U, mu=mu)
-            if (isinstance(options, str) and options.startswith('least_squares')
-                    or not isinstance(options, (str, type(None))) and options['type'].startswith('least_squares')):
-                continue
-            assert float_cmp_all(VV.l2_norm(), V.l2_norm(ind=ind), atol=1e-10, rtol=0.5)
+    for ind in valid_inds(V):
+        try:
+            U = op.apply_inverse(V, mu=mu, ind=ind)
+        except InversionError:
+            return
+        assert U in op.source
+        assert len(U) == V.len_ind(ind)
+        VV = op.apply(U, mu=mu)
+        assert float_cmp_all(VV.l2_norm(), V.l2_norm(ind=ind), atol=1e-10, rtol=0.5)
 
 
 def test_projected(operator_with_arrays):

--- a/src/pymortests/solver.py
+++ b/src/pymortests/solver.py
@@ -8,8 +8,9 @@ import numpy as np
 from scipy.sparse import diags
 import pytest
 
+import pymor.algorithms.genericsolvers
 from pymor.operators.basic import OperatorBase
-from pymor.operators.numpy import NumpyMatrixOperator
+from pymor.operators.numpy import NumpyMatrixOperator, sparse_options, dense_options
 from pymor.vectorarrays.numpy import NumpyVectorSpace, NumpyVectorArray
 
 
@@ -19,6 +20,9 @@ class GenericOperator(OperatorBase):
     op = NumpyMatrixOperator(np.eye(10) * np.arange(1, 11))
     linear = True
 
+    def __init__(self, solver_options=None):
+        self.solver_options = solver_options
+
     def apply(self, U, ind=None, mu=None):
         return self.op.apply(U, ind=ind, mu=mu)
 
@@ -26,37 +30,37 @@ class GenericOperator(OperatorBase):
         return self.op.apply_adjoint(U, ind=ind, mu=mu)
 
 
-@pytest.fixture(params=GenericOperator().invert_options.keys())
+@pytest.fixture(params=pymor.algorithms.genericsolvers.options().keys())
 def generic_solver(request):
-    return request.param
+    return {'inverse': request.param}
 
 
-@pytest.fixture(params=NumpyMatrixOperator(np.eye(10)).invert_options.keys())
+@pytest.fixture(params=dense_options().keys())
 def numpy_dense_solver(request):
-    return request.param
+    return {'inverse': request.param}
 
 
-@pytest.fixture(params=NumpyMatrixOperator(diags([np.ones(10)], [0])).invert_options.keys())
+@pytest.fixture(params=sparse_options().keys())
 def numpy_sparse_solver(request):
-    return request.param
+    return {'inverse': request.param}
 
 
 def test_generic_solvers(generic_solver):
-    op = GenericOperator()
+    op = GenericOperator(generic_solver)
     rhs = NumpyVectorArray(np.ones(10))
-    solution = op.apply_inverse(rhs, options=generic_solver)
+    solution = op.apply_inverse(rhs)
     assert ((op.apply(solution) - rhs).l2_norm() / rhs.l2_norm())[0] < 1e-8
 
 
 def test_numpy_dense_solvers(numpy_dense_solver):
-    op = NumpyMatrixOperator(np.eye(10) * np.arange(1, 11))
+    op = NumpyMatrixOperator(np.eye(10) * np.arange(1, 11), solver_options=numpy_dense_solver)
     rhs = NumpyVectorArray(np.ones(10))
-    solution = op.apply_inverse(rhs, options=numpy_dense_solver)
+    solution = op.apply_inverse(rhs)
     assert ((op.apply(solution) - rhs).l2_norm() / rhs.l2_norm())[0] < 1e-8
 
 
 def test_numpy_sparse_solvers(numpy_sparse_solver):
-    op = NumpyMatrixOperator(diags([np.arange(1., 11.)], [0]))
+    op = NumpyMatrixOperator(diags([np.arange(1., 11.)], [0]), solver_options=numpy_sparse_solver)
     rhs = NumpyVectorArray(np.ones(10))
-    solution = op.apply_inverse(rhs, options=numpy_sparse_solver)
+    solution = op.apply_inverse(rhs)
     assert ((op.apply(solution) - rhs).l2_norm() / rhs.l2_norm())[0] < 1e-8


### PR DESCRIPTION
This pull request contains the following changes:

- `options` is removed from `OperatorInterface.apply_inverse`
- `invert_options` is removed from `OperatorInterface`
- `solver_options` is added to `OperatorInterface`
- `solver_options` can be given to the implict Euler algorithm.

If not `None`, `solver_options` is a dict which can contain the keys
`'inverse'` and `'jacobian'`. The following rules apply:

- `OperatorInterface.apply_inverse` uses the `'inverse'` entry
  of `solver_options` for solver selection and configuration.
  If not available, or `None`, defaults are used.
- `OperatorInterface.jacobian` uses the values of the `'jacobian'`
  entry of `solver_options` as `solver_options` for the Jacobian
  operator. If missing, `solver_options` is set to `None`.
- `OperatorInterface.assemble` returns an assembled operator with
  the same `solver_options`.
- `OperatorInterface.projected` and `OperatorInterface.restricted`
  return operators with `solver_options` set to `None`.

This PR addresses #122.
