### PR TITLE
This removes `replace` from the VectorArray interface

### DIFF
--- a/docs/source/technical_overview.rst
+++ b/docs/source/technical_overview.rst
@@ -13,9 +13,8 @@ operating on objects of the following types:
 |VectorArrays|
     Vector arrays are ordered collections of vectors. Each vector of the array
     must be of the same |dimension|. Subsets of vectors can be
-    |copied| to a new array, |appended| to an existing array, |removed| from the
-    array or |replaced| by vectors of a different array.
-    Basic linear algebra operations can be performed on the vectors of the
+    |copied| to a new array, |appended| to an existing array or |removed| from the
+    array. Basic linear algebra operations can be performed on the vectors of the
     array: vectors can be |scaled| in-place, the BLAS |axpy| operation is
     supported and |scalar products| between vectors can be formed. Linear
     combinations of vectors can be formed using the |lincomb| method. Moreover,
@@ -66,7 +65,6 @@ operating on objects of the following types:
     .. |lincomb|          replace:: :meth:`~pymor.vectorarrays.interfaces.VectorArrayInterface.lincomb`
     .. |make_array|       replace:: :meth:`~pymor.vectorarrays.interfaces.VectorArrayInterface.make_array`
     .. |removed|          replace:: :meth:`deleted <pymor.vectorarrays.interfaces.VectorArrayInterface.remove>`
-    .. |replaced|         replace:: :meth:`replaced <pymor.vectorarrays.interfaces.VectorArrayInterface.replace>`
     .. |scalar products|  replace:: :meth:`scalar products <pymor.vectorarrays.interfaces.VectorArrayInterface.dot>`
     .. |scaled|           replace:: :meth:`scaled <pymor.vectorarrays.interfaces.VectorArrayInterface.scal>`
     .. |subtype|          replace:: :attr:`~pymor.vectorarrays.interfaces.VectorSpace.subtype`

--- a/src/pymor/playground/vectorarrays/disk.py
+++ b/src/pymor/playground/vectorarrays/disk.py
@@ -172,37 +172,6 @@ class DiskVectorArray(VectorArrayInterface):
                         os.path.join(self.dir, str(d)))
         self._len = len(remaining)
 
-    def replace(self, other, ind=None, o_ind=None, remove_from_other=False):
-        assert self.check_ind_unique(ind)
-        self._cache.clear()
-        assert other.check_ind(o_ind)
-        assert other.space == self.space
-        assert other is not self or not remove_from_other
-        ind = list(range(self._len)) if ind is None else [ind] if isinstance(ind, Number) else ind
-        o_ind = list(range(other._len)) if o_ind is None else [o_ind] if isinstance(o_ind, Number) else o_ind
-        assert len(ind) == len(o_ind)
-
-        if other is self:
-            backup = set(ind).intersection(set(o_ind))
-            for i in backup:
-                shutil.move(os.path.join(self.dir, str(i)),
-                            os.path.join(self.dir, '_' + str(i)))
-            for d, s in zip(ind, o_ind):
-                if s in backup:
-                    shutil.copy(os.path.join(self.dir, '_' + str(s)),
-                                os.path.join(self.dir, str(d)))
-                else:
-                    shutil.copy(os.path.join(self.dir, str(s)),
-                                os.path.join(self.dir, str(d)))
-            for i in backup:
-                os.remove(os.path.join(self.dir, '_' + str(i)))
-        else:
-            for d, s in zip(ind, o_ind):
-                shutil.copy(os.path.join(other.dir, str(s)),
-                            os.path.join(self.dir, str(d)))
-            if remove_from_other:
-                other.remove(o_ind)
-
     def scal(self, alpha, ind=None):
         assert self.check_ind_unique(ind)
         assert isinstance(alpha, Number) \

--- a/src/pymor/vectorarrays/block.py
+++ b/src/pymor/vectorarrays/block.py
@@ -91,13 +91,6 @@ class BlockVectorArray(VectorArrayInterface):
         for block in self._blocks:
             block.remove(ind)
 
-    def replace(self, other, ind=None, o_ind=None, remove_from_other=False):
-        assert other in self.space
-        assert self.check_ind(ind)
-        assert other.check_ind(o_ind)
-        for block, o_block in zip(self._blocks, other._blocks):
-            block.replace(o_block, ind=ind, o_ind=o_ind, remove_from_other=remove_from_other)
-
     def scal(self, alpha, ind=None):
         for block in self._blocks:
             block.scal(alpha, ind=ind)

--- a/src/pymor/vectorarrays/interfaces.py
+++ b/src/pymor/vectorarrays/interfaces.py
@@ -200,28 +200,6 @@ class VectorArrayInterface(BasicInterface):
         pass
 
     @abstractmethod
-    def replace(self, other, ind=None, o_ind=None, remove_from_other=False):
-        """Replace vectors of the array.
-
-        Parameters
-        ----------
-        other
-            A |VectorArray| containing the replacement vectors.
-        ind
-            Indices of the vectors that are to be replaced (see class documentation).
-            Repeated indices are forbidden.
-        o_ind
-            Indices of the replacement vectors (see class documentation).
-            `len(ind)` has to agree with `len(o_ind)`.
-            Repeated indices are allowed.
-        remove_from_other
-            If `True`, the new vectors are removed from `other`.
-            For list-like implementations this can be used to prevent
-            unnecessary copies of the involved vectors.
-        """
-        pass
-
-    @abstractmethod
     def scal(self, alpha, ind=None):
         """BLAS SCAL operation (in-place scalar multiplication).
 

--- a/src/pymor/vectorarrays/list.py
+++ b/src/pymor/vectorarrays/list.py
@@ -349,56 +349,6 @@ class ListVectorArray(VectorArrayInterface):
             remaining = sorted(set(range(len(self))) - set(ind))
             self._list = [thelist[i] for i in remaining]
 
-    def replace(self, other, ind=None, o_ind=None, remove_from_other=False):
-        assert self.check_ind_unique(ind)
-        assert other.check_ind(o_ind)
-        assert other.space == self.space
-        assert other is not self or not remove_from_other
-
-        if ind is None:
-            c = self.empty()
-            c.append(other, o_ind=o_ind, remove_from_other=remove_from_other)
-            assert len(c) == len(self)
-            self._list = c._list
-        elif isinstance(ind, Number):
-            if o_ind is None:
-                assert len(other._list) == 1
-                if not remove_from_other:
-                    self._list[ind] = other._list[0].copy()
-                else:
-                    self._list[ind] = other._list.pop()
-            else:
-                if not isinstance(o_ind, Number):
-                    assert len(o_ind) == 1
-                    o_ind = o_ind[0]
-                if not remove_from_other:
-                    self._list[ind] = other._list[o_ind].copy()
-                else:
-                    self._list[ind] = other._list.pop(o_ind)
-        else:
-            if isinstance(o_ind, Number):
-                assert len(ind) == 1
-                if not remove_from_other:
-                    self._list[ind[0]] = other._list[o_ind].copy()
-                else:
-                    self._list[ind[0]] = other._list.pop(o_ind)
-            else:
-                o_ind = range(len(other)) if o_ind is None else o_ind
-                assert len(ind) == len(o_ind)
-                if not remove_from_other:
-                    l = self._list
-                    # if other is self, we have to make a copy of our list, to prevent
-                    # messing things up, e.g. when swapping vectors
-                    other_list = list(l) if other is self else other._list
-                    for i, oi in zip(ind, o_ind):
-                        l[i] = other_list[oi].copy()
-                else:
-                    for i, oi in zip(ind, o_ind):
-                        self._list[i] = other._list[oi]
-                    other_list = other._list
-                    remaining = sorted(set(range(len(other_list))) - set(o_ind))
-                    other._list = [other_list[i] for i in remaining]
-
     def scal(self, alpha, ind=None):
         assert self.check_ind_unique(ind)
         assert isinstance(alpha, Number) \

--- a/src/pymor/vectorarrays/mpi.py
+++ b/src/pymor/vectorarrays/mpi.py
@@ -90,10 +90,6 @@ class MPIVectorArray(VectorArrayInterface):
     def remove(self, ind=None):
         mpi.call(mpi.method_call, self.obj_id, 'remove', ind=ind)
 
-    def replace(self, other, ind=None, o_ind=None, remove_from_other=False):
-        mpi.call(mpi.method_call, self.obj_id, 'replace', other.obj_id,
-                 ind=ind, o_ind=o_ind, remove_from_other=remove_from_other)
-
     def scal(self, alpha, ind=None):
         mpi.call(mpi.method_call, self.obj_id, 'scal', alpha, ind=ind)
 

--- a/src/pymor/vectorarrays/numpy.py
+++ b/src/pymor/vectorarrays/numpy.py
@@ -181,52 +181,6 @@ class NumpyVectorArray(VectorArrayInterface):
         if not self._array.flags['OWNDATA']:
             self._array = self._array.copy()
 
-    def replace(self, other, ind=None, o_ind=None, remove_from_other=False):
-        assert self.check_ind_unique(ind)
-        assert other.check_ind(o_ind)
-        assert self.dim == other.dim
-        assert other is not self or not remove_from_other
-
-        if self._refcount[0] > 1:
-            self._deep_copy()
-        if remove_from_other and other._refcount[0] > 1:
-            other._deep_copy()
-
-        if NUMPY_INDEX_QUIRK:
-            if self._len == 0 and hasattr(ind, '__len__'):
-                ind = None
-            if other._len == 0 and hasattr(o_ind, '__len__'):
-                o_ind = None
-
-        if ind is None:
-            if o_ind is None:
-                if other is self:
-                    return
-                assert other._len == self._len
-                self._array = other._array[:other._len].copy()
-            else:
-                if not hasattr(o_ind, '__len__'):
-                    o_ind = [o_ind]
-                assert self._len == len(o_ind)
-                self._array = other._array[o_ind]
-            self._len = self._array.shape[0]
-        else:
-            len_ind = self.len_ind(ind)
-            other_array = np.array(self._array) if other is self else other._array
-            if self._array.dtype != other._array.dtype:
-                self._array = self._array.astype(np.promote_types(self._array.dtype, other._array.dtype))
-            if o_ind is None:
-                assert len_ind == other._len
-                self._array[ind] = other_array[:other._len]
-            else:
-                len_oind = other.len_ind(o_ind)
-                assert len_ind == len_oind
-                self._array[ind] = other_array[o_ind]
-        assert self._array.flags['OWNDATA']
-
-        if remove_from_other:
-            other.remove(o_ind)
-
     def scal(self, alpha, ind=None):
         assert self.check_ind_unique(ind)
         assert isinstance(alpha, _INDEXTYPES) \

--- a/src/pymortests/complex_values.py
+++ b/src/pymortests/complex_values.py
@@ -47,17 +47,6 @@ def test_complex():
             va.append(Dva, o_ind)
             assert np.iscomplexobj(va.data)
 
-    # replace
-    va = NumpyVectorArray.make_array(subtype=5, reserve=0)
-    va.append(Cva)
-    D = np.random.randn(1, 5) + 1j * np.random.randn(1, 5)
-    Dva = NumpyVectorArray(D)
-
-    assert not np.iscomplexobj(va.data)
-    assert np.iscomplexobj(Dva.data)
-    va.replace(Dva, 1, 0)
-    assert np.iscomplexobj(va.data)
-
     # scal
     assert not np.iscomplexobj(Cva.data)
     assert np.iscomplexobj((Cva * 1j).data)

--- a/src/pymortests/vectorarray.py
+++ b/src/pymortests/vectorarray.py
@@ -274,88 +274,6 @@ def test_remove(vector_array):
         assert len(c) == 0
 
 
-def test_replace(compatible_vector_array_pair):
-    v1, v2 = compatible_vector_array_pair
-    len_v1, len_v2 = len(v1), len(v2)
-    if hasattr(v1, 'data'):
-        dv1 = v1.data
-        dv2 = v2.data
-    for ind1, ind2 in valid_inds_of_same_length(v1, v2):
-        if v1.len_ind(ind1) != v1.len_ind_unique(ind1):
-            with pytest.raises(Exception):
-                c1, c2 = v1.copy(), v2.copy()
-                c1.replace(c2, ind=ind1, o_ind=ind2, remove_from_other=False)
-            with pytest.raises(Exception):
-                c1, c2 = v1.copy(), v2.copy()
-                c1.replace(c2, ind=ind1, o_ind=ind2, remove_from_other=True)
-            continue
-        c1, c2 = v1.copy(), v2.copy()
-        c1.replace(c2, ind=ind1, o_ind=ind2, remove_from_other=False)
-        assert len(c1) == len(v1)
-        assert c1.dim == v1.dim
-        assert c1.subtype == v1.subtype
-        assert np.all(almost_equal(c1, v2, U_ind=ind1, V_ind=ind2))
-        assert np.all(almost_equal(c2, v2))
-        if hasattr(v1, 'data'):
-            x = dv1.copy()
-            if NUMPY_INDEX_QUIRK and len(x) == 0 and hasattr(ind1, '__len__') and len(ind1) == 0:
-                pass
-            else:
-                x[ind1] = indexed(dv2, ind2)
-            assert np.allclose(c1.data, x)
-
-        c1, c2 = v1.copy(), v2.copy()
-        c1.replace(c2, ind=ind1, o_ind=ind2, remove_from_other=True)
-        assert len(c1) == len(v1)
-        assert c1.dim == v1.dim
-        assert c1.subtype == v1.subtype
-        ind2_complement = ind_complement(v2, ind2)
-        assert np.all(almost_equal(c1, v2, U_ind=ind1, V_ind=ind2))
-        assert len(c2) == len(ind2_complement)
-        assert np.all(almost_equal(c2, v2, V_ind=ind2_complement))
-        if hasattr(v1, 'data'):
-            x = dv1.copy()
-            if NUMPY_INDEX_QUIRK and len(x) == 0 and hasattr(ind1, '__len__') and len(ind1) == 0:
-                pass
-            else:
-                x[ind1] = indexed(dv2, ind2)
-            assert np.allclose(c1.data, x)
-            assert np.allclose(c2.data, indexed(dv2, ind2_complement))
-
-
-def test_replace_self(vector_array):
-    v = vector_array
-    if hasattr(v, 'data'):
-        dv = v.data
-    for ind1, ind2 in valid_inds_of_same_length(v, v):
-        if v.len_ind(ind1) != v.len_ind_unique(ind1):
-            c = v.copy()
-            with pytest.raises(Exception):
-                c.replace(c, ind=ind1, o_ind=ind2, remove_from_other=False)
-            c = v.copy()
-            with pytest.raises(Exception):
-                c.replace(c, ind=ind1, o_ind=ind2, remove_from_other=True)
-            continue
-
-        c = v.copy()
-        with pytest.raises(Exception):
-            c.replace(c, ind=ind1, o_ind=ind2, remove_from_other=True)
-
-        c = v.copy()
-        c.replace(c, ind=ind1, o_ind=ind2, remove_from_other=False)
-        assert len(c) == len(v)
-        assert c.dim == v.dim
-        assert c.subtype == v.subtype
-        assert np.all(almost_equal(c, v, U_ind=ind1, V_ind=ind2))
-        if hasattr(v, 'data'):
-            x = dv.copy()
-            if NUMPY_INDEX_QUIRK and len(x) == 0 and hasattr(ind1, '__len__') and len(ind1) == 0:
-                pass
-            else:
-                x[ind1] = indexed(dv, ind2)
-            assert np.allclose(c.data, x)
-
-
 def test_scal(vector_array):
     v = vector_array
     if hasattr(v, 'data'):
@@ -940,17 +858,6 @@ def test_append_incompatible(incompatible_vector_array_pair):
         c1.append(c2, ind=0)
 
 
-def test_replace_incompatible(incompatible_vector_array_pair):
-    v1, v2 = incompatible_vector_array_pair
-    for ind1, ind2 in valid_inds_of_same_length(v1, v2):
-        c1, c2 = v1.copy(), v2.copy()
-        with pytest.raises(Exception):
-            c1.replace(c2, ind=ind1, o_ind=ind2, remove_from_other=False)
-        c1, c2 = v1.copy(), v2.copy()
-        with pytest.raises(Exception):
-            c1.replace(c2, ind=ind1, o_ind=ind2, remove_from_other=True)
-
-
 def test_axpy_incompatible(incompatible_vector_array_pair):
     v1, v2 = incompatible_vector_array_pair
     for ind1, ind2 in valid_inds_of_same_length(v1, v2):
@@ -1032,17 +939,6 @@ def test_remove_wrong_ind(vector_array):
         c = v.copy()
         with pytest.raises(Exception):
             c.remove(ind)
-
-
-def test_replace_wrong_ind(compatible_vector_array_pair):
-    v1, v2 = compatible_vector_array_pair
-    for ind1, ind2 in invalid_ind_pairs(v1, v2):
-        c1, c2 = v1.copy(), v2.copy()
-        with pytest.raises(Exception):
-            c1.replace(c2, ind=ind1, o_ind=ind2, remove_from_other=False)
-        c1, c2 = v1.copy(), v2.copy()
-        with pytest.raises(Exception):
-            c1.replace(c2, ind=ind1, o_ind=ind2, remove_from_other=True)
 
 
 def test_scal_wrong_ind(vector_array):


### PR DESCRIPTION
and its implementations. See #261