### PR TITLE
[iosys] use caching in discretizations

### DIFF
--- a/src/pymor/discretizations/iosys.py
+++ b/src/pymor/discretizations/iosys.py
@@ -12,6 +12,7 @@ import scipy.sparse as sps
 from pymor.algorithms.lyapunov import solve_lyap
 from pymor.algorithms.riccati import solve_ricc
 from pymor.algorithms.to_matrix import to_matrix
+from pymor.core.cache import cached
 from pymor.discretizations.interfaces import DiscretizationInterface
 from pymor.operators.block import BlockOperator, BlockDiagonalOperator
 from pymor.operators.constructions import Concatenation, IdentityOperator, LincombOperator, ZeroOperator
@@ -24,8 +25,8 @@ from pymor.vectorarrays.numpy import NumpyVectorArray
 class InputOutputSystem(DiscretizationInterface):
     """Base class for input-output systems."""
 
-    def __init__(self, m, p, ss_operators, is_operators, so_operators, io_operators, cont_time=True, cache_region=None,
-                 name=None):
+    def __init__(self, m, p, ss_operators, is_operators, so_operators, io_operators, cont_time=True,
+                 cache_region='memory', name=None):
         self.m = m
         self.p = p
         self.ss_operators = FrozenDict(ss_operators)
@@ -35,16 +36,6 @@ class InputOutputSystem(DiscretizationInterface):
         self.cont_time = cont_time
         self.enable_caching(cache_region)
         self.name = name
-        self._poles = None
-        self._w = None
-        self._tfw = None
-        self._gramian = {}
-        self._sv = {}
-        self._U = {}
-        self._V = {}
-        self._H2_norm = None
-        self._Hinf_norm = None
-        self._fpeak = None
 
     def _solve(self, mu=None):
         raise NotImplementedError
@@ -88,6 +79,7 @@ class InputOutputSystem(DiscretizationInterface):
         """Evaluate the derivative of the transfer function of the system."""
         raise NotImplementedError
 
+    @cached
     def bode(self, w):
         """Evaluate the transfer function on the imaginary axis.
 
@@ -105,9 +97,7 @@ class InputOutputSystem(DiscretizationInterface):
         if not self.cont_time:
             raise NotImplementedError
 
-        self._w = w
-        self._tfw = np.dstack([self.eval_tf(1j * wi) for wi in w])
-        return self._tfw.copy()
+        return np.dstack([self.eval_tf(1j * wi) for wi in w])
 
     @classmethod
     def mag_plot(cls, sys_list, plot_style_list=None, w=None, ord=None, dB=False, Hz=False):
@@ -123,8 +113,6 @@ class InputOutputSystem(DiscretizationInterface):
             If `None`, matplotlib defaults are used.
         w
             Frequencies at which to compute the transfer function.
-
-            If `None`, use `self._w`.
         ord
             The order of the norm used to compute the magnitude (the default is
             the Frobenius norm).
@@ -150,17 +138,12 @@ class InputOutputSystem(DiscretizationInterface):
         if isinstance(plot_style_list, str):
             plot_style_list = (plot_style_list,)
 
-        assert w is not None or all(sys._w is not None for sys in sys_list)
-
-        if w is not None:
-            for sys in sys_list:
-                sys.bode(w)
-
         import matplotlib.pyplot as plt
         fig, ax = plt.subplots()
         for i, sys in enumerate(sys_list):
-            freq = sys._w / (2 * np.pi) if Hz else sys._w
-            mag = spla.norm(sys._tfw, ord=ord, axis=(0, 1))
+            tfw = sys.bode(w)
+            freq = w / (2 * np.pi) if Hz else w
+            mag = spla.norm(tfw, ord=ord, axis=(0, 1))
             style = '' if plot_style_list is None else plot_style_list[i]
             if dB:
                 mag = 20 * np.log2(mag)
@@ -448,12 +431,12 @@ class LTISystem(InputOutputSystem):
 
         return self.__class__(A, B, C, D, E, cont_time=self.cont_time)
 
-    def compute_poles(self):
+    @cached
+    def poles(self):
         """Compute system poles."""
-        if self._poles is None:
-            A = to_matrix(self.A)
-            E = None if isinstance(self.E, IdentityOperator) else to_matrix(self.E)
-            self._poles = spla.eigvals(A, E)
+        A = to_matrix(self.A)
+        E = None if isinstance(self.E, IdentityOperator) else to_matrix(self.E)
+        return spla.eigvals(A, E)
 
     def eval_tf(self, s):
         """Evaluate the transfer function.
@@ -536,7 +519,8 @@ class LTISystem(InputOutputSystem):
                 C.apply_adjoint(I_p))))).data.conj()
         return dtfs
 
-    def compute_gramian(self, typ, subtyp, me_solver=None, tol=None):
+    @cached
+    def gramian(self, typ, subtyp, me_solver=None, tol=None):
         """Compute a Gramian.
 
         Parameters
@@ -569,68 +553,62 @@ class LTISystem(InputOutputSystem):
         if not self.cont_time:
             raise NotImplementedError
 
-        if typ not in self._gramian or subtyp not in self._gramian[typ] or tol is not None:
-            A = self.A
-            B = self.B
-            C = self.C
-            E = self.E if not isinstance(self.E, IdentityOperator) else None
-            if typ == 'lyap':
-                self._gramian.setdefault(typ, {})
-                if subtyp == 'cf':
-                    self._gramian[typ][subtyp] = solve_lyap(A, E, B, trans=False, me_solver=me_solver, tol=tol)
-                elif subtyp == 'of':
-                    self._gramian[typ][subtyp] = solve_lyap(A, E, C, trans=True, me_solver=me_solver, tol=tol)
-                else:
-                    raise NotImplementedError("Only 'cf' and 'of' subtypes are possible for 'lyap' type.")
-            elif typ == 'lqg':
-                self._gramian.setdefault(typ, {})
-                if subtyp == 'cf':
-                    self._gramian[typ][subtyp] = solve_ricc(A, E=E, B=B, C=C, trans=True, me_solver=me_solver, tol=tol)
-                elif subtyp == 'of':
-                    self._gramian[typ][subtyp] = solve_ricc(A, E=E, B=B, C=C, trans=False, me_solver=me_solver, tol=tol)
-                else:
-                    raise NotImplementedError("Only 'cf' and 'of' subtypes are possible for 'lqg' type.")
-            elif isinstance(typ, tuple) and typ[0] == 'br':
-                assert isinstance(typ[1], float)
-                assert typ[1] > 0
-                self._gramian.setdefault(typ, {})
-                c = 1 / np.sqrt(typ[1])
-                if subtyp == 'cf':
-                    self._gramian[typ][subtyp] = solve_ricc(A, E=E, B=B * c, C=C * c,
-                                                            R=IdentityOperator(C.range) * (-1),
-                                                            trans=True, me_solver=me_solver, tol=tol)
-                elif subtyp == 'of':
-                    self._gramian[typ][subtyp] = solve_ricc(A, E=E, B=B * c, C=C * c,
-                                                            R=IdentityOperator(B.source) * (-1),
-                                                            trans=False, me_solver=me_solver, tol=tol)
-                else:
-                    raise NotImplementedError("Only 'cf' and 'of' subtypes are possible for ('br', gamma) type.")
-            else:
-                raise NotImplementedError("Only 'lyap', 'lqg', and ('br', gamma) types are available.")
+        A = self.A
+        B = self.B
+        C = self.C
+        E = self.E if not isinstance(self.E, IdentityOperator) else None
 
-    def compute_sv_U_V(self, typ, me_solver=None):
+        if typ == 'lyap':
+            if subtyp == 'cf':
+                return solve_lyap(A, E, B, trans=False, me_solver=me_solver, tol=tol)
+            elif subtyp == 'of':
+                return solve_lyap(A, E, C, trans=True, me_solver=me_solver, tol=tol)
+            else:
+                raise NotImplementedError("Only 'cf' and 'of' subtypes are possible for 'lyap' type.")
+        elif typ == 'lqg':
+            if subtyp == 'cf':
+                return solve_ricc(A, E=E, B=B, C=C, trans=True, me_solver=me_solver, tol=tol)
+            elif subtyp == 'of':
+                return solve_ricc(A, E=E, B=B, C=C, trans=False, me_solver=me_solver, tol=tol)
+            else:
+                raise NotImplementedError("Only 'cf' and 'of' subtypes are possible for 'lqg' type.")
+        elif isinstance(typ, tuple) and typ[0] == 'br':
+            assert isinstance(typ[1], float)
+            assert typ[1] > 0
+            c = 1 / np.sqrt(typ[1])
+            if subtyp == 'cf':
+                return solve_ricc(A, E=E, B=B * c, C=C * c, R=IdentityOperator(C.range) * (-1),
+                                  trans=True, me_solver=me_solver, tol=tol)
+            elif subtyp == 'of':
+                return solve_ricc(A, E=E, B=B * c, C=C * c, R=IdentityOperator(B.source) * (-1),
+                                  trans=False, me_solver=me_solver, tol=tol)
+            else:
+                raise NotImplementedError("Only 'cf' and 'of' subtypes are possible for ('br', gamma) type.")
+        else:
+            raise NotImplementedError("Only 'lyap', 'lqg', and ('br', gamma) types are available.")
+
+    @cached
+    def sv_U_V(self, typ, me_solver=None):
         """Compute singular values and vectors.
 
         Parameters
         ----------
         typ
             The type of the Gramian (see
-            :func:`~pymor.discretizations.iosys.LTISystem.compute_gramian`).
+            :func:`~pymor.discretizations.iosys.LTISystem.gramian`).
         me_solver
             The matrix equation solver to use (see
             :func:`pymor.algorithms.lyapunov.solve_lyap` or
             :func:`pymor.algorithms.riccati.solve_ricc`).
         """
-        if typ not in self._sv or typ not in self._U or typ not in self._V:
-            self.compute_gramian(typ, 'cf', me_solver=me_solver)
-            self.compute_gramian(typ, 'of', me_solver=me_solver)
+        cf = self.gramian(typ, 'cf', me_solver=me_solver)
+        of = self.gramian(typ, 'of', me_solver=me_solver)
 
-            U, self._sv[typ], Vh = spla.svd(self.E.apply2(self._gramian[typ]['of'], self._gramian[typ]['cf']))
+        U, sv, Vh = spla.svd(self.E.apply2(of, cf))
+        return sv, NumpyVectorArray(U.T), NumpyVectorArray(Vh)
 
-            self._U[typ] = NumpyVectorArray(U.T)
-            self._V[typ] = NumpyVectorArray(Vh)
-
-    def norm(self, name='H2'):
+    @cached
+    def norm(self, name='H2', me_solver=None):
         """Compute a norm of the |LTISystem|.
 
         Parameters
@@ -639,27 +617,16 @@ class LTISystem(InputOutputSystem):
             The name of the norm (`'H2'`, `'Hinf'`, `'Hankel'`).
         """
         if name == 'H2':
-            if self._H2_norm is not None:
-                return self._H2_norm
-
             B, C = self.B, self.C
 
-            if 'lyap' in self._gramian and 'cf' in self._gramian['lyap']:
-                self._H2_norm = np.sqrt(C.apply(self._gramian['lyap']['cf']).l2_norm2().sum())
-            elif 'lyap' in self._gramian and 'of' in self._gramian['lyap']:
-                self._H2_norm = np.sqrt(B.apply_adjoint(self._gramian['lyap']['of']).l2_norm2().sum())
-            elif self.m <= self.p:
-                self.compute_gramian('lyap', 'cf')
-                self._H2_norm = np.sqrt(C.apply(self._gramian['lyap']['cf']).l2_norm2().sum())
+            if self.m <= self.p:
+                cf = self.gramian('lyap', 'cf')
+                return np.sqrt(C.apply(cf).l2_norm2().sum())
             else:
-                self.compute_gramian('lyap', 'of')
-                self._H2_norm = np.sqrt(B.apply_adjoint(self._gramian['lyap']['of']).l2_norm2().sum())
+                of = self.gramian('lyap', 'of')
+                return np.sqrt(B.apply_adjoint(of).l2_norm2().sum())
 
-            return self._H2_norm
         elif name == 'Hinf':
-            if self._Hinf_norm is not None:
-                return self._Hinf_norm
-
             from slycot import ab13dd
             dico = 'C' if self.cont_time else 'D'
             jobe = 'I' if isinstance(self.E, IdentityOperator) else 'G'
@@ -667,12 +634,9 @@ class LTISystem(InputOutputSystem):
             jobd = 'Z' if isinstance(self.D, ZeroOperator) else 'D'
             A, B, C, D, E = map(to_matrix, (self.A, self.B, self.C,
                                             self.D, self.E))
-            self._Hinf_norm, self._fpeak = ab13dd(dico, jobe, equil, jobd, self.n, self.m, self.p, A, E, B, C, D)
-
-            return self._Hinf_norm
+            return ab13dd(dico, jobe, equil, jobd, self.n, self.m, self.p, A, E, B, C, D)
         elif name == 'Hankel':
-            self.compute_sv_U_V('lyap')
-            return self._sv['lyap'][0]
+            return self.sv_U_V('lyap', me_solver)[0]
         else:
             raise NotImplementedError('Only H2, Hinf, and Hankel norms are implemented.')
 

--- a/src/pymor/discretizations/iosys.py
+++ b/src/pymor/discretizations/iosys.py
@@ -626,7 +626,7 @@ class LTISystem(InputOutputSystem):
                 of = self.gramian('lyap', 'of', me_solver=me_solver)
                 return np.sqrt(B.apply_adjoint(of).l2_norm2().sum())
 
-        elif name == 'Hinf' or name == 'Hinf_fpeak':
+        elif name == 'Hinf_fpeak':
             from slycot import ab13dd
             dico = 'C' if self.cont_time else 'D'
             jobe = 'I' if isinstance(self.E, IdentityOperator) else 'G'
@@ -634,10 +634,9 @@ class LTISystem(InputOutputSystem):
             jobd = 'Z' if isinstance(self.D, ZeroOperator) else 'D'
             A, B, C, D, E = map(to_matrix, (self.A, self.B, self.C, self.D, self.E))
             Hinf, fpeak = ab13dd(dico, jobe, equil, jobd, self.n, self.m, self.p, A, E, B, C, D)
-            if name == 'Hinf':
-                return Hinf
-            else:
-                return Hinf, fpeak
+            return Hinf, fpeak
+        elif name == 'Hinf':
+            return self.norm('Hinf_fpeak', me_solver=me_solver)[0]
         elif name == 'Hankel':
             return self.sv_U_V('lyap', me_solver=me_solver)[0][0]
         else:

--- a/src/pymor/discretizations/iosys.py
+++ b/src/pymor/discretizations/iosys.py
@@ -226,7 +226,7 @@ class LTISystem(InputOutputSystem):
     linear = True
 
     def __init__(self, A=None, B=None, C=None, D=None, E=None, ss_operators=None, is_operators=None,
-                 so_operators=None, io_operators=None, cont_time=True, cache_region=None, name=None):
+                 so_operators=None, io_operators=None, cont_time=True, cache_region='memory', name=None):
         ss_operators = ss_operators or {}
         is_operators = is_operators or {}
         so_operators = so_operators or {}
@@ -679,7 +679,7 @@ class TF(InputOutputSystem):
     """
     linear = True
 
-    def __init__(self, m, p, H, dH, cont_time=True, cache_region=None, name=None):
+    def __init__(self, m, p, H, dH, cont_time=True, cache_region='memory', name=None):
         assert cont_time in (True, False)
 
         self.tf = H
@@ -761,7 +761,7 @@ class SecondOrderSystem(InputOutputSystem):
     linear = True
 
     def __init__(self, M=None, D=None, K=None, B=None, Cp=None, Cv=None, ss_operators=None, is_operators=None,
-                 so_operators=None, io_operators=None, cont_time=True, cache_region=None, name=None):
+                 so_operators=None, io_operators=None, cont_time=True, cache_region='memory', name=None):
         ss_operators = ss_operators or {}
         is_operators = is_operators or {}
         so_operators = so_operators or {}
@@ -977,7 +977,7 @@ class LinearDelaySystem(InputOutputSystem):
     linear = True
 
     def __init__(self, E=None, A=None, Ad=None, tau=None, B=None, C=None, ss_operators=None, is_operators=None,
-                 so_operators=None, io_operators=None, cont_time=True, cache_region=None, name=None):
+                 so_operators=None, io_operators=None, cont_time=True, cache_region='memory', name=None):
         ss_operators = ss_operators or {}
         is_operators = is_operators or {}
         so_operators = so_operators or {}
@@ -1188,7 +1188,7 @@ class LinearStochasticSystem(InputOutputSystem):
     linear = True
 
     def __init__(self, E=None, A=None, As=None, tau=None, B=None, C=None, ss_operators=None, is_operators=None,
-                 so_operators=None, io_operators=None, cont_time=True, cache_region=None, name=None):
+                 so_operators=None, io_operators=None, cont_time=True, cache_region='memory', name=None):
         ss_operators = ss_operators or {}
         is_operators = is_operators or {}
         so_operators = so_operators or {}
@@ -1314,7 +1314,7 @@ class BilinearSystem(InputOutputSystem):
     linear = False
 
     def __init__(self, E=None, A=None, N=None, B=None, C=None, ss_operators=None, is_operators=None,
-                 so_operators=None, io_operators=None, cont_time=True, cache_region=None, name=None):
+                 so_operators=None, io_operators=None, cont_time=True, cache_region='memory', name=None):
         ss_operators = ss_operators or {}
         is_operators = is_operators or {}
         so_operators = so_operators or {}

--- a/src/pymor/reductors/bt.py
+++ b/src/pymor/reductors/bt.py
@@ -74,7 +74,7 @@ def bt(discretization, r=None, tol=None, typ='lyap', me_solver=None, method='bfs
         bounds = np.zeros((discretization.n,))
         sv_reverse = np.zeros((discretization.n,))
         sv_reverse[:len(sv)] = sv
-        sv_reverse[len(sv):] = sv[typ][-1]
+        sv_reverse[len(sv):] = sv[-1]
         sv_reverse = sv_reverse[-1:0:-1]
         if typ == 'lyap':
             bounds[:-1] = 2 * sv_reverse.cumsum()[::-1]

--- a/src/pymordemos/heat.py
+++ b/src/pymordemos/heat.py
@@ -84,16 +84,16 @@ if __name__ == '__main__':
 
     # Norms of the system
     print('H_2-norm of the full model:   {}'.format(lti.norm()))
-    print('H_inf-norm of the full model: {}'.format(lti.norm('Hinf')[0]))
+    print('H_inf-norm of the full model: {}'.format(lti.norm('Hinf')))
 
     # Balanced Truncation
     r = 5
-    rom_bt, _, _ = bt(lti, r)
+    rom_bt, _, _ = bt(lti, r, tol=1e-5)
     print('H_2-norm of the BT ROM:       {}'.format(rom_bt.norm()))
-    print('H_inf-norm of the BT ROM:     {}'.format(rom_bt.norm('Hinf')[0]))
+    print('H_inf-norm of the BT ROM:     {}'.format(rom_bt.norm('Hinf')))
     err_bt = lti - rom_bt
     print('H_2-error for the BT ROM:     {}'.format(err_bt.norm()))
-    print('H_inf-error for the BT ROM:   {}'.format(err_bt.norm('Hinf')[0]))
+    print('H_inf-error for the BT ROM:   {}'.format(err_bt.norm('Hinf')))
 
     # Bode plot of the full and BT reduced model
     fig, ax = LTISystem.mag_plot((lti, rom_bt), w=w)
@@ -118,10 +118,10 @@ if __name__ == '__main__':
     plt.show()
 
     print('H_2-norm of the IRKA ROM:     {}'.format(rom_irka.norm()))
-    print('H_inf-norm of the IRKA ROM:   {}'.format(rom_irka.norm('Hinf')[0]))
+    print('H_inf-norm of the IRKA ROM:   {}'.format(rom_irka.norm('Hinf')))
     err_irka = lti - rom_irka
     print('H_2-error for the IRKA ROM:   {}'.format(err_irka.norm()))
-    print('H_inf-error for the IRKA ROM: {}'.format(err_irka.norm('Hinf')[0]))
+    print('H_inf-error for the IRKA ROM: {}'.format(err_irka.norm('Hinf')))
 
     # Bode plot of the full and IRKA reduced model
     fig, ax = LTISystem.mag_plot((lti, rom_irka), w=w)

--- a/src/pymordemos/heat.py
+++ b/src/pymordemos/heat.py
@@ -63,8 +63,7 @@ if __name__ == '__main__':
     print('p = {}'.format(lti.p))
 
     # System poles
-    lti.compute_poles()
-    poles = lti._poles
+    poles = lti.poles()
     fig, ax = plt.subplots()
     ax.plot(poles.real, poles.imag, '.')
     ax.set_title('System poles')
@@ -72,40 +71,37 @@ if __name__ == '__main__':
 
     # Bode plot of the full model
     w = np.logspace(-2, 3, 100)
-    lti.bode(w)
-    fig, ax = LTISystem.mag_plot(lti)
+    fig, ax = LTISystem.mag_plot(lti, w=w)
     ax.set_title('Bode plot of the full model')
     plt.show()
 
     # Hankel singular values
-    lti.compute_sv_U_V('lyap')
+    sv = lti.sv_U_V('lyap')[0]
     fig, ax = plt.subplots()
-    ax.semilogy(range(1, len(lti._sv['lyap']) + 1), lti._sv['lyap'], '.-')
+    ax.semilogy(range(1, len(sv) + 1), sv, '.-')
     ax.set_title('Hankel singular values')
     plt.show()
 
     # Norms of the system
     print('H_2-norm of the full model:   {}'.format(lti.norm()))
-    print('H_inf-norm of the full model: {}'.format(lti.norm('Hinf')))
+    print('H_inf-norm of the full model: {}'.format(lti.norm('Hinf')[0]))
 
     # Balanced Truncation
     r = 5
     rom_bt, _, _ = bt(lti, r)
     print('H_2-norm of the BT ROM:       {}'.format(rom_bt.norm()))
-    print('H_inf-norm of the BT ROM:     {}'.format(rom_bt.norm('Hinf')))
+    print('H_inf-norm of the BT ROM:     {}'.format(rom_bt.norm('Hinf')[0]))
     err_bt = lti - rom_bt
     print('H_2-error for the BT ROM:     {}'.format(err_bt.norm()))
-    print('H_inf-error for the BT ROM:   {}'.format(err_bt.norm('Hinf')))
+    print('H_inf-error for the BT ROM:   {}'.format(err_bt.norm('Hinf')[0]))
 
     # Bode plot of the full and BT reduced model
-    rom_bt.bode(w)
-    fig, ax = LTISystem.mag_plot((lti, rom_bt))
+    fig, ax = LTISystem.mag_plot((lti, rom_bt), w=w)
     ax.set_title('Bode plot of the full and BT reduced model')
     plt.show()
 
     # Bode plot of the BT error system
-    err_bt.bode(w)
-    fig, ax = LTISystem.mag_plot(err_bt)
+    fig, ax = LTISystem.mag_plot(err_bt, w=w)
     ax.set_title('Bode plot of the BT error system')
     plt.show()
 
@@ -122,19 +118,17 @@ if __name__ == '__main__':
     plt.show()
 
     print('H_2-norm of the IRKA ROM:     {}'.format(rom_irka.norm()))
-    print('H_inf-norm of the IRKA ROM:   {}'.format(rom_irka.norm('Hinf')))
+    print('H_inf-norm of the IRKA ROM:   {}'.format(rom_irka.norm('Hinf')[0]))
     err_irka = lti - rom_irka
     print('H_2-error for the IRKA ROM:   {}'.format(err_irka.norm()))
-    print('H_inf-error for the IRKA ROM: {}'.format(err_irka.norm('Hinf')))
+    print('H_inf-error for the IRKA ROM: {}'.format(err_irka.norm('Hinf')[0]))
 
     # Bode plot of the full and IRKA reduced model
-    rom_irka.bode(w)
-    fig, ax = LTISystem.mag_plot((lti, rom_irka))
+    fig, ax = LTISystem.mag_plot((lti, rom_irka), w=w)
     ax.set_title('Bode plot of the full and IRKA reduced model')
     plt.show()
 
     # Bode plot of the IRKA error system
-    err_irka.bode(w)
-    fig, ax = LTISystem.mag_plot(err_irka)
+    fig, ax = LTISystem.mag_plot(err_irka, w=w)
     ax.set_title('Bode plot of the IRKA error system')
     plt.show()

--- a/src/pymorexamples/heat.ipynb
+++ b/src/pymorexamples/heat.ipynb
@@ -225,7 +225,7 @@
    "outputs": [],
    "source": [
     "print('H_2-norm of the full model:   {}'.format(lti.norm()))\n",
-    "print('H_inf-norm of the full model: {}'.format(lti.norm('Hinf')[0]))"
+    "print('H_inf-norm of the full model: {}'.format(lti.norm('Hinf')))"
    ]
   },
   {
@@ -244,7 +244,7 @@
    "outputs": [],
    "source": [
     "r = 5\n",
-    "rom_bt, _, _ = bt(lti, r)"
+    "rom_bt, _, _ = bt(lti, r, tol=1e-5)"
    ]
   },
   {
@@ -256,10 +256,10 @@
    "outputs": [],
    "source": [
     "print('H_2-norm of the BT ROM:       {}'.format(rom_bt.norm()))\n",
-    "print('H_inf-norm of the BT ROM:     {}'.format(rom_bt.norm('Hinf')[0]))\n",
+    "print('H_inf-norm of the BT ROM:     {}'.format(rom_bt.norm('Hinf')))\n",
     "err_bt = lti - rom_bt\n",
     "print('H_2-error for the BT ROM:     {}'.format(err_bt.norm()))\n",
-    "print('H_inf-error for the BT ROM:   {}'.format(err_bt.norm('Hinf')[0]))"
+    "print('H_inf-error for the BT ROM:   {}'.format(err_bt.norm('Hinf')))"
    ]
   },
   {
@@ -346,10 +346,10 @@
    "outputs": [],
    "source": [
     "print('H_2-norm of the IRKA ROM:     {}'.format(rom_irka.norm()))\n",
-    "print('H_inf-norm of the IRKA ROM:   {}'.format(rom_irka.norm('Hinf')[0]))\n",
+    "print('H_inf-norm of the IRKA ROM:   {}'.format(rom_irka.norm('Hinf')))\n",
     "err_irka = lti - rom_irka\n",
     "print('H_2-error for the IRKA ROM:   {}'.format(err_irka.norm()))\n",
-    "print('H_inf-error for the IRKA ROM: {}'.format(err_irka.norm('Hinf')[0]))"
+    "print('H_inf-error for the IRKA ROM: {}'.format(err_irka.norm('Hinf')))"
    ]
   },
   {

--- a/src/pymorexamples/heat.ipynb
+++ b/src/pymorexamples/heat.ipynb
@@ -159,8 +159,7 @@
    },
    "outputs": [],
    "source": [
-    "lti.compute_poles()\n",
-    "poles = lti._poles\n",
+    "poles = lti.poles()\n",
     "fig, ax = plt.subplots()\n",
     "ax.plot(poles.real, poles.imag, '.')\n",
     "ax.set_title('System poles')\n",
@@ -183,8 +182,7 @@
    "outputs": [],
    "source": [
     "w = np.logspace(-2, 3, 100)\n",
-    "lti.bode(w)\n",
-    "fig, ax = LTISystem.mag_plot(lti)\n",
+    "fig, ax = LTISystem.mag_plot(lti, w=w)\n",
     "ax.set_title('Bode plot of the full model')\n",
     "plt.show()"
    ]
@@ -204,9 +202,9 @@
    },
    "outputs": [],
    "source": [
-    "lti.compute_sv_U_V('lyap')\n",
+    "sv = lti.sv_U_V('lyap')[0]\n",
     "fig, ax = plt.subplots()\n",
-    "ax.semilogy(range(1, len(lti._sv['lyap']) + 1), lti._sv['lyap'], '.-')\n",
+    "ax.semilogy(range(1, len(sv) + 1), sv, '.-')\n",
     "ax.set_title('Hankel singular values')\n",
     "plt.show()"
    ]
@@ -227,7 +225,7 @@
    "outputs": [],
    "source": [
     "print('H_2-norm of the full model:   {}'.format(lti.norm()))\n",
-    "print('H_inf-norm of the full model: {}'.format(lti.norm('Hinf')))"
+    "print('H_inf-norm of the full model: {}'.format(lti.norm('Hinf')[0]))"
    ]
   },
   {
@@ -258,10 +256,10 @@
    "outputs": [],
    "source": [
     "print('H_2-norm of the BT ROM:       {}'.format(rom_bt.norm()))\n",
-    "print('H_inf-norm of the BT ROM:     {}'.format(rom_bt.norm('Hinf')))\n",
+    "print('H_inf-norm of the BT ROM:     {}'.format(rom_bt.norm('Hinf')[0]))\n",
     "err_bt = lti - rom_bt\n",
     "print('H_2-error for the BT ROM:     {}'.format(err_bt.norm()))\n",
-    "print('H_inf-error for the BT ROM:   {}'.format(err_bt.norm('Hinf')))"
+    "print('H_inf-error for the BT ROM:   {}'.format(err_bt.norm('Hinf')[0]))"
    ]
   },
   {
@@ -279,8 +277,7 @@
    },
    "outputs": [],
    "source": [
-    "rom_bt.bode(w)\n",
-    "fig, ax = LTISystem.mag_plot((lti, rom_bt))\n",
+    "fig, ax = LTISystem.mag_plot((lti, rom_bt), w=w)\n",
     "ax.set_title('Bode plot of the full and BT reduced model')\n",
     "plt.show()"
    ]
@@ -300,8 +297,7 @@
    },
    "outputs": [],
    "source": [
-    "err_bt.bode(w)\n",
-    "fig, ax = LTISystem.mag_plot(err_bt)\n",
+    "fig, ax = LTISystem.mag_plot(err_bt, w=w)\n",
     "ax.set_title('Bode plot of the BT error system')\n",
     "plt.show()"
    ]
@@ -350,10 +346,10 @@
    "outputs": [],
    "source": [
     "print('H_2-norm of the IRKA ROM:     {}'.format(rom_irka.norm()))\n",
-    "print('H_inf-norm of the IRKA ROM:   {}'.format(rom_irka.norm('Hinf')))\n",
+    "print('H_inf-norm of the IRKA ROM:   {}'.format(rom_irka.norm('Hinf')[0]))\n",
     "err_irka = lti - rom_irka\n",
     "print('H_2-error for the IRKA ROM:   {}'.format(err_irka.norm()))\n",
-    "print('H_inf-error for the IRKA ROM: {}'.format(err_irka.norm('Hinf')))"
+    "print('H_inf-error for the IRKA ROM: {}'.format(err_irka.norm('Hinf')[0]))"
    ]
   },
   {
@@ -371,8 +367,7 @@
    },
    "outputs": [],
    "source": [
-    "rom_irka.bode(w)\n",
-    "fig, ax = LTISystem.mag_plot((lti, rom_irka))\n",
+    "fig, ax = LTISystem.mag_plot((lti, rom_irka), w=w)\n",
     "ax.set_title('Bode plot of the full and IRKA reduced model')\n",
     "plt.show()"
    ]
@@ -392,8 +387,7 @@
    },
    "outputs": [],
    "source": [
-    "err_irka.bode(w)\n",
-    "fig, ax = LTISystem.mag_plot(err_irka)\n",
+    "fig, ax = LTISystem.mag_plot(err_irka, w=w)\n",
     "ax.set_title('Bode plot of the IRKA error system')\n",
     "plt.show()"
    ]


### PR DESCRIPTION
This pull request replaces the hand-rolled caching in `InputOutputSystem` and subclasses by pyMOR's caching infrastructure. Not only is the code simplified, the change also makes it easier to ensure that the semantics of `ImmutableInterface` are fulfilled by these classes. (E.g., in the old implementation, the `_gramian` dict did not keep track of the `me_solver`. So if `compute_gramian` was called before calling `compue_sv_U_V`, the `me_solver` parameter of the latter method would have had no effect.)

Some remarks:
- I have defaulted the `cache_region` to `memory` to reproduce the old behavior.
- For the Hinf-norm computation `fpeak` is now returned along with the norm. If this is unwanted, alternatives would be to drop the `fpeak` value or have an optional parameter to the `norm` method to control if `fpeak` is returned or not.
- In the old implementation, `bode` always returned a copy of the cached result. The current implementatoin of `MemoryRegion` does not make any copies. This behavior should be changed such that mutation of the cached value is either safe or impossible.

@pmli, please have a look if you like my changes.