### PR TITLE
[build] change suggested pip command to install packeges one by one

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -247,7 +247,7 @@ def setup_package():
             for d in description[1:]:
                 print(' ' * col_width + d)
             print()
-        print("\ntry: 'pip install {}'".format(' '.join(missing)))
+        print("\ntry: 'for pname in {}; do pip install $pname; done'".format(' '.join(missing)))
         print('\n' + '*' * 79 + '\n')
 
 


### PR DESCRIPTION
I observed strange effects on my machine when installing a lot of packages at once. For example, the command

`pip install scipy Sphinx docopt pytest-runner ipython ipyparallel matplotlib pyopengl pyside pyamg mpi4py pytest`

managed to install Sphinx without its dependencies. The dependencies are only installed correctly when installing packages one by one. Therefore I'd like to change the suggested command to install packages from "pip install foo bar" to "for pname in foo bar; do pip install $pname; done"