### PR TITLE
Add from_file factory methods for NumpyMatrixOperator and NumpyVectorArray

### DIFF
--- a/src/pymor/operators/numpy.py
+++ b/src/pymor/operators/numpy.py
@@ -190,6 +190,12 @@ class NumpyMatrixOperator(NumpyMatrixBasedOperator):
         self._matrix = matrix
         self.sparse = issparse(matrix)
 
+    @classmethod
+    def from_file(cls, path, key=None, solver_options=None, name=None):
+        from pymor.tools.io import load_matrix
+        matrix = load_matrix(path, key=key)
+        return cls(matrix, solver_options=solver_options, name=name or key or path)
+
     def _assemble(self, mu=None):
         pass
 

--- a/src/pymor/tools/io.py
+++ b/src/pymor/tools/io.py
@@ -1,0 +1,112 @@
+# This file is part of the pyMOR project (http://www.pymor.org).
+# Copyright Holders: Rene Milk, Stephan Rave, Felix Schindler
+# License: BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+
+from __future__ import absolute_import, division, print_function
+
+from scipy.io import loadmat, mmread
+from scipy.sparse import issparse
+import numpy as np
+
+from pymor.core.logger import getLogger
+
+
+def _loadmat(path, key=None):
+
+    try:
+        data = loadmat(path, mat_dtype=True)
+    except Exception as e:
+        raise IOError(e)
+
+    if key:
+        try:
+            return data[key]
+        except KeyError:
+            raise IOError('"{}" not found in MATLAB file {}'.format(key, path))
+
+    data = [v for v in data.values() if isinstance(v, np.ndarray) or issparse(v)]
+
+    if len(data) == 0:
+        raise IOError('No matrix data contained in MATLAB file {}'.format(key, path))
+    elif len(data) > 1:
+        raise IOError('More than one matrix object stored in MATLAB file {}'.format(key, path))
+    else:
+        return data[0]
+
+
+def _mmread(path, key=None):
+
+    if key:
+        raise IOError('Cannot specify "key" for Matrix Market file')
+    try:
+        matrix = mmread(path)
+        return matrix.tocsc()
+    except Exception as e:
+        raise IOError(e)
+
+
+def _load(path, key=None):
+    data = np.load(path)
+    if isinstance(data, dict):
+        if key:
+            try:
+                matrix = data[key]
+            except KeyError:
+                raise IOError('"{}" not found in NPY file {}'.format(key, path))
+        elif len(data) == 0:
+            raise IOError('No data contained in NPY file {}'.format(key, path))
+        elif len(data) > 1:
+            raise IOError('More than one object stored in NPY file {}'.format(key, path))
+        else:
+            matrix = next(data.itervalues())
+    else:
+        matrix = data
+    if not isinstance(matrix, np.ndarray) and not issparse(matrix):
+        raise IOError('Loaded data is not a matrix in NPY file {}').format(path)
+    return matrix
+
+
+def _loadtxt(path, key=None):
+    if key:
+        raise IOError('Cannot specify "key" for TXT file')
+    try:
+        return np.loadtxt(path)
+    except Exception as e:
+        raise IOError(e)
+
+
+def load_matrix(path, key=None):
+
+    logger = getLogger('pymor.tools.io.load_matrix')
+    logger.info('Loading matrix from file ' + path)
+
+    path_parts = path.split('.')
+    if len(path_parts[-1]) == 3:
+        extension = path_parts[-1].lower()
+    elif path_parts[-1].lower() == 'gz' and len(path_parts) >= 2 and len(path_parts[-2]) == 3:
+        extension = '.'.join(path_parts[-2:]).lower()
+    else:
+        extension = None
+
+    file_format_map = {'mat': ('MATLAB', _loadmat),
+                       'mtx': ('Matrix Market', _mmread),
+                       'mtz.gz': ('Matrix Market', _mmread),
+                       'npy': ('NPY/NPZ', _load),
+                       'npz': ('NPY/NPZ', _load),
+                       'txt': ('Text', _loadtxt)}
+
+    if extension in file_format_map:
+        file_type, loader = file_format_map[extension]
+        logger.info(file_type + ' file detected.')
+        return loader(path, key)
+
+    logger.warn('Could not detect file format. Trying all loaders ...')
+
+    loaders = [_loadmat, _mmread, _loadtxt, _load]
+    for loader in loaders:
+        try:
+            return loader(path, key)
+        except IOError:
+            pass
+
+    raise IOError('Could not load file {} (key = {})'.format(path, key))

--- a/src/pymor/vectorarrays/numpy.py
+++ b/src/pymor/vectorarrays/numpy.py
@@ -50,6 +50,22 @@ class NumpyVectorArray(VectorArrayInterface):
         self._refcount = [1]
 
     @classmethod
+    def from_file(cls, path, key=None, single_vector=False, transpose=False):
+        assert not (single_vector and transpose)
+        from pymor.tools.io import load_matrix
+        array = load_matrix(path, key=key)
+        assert isinstance(array, np.ndarray)
+        assert array.ndim <= 2
+        if array.ndim == 1:
+            array = array.reshape((1, -1))
+        if single_vector:
+            assert array.shape[0] == 1 or array.shape[1] == 1
+            array = array.reshape((1, -1))
+        if transpose:
+            array = array.T
+        return cls(array)
+
+    @classmethod
     def make_array(cls, subtype=None, count=0, reserve=0):
         assert isinstance(subtype, Number)
         assert count >= 0


### PR DESCRIPTION
This pull request adds a `tools.io.load_matrix` helper function, which tries hard to load matrix data from different possible file formats. `NumpyMatrixOperator.from_file` and `NumpyVectorArray.from_file` use this method to create new instances from data in a given file. Moreover, `discretizers.disk` have been adapted to use the new functionality.

This addresses #118.