### PR TITLE
[complex] first proposal with antilinear operator

### DIFF
--- a/src/pymor/operators/cg.py
+++ b/src/pymor/operators/cg.py
@@ -12,9 +12,9 @@ from pymor.functions.interfaces import FunctionInterface
 from pymor.grids.referenceelements import triangle, line, square
 from pymor.operators.numpy import NumpyMatrixBasedOperator
 from pymor.vectorarrays.numpy import NumpyVectorSpace
+from pymor.operators.constructions import antilinear
 
-
-class L2ProductFunctionalP1(NumpyMatrixBasedOperator):
+class L2ProductFunctionalP1(antilinear(NumpyMatrixBasedOperator)):
     """|Functional| representing the scalar product with an L2-|Function| for linear finite elements.
 
     Boundary treatment can be performed by providing `boundary_info` and `dirichlet_data`,
@@ -134,7 +134,7 @@ class L2ProductFunctionalP1(NumpyMatrixBasedOperator):
         return I.reshape((1, -1))
 
 
-class L2ProductFunctionalQ1(NumpyMatrixBasedOperator):
+class L2ProductFunctionalQ1(antilinear(NumpyMatrixBasedOperator)):
     """|Functional| representing the scalar product with an L2-|Function| for bilinear finite elements.
 
     Boundary treatment can be performed by providing `boundary_info` and `dirichlet_data`,

--- a/src/pymor/operators/constructions.py
+++ b/src/pymor/operators/constructions.py
@@ -994,3 +994,29 @@ class InducedNorm(ImmutableInterface, Parametric):
         if self.raise_negative and np.any(norm_squared < 0):
             raise ValueError('norm is negative (square = {})'.format(norm_squared))
         return np.sqrt(norm_squared)
+
+def antilinear(operator_class):
+    class Antilin(operator_class):
+        def apply(self, U, ind=None, mu=None):
+            return super(Antilin, self).apply(U.conj(), ind=ind, mu=mu)
+
+        def apply2(self, V, U, U_ind=None, V_ind=None, mu=None, product=None):
+            raise NotImplementedError
+
+        def pairwise_apply2(self, V, U, U_ind=None, V_ind=None, mu=None, product=None):
+            raise NotImplementedError
+
+        def apply_adjoint(self, V, U, U_ind=None, V_ind=None, mu=None, product=None):
+            raise NotImplementedError
+
+        def apply_inverse(self, V, ind=None, mu=None, least_squares=False):
+            return super(Antilin, self).apply_inverse(V, ind=ind, mu=mu, least_squares=least_squares).conj()
+
+        def apply_inverse_adjoint(self, U, ind=None, mu=None, source_product=None, range_product=None,
+                                  least_squares=False):
+            raise NotImplementedError
+
+        def projected(self, range_basis, source_basis, product=None, name=None):
+            return super(Antilin, self).projected(range_basis, source_basis.conj(), product=product, name=name)
+
+    return Antilin

--- a/src/pymor/operators/numpy.py
+++ b/src/pymor/operators/numpy.py
@@ -267,7 +267,7 @@ class NumpyMatrixOperator(NumpyMatrixBasedOperator):
                                                                           least_squares=least_squares)
         else:
             options = {'inverse': self.solver_options.get('inverse_adjoint') if self.solver_options else None}
-            adjoint_op = NumpyMatrixOperator(self._matrix.T, solver_options=options)
+            adjoint_op = NumpyMatrixOperator(self._matrix.T.conj(), solver_options=options)
             return adjoint_op.apply_inverse(U, ind=ind, mu=mu, least_squares=least_squares)
 
     def projected_to_subbasis(self, dim_range=None, dim_source=None, name=None):

--- a/src/pymor/playground/vectorarrays/disk.py
+++ b/src/pymor/playground/vectorarrays/disk.py
@@ -123,6 +123,9 @@ class DiskVectorArray(VectorArrayInterface):
         c._len = len(ind)
         return c
 
+    def conj(self):
+        raise NotImplementedError
+
     def append(self, other, o_ind=None, remove_from_other=False):
         assert other.check_ind(o_ind)
         assert other.space == self.space

--- a/src/pymor/vectorarrays/block.py
+++ b/src/pymor/vectorarrays/block.py
@@ -66,6 +66,9 @@ class BlockVectorArray(VectorArrayInterface):
     def data(self):
         return np.hstack([block.data for block in self.blocks])
 
+    def conj(self):
+        return BlockVectorArray([block.conj() for block in self._blocks], copy=False)
+
     def copy(self, ind=None, deep=False):
         assert self.check_ind(ind)
         return BlockVectorArray([block.copy(ind=ind, deep=deep) for block in self._blocks], copy=False)

--- a/src/pymor/vectorarrays/interfaces.py
+++ b/src/pymor/vectorarrays/interfaces.py
@@ -158,6 +158,18 @@ class VectorArrayInterface(BasicInterface):
         pass
 
     @abstractmethod
+    def conj(self):
+        """Returns the complex conjugate.
+
+        In the real case, this should be a no-op returning just self.
+
+        Returns
+        -------
+        The complex conjugate of the |VectorArray|. May return self
+        """
+        pass
+
+    @abstractmethod
     def append(self, other, o_ind=None, remove_from_other=False):
         """Append vectors to the array.
 

--- a/src/pymor/vectorarrays/list.py
+++ b/src/pymor/vectorarrays/list.py
@@ -36,6 +36,10 @@ class VectorInterface(BasicInterface):
         pass
 
     @abstractmethod
+    def conj(self):
+        pass
+
+    @abstractmethod
     def scal(self, alpha):
         pass
 
@@ -194,6 +198,12 @@ class NumpyVector(CopyOnWriteVector):
     def subtype(self):
         return len(self._array)
 
+    def conj(self):
+        if np.iscomplexobj(self.data):
+            return NumpyVector(self.data.conj())
+        else:
+            return self
+
     def _copy_data(self):
         self._array = self._array.copy()
 
@@ -286,6 +296,10 @@ class ListVectorArray(VectorArrayInterface):
     @property
     def subtype(self):
         return (self.vector_type, self.vector_subtype)
+
+    def conj(self):
+        vecs = [v.conj() for v in self._list]
+        return type(self)(vecs, subtype=self.subtype, copy=False)
 
     def copy(self, ind=None, deep=False):
         assert self.check_ind(ind)

--- a/src/pymor/vectorarrays/numpy.py
+++ b/src/pymor/vectorarrays/numpy.py
@@ -96,6 +96,12 @@ class NumpyVectorArray(VectorArrayInterface):
     def dim(self):
         return self._array.shape[1]
 
+    def conj(self):
+        if np.iscomplexobj(self.data):
+            return NumpyVectorArray(self.data.conj())
+        else:
+            return self
+
     def copy(self, ind=None, deep=False):
         assert self.check_ind(ind)
 
@@ -316,10 +322,7 @@ class NumpyVectorArray(VectorArrayInterface):
         B = other._array[:other._len] if o_ind is None else \
             other._array[o_ind] if hasattr(o_ind, '__len__') else other._array[o_ind:o_ind + 1]
 
-        if B.dtype in _complex_dtypes:
-            return A.dot(B.conj().T)
-        else:
-            return A.dot(B.T)
+        return A.conj().dot(B.T)
 
     def pairwise_dot(self, other, ind=None, o_ind=None):
         assert self.check_ind(ind)
@@ -338,10 +341,7 @@ class NumpyVectorArray(VectorArrayInterface):
         B = other._array[:other._len] if o_ind is None else \
             other._array[o_ind] if hasattr(o_ind, '__len__') else other._array[o_ind:o_ind + 1]
 
-        if B.dtype in _complex_dtypes:
-            return np.sum(A * B.conj(), axis=1)
-        else:
-            return np.sum(A * B, axis=1)
+        return np.sum(A.conj() * B, axis=1)
 
     def lincomb(self, coefficients, ind=None):
         assert self.check_ind(ind)
@@ -464,4 +464,3 @@ def NumpyVectorSpace(dim):
     return VectorSpace(NumpyVectorArray, dim)
 
 
-_complex_dtypes = (np.complex64, np.complex128)

--- a/src/pymortests/complex_values.py
+++ b/src/pymortests/complex_values.py
@@ -116,10 +116,10 @@ def test_dot():
     x = NumpyVectorArray(np.array([1 + 1j]))
     y = NumpyVectorArray(np.array([1 - 1j]))
     z = x.dot(y)
-    assert z[0, 0] == 2j
+    assert z[0, 0] == -2j
 
 def test_pairwise_dot():
     x = NumpyVectorArray(np.array([1 + 1j]))
     y = NumpyVectorArray(np.array([1 - 1j]))
     z = x.pairwise_dot(y)
-    assert z == 2j
+    assert z == -2j


### PR DESCRIPTION
# This code is not ready to be merged

Here is a proposal how we could handle complex conjugation and antilinear operators. I ask for your opinion before I continue working on this.

##################################
Behaviour of VectorArray.dot(U)

To be consistent with most of the other implementations, foo.dot(bar) is antilinear in foo and linear in bar, i.e. foo is complex conjugated.
Same goes for pairwise_dot

##################################
Behaviour of Operator.apply(U)

linear in U. So no complex conjugation going on here.

##################################
Behaviour of Operator.apply2(V,U)

antilinear in V and linear in U.
This it is equivalent to V.dot(Op.apply(U)).

Same goes for pairwise_apply2(V,U)

##################################
Interpretation in terms of linear, bilinear forms:

a(u,v) is liniear in u, antilinear in v
f(v) is antilinear in v

##################################
Problem:

This leads to the following problem:
The discrete equivalent of
a(u,v) = f(v) \forall v
is
A.apply2(V,U) = F.apply(V)

Here we have apply2 antilinear in V, which implies that F must also be antilinear in V. However, NumpyMatrixBasedOperator.apply(U) should be linear. This means that either F.apply(V) must not be implemented in terms of NumpyMatrixBasedOperator.apply() or that we need a switch to NumpyMatrixBasedOperator.apply which chooses whether it is linear or antilinear.

Functionals implemented as VectorOperator from operators/constructions.py are OK, but for example the L2ProductFunctionalP2 from operators/cg.py is implemented as a NumpyMatrixBasedOperator.

Here I created some code which can create an antilinear operator by wrapping a linear operator.

Please comment. Do you think the antilinear operator wrapper is necessary? Do you see an easier option?