### PR TITLE
Improve VectorSpace concept

### DIFF
--- a/docs/source/substitutions.py
+++ b/docs/source/substitutions.py
@@ -80,6 +80,7 @@ common = '''
 .. |NumpyVectorArray| replace:: :class:`~pymor.vectorarrays.numpy.NumpyVectorArray`
 .. |NumpyVectorArrays| replace:: :class:`NumpyVectorArrays <pymor.vectorarrays.numpy.NumpyVectorArray>`
 .. |ListVectorArray| replace:: :class:`~pymor.vectorarrays.list.ListVectorArray`
+.. |ListVectorArrays| replace:: :class:`ListVectorArrays <pymor.vectorarrays.list.ListVectorArray>`
 
 .. |OperatorBase| replace:: :class:`~pymor.operators.basic.OperatorBase`
 .. |NumpyMatrixOperator| replace:: :class:`~pymor.operators.numpy.NumpyMatrixOperator`
@@ -90,6 +91,7 @@ common = '''
 .. |EmpiricalInterpolatedOperators| replace:: :class:`EmpiricalInterpolatedOperators <pymor.operators.ei.EmpiricalInterpolatedOperator>`
 .. |Concatenation| replace:: :class:`~pymor.operators.constructions.Concatenation`
 .. |VectorSpace| replace:: :class:`~pymor.vectorarrays.interfaces.VectorSpaceInterface`
+.. |VectorSpaces| replace:: :class:`VectorSpaces <pymor.vectorarrays.interfaces.VectorSpaceInterface>`
 .. |NumpyVectorSpace| replace:: :func:`~pymor.vectorarrays.numpy.NumpyVectorSpace`
 
 .. |StationaryDiscretization| replace:: :class:`~pymor.discretizations.basic.StationaryDiscretization`

--- a/docs/source/substitutions.py
+++ b/docs/source/substitutions.py
@@ -93,6 +93,7 @@ common = '''
 .. |VectorSpace| replace:: :class:`~pymor.vectorarrays.interfaces.VectorSpaceInterface`
 .. |VectorSpaces| replace:: :class:`VectorSpaces <pymor.vectorarrays.interfaces.VectorSpaceInterface>`
 .. |NumpyVectorSpace| replace:: :func:`~pymor.vectorarrays.numpy.NumpyVectorSpace`
+.. |NumpyVectorSpaces| replace:: :func:`NumpyVectorSpaces <pymor.vectorarrays.numpy.NumpyVectorSpace>`
 
 .. |StationaryDiscretization| replace:: :class:`~pymor.discretizations.basic.StationaryDiscretization`
 .. |StationaryDiscretizations| replace:: :class:`StationaryDiscretizations <pymor.discretizations.basic.StationaryDiscretization>`

--- a/docs/source/substitutions.py
+++ b/docs/source/substitutions.py
@@ -89,7 +89,7 @@ common = '''
 .. |EmpiricalInterpolatedOperator| replace:: :class:`~pymor.operators.ei.EmpiricalInterpolatedOperator`
 .. |EmpiricalInterpolatedOperators| replace:: :class:`EmpiricalInterpolatedOperators <pymor.operators.ei.EmpiricalInterpolatedOperator>`
 .. |Concatenation| replace:: :class:`~pymor.operators.constructions.Concatenation`
-.. |VectorSpace| replace:: :class:`~pymor.vectorarrays.interfaces.VectorSpace`
+.. |VectorSpace| replace:: :class:`~pymor.vectorarrays.interfaces.VectorSpaceInterface`
 .. |NumpyVectorSpace| replace:: :func:`~pymor.vectorarrays.numpy.NumpyVectorSpace`
 
 .. |StationaryDiscretization| replace:: :class:`~pymor.discretizations.basic.StationaryDiscretization`

--- a/docs/source/technical_overview.rst
+++ b/docs/source/technical_overview.rst
@@ -49,10 +49,8 @@ operating on objects of the following types:
     only required datum is the dimension of the contained vectors.
     |VectorSpaces| for other backends could, e.g., hold a socket for
     communication with a specific PDE solver instance. Additionally,
-    each |VectorSpace| has a string |id| which is used to signify the
-    mathematical identity of the given space. The default id is `'STATE'`,
-    whereas `'SCALARS'` is used to signify arrays of real or complex
-    numbers (see below).
+    each |VectorSpace| has a string |id|, defaulting to `None`, which
+    is used to signify the mathematical identity of the given space.
     
     Two arrays in pyMOR are compatible (e.g. can be added) if they are from
     the same |VectorSpace|. If a |VectorArray| is contained in a given
@@ -85,11 +83,10 @@ operating on objects of the following types:
     
     Operators in pyMOR are also used to represent bilinear forms via the
     |apply2| method. A functional in pyMOR is simply an operator with
-    `NumpyVectorSpace(1, 'SCALARS')` as |range|. This space can also be obtained
-    via the `scalars(1)` shorthand. Dually, a vector-like operator is an operator
-    with `scalars(1)` as |source|. Such vector-like operators are used in pyMOR to
-    represent |Parameter| dependent vectors such as the initial data of an
-    |InstationaryDiscretization|. For linear functionals and vector-like
+    `NumpyVectorSpace(1)` as |range|. Dually, a vector-like operator is an operator
+    with `NumpyVectorSpace(1)` as |source|. Such vector-like operators are used
+    in pyMOR to represent |Parameter| dependent vectors such as the initial data
+    of an |InstationaryDiscretization|. For linear functionals and vector-like
     operators, the |as_vector| method can be called to obtain a vector
     representation of the operator as a |VectorArray| of length 1.
 

--- a/src/pymor/algorithms/image.py
+++ b/src/pymor/algorithms/image.py
@@ -10,7 +10,7 @@ from pymor.core.logger import getLogger
 from pymor.operators.constructions import AdjointOperator, Concatenation, LincombOperator, SelectionOperator
 from pymor.operators.ei import EmpiricalInterpolatedOperator
 from pymor.vectorarrays.interfaces import VectorArrayInterface
-from pymor.vectorarrays.numpy import scalars, NumpyVectorArray
+from pymor.vectorarrays.numpy import NumpyVectorSpace
 
 
 def estimate_image(operators=(), vectors=(),
@@ -69,12 +69,12 @@ def estimate_image(operators=(), vectors=(),
     domain_space = operators[0].source if operators else None
     image_space = operators[0].range if operators \
         else vectors[0].space if isinstance(vectors[0], VectorArrayInterface) \
-        else vectors[0].range if vectors[0].range != scalars(1) \
+        else vectors[0].range if vectors[0].range != NumpyVectorSpace(1) \
         else vectors[0].source
     assert all(
         isinstance(v, VectorArrayInterface) and v in image_space or
-        v.source == scalars(1) and v.range == image_space and v.linear or
-        v.range == scalars(1) and v.source == image_space and v.linear
+        v.source == NumpyVectorSpace(1) and v.range == image_space and v.linear or
+        v.range == NumpyVectorSpace(1) and v.source == image_space and v.linear
         for v in vectors
     )
     assert all(op.source == domain_space and op.range == image_space for op in operators)
@@ -105,7 +105,7 @@ def estimate_image(operators=(), vectors=(),
             if op.source not in image_space:
                 raise ImageCollectionError(op)  # Not implemented
             operator = Concatenation(op.range_product, op.operator) if op.range_product else op.operator
-            collect_operator_ranges(operator, NumpyVectorArray(np.ones(1)), image)
+            collect_operator_ranges(operator, operator.source.make_array(np.ones(1)), image)
         elif op.linear and not op.parametric:
             image.append(op.as_vector())
         else:
@@ -187,12 +187,12 @@ def estimate_image_hierarchical(operators=(), vectors=(), domain=None, extends=N
     domain_space = operators[0].source if operators else None
     image_space = operators[0].range if operators \
         else vectors[0].space if isinstance(vectors[0], VectorArrayInterface) \
-        else vectors[0].range if vectors[0].range != scalars(1) \
+        else vectors[0].range if vectors[0].range != NumpyVectorSpace(1) \
         else vectors[0].source
     assert all(
         isinstance(v, VectorArrayInterface) and v in image_space or
-        v.source == scalars(1) and v.range == image_space and v.linear or
-        v.range == scalars(1) and v.source == image_space and v.linear
+        v.source == NumpyVectorSpace(1) and v.range == image_space and v.linear or
+        v.range == NumpyVectorSpace(1) and v.source == image_space and v.linear
         for v in vectors
     )
     assert all(op.source == domain_space and op.range == image_space for op in operators)

--- a/src/pymor/algorithms/image.py
+++ b/src/pymor/algorithms/image.py
@@ -107,7 +107,7 @@ def estimate_image(operators=(), vectors=(),
             operator = Concatenation(op.range_product, op.operator) if op.range_product else op.operator
             collect_operator_ranges(operator, operator.source.make_array(np.ones(1)), image)
         elif op.linear and not op.parametric:
-            image.append(op.as_vector())
+            image.append(op.as_vector(space=image.space))
         else:
             raise ImageCollectionError(op)
 

--- a/src/pymor/algorithms/image.py
+++ b/src/pymor/algorithms/image.py
@@ -10,7 +10,7 @@ from pymor.core.logger import getLogger
 from pymor.operators.constructions import AdjointOperator, Concatenation, LincombOperator, SelectionOperator
 from pymor.operators.ei import EmpiricalInterpolatedOperator
 from pymor.vectorarrays.interfaces import VectorArrayInterface
-from pymor.vectorarrays.numpy import NumpyVectorSpace, NumpyVectorArray
+from pymor.vectorarrays.numpy import scalars, NumpyVectorArray
 
 
 def estimate_image(operators=(), vectors=(),
@@ -69,12 +69,12 @@ def estimate_image(operators=(), vectors=(),
     domain_space = operators[0].source if operators else None
     image_space = operators[0].range if operators \
         else vectors[0].space if isinstance(vectors[0], VectorArrayInterface) \
-        else vectors[0].range if vectors[0].range != NumpyVectorSpace(1) \
+        else vectors[0].range if vectors[0].range != scalars(1) \
         else vectors[0].source
     assert all(
         isinstance(v, VectorArrayInterface) and v in image_space or
-        v.source == NumpyVectorSpace(1) and v.range == image_space and v.linear or
-        v.range == NumpyVectorSpace(1) and v.source == image_space and v.linear
+        v.source == scalars(1) and v.range == image_space and v.linear or
+        v.range == scalars(1) and v.source == image_space and v.linear
         for v in vectors
     )
     assert all(op.source == domain_space and op.range == image_space for op in operators)
@@ -187,12 +187,12 @@ def estimate_image_hierarchical(operators=(), vectors=(), domain=None, extends=N
     domain_space = operators[0].source if operators else None
     image_space = operators[0].range if operators \
         else vectors[0].space if isinstance(vectors[0], VectorArrayInterface) \
-        else vectors[0].range if vectors[0].range != NumpyVectorSpace(1) \
+        else vectors[0].range if vectors[0].range != scalars(1) \
         else vectors[0].source
     assert all(
         isinstance(v, VectorArrayInterface) and v in image_space or
-        v.source == NumpyVectorSpace(1) and v.range == image_space and v.linear or
-        v.range == NumpyVectorSpace(1) and v.source == image_space and v.linear
+        v.source == scalars(1) and v.range == image_space and v.linear or
+        v.range == scalars(1) and v.source == image_space and v.linear
         for v in vectors
     )
     assert all(op.source == domain_space and op.range == image_space for op in operators)

--- a/src/pymor/algorithms/image.py
+++ b/src/pymor/algorithms/image.py
@@ -9,6 +9,7 @@ from pymor.core.exceptions import ImageCollectionError
 from pymor.core.logger import getLogger
 from pymor.operators.constructions import AdjointOperator, Concatenation, LincombOperator, SelectionOperator
 from pymor.operators.ei import EmpiricalInterpolatedOperator
+from pymor.operators.interfaces import OperatorInterface
 from pymor.vectorarrays.interfaces import VectorArrayInterface
 from pymor.vectorarrays.numpy import NumpyVectorSpace
 
@@ -27,7 +28,7 @@ def estimate_image(operators=(), vectors=(),
     - `op.apply(U, mu=mu)` for all operators `op` in `operators`, for all possible |Parameters|
       `mu` and for all |VectorArrays| `U` contained in the linear span of `domain`,
     - `U` for all |VectorArrays| in `vectors`,
-    - `v.as_vector(mu)` for all |Operators| in `vectors` and all possible |Parameters| `mu`.
+    - `v.as_range_array(mu)` for all |Operators| in `vectors` and all possible |Parameters| `mu`.
 
     The algorithm will try to choose `image` as small as possible. However, no optimality
     is guaranteed.
@@ -69,20 +70,24 @@ def estimate_image(operators=(), vectors=(),
     domain_space = operators[0].source if operators else None
     image_space = operators[0].range if operators \
         else vectors[0].space if isinstance(vectors[0], VectorArrayInterface) \
-        else vectors[0].range if vectors[0].range != NumpyVectorSpace(1) \
-        else vectors[0].source
+        else vectors[0].range
+    assert all(op.source == domain_space and op.range == image_space for op in operators)
     assert all(
-        isinstance(v, VectorArrayInterface) and v in image_space or
-        v.source == NumpyVectorSpace(1) and v.range == image_space and v.linear or
-        v.range == NumpyVectorSpace(1) and v.source == image_space and v.linear
+        isinstance(v, VectorArrayInterface) and (
+            v in image_space
+        ) or
+        isinstance(v, OperatorInterface) and (
+            v.range == image_space and isinstance(v.source, NumpyVectorSpace) and v.linear
+        )
         for v in vectors
     )
-    assert all(op.source == domain_space and op.range == image_space for op in operators)
     assert domain is None or domain_space is None or domain in domain_space
     assert product is None or product.source == product.range == image_space
 
     def collect_operator_ranges(op, source, image):
-        if isinstance(op, (LincombOperator, SelectionOperator)):
+        if op.linear and not op.parametric:
+            image.append(op.apply(source))
+        elif isinstance(op, (LincombOperator, SelectionOperator)):
             for o in op.operators:
                 collect_operator_ranges(o, source, image)
         elif isinstance(op, EmpiricalInterpolatedOperator):
@@ -92,29 +97,24 @@ def estimate_image(operators=(), vectors=(),
             firstrange = op.first.range.empty()
             collect_operator_ranges(op.first, source, firstrange)
             collect_operator_ranges(op.second, firstrange, image)
-        elif op.linear and not op.parametric:
-            image.append(op.apply(source))
         else:
             raise ImageCollectionError(op)
 
     def collect_vector_ranges(op, image):
-        if isinstance(op, (LincombOperator, SelectionOperator)):
+        if isinstance(op, VectorArrayInterface):
+            image.append(op)
+        elif op.linear and not op.parametric:
+            image.append(op.as_range_array())
+        elif isinstance(op, (LincombOperator, SelectionOperator)):
             for o in op.operators:
                 collect_vector_ranges(o, image)
-        elif isinstance(op, AdjointOperator):
-            if op.source not in image_space:
-                raise ImageCollectionError(op)  # Not implemented
-            operator = Concatenation(op.range_product, op.operator) if op.range_product else op.operator
-            collect_operator_ranges(operator, operator.source.make_array(np.ones(1)), image)
-        elif op.linear and not op.parametric:
-            image.append(op.as_vector(space=image.space))
         else:
             raise ImageCollectionError(op)
 
     image = image_space.empty()
     if not extends:
-        for f in vectors:
-            collect_vector_ranges(f, image)
+        for v in vectors:
+            collect_vector_ranges(v, image)
 
     if operators and domain is None:
         domain = domain_space.empty()
@@ -187,15 +187,17 @@ def estimate_image_hierarchical(operators=(), vectors=(), domain=None, extends=N
     domain_space = operators[0].source if operators else None
     image_space = operators[0].range if operators \
         else vectors[0].space if isinstance(vectors[0], VectorArrayInterface) \
-        else vectors[0].range if vectors[0].range != NumpyVectorSpace(1) \
-        else vectors[0].source
+        else vectors[0].range
+    assert all(op.source == domain_space and op.range == image_space for op in operators)
     assert all(
-        isinstance(v, VectorArrayInterface) and v in image_space or
-        v.source == NumpyVectorSpace(1) and v.range == image_space and v.linear or
-        v.range == NumpyVectorSpace(1) and v.source == image_space and v.linear
+        isinstance(v, VectorArrayInterface) and (
+            v in image_space
+        ) or
+        isinstance(v, OperatorInterface) and (
+            v.range == image_space and isinstance(v.source, NumpyVectorSpace) and v.linear
+        )
         for v in vectors
     )
-    assert all(op.source == domain_space and op.range == image_space for op in operators)
     assert domain is None or domain_space is None or domain in domain_space
     assert product is None or product.source == product.range == image_space
     assert extends is None or len(extends) == 2

--- a/src/pymor/algorithms/timestepping.py
+++ b/src/pymor/algorithms/timestepping.py
@@ -135,7 +135,7 @@ def implicit_euler(A, F, M, U0, t0, t1, nt, mu=None, num_values=None, solver_opt
         assert F.source == A.range
         F_time_dep = F.parametric and '_t' in F.parameter_type
         if not F_time_dep:
-            dt_F = F.as_vector(mu) * dt
+            dt_F = F.as_vector(mu, space=A.source) * dt
     else:
         assert len(F) == 1
         assert F in A.range
@@ -171,7 +171,7 @@ def implicit_euler(A, F, M, U0, t0, t1, nt, mu=None, num_values=None, solver_opt
         mu['_t'] = t
         rhs = M.apply(U)
         if F_time_dep:
-            dt_F = F.as_vector(mu) * dt
+            dt_F = F.as_vector(mu, space=A.source) * dt
         if F:
             rhs += dt_F
         U = M_dt_A.apply_inverse(rhs, mu=mu)
@@ -192,7 +192,7 @@ def explicit_euler(A, F, U0, t0, t1, nt, mu=None, num_values=None):
         assert F.source == A.source
         F_time_dep = F.parametric and '_t' in F.parameter_type
         if not F_time_dep:
-            F_ass = F.as_vector(mu)
+            F_ass = F.as_vector(mu, space=A.source)
     elif isinstance(F, VectorArrayInterface):
         assert len(F) == 1
         assert F in A.source
@@ -226,7 +226,7 @@ def explicit_euler(A, F, U0, t0, t1, nt, mu=None, num_values=None):
             t += dt
             mu['_t'] = t
             if F_time_dep:
-                F_ass = F.as_vector(mu)
+                F_ass = F.as_vector(mu, space=A.source)
             U.axpy(dt, F_ass - A.apply(U, mu=mu))
             while t - t0 + (min(dt, DT) * 0.5) >= len(R) * DT:
                 R.append(U)

--- a/src/pymor/algorithms/to_matrix.py
+++ b/src/pymor/algorithms/to_matrix.py
@@ -63,7 +63,7 @@ def _to_matrix(op, format, mapping, mu):
             for j in range(op.num_source_blocks):
                 if op_blocks[i, j] is None:
                     if format is None:
-                        mat_blocks[i].append(np.zeros((op.range.subtype[i].dim, op.source.subtype[j].dim)))
+                        mat_blocks[i].append(np.zeros((op.range.subspaces[i].dim, op.source.subspaces[j].dim)))
                     else:
                         mat_blocks[i].append(None)
                 else:

--- a/src/pymor/basic.py
+++ b/src/pymor/basic.py
@@ -71,6 +71,5 @@ from pymor.reductors.parabolic import reduce_parabolic
 from pymor.tools.random import new_random_state
 
 from pymor.vectorarrays.constructions import cat_arrays
-from pymor.vectorarrays.interfaces import VectorSpace
-from pymor.vectorarrays.list import ListVectorArray
-from pymor.vectorarrays.numpy import NumpyVectorArray, NumpyVectorSpace
+from pymor.vectorarrays.list import ListVectorSpace
+from pymor.vectorarrays.numpy import NumpyVectorSpace, scalars

--- a/src/pymor/basic.py
+++ b/src/pymor/basic.py
@@ -72,4 +72,4 @@ from pymor.tools.random import new_random_state
 
 from pymor.vectorarrays.constructions import cat_arrays
 from pymor.vectorarrays.list import ListVectorSpace
-from pymor.vectorarrays.numpy import NumpyVectorSpace, scalars
+from pymor.vectorarrays.numpy import NumpyVectorSpace

--- a/src/pymor/core/interfaces.py
+++ b/src/pymor/core/interfaces.py
@@ -20,14 +20,14 @@ are the following:
     3. Logging can be disabled and re-enabled for each *instance* using the
        :meth:`BasicInterface.disable_logging` and :meth:`BasicInterface.enable_logging`
        methods.
-    5. :meth:`BasicInterface.uid` provides a unique id for each instance. While
+    4. :meth:`BasicInterface.uid` provides a unique id for each instance. While
        `id(obj)` is only guaranteed to be unique among all living Python objects,
        :meth:`BasicInterface.uid` will be (almost) unique among all pyMOR objects
        that have ever existed, including previous runs of the application. This
        is achieved by building the id from a uuid4 which is newly created for
        each pyMOR run and a counter which is increased for any object that requests
        an uid.
-    6. If not set by the user to another value, :attr:`BasicInterface.name` is
+    5. If not set by the user to another value, :attr:`BasicInterface.name` is
        set to the name of the object's class.
 
 

--- a/src/pymor/core/interfaces.py
+++ b/src/pymor/core/interfaces.py
@@ -269,6 +269,28 @@ else:
     abstractstaticmethod = abc.abstractstaticmethod
 
 
+class classinstancemethod:
+
+    def __init__(self, cls_meth):
+        self.cls_meth = cls_meth
+
+    def __get__(self, instance, cls):
+        if cls is None:
+            return self
+        if instance is None:
+            def the_class_method(*args, **kwargs):
+                return self.cls_meth(cls, *args, **kwargs)
+            return the_class_method
+        else:
+            def the_instance_method(*args, **kwargs):
+                return self.inst_meth(instance, *args, **kwargs)
+            return the_instance_method
+
+    def instancemethod(self, inst_meth):
+        self.inst_meth = inst_meth
+        return self
+
+
 class ImmutableMeta(UberMeta):
     """Metaclass for :class:`ImmutableInterface`."""
 

--- a/src/pymor/discretizations/basic.py
+++ b/src/pymor/discretizations/basic.py
@@ -9,7 +9,7 @@ from pymor.operators.constructions import VectorOperator, induced_norm
 from pymor.operators.interfaces import OperatorInterface
 from pymor.tools.frozendict import FrozenDict
 from pymor.vectorarrays.interfaces import VectorArrayInterface
-from pymor.vectorarrays.numpy import scalars
+from pymor.vectorarrays.numpy import NumpyVectorSpace
 
 
 class DiscretizationBase(DiscretizationInterface):
@@ -151,7 +151,7 @@ class StationaryDiscretization(DiscretizationBase):
         self.build_parameter_type(self.operator, self.rhs)
         self.parameter_space = parameter_space
         assert self.operator.source == self.operator.range == self.rhs.source
-        assert self.rhs.source == self.operator.source and self.rhs.range == scalars(1) and self.rhs.linear
+        assert self.rhs.source == self.operator.source and self.rhs.range == NumpyVectorSpace(1) and self.rhs.linear
 
     def _solve(self, mu=None):
         mu = self.parse_parameter(mu)
@@ -261,10 +261,10 @@ class InstationaryDiscretization(DiscretizationBase):
             self.add_with_arguments = self.add_with_arguments | {'time_stepper_nt'}
 
         assert isinstance(time_stepper, TimeStepperInterface)
-        assert self.initial_data.source == scalars(1)
+        assert self.initial_data.source == NumpyVectorSpace(1)
         assert self.operator.source == self.operator.range == self.initial_data.range
         assert self.rhs is None \
-            or self.rhs.linear and self.rhs.source == self.operator.source and self.rhs.range == scalars(1)
+            or self.rhs.linear and self.rhs.source == self.operator.source and self.rhs.range == NumpyVectorSpace(1)
         assert self.mass is None \
             or self.mass.linear and self.mass.source == self.mass.range == self.operator.source
 

--- a/src/pymor/discretizations/basic.py
+++ b/src/pymor/discretizations/basic.py
@@ -9,7 +9,6 @@ from pymor.operators.constructions import VectorOperator, induced_norm
 from pymor.operators.interfaces import OperatorInterface
 from pymor.tools.frozendict import FrozenDict
 from pymor.vectorarrays.interfaces import VectorArrayInterface
-from pymor.vectorarrays.numpy import NumpyVectorSpace
 
 
 class DiscretizationBase(DiscretizationInterface):
@@ -151,7 +150,7 @@ class StationaryDiscretization(DiscretizationBase):
         self.build_parameter_type(self.operator, self.rhs)
         self.parameter_space = parameter_space
         assert self.operator.source == self.operator.range == self.rhs.source
-        assert self.rhs.source == self.operator.source and self.rhs.range == NumpyVectorSpace(1) and self.rhs.linear
+        assert self.rhs.source == self.operator.source and self.rhs.range.is_scalar and self.rhs.linear
 
     def _solve(self, mu=None):
         mu = self.parse_parameter(mu)
@@ -261,10 +260,10 @@ class InstationaryDiscretization(DiscretizationBase):
             self.add_with_arguments = self.add_with_arguments | {'time_stepper_nt'}
 
         assert isinstance(time_stepper, TimeStepperInterface)
-        assert self.initial_data.source == NumpyVectorSpace(1)
+        assert self.initial_data.source.is_scalar
         assert self.operator.source == self.operator.range == self.initial_data.range
         assert self.rhs is None \
-            or self.rhs.linear and self.rhs.source == self.operator.source and self.rhs.range == NumpyVectorSpace(1)
+            or self.rhs.linear and self.rhs.source == self.operator.source and self.rhs.range.is_scalar
         assert self.mass is None \
             or self.mass.linear and self.mass.source == self.mass.range == self.operator.source
 

--- a/src/pymor/discretizations/basic.py
+++ b/src/pymor/discretizations/basic.py
@@ -160,7 +160,7 @@ class StationaryDiscretization(DiscretizationBase):
         if not self.logging_disabled:
             self.logger.info('Solving {} for {} ...'.format(self.name, mu))
 
-        return self.operator.apply_inverse(self.rhs.as_vector(mu), mu=mu)
+        return self.operator.apply_inverse(self.rhs.as_source_array(mu), mu=mu)
 
 
 class InstationaryDiscretization(DiscretizationBase):
@@ -283,6 +283,6 @@ class InstationaryDiscretization(DiscretizationBase):
             self.logger.info('Solving {} for {} ...'.format(self.name, mu))
 
         mu['_t'] = 0
-        U0 = self.initial_data.as_vector(mu)
+        U0 = self.initial_data.as_range_array(mu)
         return self.time_stepper.solve(operator=self.operator, rhs=self.rhs, initial_data=U0, mass=self.mass,
                                        initial_time=0, end_time=self.T, mu=mu, num_values=self.num_values)

--- a/src/pymor/discretizations/basic.py
+++ b/src/pymor/discretizations/basic.py
@@ -11,7 +11,7 @@ from pymor.operators.constructions import VectorOperator, induced_norm
 from pymor.operators.interfaces import OperatorInterface
 from pymor.tools.frozendict import FrozenDict
 from pymor.vectorarrays.interfaces import VectorArrayInterface
-from pymor.vectorarrays.numpy import NumpyVectorSpace
+from pymor.vectorarrays.numpy import scalars
 
 
 class DiscretizationBase(DiscretizationInterface):
@@ -297,7 +297,7 @@ class InstationaryDiscretization(DiscretizationBase):
             self.add_with_arguments = self.add_with_arguments | {'time_stepper_nt'}
 
         assert isinstance(time_stepper, TimeStepperInterface)
-        assert self.initial_data.source == NumpyVectorSpace(1)
+        assert self.initial_data.source == scalars(1)
         assert self.operator.source == self.operator.range == self.initial_data.range
         assert self.rhs is None \
             or self.rhs.linear and self.rhs.source == self.operator.source and self.rhs.range.dim == 1

--- a/src/pymor/discretizations/mpi.py
+++ b/src/pymor/discretizations/mpi.py
@@ -6,7 +6,7 @@ from pymor.core.interfaces import ImmutableInterface
 from pymor.discretizations.basic import DiscretizationBase
 from pymor.operators.mpi import mpi_wrap_operator
 from pymor.tools import mpi
-from pymor.vectorarrays.interfaces import VectorSpace
+from pymor.vectorarrays.interfaces import VectorSpaceInterface
 from pymor.vectorarrays.mpi import MPIVectorArray, _register_subtype
 
 

--- a/src/pymor/discretizations/mpi.py
+++ b/src/pymor/discretizations/mpi.py
@@ -36,19 +36,9 @@ class MPIDiscretization(DiscretizationBase):
     products
         See `operators`.
     pickle_local_spaces
-        If `pickle_subtypes` is `False`, a unique identifier
-        is computed for each local `solution_space` subtype, which is then
-        transferred to rank 0 instead of the true subtype. This
-        allows to use :class:`~pymor.vectorarrays.mpi.MPIVectorArray`,
-        :class:`~pymor.operators.mpi.MPIOperator`, :class:`MPIDiscretization`
-        even when the local subtypes are not picklable.
+        See :class:`~pymor.operators.mpi.MPIOperator`.
     space_type
-        This class will be used to wrap the local |VectorArrays|
-        returned by :meth:`~pymor.discretizations.interfaces.DiscretizationInterface.solve`
-        on each rank into an MPI distributed |VectorArray| managed from rank 0. By default,
-        :class:`~pymor.vectorarrays.mpi.MPIVectorArray` will be used,
-        other options are :class:`~pymor.vectorarrays.mpi.MPIVectorArrayAutoComm`
-        and :class:`~pymor.vectorarrays.mpi.MPIVectorArrayNoComm`.
+        See :class:`~pymor.operators.mpi.MPIOperator`.
     """
 
     def __init__(self, obj_id, operators, products=None,

--- a/src/pymor/discretizers/advection.py
+++ b/src/pymor/discretizers/advection.py
@@ -14,7 +14,7 @@ from pymor.operators.fv import (nonlinear_advection_lax_friedrichs_operator,
                                 nonlinear_advection_engquist_osher_operator,
                                 nonlinear_advection_simplified_engquist_osher_operator,
                                 L2Product, L2ProductFunctional)
-from pymor.vectorarrays.numpy import NumpyVectorArray
+from pymor.vectorarrays.numpy import NumpyVectorSpace
 
 
 def discretize_nonlinear_instationary_advection_fv(analytical_problem, diameter=None, nt=100, num_flux='lax_friedrichs',
@@ -106,14 +106,14 @@ def discretize_nonlinear_instationary_advection_fv(analytical_problem, diameter=
         def initial_projection(U, mu):
             I = p.initial_data.evaluate(grid.quadrature_points(0, order=2), mu).squeeze()
             I = np.sum(I * grid.reference_element.quadrature(order=2)[1], axis=1) * (1. / grid.reference_element.volume)
-            I = NumpyVectorArray(I, copy=False)
+            I = NumpyVectorSpace.make_array(I)
             return I.lincomb(U).data
         I = NumpyGenericOperator(initial_projection, dim_range=grid.size(0), linear=True,
                                  parameter_type=p.initial_data.parameter_type)
     else:
         I = p.initial_data.evaluate(grid.quadrature_points(0, order=2)).squeeze()
         I = np.sum(I * grid.reference_element.quadrature(order=2)[1], axis=1) * (1. / grid.reference_element.volume)
-        I = NumpyVectorArray(I, copy=False)
+        I = NumpyVectorSpace.make_array(I)
 
     products = {'l2': L2Product(grid, boundary_info)}
     if grid.dim == 2:

--- a/src/pymor/discretizers/advection.py
+++ b/src/pymor/discretizers/advection.py
@@ -14,7 +14,6 @@ from pymor.operators.fv import (nonlinear_advection_lax_friedrichs_operator,
                                 nonlinear_advection_engquist_osher_operator,
                                 nonlinear_advection_simplified_engquist_osher_operator,
                                 L2Product, L2ProductFunctional)
-from pymor.vectorarrays.numpy import NumpyVectorSpace
 
 
 def discretize_nonlinear_instationary_advection_fv(analytical_problem, diameter=None, nt=100, num_flux='lax_friedrichs',
@@ -106,14 +105,14 @@ def discretize_nonlinear_instationary_advection_fv(analytical_problem, diameter=
         def initial_projection(U, mu):
             I = p.initial_data.evaluate(grid.quadrature_points(0, order=2), mu).squeeze()
             I = np.sum(I * grid.reference_element.quadrature(order=2)[1], axis=1) * (1. / grid.reference_element.volume)
-            I = NumpyVectorSpace.make_array(I)
+            I = L.source.make_array(I)
             return I.lincomb(U).data
         I = NumpyGenericOperator(initial_projection, dim_range=grid.size(0), linear=True,
                                  parameter_type=p.initial_data.parameter_type)
     else:
         I = p.initial_data.evaluate(grid.quadrature_points(0, order=2)).squeeze()
         I = np.sum(I * grid.reference_element.quadrature(order=2)[1], axis=1) * (1. / grid.reference_element.volume)
-        I = NumpyVectorSpace.make_array(I)
+        I = L.source.make_array(I)
 
     products = {'l2': L2Product(grid, boundary_info)}
     if grid.dim == 2:

--- a/src/pymor/discretizers/disk.py
+++ b/src/pymor/discretizers/disk.py
@@ -126,7 +126,7 @@ def discretize_stationary_from_disk(parameter_file):
         path = os.path.join(base_path, system_mat[i][0])
         expr = system_mat[i][1]
         parameter_functional = ExpressionParameterFunctional(expr, parameter_type=parameter_type)
-        system_operators.append(NumpyMatrixOperator.from_file(path))
+        system_operators.append(NumpyMatrixOperator.from_file(path, source_id='STATE', range_id='STATE'))
         system_functionals.append(parameter_functional)
 
     system_lincombOperator = LincombOperator(system_operators, coefficients=system_functionals)
@@ -138,7 +138,7 @@ def discretize_stationary_from_disk(parameter_file):
         path = os.path.join(base_path, rhs_vec[i][0])
         expr = rhs_vec[i][1]
         parameter_functional = ExpressionParameterFunctional(expr, parameter_type=parameter_type)
-        op = NumpyMatrixOperator.from_file(path, range_id='SCALARS')
+        op = NumpyMatrixOperator.from_file(path, source_id='STATE')
         assert isinstance(op._matrix, np.ndarray)
         op = op.with_(matrix=op._matrix.reshape((1, -1)))
         rhs_operators.append(op)
@@ -153,7 +153,7 @@ def discretize_stationary_from_disk(parameter_file):
         for i in range(len(product)):
             product_name = product[i][0]
             product_path = os.path.join(base_path, product[i][1])
-            products[product_name] = NumpyMatrixOperator.from_file(product_path)
+            products[product_name] = NumpyMatrixOperator.from_file(product_path, source_id='STATE', range_id='STATE')
     else:
         products = None
 
@@ -264,7 +264,7 @@ def discretize_instationary_from_disk(parameter_file, T=None, steps=None, u0=Non
         path = os.path.join(base_path, system_mat[i][0])
         expr = system_mat[i][1]
         parameter_functional = ExpressionParameterFunctional(expr, parameter_type=parameter_type)
-        system_operators.append(NumpyMatrixOperator.from_file(path))
+        system_operators.append(NumpyMatrixOperator.from_file(path, source_id='STATE', range_id='STATE'))
         system_functionals.append(parameter_functional)
 
     system_lincombOperator = LincombOperator(system_operators, coefficients=system_functionals)
@@ -276,7 +276,7 @@ def discretize_instationary_from_disk(parameter_file, T=None, steps=None, u0=Non
         path = os.path.join(base_path, rhs_vec[i][0])
         expr = rhs_vec[i][1]
         parameter_functional = ExpressionParameterFunctional(expr, parameter_type=parameter_type)
-        op = NumpyMatrixOperator.from_file(path, range_id='SCALARS')
+        op = NumpyMatrixOperator.from_file(path, source_id='STATE')
         assert isinstance(op._matrix, np.ndarray)
         op = op.with_(matrix=op._matrix.reshape((1, -1)))
         rhs_operators.append(op)
@@ -286,13 +286,13 @@ def discretize_instationary_from_disk(parameter_file, T=None, steps=None, u0=Non
 
     # get mass matrix
     path = os.path.join(base_path, mass_mat[0][1])
-    mass_operator = NumpyMatrixOperator.from_file(path)
+    mass_operator = NumpyMatrixOperator.from_file(path, source_id='STATE', range_id='STATE')
 
     # Obtain initial solution if not given
     if u0 is None:
         u_0 = config.items('initial-solution')
         path = os.path.join(base_path, u_0[0][1])
-        op = NumpyMatrixOperator.from_file(path, source_id='SCALARS')
+        op = NumpyMatrixOperator.from_file(path, range_id='STATE')
         assert isinstance(op._matrix, np.ndarray)
         u0 = op.with_(matrix=op._matrix.reshape((-1, 1)))
 
@@ -303,7 +303,7 @@ def discretize_instationary_from_disk(parameter_file, T=None, steps=None, u0=Non
         for i in range(len(product)):
             product_name = product[i][0]
             product_path = os.path.join(base_path, product[i][1])
-            products[product_name] = NumpyMatrixOperator.from_file(product_path)
+            products[product_name] = NumpyMatrixOperator.from_file(product_path, source_id='STATE', range_id='STATE')
     else:
         products = None
 

--- a/src/pymor/discretizers/disk.py
+++ b/src/pymor/discretizers/disk.py
@@ -138,7 +138,7 @@ def discretize_stationary_from_disk(parameter_file):
         path = os.path.join(base_path, rhs_vec[i][0])
         expr = rhs_vec[i][1]
         parameter_functional = ExpressionParameterFunctional(expr, parameter_type=parameter_type)
-        op = NumpyMatrixOperator.from_file(path)
+        op = NumpyMatrixOperator.from_file(path, range_id='SCALARS')
         assert isinstance(op._matrix, np.ndarray)
         op = op.with_(matrix=op._matrix.reshape((1, -1)))
         rhs_operators.append(op)
@@ -276,7 +276,7 @@ def discretize_instationary_from_disk(parameter_file, T=None, steps=None, u0=Non
         path = os.path.join(base_path, rhs_vec[i][0])
         expr = rhs_vec[i][1]
         parameter_functional = ExpressionParameterFunctional(expr, parameter_type=parameter_type)
-        op = NumpyMatrixOperator.from_file(path)
+        op = NumpyMatrixOperator.from_file(path, range_id='SCALARS')
         assert isinstance(op._matrix, np.ndarray)
         op = op.with_(matrix=op._matrix.reshape((1, -1)))
         rhs_operators.append(op)
@@ -292,7 +292,7 @@ def discretize_instationary_from_disk(parameter_file, T=None, steps=None, u0=Non
     if u0 is None:
         u_0 = config.items('initial-solution')
         path = os.path.join(base_path, u_0[0][1])
-        op = NumpyMatrixOperator.from_file(path)
+        op = NumpyMatrixOperator.from_file(path, source_id='SCALARS')
         assert isinstance(op._matrix, np.ndarray)
         u0 = op.with_(matrix=op._matrix.reshape((-1, 1)))
 

--- a/src/pymor/discretizers/parabolic.py
+++ b/src/pymor/discretizers/parabolic.py
@@ -11,7 +11,7 @@ from pymor.discretizations.basic import InstationaryDiscretization
 from pymor.algorithms.timestepping import ImplicitEulerTimeStepper
 from pymor.operators.cg import InterpolationOperator
 from pymor.operators.numpy import NumpyGenericOperator
-from pymor.vectorarrays.numpy import NumpyVectorArray
+from pymor.vectorarrays.numpy import NumpyVectorSpace
 
 
 def discretize_parabolic_cg(analytical_problem, diameter=None, domain_discretizer=None,
@@ -72,7 +72,7 @@ def discretize_parabolic_cg(analytical_problem, diameter=None, domain_discretize
         I = InterpolationOperator(data['grid'], p.initial_data)
     else:
         I = p.initial_data.evaluate(data['grid'].centers(data['grid'].dim))
-        I = NumpyVectorArray(I, copy=False)
+        I = NumpyVectorSpace.make_array(I)
 
     if time_stepper is None:
         time_stepper = ImplicitEulerTimeStepper(nt=nt)
@@ -146,14 +146,14 @@ def discretize_parabolic_fv(analytical_problem, diameter=None, domain_discretize
         def initial_projection(U, mu):
             I = p.initial_data.evaluate(grid.quadrature_points(0, order=2), mu).squeeze()
             I = np.sum(I * grid.reference_element.quadrature(order=2)[1], axis=1) * (1. / grid.reference_element.volume)
-            I = NumpyVectorArray(I, copy=False)
+            I = NumpyVectorSpace.make_array(I)
             return I.lincomb(U).data
         I = NumpyGenericOperator(initial_projection, dim_range=grid.size(0), linear=True,
                                  parameter_type=p.initial_data.parameter_type)
     else:
         I = p.initial_data.evaluate(grid.quadrature_points(0, order=2)).squeeze()
         I = np.sum(I * grid.reference_element.quadrature(order=2)[1], axis=1) * (1. / grid.reference_element.volume)
-        I = NumpyVectorArray(I, copy=False)
+        I = NumpyVectorSpace.make_array(I)
 
     if time_stepper is None:
         time_stepper = ImplicitEulerTimeStepper(nt=nt)

--- a/src/pymor/discretizers/parabolic.py
+++ b/src/pymor/discretizers/parabolic.py
@@ -11,7 +11,6 @@ from pymor.discretizations.basic import InstationaryDiscretization
 from pymor.algorithms.timestepping import ImplicitEulerTimeStepper
 from pymor.operators.cg import InterpolationOperator
 from pymor.operators.numpy import NumpyGenericOperator
-from pymor.vectorarrays.numpy import NumpyVectorSpace
 
 
 def discretize_parabolic_cg(analytical_problem, diameter=None, domain_discretizer=None,
@@ -72,7 +71,7 @@ def discretize_parabolic_cg(analytical_problem, diameter=None, domain_discretize
         I = InterpolationOperator(data['grid'], p.initial_data)
     else:
         I = p.initial_data.evaluate(data['grid'].centers(data['grid'].dim))
-        I = NumpyVectorSpace.make_array(I)
+        I = d.solution_space.make_array(I)
 
     if time_stepper is None:
         time_stepper = ImplicitEulerTimeStepper(nt=nt)
@@ -146,14 +145,14 @@ def discretize_parabolic_fv(analytical_problem, diameter=None, domain_discretize
         def initial_projection(U, mu):
             I = p.initial_data.evaluate(grid.quadrature_points(0, order=2), mu).squeeze()
             I = np.sum(I * grid.reference_element.quadrature(order=2)[1], axis=1) * (1. / grid.reference_element.volume)
-            I = NumpyVectorSpace.make_array(I)
+            I = d.solution_space.make_array(I)
             return I.lincomb(U).data
-        I = NumpyGenericOperator(initial_projection, dim_range=grid.size(0), linear=True,
+        I = NumpyGenericOperator(initial_projection, dim_range=grid.size(0), linear=True, range_id=d.solution_space.id,
                                  parameter_type=p.initial_data.parameter_type)
     else:
         I = p.initial_data.evaluate(grid.quadrature_points(0, order=2)).squeeze()
         I = np.sum(I * grid.reference_element.quadrature(order=2)[1], axis=1) * (1. / grid.reference_element.volume)
-        I = NumpyVectorSpace.make_array(I)
+        I = d.solution_space.make_array(I)
 
     if time_stepper is None:
         time_stepper = ImplicitEulerTimeStepper(nt=nt)

--- a/src/pymor/gui/fenics.py
+++ b/src/pymor/gui/fenics.py
@@ -13,20 +13,18 @@ if HAVE_FENICS:
     import numpy as np
 
     from pymor.core.interfaces import BasicInterface
-    from pymor.vectorarrays.fenics import FenicsVectorSpace
 
     class FenicsVisualizer(BasicInterface):
         """Visualize a FEniCS grid function.
 
         Parameters
         ----------
-        function_space
-            The FEniCS `FunctionSpace` for which we want to visualize DOF vectors.
+        space
+            The `FenicsVectorSpace` for which we want to visualize DOF vectors.
         """
 
-        def __init__(self, function_space):
-            self.function_space = function_space
-            self.space = FenicsVectorSpace(function_space)
+        def __init__(self, space):
+            self.space = space
 
         def visualize(self, U, discretization, title='', legend=None, filename=None, block=True,
                       separate_colorbars=True):
@@ -62,7 +60,7 @@ if HAVE_FENICS:
                 assert not isinstance(U, tuple)
                 assert U in self.space
                 f = df.File(filename)
-                function = df.Function(self.function_space)
+                function = df.Function(self.space.V)
                 if legend:
                     function.rename(legend, legend)
                 for u in U._list:
@@ -86,7 +84,7 @@ if HAVE_FENICS:
                         vmax = max(vmax, vec.max())
 
                 for i, u in enumerate(U):
-                    function = df.Function(self.function_space)
+                    function = df.Function(self.space.V)
                     function.vector()[:] = u._list[0].impl
                     if legend:
                         tit = title + ' -- ' if title else ''

--- a/src/pymor/operators/basic.py
+++ b/src/pymor/operators/basic.py
@@ -272,6 +272,14 @@ class ProjectedOperator(OperatorBase):
         self.linear = operator.linear
         self.product = product
 
+    @property
+    def T(self):
+        if self.product:
+            return super().T
+        else:
+            return ProjectedOperator(self.operator.T, self.source_basis, self.range_basis,
+                                     name=self.name + '_transposed')
+
     def apply(self, U, mu=None):
         mu = self.parse_parameter(mu)
         if self.source_basis is None:

--- a/src/pymor/operators/basic.py
+++ b/src/pymor/operators/basic.py
@@ -5,13 +5,11 @@
 
 from numbers import Number
 
-import numpy as np
-
 from pymor.algorithms import genericsolvers
 from pymor.core.exceptions import InversionError
 from pymor.operators.interfaces import OperatorInterface
 from pymor.vectorarrays.interfaces import VectorArrayInterface
-from pymor.vectorarrays.numpy import scalars, NumpyVectorSpace
+from pymor.vectorarrays.numpy import NumpyVectorSpace
 
 
 class OperatorBase(OperatorInterface):
@@ -164,10 +162,10 @@ class OperatorBase(OperatorInterface):
     def as_vector(self, mu=None):
         if not self.linear:
             raise TypeError('This nonlinear operator does not represent a vector or linear functional.')
-        elif self.source == scalars(1):
-            return self.apply(scalars(1).make_array(1), mu=mu)
-        elif self.range == scalars(1):
-            return self.apply_adjoint(scalars(1).make_array(1), mu=mu)
+        elif self.source == NumpyVectorSpace(1):
+            return self.apply(self.source.make_array(1), mu=mu)
+        elif self.range == NumpyVectorSpace(1):
+            return self.apply_adjoint(self.range.make_array(1), mu=mu)
         else:
             raise TypeError('This operator does not represent a vector or linear functional.')
 

--- a/src/pymor/operators/basic.py
+++ b/src/pymor/operators/basic.py
@@ -5,6 +5,8 @@
 
 from numbers import Number
 
+import numpy as np
+
 from pymor.algorithms import genericsolvers
 from pymor.core.exceptions import InversionError
 from pymor.operators.interfaces import OperatorInterface
@@ -159,15 +161,13 @@ class OperatorBase(OperatorInterface):
             adjoint_op = AdjointOperator(self, with_apply_inverse=False, solver_options=options)
             return adjoint_op.apply_inverse(U, mu=mu, least_squares=least_squares)
 
-    def as_vector(self, mu=None):
-        if not self.linear:
-            raise TypeError('This nonlinear operator does not represent a vector or linear functional.')
-        elif self.source == NumpyVectorSpace(1):
-            return self.apply(self.source.make_array(1), mu=mu)
-        elif self.range == NumpyVectorSpace(1):
-            return self.apply_adjoint(self.range.make_array(1), mu=mu)
-        else:
-            raise TypeError('This operator does not represent a vector or linear functional.')
+    def as_range_array(self, mu=None):
+        assert isinstance(self.source, NumpyVectorSpace)
+        return self.apply(self.source.make_array(np.eye(self.source.dim)), mu=mu)
+
+    def as_source_array(self, mu=None):
+        assert isinstance(self.range, NumpyVectorSpace)
+        return self.apply_adjoint(self.range.make_array(np.eye(self.range.dim)), mu=mu)
 
     def projected(self, range_basis, source_basis, product=None, name=None):
         name = name or '{}_projected'.format(self.name)

--- a/src/pymor/operators/block.py
+++ b/src/pymor/operators/block.py
@@ -15,8 +15,7 @@ class BlockOperator(OperatorBase):
     """A matrix of arbitrary |Operators|.
 
     This operator can be :meth:`applied <pymor.operators.interfaces.OperatorInterface.apply>`
-    to :class:`BlockVectorArrays <pymor.vectorarrays.block.BlockVectorArray>` of an
-    appropriate :attr:`~pymor.vectorarrays.interfaces.VectorArrayInterface.subtype`.
+    to a compatible :class:`BlockVectorArrays <pymor.vectorarrays.block.BlockVectorArray>`.
 
     Parameters
     ----------
@@ -70,7 +69,7 @@ class BlockOperator(OperatorBase):
         Parameters
         ----------
         operators
-            An iterable of |Operators| or `None`s.
+            An iterable where each item is an |Operator| or `None`.
         """
         blocks = np.array([[op for op in operators]])
         return cls(blocks)
@@ -82,7 +81,7 @@ class BlockOperator(OperatorBase):
         Parameters
         ----------
         operators
-            An iterable of |Operators| or `None`s.
+            An iterable where each item is an |Operator| or `None`.
         """
         blocks = np.array([[op] for op in operators])
         return cls(blocks)

--- a/src/pymor/operators/block.py
+++ b/src/pymor/operators/block.py
@@ -62,6 +62,10 @@ class BlockOperator(OperatorBase):
         self.linear = all(op.linear for op in self._operators())
         self.build_parameter_type(*self._operators())
 
+    @property
+    def T(self):
+        return type(self)(np.vectorize(lambda op: op.T if op else None)(self._blocks.T))
+
     @classmethod
     def hstack(cls, operators):
         """Horizontal stacking of |Operators|.
@@ -158,6 +162,10 @@ class BlockDiagonalOperator(BlockOperator):
     """
 
     def __init__(self, blocks):
+        blocks = np.array(blocks)
+        assert 1 <= blocks.ndim <= 2
+        if blocks.ndim == 2:
+            blocks = np.diag(blocks)
         n = len(blocks)
         blocks2 = np.empty((n, n), dtype=object)
         for i, op in enumerate(blocks):

--- a/src/pymor/operators/cg.py
+++ b/src/pymor/operators/cg.py
@@ -11,7 +11,7 @@ from scipy.sparse import coo_matrix, csc_matrix
 from pymor.functions.interfaces import FunctionInterface
 from pymor.grids.referenceelements import triangle, line, square
 from pymor.operators.numpy import NumpyMatrixBasedOperator
-from pymor.vectorarrays.numpy import NumpyVectorSpace
+from pymor.vectorarrays.numpy import NumpyVectorSpace, scalars
 
 
 class L2ProductFunctionalP1(NumpyMatrixBasedOperator):
@@ -51,7 +51,7 @@ class L2ProductFunctionalP1(NumpyMatrixBasedOperator):
     """
 
     sparse = False
-    range = NumpyVectorSpace(1)
+    range = scalars(1)
 
     def __init__(self, grid, function, boundary_info=None, dirichlet_data=None, neumann_data=None, robin_data=None,
                  order=2, solver_options=None, name=None):
@@ -172,7 +172,7 @@ class L2ProductFunctionalQ1(NumpyMatrixBasedOperator):
     """
 
     sparse = False
-    range = NumpyVectorSpace(1)
+    range = scalars(1)
 
     def __init__(self, grid, function, boundary_info=None, dirichlet_data=None, neumann_data=None, robin_data=None,
                  order=2, name=None):
@@ -1012,7 +1012,7 @@ class InterpolationOperator(NumpyMatrixBasedOperator):
         The |Function| to interpolate.
     """
 
-    source = NumpyVectorSpace(1)
+    source = scalars(1)
     linear = True
 
     def __init__(self, grid, function):

--- a/src/pymor/operators/cg.py
+++ b/src/pymor/operators/cg.py
@@ -11,7 +11,11 @@ from scipy.sparse import coo_matrix, csc_matrix
 from pymor.functions.interfaces import FunctionInterface
 from pymor.grids.referenceelements import triangle, line, square
 from pymor.operators.numpy import NumpyMatrixBasedOperator
-from pymor.vectorarrays.numpy import NumpyVectorSpace, scalars
+from pymor.vectorarrays.numpy import NumpyVectorSpace
+
+
+def CGVectorSpace(grid, id_='STATE'):
+    return NumpyVectorSpace(grid.size(grid.dim), id_)
 
 
 class L2ProductFunctionalP1(NumpyMatrixBasedOperator):
@@ -51,13 +55,13 @@ class L2ProductFunctionalP1(NumpyMatrixBasedOperator):
     """
 
     sparse = False
-    range = scalars(1)
+    range = NumpyVectorSpace(1)
 
     def __init__(self, grid, function, boundary_info=None, dirichlet_data=None, neumann_data=None, robin_data=None,
                  order=2, solver_options=None, name=None):
         assert grid.reference_element(0) in {line, triangle}
         assert function.shape_range == ()
-        self.source = NumpyVectorSpace(grid.size(grid.dim))
+        self.source = CGVectorSpace(grid)
         self.grid = grid
         self.boundary_info = boundary_info
         self.function = function
@@ -172,13 +176,13 @@ class L2ProductFunctionalQ1(NumpyMatrixBasedOperator):
     """
 
     sparse = False
-    range = scalars(1)
+    range = NumpyVectorSpace(1)
 
     def __init__(self, grid, function, boundary_info=None, dirichlet_data=None, neumann_data=None, robin_data=None,
                  order=2, name=None):
         assert grid.reference_element(0) in {square}
         assert function.shape_range == ()
-        self.source = NumpyVectorSpace(grid.size(grid.dim))
+        self.source = CGVectorSpace(grid)
         self.grid = grid
         self.boundary_info = boundary_info
         self.function = function
@@ -280,7 +284,7 @@ class L2ProductP1(NumpyMatrixBasedOperator):
     def __init__(self, grid, boundary_info, dirichlet_clear_rows=True, dirichlet_clear_columns=False,
                  dirichlet_clear_diag=False, coefficient_function=None, solver_options=None, name=None):
         assert grid.reference_element in (line, triangle)
-        self.source = self.range = NumpyVectorSpace(grid.size(grid.dim))
+        self.source = self.range = CGVectorSpace(grid)
         self.grid = grid
         self.boundary_info = boundary_info
         self.dirichlet_clear_rows = dirichlet_clear_rows
@@ -378,7 +382,7 @@ class L2ProductQ1(NumpyMatrixBasedOperator):
     def __init__(self, grid, boundary_info, dirichlet_clear_rows=True, dirichlet_clear_columns=False,
                  dirichlet_clear_diag=False, coefficient_function=None, solver_options=None, name=None):
         assert grid.reference_element in {square}
-        self.source = self.range = NumpyVectorSpace(grid.size(grid.dim))
+        self.source = self.range = CGVectorSpace(grid)
         self.grid = grid
         self.boundary_info = boundary_info
         self.dirichlet_clear_rows = dirichlet_clear_rows
@@ -484,7 +488,7 @@ class DiffusionOperatorP1(NumpyMatrixBasedOperator):
             or (isinstance(diffusion_function, FunctionInterface) and
                 diffusion_function.dim_domain == grid.dim and
                 diffusion_function.shape_range == () or diffusion_function.shape_range == (grid.dim,) * 2)
-        self.source = self.range = NumpyVectorSpace(grid.size(grid.dim))
+        self.source = self.range = CGVectorSpace(grid)
         self.grid = grid
         self.boundary_info = boundary_info
         self.diffusion_constant = diffusion_constant
@@ -604,7 +608,7 @@ class DiffusionOperatorQ1(NumpyMatrixBasedOperator):
             or (isinstance(diffusion_function, FunctionInterface) and
                 diffusion_function.dim_domain == grid.dim and
                 diffusion_function.shape_range == () or diffusion_function.shape_range == (grid.dim,) * 2)
-        self.source = self.range = NumpyVectorSpace(grid.size(grid.dim))
+        self.source = self.range = CGVectorSpace(grid)
         self.grid = grid
         self.boundary_info = boundary_info
         self.diffusion_constant = diffusion_constant
@@ -723,7 +727,7 @@ class AdvectionOperatorP1(NumpyMatrixBasedOperator):
             or (isinstance(advection_function, FunctionInterface) and
                 advection_function.dim_domain == grid.dim and
                 advection_function.shape_range == (grid.dim,))
-        self.source = self.range = NumpyVectorSpace(grid.size(grid.dim))
+        self.source = self.range = CGVectorSpace(grid)
         self.grid = grid
         self.boundary_info = boundary_info
         self.advection_constant = advection_constant
@@ -841,7 +845,7 @@ class AdvectionOperatorQ1(NumpyMatrixBasedOperator):
             or (isinstance(advection_function, FunctionInterface) and
                 advection_function.dim_domain == grid.dim and
                 advection_function.shape_range == (grid.dim,))
-        self.source = self.range = NumpyVectorSpace(grid.size(grid.dim))
+        self.source = self.range = CGVectorSpace(grid)
         self.grid = grid
         self.boundary_info = boundary_info
         self.advection_constant = advection_constant
@@ -954,7 +958,7 @@ class RobinBoundaryOperator(NumpyMatrixBasedOperator):
                                           and (f.shape_range == ()
                                                or f.shape_range == (grid.dim,)
                                                ) for f in robin_data])
-        self.source = self.range = NumpyVectorSpace(grid.size(grid.dim))
+        self.source = self.range = CGVectorSpace(grid)
         self.grid = grid
         self.boundary_info = boundary_info
         self.robin_data = robin_data
@@ -1012,7 +1016,7 @@ class InterpolationOperator(NumpyMatrixBasedOperator):
         The |Function| to interpolate.
     """
 
-    source = scalars(1)
+    source = NumpyVectorSpace(1)
     linear = True
 
     def __init__(self, grid, function):
@@ -1020,7 +1024,7 @@ class InterpolationOperator(NumpyMatrixBasedOperator):
         assert function.shape_range == ()
         self.grid = grid
         self.function = function
-        self.range = NumpyVectorSpace(grid.size(grid.dim))
+        self.range = CGVectorSpace(grid)
         self.build_parameter_type(function)
 
     def _assemble(self, mu=None):

--- a/src/pymor/operators/ei.py
+++ b/src/pymor/operators/ei.py
@@ -12,7 +12,7 @@ from pymor.operators.constructions import VectorArrayOperator, Concatenation, Co
 from pymor.operators.interfaces import OperatorInterface
 from pymor.operators.numpy import NumpyMatrixOperator
 from pymor.vectorarrays.interfaces import VectorArrayInterface
-from pymor.vectorarrays.numpy import NumpyVectorArray, NumpyVectorSpace
+from pymor.vectorarrays.numpy import NumpyVectorSpace
 
 
 class EmpiricalInterpolatedOperator(OperatorBase):
@@ -90,10 +90,11 @@ class EmpiricalInterpolatedOperator(OperatorBase):
             return self.range.zeros(len(U))
 
         if hasattr(self, 'restricted_operator'):
-            U_components = NumpyVectorArray(U.components(self.source_dofs))
+            U_components = NumpyVectorSpace.make_array(U.components(self.source_dofs), 'SCALARS')
             AU = self.restricted_operator.apply(U_components, mu=mu)
         else:
-            AU = NumpyVectorArray(self.operator.apply(U, mu=mu).components(self.interpolation_dofs), copy=False)
+            AU = NumpyVectorSpace.make_array(self.operator.apply(U, mu=mu).components(self.interpolation_dofs),
+                                             'SCALARS')
         try:
             if self.triangular:
                 interpolation_coefficients = solve_triangular(self.interpolation_matrix, AU.data.T,
@@ -118,23 +119,27 @@ class EmpiricalInterpolatedOperator(OperatorBase):
 
             if range_basis is not None:
                 if product is None:
-                    projected_collateral_basis = NumpyVectorArray(self.collateral_basis.dot(range_basis))
+                    projected_collateral_basis = NumpyVectorSpace.make_array(self.collateral_basis.dot(range_basis),
+                                                                             self.range.id)
                 else:
-                    projected_collateral_basis = NumpyVectorArray(product.apply2(self.collateral_basis, range_basis))
+                    projected_collateral_basis = NumpyVectorSpace.make_array(product.apply2(self.collateral_basis,
+                                                                                            range_basis),
+                                                                             self.range.id)
             else:
                 projected_collateral_basis = self.collateral_basis
 
             return ProjectedEmpiciralInterpolatedOperator(self.restricted_operator, self.interpolation_matrix,
-                                                          NumpyVectorArray(source_basis.components(self.source_dofs),
-                                                                           copy=False),
-                                                          projected_collateral_basis, self.triangular, None, name)
+                                                          NumpyVectorSpace.make_array(source_basis.components(self.source_dofs),
+                                                                                      'SCALARS'),
+                                                          projected_collateral_basis, self.triangular,
+                                                          self.source.id, None, name)
 
     def jacobian(self, U, mu=None):
         mu = self.parse_parameter(mu)
         options = self.solver_options.get('jacobian') if self.solver_options else None
 
         if len(self.interpolation_dofs) == 0:
-            if self.source.type == self.range.type == NumpyVectorArray:
+            if isinstance(self.source, NumpyVectorSpace) and isinstance(self.range, NumpyVectorSpace):
                 return NumpyMatrixOperator(np.zeros((self.range.dim, self.source.dim)), solver_options=options,
                                            name=self.name + '_jacobian')
             else:
@@ -144,9 +149,10 @@ class EmpiricalInterpolatedOperator(OperatorBase):
                                                  self.collateral_basis, self.triangular,
                                                  solver_options=options, name=self.name + '_jacobian')
         else:
-            U_components = NumpyVectorArray(U.components(self.source_dofs), copy=False)
+            restricted_source = self.restricted_operator.source
+            U_components = restricted_source.make_array(U.components(self.source_dofs))
             JU = self.restricted_operator.jacobian(U_components, mu=mu) \
-                                         .apply(NumpyVectorArray(np.eye(len(self.source_dofs)), copy=False))
+                                         .apply(restricted_source.make_array(np.eye(len(self.source_dofs))))
             try:
                 if self.triangular:
                     interpolation_coefficients = solve_triangular(self.interpolation_matrix, JU.data.T,
@@ -156,8 +162,8 @@ class EmpiricalInterpolatedOperator(OperatorBase):
             except ValueError:  # this exception occurs when AU contains NaNs ...
                 interpolation_coefficients = np.empty((len(JU), len(self.collateral_basis))) + np.nan
             J = self.collateral_basis.lincomb(interpolation_coefficients)
-            if isinstance(J, NumpyVectorArray):
-                J = NumpyMatrixOperator(J.data.T)
+            if isinstance(J.space, NumpyVectorSpace):
+                J = NumpyMatrixOperator(J.data.T, source_id='SCALARS', range_id=self.range.id)
             else:
                 J = VectorArrayOperator(J)
             return Concatenation(J, ComponentProjection(self.source_dofs, self.source),
@@ -171,8 +177,8 @@ class ProjectedEmpiciralInterpolatedOperator(OperatorBase):
     """
 
     def __init__(self, restricted_operator, interpolation_matrix, source_basis_dofs,
-                 projected_collateral_basis, triangular, solver_options=None, name=None):
-        self.source = NumpyVectorSpace(len(source_basis_dofs))
+                 projected_collateral_basis, triangular, source_id, solver_options=None, name=None):
+        self.source = NumpyVectorSpace(len(source_basis_dofs), source_id)
         self.range = projected_collateral_basis.space
         self.linear = restricted_operator.linear
         self.build_parameter_type(restricted_operator)
@@ -181,6 +187,7 @@ class ProjectedEmpiciralInterpolatedOperator(OperatorBase):
         self.source_basis_dofs = source_basis_dofs
         self.projected_collateral_basis = projected_collateral_basis
         self.triangular = triangular
+        self.source_id = source_id
         self.solver_options = solver_options
         self.name = name or '{}_projected'.format(restricted_operator.name)
 
@@ -219,8 +226,9 @@ class ProjectedEmpiciralInterpolatedOperator(OperatorBase):
             interpolation_coefficients = (np.empty((len(self.source_basis_dofs), len(self.projected_collateral_basis)))
                                           + np.nan)
         M = self.projected_collateral_basis.lincomb(interpolation_coefficients)
-        if isinstance(M, NumpyVectorArray):
-            return NumpyMatrixOperator(M.data.T, solver_options=options)
+        if isinstance(M.space, NumpyVectorSpace):
+            return NumpyMatrixOperator(M.data.T, source_id=self.source.id, range_id=self.range.id,
+                                       solver_options=options)
         else:
             assert not options
             return VectorArrayOperator(M)
@@ -229,7 +237,7 @@ class ProjectedEmpiciralInterpolatedOperator(OperatorBase):
         assert dim_source is None or dim_source <= self.source.dim
         assert dim_range is None or dim_range <= self.range.dim
         assert dim_collateral is None or dim_collateral <= self.restricted_operator.range.dim
-        if not isinstance(self.projected_collateral_basis, NumpyVectorArray):
+        if not isinstance(self.projected_collateral_basis.space, NumpyVectorSpace):
             raise NotImplementedError
         name = name or '{}_projected_to_subbasis'.format(self.name)
 
@@ -241,12 +249,13 @@ class ProjectedEmpiciralInterpolatedOperator(OperatorBase):
             restricted_operator = self.restricted_operator
 
         old_pcb = self.projected_collateral_basis
-        projected_collateral_basis = NumpyVectorArray(old_pcb.data[:dim_collateral, :dim_range], copy=False)
+        projected_collateral_basis = NumpyVectorSpace.make_array(old_pcb.data[:dim_collateral, :dim_range],
+                                                                 old_pcb.space.id)
 
         old_sbd = self.source_basis_dofs
-        source_basis_dofs = NumpyVectorArray(old_sbd.data[:dim_source], copy=False) if dim_collateral is None \
-            else NumpyVectorArray(old_sbd.data[:dim_source, source_dofs], copy=False)
+        source_basis_dofs = NumpyVectorSpace.make_array(old_sbd.data[:dim_source], 'SCALARS') if dim_collateral is None \
+            else NumpyVectorSpace.make_array(old_sbd.data[:dim_source, source_dofs], 'SCALARS')
 
         return ProjectedEmpiciralInterpolatedOperator(restricted_operator, interpolation_matrix,
                                                       source_basis_dofs, projected_collateral_basis, self.triangular,
-                                                      solver_options=self.solver_options, name=name)
+                                                      self.source.id, solver_options=self.solver_options, name=name)

--- a/src/pymor/operators/fenics.py
+++ b/src/pymor/operators/fenics.py
@@ -79,7 +79,7 @@ if HAVE_FENICS:
                 matrix.axpy(c, op.matrix, False)  # in general, we cannot assume the same nonzero pattern for
                                                   # all matrices. how to improve this?
 
-            return FenicsMatrixOperator(matrix, self.source.subtype[1], self.range.subtype[1], name=name)
+            return FenicsMatrixOperator(matrix, self.source.V, self.range.V, name=name)
 
 
     @defaults('solver', 'preconditioner')

--- a/src/pymor/operators/fv.py
+++ b/src/pymor/operators/fv.py
@@ -20,7 +20,7 @@ from pymor.operators.numpy import NumpyMatrixBasedOperator, NumpyMatrixOperator
 from pymor.parameters.base import Parametric
 from pymor.tools.inplace import iadd_masked, isub_masked
 from pymor.tools.quadratures import GaussQuadratures
-from pymor.vectorarrays.numpy import NumpyVectorArray, NumpyVectorSpace
+from pymor.vectorarrays.numpy import NumpyVectorSpace, scalars
 
 
 class NumericalConvectiveFluxInterface(ImmutableInterface, Parametric):
@@ -213,7 +213,8 @@ class NonlinearAdvectionOperator(OperatorBase):
 
     linear = False
 
-    def __init__(self, grid, boundary_info, numerical_flux, dirichlet_data=None, solver_options=None, name=None):
+    def __init__(self, grid, boundary_info, numerical_flux, dirichlet_data=None, solver_options=None,
+                 space_id='STATE', name=None):
         assert dirichlet_data is None or isinstance(dirichlet_data, FunctionInterface)
 
         self.grid = grid
@@ -221,6 +222,7 @@ class NonlinearAdvectionOperator(OperatorBase):
         self.numerical_flux = numerical_flux
         self.dirichlet_data = dirichlet_data
         self.solver_options = solver_options
+        self.space_id = space_id
         self.name = name
         if (isinstance(dirichlet_data, FunctionInterface) and boundary_info.has_dirichlet
                 and not dirichlet_data.parametric):
@@ -228,7 +230,7 @@ class NonlinearAdvectionOperator(OperatorBase):
             self._dirichlet_values = self._dirichlet_values.ravel()
             self._dirichlet_values_flux_shaped = self._dirichlet_values.reshape((-1, 1))
         self.build_parameter_type(numerical_flux, dirichlet_data)
-        self.source = self.range = NumpyVectorSpace(grid.size(0))
+        self.source = self.range = NumpyVectorSpace(grid.size(0), space_id)
         self.add_with_arguments = self.add_with_arguments.union('numerical_flux_{}'.format(arg)
                                                                 for arg in numerical_flux.with_arguments)
 
@@ -246,7 +248,8 @@ class NonlinearAdvectionOperator(OperatorBase):
                                    assume_unique=True)
         sub_grid = SubGrid(self.grid, entities=source_dofs)
         sub_boundary_info = SubGridBoundaryInfo(sub_grid, self.grid, self.boundary_info)
-        op = self.with_(grid=sub_grid, boundary_info=sub_boundary_info, name='{}_restricted'.format(self.name))
+        op = self.with_(grid=sub_grid, boundary_info=sub_boundary_info, space_id='SCALARS',
+                        name='{}_restricted'.format(self.name))
         sub_grid_indices = sub_grid.indices_from_parent_indices(dofs, codim=0)
         proj = ComponentProjection(sub_grid_indices, op.range)
         return Concatenation(proj, op), sub_grid.parent_indices(0)
@@ -267,7 +270,6 @@ class NonlinearAdvectionOperator(OperatorBase):
                                                                          self._grid_data['SUPI'][:, 0]])
 
     def apply(self, U, mu=None):
-        assert isinstance(U, NumpyVectorArray)
         assert U in self.source
         mu = self.parse_parameter(mu)
 
@@ -320,10 +322,9 @@ class NonlinearAdvectionOperator(OperatorBase):
 
         R /= VOLS0
 
-        return NumpyVectorArray(R)
+        return self.range.make_array(R)
 
     def jacobian(self, U, mu=None):
-        assert isinstance(U, NumpyVectorArray)
         assert U in self.source and len(U) == 1
         mu = self.parse_parameter(mu)
 
@@ -431,28 +432,28 @@ class NonlinearAdvectionOperator(OperatorBase):
         A = csc_matrix(A).copy()   # See pymor.operators.cg.DiffusionOperatorP1 for why copy() is necessary
         A = dia_matrix(([1. / VOLS0], [0]), shape=(g.size(0),) * 2) * A
 
-        return NumpyMatrixOperator(A)
+        return NumpyMatrixOperator(A, source_id=self.source.id, range_id=self.range.id)
 
 
 def nonlinear_advection_lax_friedrichs_operator(grid, boundary_info, flux, lxf_lambda=1.0,
                                                 dirichlet_data=None, solver_options=None, name=None):
     """Instantiate a :class:`NonlinearAdvectionOperator` using :class:`LaxFriedrichsFlux`."""
     num_flux = LaxFriedrichsFlux(flux, lxf_lambda)
-    return NonlinearAdvectionOperator(grid, boundary_info, num_flux, dirichlet_data, solver_options, name)
+    return NonlinearAdvectionOperator(grid, boundary_info, num_flux, dirichlet_data, solver_options, name=name)
 
 
 def nonlinear_advection_simplified_engquist_osher_operator(grid, boundary_info, flux, flux_derivative,
                                                            dirichlet_data=None, solver_options=None, name=None):
     """Instantiate a :class:`NonlinearAdvectionOperator` using :class:`SimplifiedEngquistOsherFlux`."""
     num_flux = SimplifiedEngquistOsherFlux(flux, flux_derivative)
-    return NonlinearAdvectionOperator(grid, boundary_info, num_flux, dirichlet_data, solver_options, name)
+    return NonlinearAdvectionOperator(grid, boundary_info, num_flux, dirichlet_data, solver_options, name=name)
 
 
 def nonlinear_advection_engquist_osher_operator(grid, boundary_info, flux, flux_derivative, gausspoints=5, intervals=1,
                                                 dirichlet_data=None, solver_options=None, name=None):
     """Instantiate a :class:`NonlinearAdvectionOperator` using :class:`EngquistOsherFlux`."""
     num_flux = EngquistOsherFlux(flux, flux_derivative, gausspoints=gausspoints, intervals=intervals)
-    return NonlinearAdvectionOperator(grid, boundary_info, num_flux, dirichlet_data, solver_options, name)
+    return NonlinearAdvectionOperator(grid, boundary_info, num_flux, dirichlet_data, solver_options, name=name)
 
 
 class LinearAdvectionLaxFriedrichs(NumpyMatrixBasedOperator):
@@ -588,7 +589,7 @@ class L2ProductFunctional(NumpyMatrixBasedOperator):
         The name of the functional.
     """
 
-    range = NumpyVectorSpace(1)
+    range = scalars(1)
     sparse = False
 
     def __init__(self, grid, function=None, boundary_info=None, dirichlet_data=None, diffusion_function=None,

--- a/src/pymor/operators/interfaces.py
+++ b/src/pymor/operators/interfaces.py
@@ -332,12 +332,12 @@ class OperatorInterface(ImmutableInterface, Parametric):
                 return V
             else:
                 raise TypeError('This operator cannot be represented by a VectorArray in the given space.')
-        elif self.source.dim == 1 and isinstance(self.source, NumpyVectorSpace):
-            if self.range.dim == 1 and isinstance(self.range, NumpyVectorSpace) and self.range.id != self.source.id:
+        elif self.source.is_scalar:
+            if self.range.is_scalar and self.range.id != self.source.id:
                 raise TypeError("Cannot determine space of VectorArray representation (specify 'space' parameter).")
             return self.as_range_array(mu)
-        elif self.range.dim == 1 and isinstance(self.range, NumpyVectorSpace):
-            if self.source.dim == 1 and isinstance(self.source, NumpyVectorSpace) and self.source.id != self.range.id:
+        elif self.range.is_scalar:
+            if self.source.is_scalar and self.source.id != self.range.id:
                 raise TypeError("Cannot determine space of VectorArray representation (specify 'space' parameter).")
             return self.as_source_array(mu)
         else:

--- a/src/pymor/operators/interfaces.py
+++ b/src/pymor/operators/interfaces.py
@@ -46,9 +46,20 @@ class OperatorInterface(ImmutableInterface, Parametric):
         The source |VectorSpace|.
     range
         The range |VectorSpace|.
+    T
+        The transposed operator, i.e. ::
+
+            self.T.apply(V, mu) == self.apply_adjoint(V, mu)
+
+        for all V, mu.
     """
 
     solver_options = None
+
+    @property
+    def T(self):
+        from pymor.operators.constructions import AdjointOperator
+        return AdjointOperator(self)
 
     @abstractmethod
     def apply(self, U, mu=None):

--- a/src/pymor/operators/mpi.py
+++ b/src/pymor/operators/mpi.py
@@ -88,14 +88,13 @@ class MPIOperator(OperatorBase):
         else:
             return self.range.make_array(mpi.call(mpi.method_call_manage, self.obj_id, 'apply', U, mu=mu))
 
-    def as_vector(self, mu=None):
+    def as_range_array(self, mu=None):
         mu = self.parse_parameter(mu)
-        if self.source == NumpyVectorSpace(1):
-            return self.range.make_array(mpi.call(mpi.method_call_manage, self.obj_id, 'as_vector', mu=mu))
-        elif self.range == NumpyVectorSpace(1):
-            return self.source.make_array(mpi.call(mpi.method_call_manage, self.obj_id, 'as_vector', mu=mu))
-        else:
-            raise TypeError('This operator does not represent a vector or linear functional.')
+        return self.range.make_array(mpi.call(mpi.method_call_manage, self.obj_id, 'as_range_array', mu=mu))
+
+    def as_source_array(self, mu=None):
+        mu = self.parse_parameter(mu)
+        return self.source.make_array(mpi.call(mpi.method_call_manage, self.obj_id, 'as_source_array', mu=mu))
 
     def apply2(self, V, U, mu=None):
         if not self.with_apply2:

--- a/src/pymor/operators/mpi.py
+++ b/src/pymor/operators/mpi.py
@@ -5,7 +5,7 @@
 from pymor.operators.basic import OperatorBase
 from pymor.operators.constructions import LincombOperator, VectorArrayOperator
 from pymor.tools import mpi
-from pymor.vectorarrays.interfaces import VectorSpace
+from pymor.vectorarrays.interfaces import VectorSpaceInterface
 from pymor.vectorarrays.mpi import MPIVectorArray, _register_subtype
 from pymor.vectorarrays.numpy import NumpyVectorSpace
 

--- a/src/pymor/operators/mpi.py
+++ b/src/pymor/operators/mpi.py
@@ -40,18 +40,18 @@ class MPIOperator(OperatorBase):
         :meth:`~pymor.vectorarrays.interfaces.VectorArrayInterface.dot`
         will be used.
     pickle_local_spaces
-        If `pickle_subtypes` is `False`, a unique identifier
-        is computed for each local source/range subtype, which is then
-        transferred to rank 0 instead of the true subtype. This
+        If `pickle_local_spaces` is `False`, a unique identifier
+        is computed for each local source/range |VectorSpace|, which is then
+        transferred to rank 0 instead of the true |VectorSpace|. This
         allows the useage of :class:`~pymor.vectorarrays.mpi.MPIVectorArray`
-        even when the local subtypes are not picklable.
+        even when the local |VectorSpaces| are not picklable.
     space_type
         This class will be used to wrap the local |VectorArrays|
         returned by the local operators into an MPI distributed
         |VectorArray| managed from rank 0. By default,
-        :class:`~pymor.vectorarrays.mpi.MPIVectorArray` will be used,
-        other options are :class:`~pymor.vectorarrays.mpi.MPIVectorArrayAutoComm`
-        and :class:`~pymor.vectorarrays.mpi.MPIVectorArrayNoComm`.
+        :class:`~pymor.vectorarrays.mpi.MPIVectorSpace` will be used,
+        other options are :class:`~pymor.vectorarrays.mpi.MPIVectorSpaceAutoComm`
+        and :class:`~pymor.vectorarrays.mpi.MPIVectorSpaceNoComm`.
     """
 
     def __init__(self, obj_id, with_apply2=False, pickle_local_spaces=True, space_type=MPIVectorSpace):

--- a/src/pymor/operators/mpi.py
+++ b/src/pymor/operators/mpi.py
@@ -5,9 +5,8 @@
 from pymor.operators.basic import OperatorBase
 from pymor.operators.constructions import LincombOperator, VectorArrayOperator
 from pymor.tools import mpi
-from pymor.vectorarrays.interfaces import VectorSpaceInterface
-from pymor.vectorarrays.mpi import MPIVectorArray, _register_subtype
-from pymor.vectorarrays.numpy import NumpyVectorSpace
+from pymor.vectorarrays.mpi import MPIVectorSpace, _register_local_space
+from pymor.vectorarrays.numpy import scalars
 
 
 class MPIOperator(OperatorBase):
@@ -34,30 +33,19 @@ class MPIOperator(OperatorBase):
     obj_id
         :class:`~pymor.tools.mpi.ObjectId` of the local |Operators|
         on each rank.
-    functional
-        Set to `True` if the operator represents a |Functional|. As
-        required for functionals in pyMOR, this will set the range
-        of the operator to `NumpyVectorSpace(1)` instead of
-        :class:`~pymor.vectorarrays.mpi.MPIVectorArray`-based space.
-    vector
-        Set to `True` if the operator represents a (parametric)
-        vector. As required for vector-like |Operators| in pyMOR,
-        this will set the source of the operator to `NumpyVectorSpace(1)`
-        instead of an :class:`~pymor.vectorarrays.mpi.MPIVectorArray`-based
-        space.
     with_apply2
         Set to `True` if the operator implementation has its own
         MPI aware implementation of `apply2` and `pairwise_apply2`.
         Otherwise, the default implementations using `apply` and
         :meth:`~pymor.vectorarrays.interfaces.VectorArrayInterface.dot`
         will be used.
-    pickle_subtypes
+    pickle_local_spaces
         If `pickle_subtypes` is `False`, a unique identifier
         is computed for each local source/range subtype, which is then
         transferred to rank 0 instead of the true subtype. This
         allows the useage of :class:`~pymor.vectorarrays.mpi.MPIVectorArray`
         even when the local subtypes are not picklable.
-    array_type
+    space_type
         This class will be used to wrap the local |VectorArrays|
         returned by the local operators into an MPI distributed
         |VectorArray| managed from rank 0. By default,
@@ -66,55 +54,48 @@ class MPIOperator(OperatorBase):
         and :class:`~pymor.vectorarrays.mpi.MPIVectorArrayNoComm`.
     """
 
-    def __init__(self, obj_id, functional=False, vector=False, with_apply2=False,
-                 pickle_subtypes=True, array_type=MPIVectorArray):
-        assert not (functional and vector)
+    def __init__(self, obj_id, with_apply2=False, pickle_local_spaces=True, space_type=MPIVectorSpace):
         self.obj_id = obj_id
         self.op = op = mpi.get_object(obj_id)
-        self.functional = functional
-        self.vector = vector
+        assert not op.source.id == op.range.id == 'SCALARS'
         self.with_apply2 = with_apply2
-        self.pickle_subtypes = pickle_subtypes
-        self.array_type = array_type
+        self.pickle_local_spaces = pickle_local_spaces
+        self.space_type = space_type
         self.linear = op.linear
         self.name = op.name
         self.build_parameter_type(op)
-        if vector:
-            self.source = NumpyVectorSpace(1)
-            assert self.source == op.source
+        if op.source.id == 'SCALARS':
+            self.source = op.source
         else:
-            subtypes = mpi.call(_MPIOperator_get_source_subtypes, obj_id, pickle_subtypes)
-            if all(subtype == subtypes[0] for subtype in subtypes):
-                subtypes = (subtypes[0],)
-            self.source = VectorSpace(array_type, (op.source.type, subtypes))
-        if functional:
-            self.range = NumpyVectorSpace(1)
-            assert self.range == op.range
+            local_spaces = mpi.call(_MPIOperator_get_local_spaces, obj_id, True, pickle_local_spaces)
+            if all(ls == local_spaces[0] for ls in local_spaces):
+                local_spaces = (local_spaces[0],)
+            self.source = space_type(local_spaces, op.source.id)
+        if op.range.id == 'SCALARS':
+            self.range = op.range
         else:
-            subtypes = mpi.call(_MPIOperator_get_range_subtypes, obj_id, pickle_subtypes)
-            if all(subtype == subtypes[0] for subtype in subtypes):
-                subtypes = (subtypes[0],)
-            self.range = VectorSpace(array_type, (op.range.type, subtypes))
+            local_spaces = mpi.call(_MPIOperator_get_local_spaces, obj_id, False, pickle_local_spaces)
+            if all(ls == local_spaces[0] for ls in local_spaces):
+                local_spaces = (local_spaces[0],)
+            self.range = space_type(local_spaces, op.range.id)
 
     def apply(self, U, mu=None):
         assert U in self.source
         mu = self.parse_parameter(mu)
-        U = U if self.vector else U.obj_id
-        if self.functional:
+        U = U if self.source.id == 'SCALARS' else U.obj_id
+        if self.range.id == 'SCALARS':
             return mpi.call(mpi.method_call, self.obj_id, 'apply', U, mu=mu)
         else:
-            space = self.range
-            return space.type(space.subtype[0], space.subtype[1],
-                              mpi.call(mpi.method_call_manage, self.obj_id, 'apply', U, mu=mu))
+            return self.range.make_array(mpi.call(mpi.method_call_manage, self.obj_id, 'apply', U, mu=mu))
 
     def as_vector(self, mu=None):
         mu = self.parse_parameter(mu)
-        if self.functional:
-            space = self.source
-            return space.type(space.subtype[0], space.subtype[1],
-                              mpi.call(mpi.method_call_manage, self.obj_id, 'as_vector', mu=mu))
+        if self.source == scalars(1):
+            return self.range.make_array(mpi.call(mpi.method_call_manage, self.obj_id, 'as_vector', mu=mu))
+        elif self.range == scalars(1):
+            return self.source.make_array(mpi.call(mpi.method_call_manage, self.obj_id, 'as_vector', mu=mu))
         else:
-            raise NotImplementedError
+            raise TypeError('This operator does not represent a vector or linear functional.')
 
     def apply2(self, V, U, mu=None):
         if not self.with_apply2:
@@ -122,10 +103,9 @@ class MPIOperator(OperatorBase):
         assert V in self.range
         assert U in self.source
         mu = self.parse_parameter(mu)
-        U = U if self.vector else U.obj_id
-        V = V if self.functional else V.obj_id
-        return mpi.call(mpi.method_call, self.obj_id, 'apply2',
-                        V, U, mu=mu)
+        U = U if self.source.id == 'SCALARS' else U.obj_id
+        V = V if self.range.id == 'SCALARS' else V.obj_id
+        return mpi.call(mpi.method_call, self.obj_id, 'apply2', V, U, mu=mu)
 
     def pairwise_apply2(self, V, U, mu=None):
         if not self.with_apply2:
@@ -133,35 +113,32 @@ class MPIOperator(OperatorBase):
         assert V in self.range
         assert U in self.source
         mu = self.parse_parameter(mu)
-        U = U if self.vector else U.obj_id
-        V = V if self.functional else V.obj_id
-        return mpi.call(mpi.method_call, self.obj_id, 'pairwise_apply2',
-                        V, U, mu=mu)
+        U = U if self.source.id == 'SCALARS' else U.obj_id
+        V = V if self.range.id == 'SCALARS' else V.obj_id
+        return mpi.call(mpi.method_call, self.obj_id, 'pairwise_apply2', V, U, mu=mu)
 
     def apply_adjoint(self, U, mu=None, source_product=None, range_product=None):
         assert U in self.range
         mu = self.parse_parameter(mu)
-        U = U if self.functional else U.obj_id
+        U = U if self.range.id == 'SCALARS' else U.obj_id
         source_product = source_product and source_product.obj_id
         range_product = range_product and range_product.obj_id
-        if self.vector:
+        if self.source.id == 'SCALARS':
             return mpi.call(mpi.method_call, self.obj_id, 'apply_adjoint',
                             U, mu=mu, source_product=source_product, range_product=range_product)
         else:
-            space = self.source
-            return space.type(space.subtype[0], space.subtype[1],
-                              mpi.call(mpi.method_call_manage, self.obj_id, 'apply_adjoint',
-                                       U, mu=mu, source_product=source_product, range_product=range_product))
+            return self.source.make_array(
+                mpi.call(mpi.method_call_manage, self.obj_id, 'apply_adjoint',
+                         U, mu=mu, source_product=source_product, range_product=range_product)
+            )
 
     def apply_inverse(self, V, mu=None, least_squares=False):
-        if self.vector or self.functional:
+        if self.source.id == 'SCALARS' or self.range.id == 'SCALARS':
             raise NotImplementedError
         assert V in self.range
         mu = self.parse_parameter(mu)
-        space = self.source
-        return space.type(space.subtype[0], space.subtype[1],
-                          mpi.call(mpi.method_call_manage, self.obj_id, 'apply_inverse',
-                                   V.obj_id, mu=mu, least_squares=least_squares))
+        return self.source.make_array(mpi.call(mpi.method_call_manage, self.obj_id, 'apply_inverse',
+                                               V.obj_id, mu=mu, least_squares=least_squares))
 
     def jacobian(self, U, mu=None):
         assert U in self.source
@@ -192,24 +169,14 @@ class MPIOperator(OperatorBase):
         mpi.call(mpi.remove_object, self.obj_id)
 
 
-def _MPIOperator_get_source_subtypes(self, pickle_subtypes):
+def _MPIOperator_get_local_spaces(self, source, pickle_local_spaces):
     self = mpi.get_object(self)
-    subtype = self.source.subtype
-    if not pickle_subtypes:
-        subtype = _register_subtype(subtype)
-    subtypes = mpi.comm.gather(subtype, root=0)
+    local_space = self.source if source else self.range
+    if not pickle_local_spaces:
+        local_space = _register_local_space(local_space)
+    local_spaces = mpi.comm.gather(local_space, root=0)
     if mpi.rank0:
-        return tuple(subtypes)
-
-
-def _MPIOperator_get_range_subtypes(self, pickle_subtypes):
-    self = mpi.get_object(self)
-    subtype = self.range.subtype
-    if not pickle_subtypes:
-        subtype = _register_subtype(subtype)
-    subtypes = mpi.comm.gather(subtype, root=0)
-    if mpi.rank0:
-        return tuple(subtypes)
+        return tuple(local_spaces)
 
 
 def _MPIOperator_assemble_lincomb(operators, coefficients, name):
@@ -217,8 +184,7 @@ def _MPIOperator_assemble_lincomb(operators, coefficients, name):
     return mpi.manage_object(operators[0].assemble_lincomb(operators, coefficients, name=name))
 
 
-def mpi_wrap_operator(obj_id, functional=False, vector=False, with_apply2=False,
-                      pickle_subtypes=True, array_type=MPIVectorArray):
+def mpi_wrap_operator(obj_id, with_apply2=False, pickle_local_spaces=True, space_type=MPIVectorSpace):
     """Wrap MPI distributed local |Operators| to a global |Operator| on rank 0.
 
     Given MPI distributed local |Operators| referred to by the
@@ -239,16 +205,17 @@ def mpi_wrap_operator(obj_id, functional=False, vector=False, with_apply2=False,
     op = mpi.get_object(obj_id)
     if isinstance(op, LincombOperator):
         obj_ids = mpi.call(_mpi_wrap_operator_LincombOperator_manage_operators, obj_id)
-        return LincombOperator([mpi_wrap_operator(o, functional, vector, with_apply2, pickle_subtypes, array_type)
+        return LincombOperator([mpi_wrap_operator(o, with_apply2, pickle_local_spaces, space_type)
                                 for o in obj_ids], op.coefficients, name=op.name)
     elif isinstance(op, VectorArrayOperator):
-        array_obj_id, subtypes = mpi.call(_mpi_wrap_operator_VectorArrayOperator_manage_array, obj_id, pickle_subtypes)
-        if all(subtype == subtypes[0] for subtype in subtypes):
-            subtypes = (subtypes[0],)
-        return VectorArrayOperator(array_type(type(op._array), subtypes, array_obj_id),
+        array_obj_id, local_spaces = mpi.call(_mpi_wrap_operator_VectorArrayOperator_manage_array,
+                                              obj_id, pickle_local_spaces)
+        if all(ls == local_spaces[0] for ls in local_spaces):
+            local_spaces = (local_spaces[0],)
+        return VectorArrayOperator(space_type(local_spaces).make_array(array_obj_id),
                                    transposed=op.transposed, name=op.name)
     else:
-        return MPIOperator(obj_id, functional, vector, with_apply2, pickle_subtypes, array_type)
+        return MPIOperator(obj_id, with_apply2, pickle_local_spaces, space_type)
 
 
 def _mpi_wrap_operator_LincombOperator_manage_operators(obj_id):
@@ -259,13 +226,13 @@ def _mpi_wrap_operator_LincombOperator_manage_operators(obj_id):
         return obj_ids
 
 
-def _mpi_wrap_operator_VectorArrayOperator_manage_array(obj_id, pickle_subtypes):
+def _mpi_wrap_operator_VectorArrayOperator_manage_array(obj_id, pickle_local_spaces):
     op = mpi.get_object(obj_id)
     array_obj_id = mpi.manage_object(op._array)
-    subtype = op._array.subtype
-    if not pickle_subtypes:
-        subtype = _register_subtype(subtype)
-    subtypes = mpi.comm.gather(subtype, root=0)
+    local_space = op._array.space
+    if not pickle_local_spaces:
+        local_space = _register_local_space(local_space)
+    local_spaces = mpi.comm.gather(local_space, root=0)
     mpi.remove_object(obj_id)
     if mpi.rank0:
-        return array_obj_id, tuple(subtypes)
+        return array_obj_id, tuple(local_spaces)

--- a/src/pymor/operators/numpy.py
+++ b/src/pymor/operators/numpy.py
@@ -117,6 +117,13 @@ class NumpyMatrixBasedOperator(OperatorBase):
     linear = True
     sparse = None
 
+    @property
+    def T(self):
+        if not self.parametric:
+            return self.assemble().T
+        else:
+            return super().T
+
     @abstractmethod
     def _assemble(self, mu=None):
         pass
@@ -231,6 +238,12 @@ class NumpyMatrixOperator(NumpyMatrixBasedOperator):
         matrix = load_matrix(path, key=key)
         return cls(matrix, solver_options=solver_options, source_id=source_id, range_id=range_id,
                    name=name or key or path)
+
+    @property
+    def T(self):
+        # TODO: Process solver_options
+        return self.with_(matrix=self._matrix.T, source_id=self.range_id, range_id=self.source_id,
+                          solver_options=None, name=self.name + '_transposed')
 
     def _assemble(self, mu=None):
         pass

--- a/src/pymor/operators/numpy.py
+++ b/src/pymor/operators/numpy.py
@@ -163,8 +163,11 @@ class NumpyMatrixBasedOperator(OperatorBase):
     def apply_adjoint(self, U, mu=None, source_product=None, range_product=None):
         return self.assemble(mu).apply_adjoint(U, source_product=source_product, range_product=range_product)
 
-    def as_vector(self, mu=None):
-        return self.assemble(mu).as_vector()
+    def as_range_array(self, mu=None):
+        return self.assemble(mu).as_range_array()
+
+    def as_source_array(self, mu=None):
+        return self.assemble(mu).as_source_array()
 
     def apply_inverse(self, V, mu=None, least_squares=False):
         return self.assemble(mu).apply_inverse(V, least_squares=least_squares)
@@ -235,13 +238,13 @@ class NumpyMatrixOperator(NumpyMatrixBasedOperator):
     def assemble(self, mu=None):
         return self
 
-    def as_vector(self, mu=None):
-        if self.range == NumpyVectorSpace(1):
-            return self.source.make_array(self._matrix.ravel())
-        elif self.source == NumpyVectorSpace(1):
-            return self.range.make_array(self._matrix.ravel())
-        else:
-            raise TypeError('This operator does not represent a vector or linear functional.')
+    def as_range_array(self, mu=None):
+        assert not self.sparse
+        return self.range.make_array(self._matrix.T.copy())
+
+    def as_source_array(self, mu=None):
+        assert not self.sparse
+        return self.source.make_array(self._matrix.copy())
 
     def apply(self, U, mu=None):
         assert U in self.source

--- a/src/pymor/operators/numpy.py
+++ b/src/pymor/operators/numpy.py
@@ -27,7 +27,7 @@ from pymor.core.interfaces import abstractmethod
 from pymor.core.logger import getLogger
 from pymor.operators.basic import OperatorBase
 from pymor.operators.constructions import IdentityOperator, ZeroOperator
-from pymor.vectorarrays.numpy import NumpyVectorSpace, scalars
+from pymor.vectorarrays.numpy import NumpyVectorSpace
 
 
 class NumpyGenericOperator(OperatorBase):
@@ -64,7 +64,7 @@ class NumpyGenericOperator(OperatorBase):
     """
 
     def __init__(self, mapping, adjoint_mapping=None, dim_source=1, dim_range=1, linear=False, parameter_type=None,
-                 source_id='STATE', range_id='STATE', solver_options=None, name=None):
+                 source_id=None, range_id=None, solver_options=None, name=None):
         self.source = NumpyVectorSpace(dim_source, source_id)
         self.range = NumpyVectorSpace(dim_range, range_id)
         self.solver_options = solver_options
@@ -209,7 +209,7 @@ class NumpyMatrixOperator(NumpyMatrixBasedOperator):
         Name of the operator.
     """
 
-    def __init__(self, matrix, source_id='STATE', range_id='STATE', solver_options=None, name=None):
+    def __init__(self, matrix, source_id=None, range_id=None, solver_options=None, name=None):
         assert matrix.ndim <= 2
         if matrix.ndim == 1:
             matrix = np.reshape(matrix, (1, -1))
@@ -223,7 +223,7 @@ class NumpyMatrixOperator(NumpyMatrixBasedOperator):
         self.sparse = issparse(matrix)
 
     @classmethod
-    def from_file(cls, path, key=None, source_id='STATE', range_id='STATE', solver_options=None, name=None):
+    def from_file(cls, path, key=None, source_id=None, range_id=None, solver_options=None, name=None):
         from pymor.tools.io import load_matrix
         matrix = load_matrix(path, key=key)
         return cls(matrix, solver_options=solver_options, source_id=source_id, range_id=range_id,
@@ -236,9 +236,9 @@ class NumpyMatrixOperator(NumpyMatrixBasedOperator):
         return self
 
     def as_vector(self, mu=None):
-        if self.range == scalars(1):
+        if self.range == NumpyVectorSpace(1):
             return self.source.make_array(self._matrix.ravel())
-        elif self.source == scalars(1):
+        elif self.source == NumpyVectorSpace(1):
             return self.range.make_array(self._matrix.ravel())
         else:
             raise TypeError('This operator does not represent a vector or linear functional.')

--- a/src/pymor/operators/numpy.py
+++ b/src/pymor/operators/numpy.py
@@ -27,7 +27,7 @@ from pymor.core.interfaces import abstractmethod
 from pymor.core.logger import getLogger
 from pymor.operators.basic import OperatorBase
 from pymor.operators.constructions import IdentityOperator, ZeroOperator
-from pymor.vectorarrays.numpy import NumpyVectorArray, NumpyVectorSpace
+from pymor.vectorarrays.numpy import NumpyVectorSpace, scalars
 
 
 class NumpyGenericOperator(OperatorBase):
@@ -64,9 +64,9 @@ class NumpyGenericOperator(OperatorBase):
     """
 
     def __init__(self, mapping, adjoint_mapping=None, dim_source=1, dim_range=1, linear=False, parameter_type=None,
-                 solver_options=None, name=None):
-        self.source = NumpyVectorSpace(dim_source)
-        self.range = NumpyVectorSpace(dim_range)
+                 source_id='STATE', range_id='STATE', solver_options=None, name=None):
+        self.source = NumpyVectorSpace(dim_source, source_id)
+        self.range = NumpyVectorSpace(dim_range, range_id)
         self.solver_options = solver_options
         self.name = name
         self._mapping = mapping
@@ -74,14 +74,16 @@ class NumpyGenericOperator(OperatorBase):
         self.linear = linear
         if parameter_type is not None:
             self.build_parameter_type(parameter_type)
+        self.source_id = source_id  # needed for with_
+        self.range_id = range_id
 
     def apply(self, U, mu=None):
         assert U in self.source
         if self.parametric:
             mu = self.parse_parameter(mu)
-            return NumpyVectorArray(self._mapping(U.data, mu=mu), copy=False)
+            return self.range.make_array(self._mapping(U.data, mu=mu))
         else:
-            return NumpyVectorArray(self._mapping(U.data), copy=False)
+            return self.range.make_array(self._mapping(U.data))
 
     def apply_adjoint(self, U, mu=None, source_product=None, range_product=None):
         if self._adjoint_mapping is None:
@@ -93,9 +95,9 @@ class NumpyGenericOperator(OperatorBase):
             PrU = U.data
         if self.parametric:
             mu = self.parse_parameter(mu)
-            ATPrU = NumpyVectorArray(self._adjoint_mapping(PrU, mu=mu), copy=False)
+            ATPrU = self.source.make_array(self._adjoint_mapping(PrU, mu=mu))
         else:
-            ATPrU = NumpyVectorArray(self._adjoint_mapping(PrU), copy=False)
+            ATPrU = self.source.make_array(self._adjoint_mapping(PrU))
         if source_product:
             return source_product.apply_inverse(ATPrU)
         else:
@@ -135,17 +137,25 @@ class NumpyMatrixBasedOperator(OperatorBase):
             if self._defaults_sid != defaults_sid():
                 self.logger.warn('Re-assembling since state of global defaults has changed.')
                 op = self._assembled_operator = NumpyMatrixOperator(self._assemble(),
+                                                                    source_id=self.source.id,
+                                                                    range_id=self.range.id,
                                                                     solver_options=self.solver_options)
                 self._defaults_sid = defaults_sid()
                 return op
             else:
                 return self._assembled_operator
         elif not self.parameter_type:
-            op = self._assembled_operator = NumpyMatrixOperator(self._assemble(), solver_options=self.solver_options)
+            op = self._assembled_operator = NumpyMatrixOperator(self._assemble(),
+                                                                source_id=self.source.id,
+                                                                range_id=self.range.id,
+                                                                solver_options=self.solver_options)
             self._defaults_sid = defaults_sid()
             return op
         else:
-            return NumpyMatrixOperator(self._assemble(self.parse_parameter(mu)), solver_options=self.solver_options)
+            return NumpyMatrixOperator(self._assemble(self.parse_parameter(mu)),
+                                       source_id=self.source.id,
+                                       range_id=self.range.id,
+                                       solver_options=self.solver_options)
 
     def apply(self, U, mu=None):
         return self.assemble(mu).apply(U)
@@ -158,7 +168,6 @@ class NumpyMatrixBasedOperator(OperatorBase):
 
     def apply_inverse(self, V, mu=None, least_squares=False):
         return self.assemble(mu).apply_inverse(V, least_squares=least_squares)
-
 
     def export_matrix(self, filename, matrix_name=None, output_format='matlab', mu=None):
         """Save the matrix of the operator to a file.
@@ -200,22 +209,25 @@ class NumpyMatrixOperator(NumpyMatrixBasedOperator):
         Name of the operator.
     """
 
-    def __init__(self, matrix, solver_options=None, name=None):
+    def __init__(self, matrix, source_id='STATE', range_id='STATE', solver_options=None, name=None):
         assert matrix.ndim <= 2
         if matrix.ndim == 1:
             matrix = np.reshape(matrix, (1, -1))
-        self.source = NumpyVectorSpace(matrix.shape[1])
-        self.range = NumpyVectorSpace(matrix.shape[0])
+        self.source = NumpyVectorSpace(matrix.shape[1], source_id)
+        self.range = NumpyVectorSpace(matrix.shape[0], range_id)
         self.solver_options = solver_options
         self.name = name
         self._matrix = matrix
+        self.source_id = source_id
+        self.range_id = range_id
         self.sparse = issparse(matrix)
 
     @classmethod
-    def from_file(cls, path, key=None, solver_options=None, name=None):
+    def from_file(cls, path, key=None, source_id='STATE', range_id='STATE', solver_options=None, name=None):
         from pymor.tools.io import load_matrix
         matrix = load_matrix(path, key=key)
-        return cls(matrix, solver_options=solver_options, name=name or key or path)
+        return cls(matrix, solver_options=solver_options, source_id=source_id, range_id=range_id,
+                   name=name or key or path)
 
     def _assemble(self, mu=None):
         pass
@@ -224,14 +236,16 @@ class NumpyMatrixOperator(NumpyMatrixBasedOperator):
         return self
 
     def as_vector(self, mu=None):
-        matrix = self._matrix
-        if matrix.shape[0] != 1 and matrix.shape[1] != 1:
+        if self.range == scalars(1):
+            return self.source.make_array(self._matrix.ravel())
+        elif self.source == scalars(1):
+            return self.range.make_array(self._matrix.ravel())
+        else:
             raise TypeError('This operator does not represent a vector or linear functional.')
-        return NumpyVectorArray(matrix.ravel(), copy=True)
 
     def apply(self, U, mu=None):
         assert U in self.source
-        return NumpyVectorArray(self._matrix.dot(U.data.T).T, copy=False)
+        return self.range.make_array(self._matrix.dot(U.data.T).T)
 
     def apply_adjoint(self, U, mu=None, source_product=None, range_product=None):
         assert U in self.range
@@ -241,7 +255,7 @@ class NumpyMatrixOperator(NumpyMatrixBasedOperator):
             PrU = range_product.apply(U).data
         else:
             PrU = U.data
-        ATPrU = NumpyVectorArray(self._matrix.T.dot(PrU.T).T, copy=False)
+        ATPrU = self.source.make_array(self._matrix.T.dot(PrU.T).T)
         if source_product:
             return source_product.apply_inverse(ATPrU)
         else:
@@ -252,7 +266,7 @@ class NumpyMatrixOperator(NumpyMatrixBasedOperator):
 
         if V.dim == 0:
             if self.source.dim == 0 or least_squares:
-                return NumpyVectorArray(np.zeros((len(V), self.source.dim)))
+                return self.source.make_array(np.zeros((len(V), self.source.dim)))
             else:
                 raise InversionError
 
@@ -266,7 +280,7 @@ class NumpyMatrixOperator(NumpyMatrixBasedOperator):
                 self.logger.warn('Least squares solver selected but "least_squares == False"')
 
         try:
-            return NumpyVectorArray(_apply_inverse(self._matrix, V.data, options=options))
+            return self.source.make_array(_apply_inverse(self._matrix, V.data, options=options))
         except InversionError as e:
             if least_squares and options:
                 solver_type = options if isinstance(options, str) else options['type']
@@ -285,7 +299,8 @@ class NumpyMatrixOperator(NumpyMatrixBasedOperator):
                                                  least_squares=least_squares)
         else:
             options = {'inverse': self.solver_options.get('inverse_adjoint') if self.solver_options else None}
-            adjoint_op = NumpyMatrixOperator(self._matrix.T, solver_options=options)
+            adjoint_op = NumpyMatrixOperator(self._matrix.T, source_id=self.range.id, range_id=self.source.id,
+                                             solver_options=options)
             return adjoint_op.apply_inverse(U, mu=mu, least_squares=least_squares)
 
     def projected_to_subbasis(self, dim_range=None, dim_source=None, name=None):
@@ -319,7 +334,10 @@ class NumpyMatrixOperator(NumpyMatrixBasedOperator):
         assert dim_range is None or dim_range <= self.range.dim
         name = name or '{}_projected_to_subbasis'.format(self.name)
         # copy instead of just slicing the matrix to ensure contiguous memory
-        return NumpyMatrixOperator(self._matrix[:dim_range, :dim_source].copy(), solver_options=self.solver_options,
+        return NumpyMatrixOperator(self._matrix[:dim_range, :dim_source].copy(),
+                                   source_id=self.source.id,
+                                   range_id=self.range.id,
+                                   solver_options=self.solver_options,
                                    name=name)
 
     def assemble_lincomb(self, operators, coefficients, solver_options=None, name=None):
@@ -372,7 +390,10 @@ class NumpyMatrixOperator(NumpyMatrixBasedOperator):
                     matrix += (op._matrix * c)
                 except NotImplementedError:
                     matrix = matrix + (op._matrix * c)
-        return NumpyMatrixOperator(matrix, solver_options=solver_options)
+        return NumpyMatrixOperator(matrix,
+                                   source_id=self.source.id,
+                                   range_id=self.range.id,
+                                   solver_options=solver_options)
 
     def __getstate__(self):
         if hasattr(self._matrix, 'factorization'):  # remove unplicklable SuperLU factorization
@@ -978,9 +999,8 @@ def _apply_inverse(matrix, V, options=None, check_finite=True):
         logger = getLogger('pymor.operators.numpy._apply_inverse')
         logger.warn('You have selected a (potentially slow) generic solver for a NumPy matrix operator!')
         from pymor.operators.numpy import NumpyMatrixOperator
-        from pymor.vectorarrays.numpy import NumpyVectorArray
         return genericsolvers.apply_inverse(NumpyMatrixOperator(matrix),
-                                            NumpyVectorArray(V, copy=False),
+                                            NumpyVectorSpace.make_array(V),
                                             options=options).data
     else:
         raise ValueError('Unknown solver type')

--- a/src/pymor/playground/discretizers/numpylistvectorarray.py
+++ b/src/pymor/playground/discretizers/numpylistvectorarray.py
@@ -23,6 +23,7 @@ def convert_to_numpy_list_vector_array(d):
             op = op.assemble()
             if isinstance(op, NumpyMatrixOperator):
                 return NumpyListVectorArrayMatrixOperator(op._matrix, functional=functional, vector=vector,
+                                                          source_id=op.source.id, range_id=op.range.id,
                                                           name=op.name)
             else:
                 raise NotImplementedError

--- a/src/pymor/playground/operators/numpy.py
+++ b/src/pymor/playground/operators/numpy.py
@@ -77,13 +77,13 @@ class NumpyListVectorArrayMatrixOperator(NumpyMatrixOperator):
                     raise InversionError(msg)
             raise e
 
-    def as_vector(self, mu=None):
-        if self.range == NumpyVectorSpace(1):
-            return self.source.make_array([self._matrix.ravel()])
-        elif self.source == NumpyVectorSpace(1):
-            return self.range.make_array([self._matrix.ravel()])
-        else:
-            raise TypeError('This operator does not represent a vector or linear functional.')
+    def as_range_array(self, mu=None):
+        assert not self.sparse
+        return self.range.make_array(list(self._matrix.T.copy()))
+
+    def as_source_array(self, mu=None):
+        assert not self.sparse
+        return self.source.make_array(list(self._matrix.copy()))
 
     def assemble_lincomb(self, operators, coefficients, solver_options=None, name=None):
         lincomb = super().assemble_lincomb(operators, coefficients)

--- a/src/pymor/playground/vectorarrays/mpi.py
+++ b/src/pymor/playground/vectorarrays/mpi.py
@@ -7,39 +7,21 @@ from numbers import Number
 import numpy as np
 
 from pymor.tools import mpi
-from pymor.vectorarrays.numpy import NumpyVectorArray
-from pymor.vectorarrays.mpi import MPIVectorArrayAutoComm, MPIVectorAutoComm
-from pymor.vectorarrays.list import ListVectorArray, NumpyVector
+from pymor.vectorarrays.numpy import NumpyVectorSpace
+from pymor.vectorarrays.mpi import MPIVectorSpaceAutoComm
 
 
 def random_array(dims, length, seed):
     if isinstance(dims, Number):
         dims = (dims,)
-    return MPIVectorArrayAutoComm(NumpyVectorArray, tuple(dims),
-                                  mpi.call(_random_array, dims, length, seed))
+    return MPIVectorSpaceAutoComm(tuple(NumpyVectorSpace(dim) for dim in dims)).make_array(
+        mpi.call(_random_array, dims, length, seed)
+    )
 
 
 def _random_array(dims, length, seed):
     np.random.seed(seed + mpi.rank)
     dim = dims[mpi.rank] if len(dims) > 1 else dims[0]
-    array = NumpyVectorArray(np.random.random((length, dim)))
+    array = NumpyVectorSpace.make_array(np.random.random((length, dim)))
     obj_id = mpi.manage_object(array)
-    return obj_id
-
-
-def random_list_array(dims, length, seed):
-    if isinstance(dims, Number):
-        dims = (dims,)
-    return ListVectorArray([MPIVectorAutoComm(NumpyVector, tuple(dims),
-                                              mpi.call(_random_vector, dims, seed + i))
-                            for i in range(length)],
-                           copy=False,
-                           subtype=(MPIVectorAutoComm, (NumpyVector, tuple(dims))))
-
-
-def _random_vector(dims, seed):
-    np.random.seed(seed + mpi.rank)
-    dim = dims[mpi.rank] if len(dims) > 1 else dims[0]
-    vector = NumpyVector(np.random.random(dim), copy=False)
-    obj_id = mpi.manage_object(vector)
     return obj_id

--- a/src/pymor/reductors/basic.py
+++ b/src/pymor/reductors/basic.py
@@ -5,7 +5,7 @@
 import numpy as np
 
 from pymor.core.interfaces import BasicInterface
-from pymor.vectorarrays.numpy import NumpyVectorArray
+from pymor.vectorarrays.numpy import NumpyVectorSpace
 
 
 class GenericRBReconstructor(BasicInterface):
@@ -16,7 +16,8 @@ class GenericRBReconstructor(BasicInterface):
 
     def reconstruct(self, U):
         """Reconstruct high-dimensional vector from reduced vector `U`."""
-        assert isinstance(U, NumpyVectorArray)
+        RB = self.RB
+        assert U in NumpyVectorSpace(len(RB), RB.space.id)
         return self.RB.lincomb(U.data)
 
     def restricted_to_subbasis(self, dim):
@@ -100,10 +101,10 @@ class SubbasisReconstructor(BasicInterface):
 
     def reconstruct(self, U):
         """Reconstruct high-dimensional vector from reduced vector `U`."""
-        assert isinstance(U, NumpyVectorArray)
+        assert isinstance(U.space, NumpyVectorSpace)
         UU = np.zeros((len(U), self.dim))
         UU[:, :self.dim_subbasis] = U.data
-        UU = NumpyVectorArray(UU, copy=False)
+        UU = NumpyVectorSpace.make_array(UU, U.space.id)
         if self.old_recontructor:
             return self.old_recontructor.reconstruct(UU)
         else:

--- a/src/pymor/reductors/coercive.py
+++ b/src/pymor/reductors/coercive.py
@@ -202,12 +202,12 @@ def reduce_coercive_simple(discretization, RB, product=None, coercivity_estimato
     elif not d.rhs.parametric:
         R_R = space.empty(reserve=1)
         RR_R = space.empty(reserve=1)
-        append_vector(d.rhs.as_vector(), R_R, RR_R)
+        append_vector(d.rhs.as_source_array(), R_R, RR_R)
     else:
         R_R = space.empty(reserve=len(d.rhs.operators))
         RR_R = space.empty(reserve=len(d.rhs.operators))
         for op in d.rhs.operators:
-            append_vector(op.as_vector(), R_R, RR_R)
+            append_vector(op.as_source_array(), R_R, RR_R)
 
     if len(RB) == 0:
         R_Os = [space.empty()]

--- a/src/pymor/reductors/coercive.py
+++ b/src/pymor/reductors/coercive.py
@@ -10,7 +10,7 @@ from pymor.operators.constructions import LincombOperator, induced_norm
 from pymor.operators.numpy import NumpyMatrixOperator
 from pymor.reductors.basic import reduce_generic_rb
 from pymor.reductors.residual import reduce_residual
-from pymor.vectorarrays.numpy import NumpyVectorArray
+from pymor.vectorarrays.numpy import NumpyVectorSpace
 
 
 def reduce_coercive(discretization, RB, product=None, coercivity_estimator=None,
@@ -276,7 +276,7 @@ class ReduceCoerciveSimpleEstimator(ImmutableInterface):
 
         C = np.hstack((CR, np.dot(CO[..., np.newaxis], U.data).ravel()))
 
-        est = self.norm(NumpyVectorArray(C))
+        est = self.norm(NumpyVectorSpace.make_array(C))
         if self.coercivity_estimator:
             est /= self.coercivity_estimator(mu)
 

--- a/src/pymor/reductors/parabolic.py
+++ b/src/pymor/reductors/parabolic.py
@@ -93,7 +93,7 @@ def reduce_parabolic(discretization, RB, product=None, coercivity_estimator=None
     old_initial_resdidual_data = extends[2].pop('initial_residual') if extends else None
 
     with logger.block('RB projection ...'):
-        rd, rc, data = reduce_generic_rb(discretization, RB, vector_product=product,
+        rd, rc, data = reduce_generic_rb(discretization, RB, product=product,
                                          disable_caching=disable_caching, extends=extends)
 
     dt = discretization.T / discretization.time_stepper.nt

--- a/src/pymor/reductors/parabolic.py
+++ b/src/pymor/reductors/parabolic.py
@@ -105,7 +105,7 @@ def reduce_parabolic(discretization, RB, product=None, coercivity_estimator=None
         )
 
         initial_residual, initial_residual_reconstructor, initial_residual_data = reduce_residual(
-            IdentityOperator(discretization.solution_space), discretization.initial_data, RB, False,
+            IdentityOperator(discretization.solution_space), discretization.initial_data, RB,
             product=discretization.l2_product, extends=old_initial_resdidual_data
         )
 

--- a/src/pymor/reductors/residual.py
+++ b/src/pymor/reductors/residual.py
@@ -11,7 +11,7 @@ from pymor.core.logger import getLogger
 from pymor.operators.basic import OperatorBase
 from pymor.operators.constructions import induced_norm
 from pymor.reductors.basic import GenericRBReconstructor
-from pymor.vectorarrays.numpy import NumpyVectorSpace
+from pymor.vectorarrays.numpy import scalars
 
 
 def reduce_residual(operator, rhs=None, RB=None, rhs_is_functional=True, product=None, extends=None):
@@ -76,8 +76,8 @@ def reduce_residual(operator, rhs=None, RB=None, rhs_is_functional=True, product
         Additional data produced by the reduction process (compare the `extends` parameter).
     """
     assert rhs is None \
-        or rhs_is_functional and (rhs.range == NumpyVectorSpace(1) and rhs.source == operator.range and rhs.linear) \
-        or not rhs_is_functional and (rhs.source == NumpyVectorSpace(1) and rhs.range == operator.range and rhs.linear)
+        or rhs_is_functional and (rhs.range == scalars(1) and rhs.source == operator.range and rhs.linear) \
+        or not rhs_is_functional and (rhs.source == scalars(1) and rhs.range == operator.range and rhs.linear)
     assert RB is None or RB in operator.source
     assert product is None or product.source == product.range == operator.range
     assert extends is None or len(extends) == 3
@@ -253,7 +253,7 @@ def reduce_implicit_euler_residual(operator, mass, dt, functional=None, RB=None,
         Additional data produced by the reduction process (compare the `extends` parameter).
     """
     assert functional is None \
-        or functional.range == NumpyVectorSpace(1) and functional.source == operator.source and functional.linear
+        or functional.range == scalars(1) and functional.source == operator.source and functional.linear
     assert RB is None or RB in operator.source
     assert product is None or product.source == product.range == operator.range
     assert extends is None or len(extends) == 3

--- a/src/pymor/reductors/residual.py
+++ b/src/pymor/reductors/residual.py
@@ -342,7 +342,7 @@ class NonProjectedImplicitEulerResidualOperator(ImplicitEulerResidualOperator):
         R = super().apply(U, U_old, mu=mu)
         if self.product:
             R_riesz = self.product.apply_inverse(R)
-            return R_riesz * (np.sqrt(R_riesz.dot(R)) / R_riesz.l2_norm())[0]
+            return R_riesz * (np.sqrt(R_riesz.pairwise_dot(R)) / R_riesz.l2_norm())[0]
         else:
             return R
 

--- a/src/pymor/reductors/residual.py
+++ b/src/pymor/reductors/residual.py
@@ -105,7 +105,8 @@ def reduce_residual(operator, rhs=None, RB=None, product=None, extends=None):
     with logger.block('Estimating residual range ...'):
         try:
             residual_range, residual_range_dims = \
-                estimate_image_hierarchical([operator], [rhs], RB, (residual_range, residual_range_dims),
+                estimate_image_hierarchical([operator], [rhs.T if rhs_is_functional else rhs], RB,
+                                            (residual_range, residual_range_dims),
                                             orthonormalize=True, product=product,
                                             riesz_representatives=rhs_is_functional)
         except ImageCollectionError as e:
@@ -281,7 +282,7 @@ def reduce_implicit_euler_residual(operator, mass, dt, functional=None, RB=None,
     with logger.block('Estimating residual range ...'):
         try:
             residual_range, residual_range_dims = \
-                estimate_image_hierarchical([operator, mass], [functional], RB, (residual_range, residual_range_dims),
+                estimate_image_hierarchical([operator, mass], [functional.T], RB, (residual_range, residual_range_dims),
                                             orthonormalize=True, product=product, riesz_representatives=True)
         except ImageCollectionError as e:
             logger.warn('Cannot compute range of {}. Evaluation will be slow.'.format(e.op))

--- a/src/pymor/reductors/residual.py
+++ b/src/pymor/reductors/residual.py
@@ -11,7 +11,6 @@ from pymor.core.logger import getLogger
 from pymor.operators.basic import OperatorBase
 from pymor.operators.constructions import induced_norm
 from pymor.reductors.basic import GenericRBReconstructor
-from pymor.vectorarrays.numpy import NumpyVectorSpace
 
 
 def reduce_residual(operator, rhs=None, RB=None, rhs_is_functional=True, product=None, extends=None):
@@ -76,8 +75,8 @@ def reduce_residual(operator, rhs=None, RB=None, rhs_is_functional=True, product
         Additional data produced by the reduction process (compare the `extends` parameter).
     """
     assert rhs is None \
-        or rhs_is_functional and (rhs.range == NumpyVectorSpace(1) and rhs.source == operator.range and rhs.linear) \
-        or not rhs_is_functional and (rhs.source == NumpyVectorSpace(1) and rhs.range == operator.range and rhs.linear)
+        or (rhs.range.is_scalar and rhs.source == operator.range and rhs.linear) \
+        or (rhs.source.is_scalar and rhs.range == operator.range and rhs.linear)
     assert RB is None or RB in operator.source
     assert product is None or product.source == product.range == operator.range
     assert extends is None or len(extends) == 3
@@ -253,7 +252,7 @@ def reduce_implicit_euler_residual(operator, mass, dt, functional=None, RB=None,
         Additional data produced by the reduction process (compare the `extends` parameter).
     """
     assert functional is None \
-        or functional.range == NumpyVectorSpace(1) and functional.source == operator.source and functional.linear
+        or functional.range.is_scalar and functional.source == operator.source and functional.linear
     assert RB is None or RB in operator.source
     assert product is None or product.source == product.range == operator.range
     assert extends is None or len(extends) == 3

--- a/src/pymor/reductors/residual.py
+++ b/src/pymor/reductors/residual.py
@@ -131,14 +131,14 @@ class ResidualOperator(OperatorBase):
         self.linear = operator.linear
         self.operator = operator
         self.rhs = rhs
-        self.rhs_vector = rhs.as_vector() if rhs and not rhs.parametric else None
+        self.rhs_vector = rhs.as_vector(space=operator.range) if rhs and not rhs.parametric else None
         self.rhs_is_functional = rhs_is_functional
         self.name = name
 
     def apply(self, U, mu=None):
         V = self.operator.apply(U, mu=mu)
         if self.rhs:
-            F = self.rhs_vector or self.rhs.as_vector(mu)
+            F = self.rhs_vector or self.rhs.as_vector(mu, space=self.operator.range)
             if len(V) > 1:
                 V -= F[[0]*len(V)]
             else:
@@ -305,7 +305,7 @@ class ImplicitEulerResidualOperator(OperatorBase):
         self.operator = operator
         self.mass = mass
         self.functional = functional
-        self.functional_vector = functional.as_vector() if functional and not functional.parametric else None
+        self.functional_vector = functional.as_source_array() if functional and not functional.parametric else None
         self.dt = dt
         self.name = name
 
@@ -314,7 +314,7 @@ class ImplicitEulerResidualOperator(OperatorBase):
         V.axpy(1./self.dt, self.mass.apply(U, mu=mu))
         V.axpy(-1./self.dt, self.mass.apply(U_old, mu=mu))
         if self.functional:
-            F = self.functional_vector or self.functional.as_vector(mu)
+            F = self.functional_vector or self.functional.as_source_array(mu)
             if len(V) > 1:
                 V -= F[[0]*len(V)]
             else:

--- a/src/pymor/reductors/residual.py
+++ b/src/pymor/reductors/residual.py
@@ -11,7 +11,7 @@ from pymor.core.logger import getLogger
 from pymor.operators.basic import OperatorBase
 from pymor.operators.constructions import induced_norm
 from pymor.reductors.basic import GenericRBReconstructor
-from pymor.vectorarrays.numpy import scalars
+from pymor.vectorarrays.numpy import NumpyVectorSpace
 
 
 def reduce_residual(operator, rhs=None, RB=None, rhs_is_functional=True, product=None, extends=None):
@@ -76,8 +76,8 @@ def reduce_residual(operator, rhs=None, RB=None, rhs_is_functional=True, product
         Additional data produced by the reduction process (compare the `extends` parameter).
     """
     assert rhs is None \
-        or rhs_is_functional and (rhs.range == scalars(1) and rhs.source == operator.range and rhs.linear) \
-        or not rhs_is_functional and (rhs.source == scalars(1) and rhs.range == operator.range and rhs.linear)
+        or rhs_is_functional and (rhs.range == NumpyVectorSpace(1) and rhs.source == operator.range and rhs.linear) \
+        or not rhs_is_functional and (rhs.source == NumpyVectorSpace(1) and rhs.range == operator.range and rhs.linear)
     assert RB is None or RB in operator.source
     assert product is None or product.source == product.range == operator.range
     assert extends is None or len(extends) == 3
@@ -253,7 +253,7 @@ def reduce_implicit_euler_residual(operator, mass, dt, functional=None, RB=None,
         Additional data produced by the reduction process (compare the `extends` parameter).
     """
     assert functional is None \
-        or functional.range == scalars(1) and functional.source == operator.source and functional.linear
+        or functional.range == NumpyVectorSpace(1) and functional.source == operator.source and functional.linear
     assert RB is None or RB in operator.source
     assert product is None or product.source == product.range == operator.range
     assert extends is None or len(extends) == 3

--- a/src/pymor/vectorarrays/block.py
+++ b/src/pymor/vectorarrays/block.py
@@ -15,20 +15,10 @@ class BlockVectorArray(VectorArrayInterface):
 
     Given a list of equal length |VectorArrays| `blocks`, this |VectorArray|
     represents the direct sums of the vectors contained in the arrays.
-
-    The :attr:`~pymor.vectorarrays.interfaces.VectorArrayInterface.subtype`
-    of the array will be the tuple ::
-
-        (blocks[0].space, blocks[1].space, ..., blocks[-1].space).
+    The associated |VectorSpace| is :class:`BlockVectorSpace`.
 
     :class:`BlockVectorArray` can be used in conjunction with
     :class:`~pymor.operators.block.BlockOperator`.
-
-
-    Parameters
-    ----------
-    blocks
-        The list of sub-arrays.
     """
 
     def __init__(self, blocks, space):
@@ -159,6 +149,19 @@ class BlockVectorArray(VectorArrayInterface):
 
 
 class BlockVectorSpace(VectorSpaceInterface):
+    """|VectorSpace| of :class:`BlockVectorArrays <BlockVectorArray>`.
+
+    A :class:`BlockVectorSpace` is defined by the |VectorSpaces| of the
+    individual subblocks which constitute a given array. In particular
+    for a given :class`BlockVectorArray` `U`, we have the identity ::
+
+        (U.blocks[0].space, U.blocks[1].space, ..., U.blocks[-1].space) == U.space.
+
+    Parameters
+    ----------
+    subspaces
+        The tuple defined above.
+    """
 
     def __init__(self, subspaces, id_='STATE'):
         subspaces = tuple(subspaces)

--- a/src/pymor/vectorarrays/block.py
+++ b/src/pymor/vectorarrays/block.py
@@ -163,7 +163,7 @@ class BlockVectorSpace(VectorSpaceInterface):
         The tuple defined above.
     """
 
-    def __init__(self, subspaces, id_='STATE'):
+    def __init__(self, subspaces, id_=None):
         subspaces = tuple(subspaces)
         assert all([isinstance(subspace, VectorSpaceInterface) for subspace in subspaces])
         self.subspaces = subspaces
@@ -182,7 +182,7 @@ class BlockVectorSpace(VectorSpaceInterface):
         return BlockVectorArray([subspace.zeros(count=count, reserve=reserve) for subspace in self.subspaces], self)
 
     @classinstancemethod
-    def make_array(cls, obj, id_='STATE'):
+    def make_array(cls, obj, id_=None):
         assert len(obj) > 0
         return cls(tuple(o.space for o in obj), id_=id_).make_array(obj)
 

--- a/src/pymor/vectorarrays/block.py
+++ b/src/pymor/vectorarrays/block.py
@@ -54,7 +54,7 @@ class BlockVectorArray(VectorArrayInterface):
 
     @property
     def num_blocks(self):
-        return len(self.subtype)
+        return len(self._blocks)
 
     def __len__(self):
         return len(self._blocks[0])

--- a/src/pymor/vectorarrays/fenics.py
+++ b/src/pymor/vectorarrays/fenics.py
@@ -73,7 +73,7 @@ if HAVE_FENICS:
             if len(component_indices) == 0:
                 return np.array([], dtype=np.intc)
             assert 0 <= np.min(component_indices)
-            assert np.max(component_indices) < self.dim
+            assert np.max(component_indices) < self.impl.size()
             x = df.Vector()
             self.impl.gather(x, component_indices)
             return x.array()

--- a/src/pymor/vectorarrays/fenics.py
+++ b/src/pymor/vectorarrays/fenics.py
@@ -16,7 +16,7 @@ except ImportError:
 if HAVE_FENICS:
     import numpy as np
 
-    from pymor.vectorarrays.list import CopyOnWriteVector, ListVectorArray, ListVectorSpace
+    from pymor.vectorarrays.list import CopyOnWriteVector, ListVectorSpace
 
 
     # For pyMOR's MPI support to work, subtypes need to be hashable.

--- a/src/pymor/vectorarrays/fenics.py
+++ b/src/pymor/vectorarrays/fenics.py
@@ -19,9 +19,9 @@ if HAVE_FENICS:
     from pymor.vectorarrays.list import CopyOnWriteVector, ListVectorSpace
 
 
-    # For pyMOR's MPI support to work, subtypes need to be hashable.
-    # However, FunctionSpace (our subtype) defines __eq__ but not __hash__
-    # which makes it unhashable on Pyhton 3. On the other hand, equality
+    # For pyMOR's MPI support to work, VectorSpaces need to be hashable.
+    # However, FunctionSpace defines __eq__ but not __hash__ which
+    # makes it unhashable on Pyhton 3. On the other hand, equality
     # for FunctionSpace seems to be the same as identity, so we can easily
     # monkey-patch:
     df.FunctionSpace.__hash__ = lambda self: id(self)

--- a/src/pymor/vectorarrays/interfaces.py
+++ b/src/pymor/vectorarrays/interfaces.py
@@ -548,7 +548,7 @@ class VectorSpaceInterface(ImmutableInterface):
         return other is self
 
     def __contains__(self, other):
-        return self == other.space
+        return self == getattr(other, 'space', None)
 
     # def __repr__(self):
     #     return 'VectorSpace({}, {})'.format(self.type.__name__, repr(self.subtype))

--- a/src/pymor/vectorarrays/interfaces.py
+++ b/src/pymor/vectorarrays/interfaces.py
@@ -37,8 +37,8 @@ class VectorArrayInterface(BasicInterface):
     allocated internally (e.g.  continuous block of memory vs. list of pointers to the
     individual vectors.) Thus, no general assumptions can be made on the costs of operations
     like appending to or removing vectors from the array. As a hint for 'continuous block
-    of memory' implementations, |VectorArray| constructors provide a `reserve` keyword
-    argument which allows to specify to what size the array is assumed to grow.
+    of memory' implementations, :meth:`~VectorSpaceInterface.zeros` provides a `reserve`
+    keyword argument which allows to specify to what size the array is assumed to grow.
 
     As with |Numpy array|, |VectorArrays| can be indexed with numbers, slices and
     lists or one-dimensional |NumPy arrays|. Indexing will always return a new
@@ -46,7 +46,7 @@ class VectorArrayInterface(BasicInterface):
     array is modified via :meth:`~VectorArrayInterface.scal` or :meth:`~VectorArrayInterface.axpy`,
     the vectors in the original array will be changed. Indices may be negative, in
     which case the vector is selected by counting from the end of the array. Moreover
-    Indices can be repeated, in which case the corresponding vector is selected several
+    indices can be repeated, in which case the corresponding vector is selected several
     times. The resulting view will be immutable, however.
 
     .. note::
@@ -482,10 +482,10 @@ class VectorSpaceInterface(ImmutableInterface):
     |VectorArray| from given raw data of the underlying linear algebra
     backend (e.g. a |Numpy array| in the case  of |NumpyVectorSpace|).
     Some vector spaces can create new |VectorArrays| from a given
-    |Numpy array| via the :meth:`~VectorArrayInterface.from_data`
+    |Numpy array| via the :meth:`~VectorSpaceInterface.from_data`
     method.
 
-    Each vector space is a string :attr:`~VectorArrayInterface.id`
+    Each vector space has a string :attr:`~VectorSpaceInterface.id`
     to distinguish mathematically different spaces appearing
     in the formulation of a given problem.
 
@@ -500,7 +500,10 @@ class VectorSpaceInterface(ImmutableInterface):
         A string describing the mathematical identity of the
         vector space (for instance to distinguish different
         components in an equation system). The default value
-        is `'STATE'`.
+        is `'STATE'`. To identify arrays of scalar values
+        (as the source space of vector-like |Operators| and
+        as the range space of |Functionals|) the id `'SCALARS'`
+        is used.
     dim
         The dimension (number of degrees of freedom) of the
         vectors contained in the space.

--- a/src/pymor/vectorarrays/interfaces.py
+++ b/src/pymor/vectorarrays/interfaces.py
@@ -547,6 +547,9 @@ class VectorSpaceInterface(ImmutableInterface):
     def __eq__(self, other):
         return other is self
 
+    def __ne__(self, other):
+        return not (self == other)
+
     def __contains__(self, other):
         return self == getattr(other, 'space', None)
 

--- a/src/pymor/vectorarrays/interfaces.py
+++ b/src/pymor/vectorarrays/interfaces.py
@@ -497,19 +497,15 @@ class VectorSpaceInterface(ImmutableInterface):
     Attributes
     ----------
     id
-        A string describing the mathematical identity of the
-        vector space (for instance to distinguish different
-        components in an equation system). The default value
-        is `'STATE'`. To identify arrays of scalar values
-        (as the source space of vector-like |Operators| and
-        as the range space of |Functionals|) the id `'SCALARS'`
-        is used.
+        None, or a string describing the mathematical identity
+        of the vector space (for instance to distinguish different
+        components in an equation system).
     dim
         The dimension (number of degrees of freedom) of the
         vectors contained in the space.
     """
 
-    id = 'STATE'
+    id = None
     dim = None
 
     @abstractmethod

--- a/src/pymor/vectorarrays/interfaces.py
+++ b/src/pymor/vectorarrays/interfaces.py
@@ -582,5 +582,8 @@ class VectorSpaceInterface(ImmutableInterface):
     def __contains__(self, other):
         return self == getattr(other, 'space', None)
 
+    def __hash__(self):
+        return hash(self.id)
+
     def __repr__(self):
         return '{}({})'.format(self.__class__, self.id)

--- a/src/pymor/vectorarrays/interfaces.py
+++ b/src/pymor/vectorarrays/interfaces.py
@@ -586,4 +586,4 @@ class VectorSpaceInterface(ImmutableInterface):
         return hash(self.id)
 
     def __repr__(self):
-        return '{}({})'.format(self.__class__, self.id)
+        return '{}({})'.format(self.__class__.__name__, self.id)

--- a/src/pymor/vectorarrays/interfaces.py
+++ b/src/pymor/vectorarrays/interfaces.py
@@ -503,10 +503,13 @@ class VectorSpaceInterface(ImmutableInterface):
     dim
         The dimension (number of degrees of freedom) of the
         vectors contained in the space.
+    is_scalar
+        Equivalent to `isinstance(space, NumpyVectorSpace) and space.dim == 1`.
     """
 
     id = None
     dim = None
+    is_scalar = False
 
     @abstractmethod
     def make_array(*args, **kwargs):

--- a/src/pymor/vectorarrays/list.py
+++ b/src/pymor/vectorarrays/list.py
@@ -10,12 +10,11 @@ from pymor.vectorarrays.interfaces import VectorArrayInterface, VectorSpaceInter
 
 
 class VectorInterface(BasicInterface):
-    """Interface for vectors.
+    """Interface for vectors used in conjunction with |ListVectorArray|.
 
-    This Interface is intended to be used in conjunction with |ListVectorArray|.
-    All pyMOR algorithms operate on |VectorArrays| instead of single vectors!
-    All methods of the interface have a direct counterpart in the |VectorArray|
-    interface.
+    This interface must be staisfied by the individual entries of the
+    vector `list` managed by |ListVectorArray|. All interface methods
+    have a direct counterpart in the |VectorArray| interface.
     """
 
     @abstractmethod
@@ -209,25 +208,19 @@ class NumpyVector(CopyOnWriteVector):
 
 
 class ListVectorArray(VectorArrayInterface):
-    """|VectorArray| implementation via a Python list of vectors.
+    """|VectorArray| implemented as a Python list of vectors.
 
-    The :attr:`subtypes <pymor.vectorarrays.interfaces.VectorArrayInterface.subtype>`
-    a |ListVectorArray| can have are tuples `(vector_type, vector_subtype)`
-    where `vector_type` is a subclass of :class:`VectorInterface` and
-    `vector_subtype` is a valid subtype for `vector_type`.
+    This |VectorArray| implementation is the first choice when
+    creating pyMOR wrappers for external solvers which are based
+    on single vector objects. In order to do so, a wrapping
+    subclass of :class:`VectorInterface` has to be provided
+    on which the implementation of |ListVectorArray| will operate.
+    The associated |VectorSpace| is a subclass of
+    :class:`ListVectorSpace`.
 
-    Parameters
-    ----------
-    vectors
-        List of :class:`vectors <VectorInterface>` contained in
-        the array.
-    subtype
-        If `vectors` is empty, the array's
-        :attr:`~pymor.vectorarrays.interfaces.VectorArrayInterface.subtype`
-        must be provided, as the subtype cannot be derived from `vectors`
-        in this case.
-    copy
-        If `True`, make copies of the vectors in `vectors`.
+    For an example, see :class:`NumpyVector`, :class:`NumpyListVectorSpace`
+    or :class:`~pymor.vectorarrays.fenics.FenicsVector`,
+    :class:`~pymor.vectorarrays.fenics.FenicsVectorSpace`.
     """
 
     _NONE = ()
@@ -397,6 +390,7 @@ class ListVectorArray(VectorArrayInterface):
 
 
 class ListVectorSpace(VectorSpaceInterface):
+    """|VectorSpace| of |ListVectorArrays|."""
 
     dim = None
 

--- a/src/pymor/vectorarrays/list.py
+++ b/src/pymor/vectorarrays/list.py
@@ -238,9 +238,9 @@ class ListVectorArray(VectorArrayInterface):
 
     @property
     def data(self):
-        if not hasattr(self.space.type, 'data'):
-            raise TypeError('{} does not have a data attribute'.format(self.space.type))
         if len(self._list) > 0:
+            if not hasattr(self._list[0], 'data'):
+                raise NotImplementedError('{} does not have a data attribute'.format(self._list[0]))
             return np.array([v.data for v in self._list])
         else:
             return np.empty((0, self.dim))
@@ -405,7 +405,7 @@ class ListVectorSpace(VectorSpaceInterface):
         pass
 
     @abstractmethod
-    def make_vector(self, data):
+    def make_vector(self, obj):
         pass
 
     def vector_from_data(self, data):

--- a/src/pymor/vectorarrays/list.py
+++ b/src/pymor/vectorarrays/list.py
@@ -418,7 +418,7 @@ class ListVectorSpace(VectorSpaceInterface):
         return ListVectorArray([self.zero_vector() for _ in range(count)], self)
 
     @classinstancemethod
-    def make_array(cls, obj, id_='STATE'):
+    def make_array(cls, obj, id_=None):
         if len(obj) == 0:
             raise NotImplementedError
         return cls.space_from_vector_obj(obj[0], id_=id_).make_array(obj)
@@ -428,7 +428,7 @@ class ListVectorSpace(VectorSpaceInterface):
         return ListVectorArray([self.make_vector(v) for v in obj], self)
 
     @classinstancemethod
-    def from_data(cls, data, id_='STATE'):
+    def from_data(cls, data, id_=None):
         return cls.space_from_dim(data.shape[1], id_=id_).from_data(data)
 
     @from_data.instancemethod
@@ -438,7 +438,7 @@ class ListVectorSpace(VectorSpaceInterface):
 
 class NumpyListVectorSpace(ListVectorSpace):
 
-    def __init__(self, dim, id_='STATE'):
+    def __init__(self, dim, id_=None):
         self.dim = dim
         self.id = id_
 

--- a/src/pymor/vectorarrays/list.py
+++ b/src/pymor/vectorarrays/list.py
@@ -398,6 +398,27 @@ class ListVectorArray(VectorArrayInterface):
 
 class ListVectorSpace(VectorSpaceInterface):
 
+    dim = None
+
+    @abstractmethod
+    def zero_vector(self):
+        pass
+
+    @abstractmethod
+    def make_vector(self, data):
+        pass
+
+    def vector_from_data(self, data):
+        raise NotImplementedError
+
+    @classmethod
+    def space_from_vector_obj(cls, vec, id_):
+        raise NotImplementedError
+
+    @classmethod
+    def space_from_dim(cls, dim, id_):
+        raise NotImplementedError
+
     def zeros(self, count=1, reserve=0):
         assert count >= 0 and reserve >= 0
         return ListVectorArray([self.zero_vector() for _ in range(count)], self)
@@ -419,25 +440,6 @@ class ListVectorSpace(VectorSpaceInterface):
     @from_data.instancemethod
     def from_data(self, data):
         return ListVectorArray([self.vector_from_data(v) for v in data], self)
-
-    @abstractmethod
-    def zero_vector(self):
-        pass
-
-    @abstractmethod
-    def make_vector(self, data):
-        pass
-
-    def vector_from_data(self, data):
-        raise NotImplementedError
-
-    @classmethod
-    def space_from_vector_obj(cls, vec, id_):
-        raise NotImplementedError
-
-    @classmethod
-    def space_from_dim(cls, dim, id_):
-        raise NotImplementedError
 
 
 class NumpyListVectorSpace(ListVectorSpace):

--- a/src/pymor/vectorarrays/mpi.py
+++ b/src/pymor/vectorarrays/mpi.py
@@ -7,8 +7,8 @@
 This module contains several wrapper classes which allow to
 transform single rank |VectorArrays| into MPI distributed
 |VectorArrays| which can be used on rank 0 like ordinary
-|VectorArrays|. Similar classes are provided for handling
-:class:`Vectors <pymor.vectorarrays.list.VectorInterface>`.
+|VectorArrays|.
+
 The implementations are based on the event loop provided
 by :mod:`pymor.tools.mpi`.
 """
@@ -17,7 +17,6 @@ import numpy as np
 
 from pymor.tools import mpi
 from pymor.vectorarrays.interfaces import VectorArrayInterface, VectorSpaceInterface
-from pymor.vectorarrays.list import VectorInterface, ListVectorSpace
 
 
 class MPIVectorArray(VectorArrayInterface):
@@ -41,6 +40,8 @@ class MPIVectorArray(VectorArrayInterface):
 
     Note that resource cleanup is handled by :meth:`object.__del__`.
     Please be aware of the peculiarities of destructors in Python!
+
+    The associated |VectorSpace| is :class:`MPIVectorSpace`.
     """
 
     def __init__(self, obj_id, space):
@@ -102,6 +103,16 @@ class MPIVectorArray(VectorArrayInterface):
 
 
 class MPIVectorSpace(VectorSpaceInterface):
+    """|VectorSpace| of :class:`MPIVectorArrays <MPIVectorArray>`.
+
+    Parameters
+    ----------
+    local_spaces
+        `tuple` of the different |VectorSpaces| of the local
+        |VectorArrays| on the MPI ranks.
+        Alternatively, the length of `local_spaces` may be 1, in which
+        case the same |VectorSpace| is assumed for all ranks.
+    """
 
     array_type = MPIVectorArray
 
@@ -110,6 +121,18 @@ class MPIVectorSpace(VectorSpaceInterface):
         self.id = id_
 
     def make_array(self, obj_id):
+        """Create array from rank-local |VectorArray| instances.
+
+        Parameters
+        ----------
+        obj_id
+            :class:`~pymor.tools.mpi.ObjectId` of the MPI distributed
+            instances of `cls` wrapped by this array.
+
+        Returns
+        -------
+        The newly created :class:`MPIVectorArray`.
+        """
         assert mpi.call(_MPIVectorSpace_check_local_spaces,
                         self.local_spaces, obj_id)
         return self.array_type(obj_id, self)
@@ -199,6 +222,8 @@ class MPIVectorArrayNoComm(MPIVectorArray):
     on the wrapped arrays would lead to wrong results and
     :class:`MPIVectorArrayAutoComm` cannot be used either
     (for instance in the presence of shared DOFs).
+
+    The associated |VectorSpace| is :class:`MPIVectorSpaceNoComm`.
     """
 
     def dot(self, other):
@@ -224,6 +249,7 @@ class MPIVectorArrayNoComm(MPIVectorArray):
 
 
 class MPIVectorSpaceNoComm(MPIVectorSpace):
+    """|VectorSpace| for :class:`MPIVectorArrayNoComm`."""
 
     array_type = MPIVectorArrayNoComm
 
@@ -243,6 +269,8 @@ class MPIVectorArrayAutoComm(MPIVectorArray):
     Note, however, that depending on the discretization
     these default implementations might lead to wrong results
     (for instance in the presence of shared DOFs).
+
+    The associated |VectorSpace| is :class:`MPIVectorSpaceAutoComm`.
     """
 
     def dot(self, other):
@@ -281,6 +309,7 @@ class MPIVectorArrayAutoComm(MPIVectorArray):
 
 
 class MPIVectorSpaceAutoComm(MPIVectorSpace):
+    """|VectorSpace| for :class:`MPIVectorArrayAutoComm`."""
 
     array_type = MPIVectorArrayAutoComm
 

--- a/src/pymor/vectorarrays/mpi.py
+++ b/src/pymor/vectorarrays/mpi.py
@@ -116,9 +116,12 @@ class MPIVectorSpace(VectorSpaceInterface):
 
     array_type = MPIVectorArray
 
-    def __init__(self, local_spaces, id_='STATE'):
+    def __init__(self, local_spaces):
         self.local_spaces = tuple(local_spaces)
-        self.id = id_
+        if type(local_spaces[0]) is RegisteredLocalSpace:
+            self.id = _local_space_registry[local_spaces[0]].id
+        else:
+            self.id = local_spaces[0].id
 
     def make_array(self, obj_id):
         """Create array from rank-local |VectorArray| instances.

--- a/src/pymor/vectorarrays/numpy.py
+++ b/src/pymor/vectorarrays/numpy.py
@@ -395,6 +395,10 @@ class NumpyVectorSpace(VectorSpaceInterface):
             assert array.shape[1] == space.dim
             return NumpyVectorArray(array, space)
 
+    @property
+    def is_scalar(self):
+        return self.dim == 1
+
     def __repr__(self):
         return 'NumpyVectorSpace({})'.format(self.dim) if self.id is None \
             else 'NumpyVectorSpace({}, {})'.format(self.dim, self.id)

--- a/src/pymor/vectorarrays/numpy.py
+++ b/src/pymor/vectorarrays/numpy.py
@@ -314,8 +314,6 @@ class NumpyVectorArray(VectorArrayInterface):
 
 class NumpyVectorSpace(VectorSpaceInterface):
 
-    type = NumpyVectorArray
-
     def __init__(self, dim, id_='STATE'):
         self.dim = dim
         self.id = id_

--- a/src/pymor/vectorarrays/numpy.py
+++ b/src/pymor/vectorarrays/numpy.py
@@ -325,7 +325,7 @@ class NumpyVectorSpace(VectorSpaceInterface):
         See :attr:`~pymor.vectorarrays.interfaces.VectorSpaceInterface.id`.
     """
 
-    def __init__(self, dim, id_='STATE'):
+    def __init__(self, dim, id_=None):
         self.dim = dim
         self.id = id_
 
@@ -341,7 +341,7 @@ class NumpyVectorSpace(VectorSpaceInterface):
         return va
 
     @classinstancemethod
-    def make_array(cls, obj, id_='STATE'):
+    def make_array(cls, obj, id_=None):
         return cls._array_factory(obj, id_=id_)
 
     @make_array.instancemethod
@@ -349,7 +349,7 @@ class NumpyVectorSpace(VectorSpaceInterface):
         return self._array_factory(obj, space=self)
 
     @classinstancemethod
-    def from_data(cls, data, id_='STATE'):
+    def from_data(cls, data, id_=None):
         return cls._array_factory(data, id_=id_)
 
     @from_data.instancemethod
@@ -357,7 +357,7 @@ class NumpyVectorSpace(VectorSpaceInterface):
         return self._array_factory(data, space=self)
 
     @classinstancemethod
-    def from_file(cls, path, key=None, single_vector=False, transpose=False, id_='STATE'):
+    def from_file(cls, path, key=None, single_vector=False, transpose=False, id_=None):
         assert not (single_vector and transpose)
         from pymor.tools.io import load_matrix
         array = load_matrix(path, key=key)
@@ -377,7 +377,7 @@ class NumpyVectorSpace(VectorSpaceInterface):
         return self.from_file(path, key=key, single_vector=single_vector, transpose=transpose, id_=self.id)
 
     @classmethod
-    def _array_factory(cls, array, space=None, id_='STATE'):
+    def _array_factory(cls, array, space=None, id_=None):
         if type(array) is np.ndarray:
             pass
         elif issparse(array):
@@ -396,11 +396,8 @@ class NumpyVectorSpace(VectorSpaceInterface):
             return NumpyVectorArray(array, space)
 
     def __repr__(self):
-        return 'NumpyVectorSpace({}, {})'.format(self.dim, self.id)
-
-
-def scalars(dim=1):
-    return NumpyVectorSpace(dim, 'SCALARS')
+        return 'NumpyVectorSpace({})'.format(self.dim) if self.id is None \
+            else 'NumpyVectorSpace({}, {})'.format(self.dim, self.id)
 
 
 class NumpyVectorArrayView(NumpyVectorArray):

--- a/src/pymor/vectorarrays/numpy.py
+++ b/src/pymor/vectorarrays/numpy.py
@@ -18,12 +18,14 @@ class NumpyVectorArray(VectorArrayInterface):
     in pyMOR's discretization toolkit. Moreover, all reduced |Operators|
     are based on |NumpyVectorArray|.
 
-    Note that this class is just a thin wrapper around the underlying
+    This class is just a thin wrapper around the underlying
     |NumPy array|. Thus, while operations like
     :meth:`~pymor.vectorarrays.interfaces.VectorArrayInterface.axpy` or
     :meth:`~pymor.vectorarrays.interfaces.VectorArrayInterface.dot`
     will be quite efficient, removing or appending vectors will
     be costly.
+
+    The associated |VectorSpace| is |NumpyVectorSpace|.
     """
 
     def __init__(self, array, space):
@@ -313,6 +315,15 @@ class NumpyVectorArray(VectorArrayInterface):
 
 
 class NumpyVectorSpace(VectorSpaceInterface):
+    """|VectorSpace| of |NumpyVectorArrays|.
+
+    Parameters
+    ----------
+    dim
+        The dimension of the vectors contained in the space.
+    id
+        See :attr:`~pymor.vectorarrays.interfaces.VectorSpaceInterface.id`.
+    """
 
     def __init__(self, dim, id_='STATE'):
         self.dim = dim

--- a/src/pymordemos/elliptic_unstructured.py
+++ b/src/pymordemos/elliptic_unstructured.py
@@ -32,7 +32,6 @@ from pymor.analyticalproblems.elliptic import EllipticProblem
 from pymor.discretizers.elliptic import discretize_elliptic_cg, discretize_elliptic_fv
 from pymor.domaindescriptions.polygonal import CircularSectorDomain
 from pymor.functions.basic import ConstantFunction, ExpressionFunction
-from pymor.vectorarrays.numpy import NumpyVectorArray
 
 
 def elliptic_gmsh_demo(args):
@@ -61,7 +60,7 @@ def elliptic_gmsh_demo(args):
     solution = ExpressionFunction('(lambda r, phi: r**(pi/angle) * sin(phi * pi/angle))(*polar(x))', 2, (),
                                   {}, {'angle': args['ANGLE']})
     grid = data['grid']
-    U_ref = NumpyVectorArray(solution(grid.centers(0))) if args['--fv'] else NumpyVectorArray(solution(grid.centers(2)))
+    U_ref = U.space.make_array(solution(grid.centers(0)) if args['--fv'] else solution(grid.centers(2)))
     discretization.visualize((U, U_ref, U-U_ref),
                              legend=('Solution', 'Analytical solution (circular boundary)', 'Error'),
                              separate_colorbars=True)

--- a/src/pymordemos/minimal_cpp_demo/wrapper.py
+++ b/src/pymordemos/minimal_cpp_demo/wrapper.py
@@ -3,7 +3,7 @@
 # License: BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
 
 from pymor.operators.basic import OperatorBase
-from pymor.vectorarrays.interfaces import VectorSpace
+from pymor.vectorarrays.interfaces import VectorSpaceInterface
 from pymor.vectorarrays.list import CopyOnWriteVector, ListVectorArray
 
 import numpy as np

--- a/src/pymordemos/minimal_cpp_demo/wrapper.py
+++ b/src/pymordemos/minimal_cpp_demo/wrapper.py
@@ -3,8 +3,7 @@
 # License: BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
 
 from pymor.operators.basic import OperatorBase
-from pymor.vectorarrays.interfaces import VectorSpaceInterface
-from pymor.vectorarrays.list import CopyOnWriteVector, ListVectorArray
+from pymor.vectorarrays.list import CopyOnWriteVector, ListVectorSpace
 
 import numpy as np
 import math as m
@@ -20,18 +19,6 @@ class WrappedVector(CopyOnWriteVector):
     @classmethod
     def from_instance(cls, instance):
         return cls(instance._impl)
-
-    @classmethod
-    def make_zeros(cls, subtype):
-        return cls(Vector(subtype, 0))
-
-    @property
-    def subtype(self):
-        return self._impl.dim
-
-    @property
-    def dim(self):
-        return self._impl.dim
 
     @property
     def data(self):
@@ -68,12 +55,27 @@ class WrappedVector(CopyOnWriteVector):
         raise NotImplementedError
 
 
+class WrappedVectorSpace(ListVectorSpace):
+
+    def __init__(self, dim):
+        self.dim = dim
+
+    def zero_vector(self):
+        return WrappedVector(Vector(self.dim, 0))
+
+    def make_vector(self, obj):
+        return WrappedVector(obj)
+
+    def __eq__(self, other):
+        return type(other) is WrappedVectorSpace and self.dim == other.dim
+
+
 class WrappedDiffusionOperator(OperatorBase):
     def __init__(self, op):
         assert isinstance(op, DiffusionOperator)
         self._impl = op
-        self.source = VectorSpace(ListVectorArray, (WrappedVector, op.dim_source))
-        self.range = VectorSpace(ListVectorArray, (WrappedVector, op.dim_range))
+        self.source = WrappedVectorSpace(op.dim_source)
+        self.range = WrappedVectorSpace(op.dim_range)
         self.linear = True
 
     @classmethod
@@ -86,6 +88,6 @@ class WrappedDiffusionOperator(OperatorBase):
         def apply_one_vector(u):
             v = Vector(self.range.dim, 0)
             self._impl.apply(u._impl, v)
-            return WrappedVector(v)
+            return v
 
-        return ListVectorArray([apply_one_vector(u) for u in U._list], subtype=self.range.subtype)
+        return self.range.make_array([apply_one_vector(u) for u in U._list])

--- a/src/pymordemos/parabolic_mor.py
+++ b/src/pymordemos/parabolic_mor.py
@@ -179,7 +179,7 @@ def _discretize_fenics():
 
         parameter_space=CubicParameterSpace({'top': 0}, minimum=1, maximum=100.),
 
-        visualizer=FenicsVisualizer(V)
+        visualizer=FenicsVisualizer(FenicsVectorSpace(V))
     )
 
     return d

--- a/src/pymordemos/parabolic_mor.py
+++ b/src/pymordemos/parabolic_mor.py
@@ -90,7 +90,7 @@ def discretize_fenics():
 
     if mpi.parallel:
         from pymor.discretizations.mpi import mpi_wrap_discretization
-        return mpi_wrap_discretization(_discretize_fenics, use_with=True, pickle_subtypes=False)
+        return mpi_wrap_discretization(_discretize_fenics, use_with=True, pickle_local_spaces=False)
     else:
         return _discretize_fenics()
 

--- a/src/pymordemos/parabolic_mor.py
+++ b/src/pymordemos/parabolic_mor.py
@@ -150,12 +150,12 @@ def _discretize_fenics():
 
     from pymor.gui.fenics import FenicsVisualizer
     from pymor.operators.fenics import FenicsMatrixOperator
-    from pymor.vectorarrays.fenics import FenicsVector
+    from pymor.vectorarrays.fenics import FenicsVectorSpace
 
     d = InstationaryDiscretization(
         T=1.,
 
-        initial_data=ListVectorArray([FenicsVector(u0, V)]),
+        initial_data=FenicsVectorSpace(V).make_array([u0]),
 
         operator=LincombOperator([FenicsMatrixOperator(mat0, V, V),
                                   FenicsMatrixOperator(h1_0_mat, V, V),
@@ -166,7 +166,7 @@ def _discretize_fenics():
                                   100. - 1.,
                                   ExpressionParameterFunctional('top - 1.', {'top': 0})]),
 
-        rhs=VectorFunctional(ListVectorArray([FenicsVector(f, V)])),
+        rhs=VectorFunctional(FenicsVectorSpace(V).make_array([f])),
 
         mass=FenicsMatrixOperator(l2_0_mat, V, V, name='l2'),
 

--- a/src/pymordemos/thermalblock.py
+++ b/src/pymordemos/thermalblock.py
@@ -362,7 +362,7 @@ def _discretize_fenics(xblocks, yblocks, grid_num_intervals, element_order):
     l2_product = FenicsMatrixOperator(l2_mat, V, V, name='l2')
 
     # build discretization
-    visualizer = FenicsVisualizer(V)
+    visualizer = FenicsVisualizer(FenicsVectorSpace(V))
     parameter_space = CubicParameterSpace(op.parameter_type, 0.1, 1.)
     d = StationaryDiscretization(op, rhs, products={'h1_0_semi': h1_product,
                                                     'l2': l2_product},

--- a/src/pymordemos/thermalblock.py
+++ b/src/pymordemos/thermalblock.py
@@ -337,14 +337,13 @@ def _discretize_fenics(xblocks, yblocks, grid_num_intervals, element_order):
     # FEniCS wrappers
     from pymor.gui.fenics import FenicsVisualizer
     from pymor.operators.fenics import FenicsMatrixOperator
-    from pymor.vectorarrays.fenics import FenicsVector
+    from pymor.vectorarrays.fenics import FenicsVectorSpace
 
     # generic pyMOR classes
     from pymor.discretizations.basic import StationaryDiscretization
     from pymor.operators.constructions import LincombOperator, VectorFunctional
     from pymor.parameters.functionals import ProjectionParameterFunctional
     from pymor.parameters.spaces import CubicParameterSpace
-    from pymor.vectorarrays.list import ListVectorArray
 
     # define parameter functionals (same as in pymor.analyticalproblems.thermalblock)
     def parameter_functional_factory(x, y):
@@ -358,7 +357,7 @@ def _discretize_fenics(xblocks, yblocks, grid_num_intervals, element_order):
     # wrap operators
     ops = [FenicsMatrixOperator(mat0, V, V)] + [FenicsMatrixOperator(m, V, V) for m in mats]
     op = LincombOperator(ops, (1.,) + parameter_functionals)
-    rhs = VectorFunctional(ListVectorArray([FenicsVector(F, V)]))
+    rhs = VectorFunctional(FenicsVectorSpace(V).make_array([F]))
     h1_product = FenicsMatrixOperator(h1_mat, V, V, name='h1_0_semi')
     l2_product = FenicsMatrixOperator(l2_mat, V, V, name='l2')
 

--- a/src/pymordemos/thermalblock.py
+++ b/src/pymordemos/thermalblock.py
@@ -275,7 +275,7 @@ def discretize_fenics(xblocks, yblocks, grid_num_intervals, element_order):
     if mpi.parallel:
         from pymor.discretizations.mpi import mpi_wrap_discretization
         d = mpi_wrap_discretization(lambda: _discretize_fenics(xblocks, yblocks, grid_num_intervals, element_order),
-                                    use_with=True, pickle_subtypes=False)
+                                    use_with=True, pickle_local_spaces=False)
     else:
         d = _discretize_fenics(xblocks, yblocks, grid_num_intervals, element_order)
 

--- a/src/pymordemos/thermalblock_simple.py
+++ b/src/pymordemos/thermalblock_simple.py
@@ -113,7 +113,7 @@ def _discretize_fenics():
     # FEniCS wrappers
     from pymor.gui.fenics import FenicsVisualizer
     from pymor.operators.fenics import FenicsMatrixOperator
-    from pymor.vectorarrays.fenics import FenicsVector
+    from pymor.vectorarrays.fenics import FenicsVectorSpace
 
     # define parameter functionals (same as in pymor.analyticalproblems.thermalblock)
     parameter_functionals = [ProjectionParameterFunctional(component_name='diffusion',
@@ -124,7 +124,7 @@ def _discretize_fenics():
     # wrap operators
     ops = [FenicsMatrixOperator(mat0, V, V)] + [FenicsMatrixOperator(m, V, V) for m in mats]
     op = LincombOperator(ops, [1.] + parameter_functionals)
-    rhs = VectorFunctional(ListVectorArray([FenicsVector(F, V)]))
+    rhs = VectorFunctional(FenicsVectorSpace(V).make_array([F]))
     h1_product = FenicsMatrixOperator(h1_mat, V, V, name='h1_0_semi')
 
     # build discretization

--- a/src/pymordemos/thermalblock_simple.py
+++ b/src/pymordemos/thermalblock_simple.py
@@ -128,7 +128,7 @@ def _discretize_fenics():
     h1_product = FenicsMatrixOperator(h1_mat, V, V, name='h1_0_semi')
 
     # build discretization
-    visualizer = FenicsVisualizer(V)
+    visualizer = FenicsVisualizer(FenicsVectorSpace(V))
     parameter_space = CubicParameterSpace(op.parameter_type, 0.1, 1.)
     d = StationaryDiscretization(op, rhs, products={'h1_0_semi': h1_product},
                                  parameter_space=parameter_space,

--- a/src/pymordemos/thermalblock_simple.py
+++ b/src/pymordemos/thermalblock_simple.py
@@ -59,7 +59,7 @@ def discretize_fenics():
 
     if mpi.parallel:
         from pymor.discretizations.mpi import mpi_wrap_discretization
-        return mpi_wrap_discretization(_discretize_fenics, use_with=True, pickle_subtypes=False)
+        return mpi_wrap_discretization(_discretize_fenics, use_with=True, pickle_local_spaces=False)
     else:
         return _discretize_fenics()
 

--- a/src/pymortests/algorithms/stuff.py
+++ b/src/pymortests/algorithms/stuff.py
@@ -9,13 +9,13 @@ from pymortests.base import runmodule, MonomOperator
 from pymor.algorithms.newton import newton, NewtonError
 import pymor.algorithms.basisextension as bxt
 from pymor.tools.floatcmp import float_cmp
-from pymor.vectorarrays.numpy import NumpyVectorArray
+from pymor.vectorarrays.numpy import NumpyVectorSpace
 
 
 def _newton(order, **kwargs):
     mop = MonomOperator(order)
-    rhs = NumpyVectorArray([0.0])
-    guess = NumpyVectorArray([1.0])
+    rhs = NumpyVectorSpace.from_data([0.0])
+    guess = NumpyVectorSpace.from_data([1.0])
     return newton(mop, rhs, initial_guess=guess, **kwargs)
 
 
@@ -40,8 +40,8 @@ def test_ext(extension_alg):
     ident = np.identity(size)
     current = ident[0]
     for i in range(1, size):
-        c = NumpyVectorArray(current)
-        n, _ = extension_alg(c, NumpyVectorArray(ident[i]))
+        c = NumpyVectorSpace.from_data(current)
+        n, _ = extension_alg(c, NumpyVectorSpace.from_data(ident[i]))
         assert np.allclose(n.data, ident[0:i+1])
         current = ident[0:i+1]
 

--- a/src/pymortests/base.py
+++ b/src/pymortests/base.py
@@ -15,7 +15,7 @@ from pkg_resources import resource_filename, resource_stream
 
 from pymor.core import logger
 from pymor.operators.basic import OperatorBase
-from pymor.vectorarrays.numpy import NumpyVectorArray, NumpyVectorSpace
+from pymor.vectorarrays.numpy import scalars
 
 
 class TestInterface(object):
@@ -86,8 +86,7 @@ def polynomials(max_order):
 
 
 class MonomOperator(OperatorBase):
-    source = range = NumpyVectorSpace(1)
-    type_source = type_range = NumpyVectorArray
+    source = range = scalars(1)
 
     def __init__(self, order, monom=None):
         self.monom = monom if monom else Polynomial(np.identity(order + 1)[order])
@@ -97,13 +96,13 @@ class MonomOperator(OperatorBase):
         self.linear = order == 1
 
     def apply(self, U, mu=None):
-        return NumpyVectorArray(self.monom(U.data))
+        return self.source.make_array(self.monom(U.data))
 
     def jacobian(self, U, mu=None):
         return MonomOperator(self.order - 1, self.derivative)
 
     def apply_inverse(self, V, mu=None, least_squares=False):
-        return NumpyVectorArray(1. / V.data)
+        return self.range.make_array(1. / V.data)
 
 
 def check_results(test_name, params, results, *args):

--- a/src/pymortests/base.py
+++ b/src/pymortests/base.py
@@ -15,7 +15,7 @@ from pkg_resources import resource_filename, resource_stream
 
 from pymor.core import logger
 from pymor.operators.basic import OperatorBase
-from pymor.vectorarrays.numpy import scalars
+from pymor.vectorarrays.numpy import NumpyVectorSpace
 
 
 class TestInterface(object):
@@ -86,7 +86,7 @@ def polynomials(max_order):
 
 
 class MonomOperator(OperatorBase):
-    source = range = scalars(1)
+    source = range = NumpyVectorSpace(1)
 
     def __init__(self, order, monom=None):
         self.monom = monom if monom else Polynomial(np.identity(order + 1)[order])

--- a/src/pymortests/block.py
+++ b/src/pymortests/block.py
@@ -7,8 +7,8 @@ import scipy.linalg as spla
 
 from pymor.operators.numpy import NumpyMatrixOperator
 from pymor.operators.block import BlockOperator, BlockDiagonalOperator
-from pymor.vectorarrays.block import BlockVectorArray
-from pymor.vectorarrays.numpy import NumpyVectorArray
+from pymor.vectorarrays.block import BlockVectorSpace
+from pymor.vectorarrays.numpy import NumpyVectorSpace
 
 def test_hstack():
     np.random.seed(0)
@@ -47,9 +47,9 @@ def test_apply():
     v1 = np.random.randn(3)
     v2 = np.random.randn(4)
     v = np.hstack((v1, v2))
-    v1va = NumpyVectorArray(v1)
-    v2va = NumpyVectorArray(v2)
-    vva = BlockVectorArray((v1va, v2va))
+    v1va = NumpyVectorSpace.from_data(v1)
+    v2va = NumpyVectorSpace.from_data(v2)
+    vva = BlockVectorSpace.make_array((v1va, v2va))
 
     wva = Aop.apply(vva)
     w = np.hstack((wva.block(0).data, wva.block(1).data))
@@ -72,9 +72,9 @@ def test_apply_adjoint():
     v1 = np.random.randn(2)
     v2 = np.random.randn(5)
     v = np.hstack((v1, v2))
-    v1va = NumpyVectorArray(v1)
-    v2va = NumpyVectorArray(v2)
-    vva = BlockVectorArray((v1va, v2va))
+    v1va = NumpyVectorSpace.from_data(v1)
+    v2va = NumpyVectorSpace.from_data(v2)
+    vva = BlockVectorSpace.make_array((v1va, v2va))
 
     wva = Aop.apply_adjoint(vva)
     w = np.hstack((wva.block(0).data, wva.block(1).data))
@@ -103,9 +103,9 @@ def test_blk_diag_apply_inverse():
     v1 = np.random.randn(2)
     v2 = np.random.randn(3)
     v = np.hstack((v1, v2))
-    v1va = NumpyVectorArray(v1)
-    v2va = NumpyVectorArray(v2)
-    vva = BlockVectorArray((v1va, v2va))
+    v1va = NumpyVectorSpace.from_data(v1)
+    v2va = NumpyVectorSpace.from_data(v2)
+    vva = BlockVectorSpace.make_array((v1va, v2va))
 
     wva = Cop.apply_inverse(vva)
     w = np.hstack((wva.block(0).data, wva.block(1).data))
@@ -124,9 +124,9 @@ def test_blk_diag_apply_inverse_adjoint():
     v1 = np.random.randn(2)
     v2 = np.random.randn(3)
     v = np.hstack((v1, v2))
-    v1va = NumpyVectorArray(v1)
-    v2va = NumpyVectorArray(v2)
-    vva = BlockVectorArray((v1va, v2va))
+    v1va = NumpyVectorSpace.from_data(v1)
+    v2va = NumpyVectorSpace.from_data(v2)
+    vva = BlockVectorSpace.make_array((v1va, v2va))
 
     wva = Cop.apply_inverse_adjoint(vva)
     w = np.hstack((wva.block(0).data, wva.block(1).data))

--- a/src/pymortests/complex_values.py
+++ b/src/pymortests/complex_values.py
@@ -6,7 +6,7 @@
 import numpy as np
 
 from pymor.operators.numpy import NumpyMatrixOperator
-from pymor.vectorarrays.numpy import NumpyVectorArray
+from pymor.vectorarrays.numpy import NumpyVectorSpace
 
 
 def test_complex():
@@ -19,7 +19,7 @@ def test_complex():
     Iop = NumpyMatrixOperator(I)
     Aop = NumpyMatrixOperator(A)
     Bop = NumpyMatrixOperator(B)
-    Cva = NumpyVectorArray(C)
+    Cva = NumpyVectorSpace.from_data(C)
 
     # assemble_lincomb
     assert not np.iscomplexobj(Aop.assemble_lincomb((Iop, Bop), (1, 1))._matrix)
@@ -37,10 +37,10 @@ def test_complex():
     # append
     for rsrv in (0, 10):
         for o_ind in (slice(None), [0]):
-            va = NumpyVectorArray.make_array(subtype=5, reserve=rsrv)
+            va = NumpyVectorSpace(5).empty(reserve=rsrv)
             va.append(Cva)
             D = np.random.randn(1, 5) + 1j * np.random.randn(1, 5)
-            Dva = NumpyVectorArray(D)
+            Dva = NumpyVectorSpace.from_data(D)
 
             assert not np.iscomplexobj(va.data)
             assert np.iscomplexobj(Dva.data)
@@ -57,7 +57,7 @@ def test_complex():
     Cva[0].axpy(1, Dva)
     assert np.iscomplexobj(Cva.data)
 
-    Cva = NumpyVectorArray(C)
+    Cva = NumpyVectorSpace.from_data(C)
     assert not np.iscomplexobj(Cva.data)
     Cva[0].axpy(1j, Dva)
     assert np.iscomplexobj(Cva.data)
@@ -66,7 +66,7 @@ def test_real_imag():
     A = np.array([[1 + 2j, 3 + 4j],
                   [5 + 6j, 7 + 8j],
                   [9 + 10j, 11 + 12j]])
-    Ava = NumpyVectorArray(A)
+    Ava = NumpyVectorSpace.from_data(A)
     Bva = Ava.real
     Cva = Ava.imag
 
@@ -81,7 +81,7 @@ def test_real_imag():
 def test_scal():
     v = np.array([[1, 2, 3],
                   [4, 5, 6]], dtype=float)
-    v = NumpyVectorArray(v)
+    v = NumpyVectorSpace.from_data(v)
     v.scal(1j)
 
     k = 0
@@ -91,24 +91,24 @@ def test_scal():
             assert v.data[i, j] == k * 1j
 
 def test_axpy():
-    x = NumpyVectorArray(np.array([1.]))
-    y = NumpyVectorArray(np.array([1.]))
+    x = NumpyVectorSpace.from_data(np.array([1.]))
+    y = NumpyVectorSpace.from_data(np.array([1.]))
     y.axpy(1 + 1j, x)
     assert y.data[0, 0] == 2 + 1j
 
-    x = NumpyVectorArray(np.array([1 + 1j]))
-    y = NumpyVectorArray(np.array([1.]))
+    x = NumpyVectorSpace.from_data(np.array([1 + 1j]))
+    y = NumpyVectorSpace.from_data(np.array([1.]))
     y.axpy(-1, x)
     assert y.data[0, 0] == -1j
 
 def test_dot():
-    x = NumpyVectorArray(np.array([1 + 1j]))
-    y = NumpyVectorArray(np.array([1 - 1j]))
+    x = NumpyVectorSpace.from_data(np.array([1 + 1j]))
+    y = NumpyVectorSpace.from_data(np.array([1 - 1j]))
     z = x.dot(y)
     assert z[0, 0] == 2j
 
 def test_pairwise_dot():
-    x = NumpyVectorArray(np.array([1 + 1j]))
-    y = NumpyVectorArray(np.array([1 - 1j]))
+    x = NumpyVectorSpace.from_data(np.array([1 + 1j]))
+    y = NumpyVectorSpace.from_data(np.array([1 - 1j]))
     z = x.pairwise_dot(y)
     assert z == 2j

--- a/src/pymortests/fixtures/operator.py
+++ b/src/pymortests/fixtures/operator.py
@@ -14,7 +14,7 @@ def random_integers(count, seed):
 
 
 def numpy_matrix_operator_with_arrays_factory(dim_source, dim_range, count_source, count_range, seed,
-                                              source_id='STATE', range_id='STATE'):
+                                              source_id=None, range_id=None):
     np.random.seed(seed)
     op = NumpyMatrixOperator(np.random.random((dim_range, dim_source)), source_id=source_id, range_id=range_id)
     s = op.source.make_array(np.random.random((count_source, dim_source)))
@@ -23,7 +23,7 @@ def numpy_matrix_operator_with_arrays_factory(dim_source, dim_range, count_sourc
 
 
 def numpy_matrix_operator_with_arrays_and_products_factory(dim_source, dim_range, count_source, count_range, seed,
-                                                           source_id='STATE', range_id='STATE'):
+                                                           source_id=None, range_id=None):
     from scipy.linalg import eigh
     op, _, U, V = numpy_matrix_operator_with_arrays_factory(dim_source, dim_range, count_source, count_range, seed,
                                                             source_id=source_id, range_id=range_id)
@@ -126,10 +126,10 @@ def thermalblock_vectorarray_factory(transposed, xblocks, yblocks, diameter, see
         U = V
         V = op.range.make_array(np.random.random((7, op.range.dim)))
         sp = rp
-        rp = NumpyMatrixOperator(np.eye(op.range.dim) * 2, source_id='SCALARS', range_id='SCALARS')
+        rp = NumpyMatrixOperator(np.eye(op.range.dim) * 2)
     else:
         U = op.source.make_array(np.random.random((7, op.source.dim)))
-        sp = NumpyMatrixOperator(np.eye(op.source.dim) * 2, source_id='SCALARS', range_id='SCALARS')
+        sp = NumpyMatrixOperator(np.eye(op.source.dim) * 2)
     return op, None, U, V, sp, rp
 
 
@@ -138,7 +138,7 @@ def thermalblock_vector_factory(xblocks, yblocks, diameter, seed):
     _, _, U, V, sp, rp = thermalblock_factory(xblocks, yblocks, diameter, seed)
     op = VectorOperator(U[0])
     U = op.source.make_array(np.random.random((7, 1)))
-    sp = NumpyMatrixOperator(np.eye(1) * 2, source_id='SCALARS', range_id='SCALARS')
+    sp = NumpyMatrixOperator(np.eye(1) * 2)
     return op, None, U, V, sp, rp
 
 
@@ -149,7 +149,7 @@ def thermalblock_vectorfunc_factory(product, xblocks, yblocks, diameter, seed):
     U = V
     V = op.range.make_array(np.random.random((7, 1)))
     sp = rp
-    rp = NumpyMatrixOperator(np.eye(1) * 2, source_id='SCALARS', range_id='SCALARS')
+    rp = NumpyMatrixOperator(np.eye(1) * 2)
     return op, None, U, V, sp, rp
 
 
@@ -294,17 +294,17 @@ num_misc_operators = 10
 def misc_operator_with_arrays_and_products_factory(n):
     if n == 0:
         from pymor.operators.constructions import ComponentProjection
-        _, _, U, V, sp, rp = numpy_matrix_operator_with_arrays_and_products_factory(100, 10, 4, 3, n, range_id='SCALARS')
+        _, _, U, V, sp, rp = numpy_matrix_operator_with_arrays_and_products_factory(100, 10, 4, 3, n)
         op = ComponentProjection(np.random.randint(0, 100, 10), U.space)
         return op, _, U, V, sp, rp
     elif n == 1:
         from pymor.operators.constructions import ComponentProjection
-        _, _, U, V, sp, rp = numpy_matrix_operator_with_arrays_and_products_factory(100, 0, 4, 3, n, range_id='SCALARS')
+        _, _, U, V, sp, rp = numpy_matrix_operator_with_arrays_and_products_factory(100, 0, 4, 3, n)
         op = ComponentProjection([], U.space)
         return op, _, U, V, sp, rp
     elif n == 2:
         from pymor.operators.constructions import ComponentProjection
-        _, _, U, V, sp, rp = numpy_matrix_operator_with_arrays_and_products_factory(100, 3, 4, 3, n, range_id='SCALARS')
+        _, _, U, V, sp, rp = numpy_matrix_operator_with_arrays_and_products_factory(100, 3, 4, 3, n)
         op = ComponentProjection([3, 3, 3], U.space)
         return op, _, U, V, sp, rp
     elif n == 3:

--- a/src/pymortests/fixtures/operator.py
+++ b/src/pymortests/fixtures/operator.py
@@ -6,7 +6,6 @@ import numpy as np
 import pytest
 
 from pymor.operators.numpy import NumpyMatrixOperator
-from pymor.vectorarrays.numpy import NumpyVectorArray
 
 
 def random_integers(count, seed):
@@ -14,17 +13,20 @@ def random_integers(count, seed):
     return list(np.random.randint(0, 3200, count))
 
 
-def numpy_matrix_operator_with_arrays_factory(dim_source, dim_range, count_source, count_range, seed):
+def numpy_matrix_operator_with_arrays_factory(dim_source, dim_range, count_source, count_range, seed,
+                                              source_id='STATE', range_id='STATE'):
     np.random.seed(seed)
-    op = NumpyMatrixOperator(np.random.random((dim_range, dim_source)))
-    s = NumpyVectorArray(np.random.random((count_source, dim_source)), copy=False)
-    r = NumpyVectorArray(np.random.random((count_range, dim_range)), copy=False)
+    op = NumpyMatrixOperator(np.random.random((dim_range, dim_source)), source_id=source_id, range_id=range_id)
+    s = op.source.make_array(np.random.random((count_source, dim_source)))
+    r = op.range.make_array(np.random.random((count_range, dim_range)))
     return op, None, s, r
 
 
-def numpy_matrix_operator_with_arrays_and_products_factory(dim_source, dim_range, count_source, count_range, seed):
+def numpy_matrix_operator_with_arrays_and_products_factory(dim_source, dim_range, count_source, count_range, seed,
+                                                           source_id='STATE', range_id='STATE'):
     from scipy.linalg import eigh
-    op, _, U, V = numpy_matrix_operator_with_arrays_factory(dim_source, dim_range, count_source, count_range, seed)
+    op, _, U, V = numpy_matrix_operator_with_arrays_factory(dim_source, dim_range, count_source, count_range, seed,
+                                                            source_id=source_id, range_id=range_id)
     if dim_source > 0:
         while True:
             sp = np.random.random((dim_source, dim_source))
@@ -32,9 +34,9 @@ def numpy_matrix_operator_with_arrays_and_products_factory(dim_source, dim_range
             evals = eigh(sp, eigvals_only=True)
             if np.min(evals) > 1e-6:
                 break
-        sp = NumpyMatrixOperator(sp)
+        sp = NumpyMatrixOperator(sp, source_id=source_id, range_id=source_id)
     else:
-        sp = NumpyMatrixOperator(np.zeros((0, 0)))
+        sp = NumpyMatrixOperator(np.zeros((0, 0)), source_id=source_id, range_id=source_id)
     if dim_range > 0:
         while True:
             rp = np.random.random((dim_range, dim_range))
@@ -42,9 +44,9 @@ def numpy_matrix_operator_with_arrays_and_products_factory(dim_source, dim_range
             evals = eigh(rp, eigvals_only=True)
             if np.min(evals) > 1e-6:
                 break
-        rp = NumpyMatrixOperator(rp)
+        rp = NumpyMatrixOperator(rp, source_id=range_id, range_id=range_id)
     else:
-        rp = NumpyMatrixOperator(np.zeros((0, 0)))
+        rp = NumpyMatrixOperator(np.zeros((0, 0)), source_id=range_id, range_id=range_id)
     return op, None, U, V, sp, rp
 
 
@@ -122,12 +124,12 @@ def thermalblock_vectorarray_factory(transposed, xblocks, yblocks, diameter, see
     op = VectorArrayOperator(U, transposed)
     if transposed:
         U = V
-        V = NumpyVectorArray(np.random.random((7, op.range.dim)), copy=False)
+        V = op.range.make_array(np.random.random((7, op.range.dim)))
         sp = rp
-        rp = NumpyMatrixOperator(np.eye(op.range.dim) * 2)
+        rp = NumpyMatrixOperator(np.eye(op.range.dim) * 2, source_id='SCALARS', range_id='SCALARS')
     else:
-        U = NumpyVectorArray(np.random.random((7, op.source.dim)), copy=False)
-        sp = NumpyMatrixOperator(np.eye(op.source.dim) * 2)
+        U = op.source.make_array(np.random.random((7, op.source.dim)))
+        sp = NumpyMatrixOperator(np.eye(op.source.dim) * 2, source_id='SCALARS', range_id='SCALARS')
     return op, None, U, V, sp, rp
 
 
@@ -135,8 +137,8 @@ def thermalblock_vector_factory(xblocks, yblocks, diameter, seed):
     from pymor.operators.constructions import VectorOperator
     _, _, U, V, sp, rp = thermalblock_factory(xblocks, yblocks, diameter, seed)
     op = VectorOperator(U[0])
-    U = NumpyVectorArray(np.random.random((7, 1)), copy=False)
-    sp = NumpyMatrixOperator(np.eye(1) * 2)
+    U = op.source.make_array(np.random.random((7, 1)))
+    sp = NumpyMatrixOperator(np.eye(1) * 2, source_id='SCALARS', range_id='SCALARS')
     return op, None, U, V, sp, rp
 
 
@@ -145,9 +147,9 @@ def thermalblock_vectorfunc_factory(product, xblocks, yblocks, diameter, seed):
     _, _, U, V, sp, rp = thermalblock_factory(xblocks, yblocks, diameter, seed)
     op = VectorFunctional(U[0], product=sp if product else None)
     U = V
-    V = NumpyVectorArray(np.random.random((7, 1)), copy=False)
+    V = op.range.make_array(np.random.random((7, 1)))
     sp = rp
-    rp = NumpyMatrixOperator(np.eye(1) * 2)
+    rp = NumpyMatrixOperator(np.eye(1) * 2, source_id='SCALARS', range_id='SCALARS')
     return op, None, U, V, sp, rp
 
 
@@ -292,17 +294,17 @@ num_misc_operators = 10
 def misc_operator_with_arrays_and_products_factory(n):
     if n == 0:
         from pymor.operators.constructions import ComponentProjection
-        _, _, U, V, sp, rp = numpy_matrix_operator_with_arrays_and_products_factory(100, 10, 4, 3, n)
+        _, _, U, V, sp, rp = numpy_matrix_operator_with_arrays_and_products_factory(100, 10, 4, 3, n, range_id='SCALARS')
         op = ComponentProjection(np.random.randint(0, 100, 10), U.space)
         return op, _, U, V, sp, rp
     elif n == 1:
         from pymor.operators.constructions import ComponentProjection
-        _, _, U, V, sp, rp = numpy_matrix_operator_with_arrays_and_products_factory(100, 0, 4, 3, n)
+        _, _, U, V, sp, rp = numpy_matrix_operator_with_arrays_and_products_factory(100, 0, 4, 3, n, range_id='SCALARS')
         op = ComponentProjection([], U.space)
         return op, _, U, V, sp, rp
     elif n == 2:
         from pymor.operators.constructions import ComponentProjection
-        _, _, U, V, sp, rp = numpy_matrix_operator_with_arrays_and_products_factory(100, 3, 4, 3, n)
+        _, _, U, V, sp, rp = numpy_matrix_operator_with_arrays_and_products_factory(100, 3, 4, 3, n, range_id='SCALARS')
         op = ComponentProjection([3, 3, 3], U.space)
         return op, _, U, V, sp, rp
     elif n == 3:
@@ -325,19 +327,17 @@ def misc_operator_with_arrays_and_products_factory(n):
         return op, op.parse_parameter((n-5)/2), V, U, rp, sp
     elif n == 8:
         from pymor.operators.block import BlockDiagonalOperator
-        from pymor.vectorarrays.block import BlockVectorArray
         op0, _, U0, V0, sp0, rp0 = numpy_matrix_operator_with_arrays_and_products_factory(10, 10, 4, 3, n)
         op1, _, U1, V1, sp1, rp1 = numpy_matrix_operator_with_arrays_and_products_factory(20, 20, 4, 3, n+1)
         op2, _, U2, V2, sp2, rp2 = numpy_matrix_operator_with_arrays_and_products_factory(30, 30, 4, 3, n+2)
         op = BlockDiagonalOperator([op0, op1, op2])
         sp = BlockDiagonalOperator([sp0, sp1, sp2])
         rp = BlockDiagonalOperator([rp0, rp1, rp2])
-        U = BlockVectorArray([U0, U1, U2])
-        V = BlockVectorArray([V0, V1, V2])
+        U = op.source.make_array([U0, U1, U2])
+        V = op.range.make_array([V0, V1, V2])
         return op, _, U, V, sp, rp
     elif n == 9:
         from pymor.operators.block import BlockDiagonalOperator, BlockOperator
-        from pymor.vectorarrays.block import BlockVectorArray
         op0, _, U0, V0, sp0, rp0 = numpy_matrix_operator_with_arrays_and_products_factory(10, 10, 4, 3, n)
         op1, _, U1, V1, sp1, rp1 = numpy_matrix_operator_with_arrays_and_products_factory(20, 20, 4, 3, n+1)
         op2, _, U2, V2, sp2, rp2 = numpy_matrix_operator_with_arrays_and_products_factory(20, 10, 4, 3, n+2)
@@ -345,8 +345,8 @@ def misc_operator_with_arrays_and_products_factory(n):
                             [None, op1]])
         sp = BlockDiagonalOperator([sp0, sp1])
         rp = BlockDiagonalOperator([rp0, rp1])
-        U = BlockVectorArray([U0, U1])
-        V = BlockVectorArray([V0, V1])
+        U = op.source.make_array([U0, U1])
+        V = op.range.make_array([V0, V1])
         return op, None, U, V, sp, rp
     else:
         assert False

--- a/src/pymortests/fixtures/vectorarray.py
+++ b/src/pymortests/fixtures/vectorarray.py
@@ -6,9 +6,9 @@ from itertools import product
 import numpy as np
 import pytest
 
-from pymor.vectorarrays.block import BlockVectorArray
-from pymor.vectorarrays.numpy import NumpyVectorArray
-from pymor.vectorarrays.list import NumpyVector, ListVectorArray
+from pymor.vectorarrays.block import BlockVectorSpace
+from pymor.vectorarrays.numpy import NumpyVectorSpace
+from pymor.vectorarrays.list import NumpyListVectorSpace
 from pymor.vectorarrays.fenics import HAVE_FENICS
 try:
     from pydealii.pymor.vectorarray import HAVE_DEALII
@@ -24,18 +24,18 @@ def random_integers(count, seed):
 
 def numpy_vector_array_factory(length, dim, seed):
     np.random.seed(seed)
-    return NumpyVectorArray(np.random.random((length, dim)), copy=False)
+    return NumpyVectorSpace.from_data(np.random.random((length, dim)))
 
 
 def numpy_list_vector_array_factory(length, dim, seed):
     np.random.seed(seed)
-    return ListVectorArray([NumpyVector(v, copy=False) for v in np.random.random((length, dim))],
-                           subtype=(NumpyVector, dim), copy=False)
+    return NumpyListVectorSpace.from_data(np.random.random((length, dim)))
 
 
 def block_vector_array_factory(length, dims, seed):
-    return BlockVectorArray([numpy_vector_array_factory(length, dim, seed + i) for i, dim in enumerate(dims)],
-                            copy=False)
+    return BlockVectorSpace([NumpyVectorSpace(dim) for dim in dims]).from_data(
+        numpy_vector_array_factory(length, sum(dims), seed).data
+    )
 
 if HAVE_FENICS:
     import dolfin as df

--- a/src/pymortests/la.py
+++ b/src/pymortests/la.py
@@ -11,24 +11,24 @@ from pymor.operators.cg import L2ProductP1
 from pymortests.base import runmodule
 from pymor.grids.tria import TriaGrid
 from pymor.grids.boundaryinfos import AllDirichletBoundaryInfo
-from pymor.vectorarrays.numpy import NumpyVectorArray
+from pymor.vectorarrays.numpy import NumpyVectorSpace
 
 
 def test_induced():
     grid = TriaGrid(num_intervals=(10, 10))
     boundary_info = AllDirichletBoundaryInfo(grid)
     product = L2ProductP1(grid, boundary_info)
-    zero = NumpyVectorArray(np.zeros(grid.size(2)))
+    zero = NumpyVectorSpace.from_data(np.zeros(grid.size(2)))
     norm = induced_norm(product)
     value = norm(zero)
     np.testing.assert_almost_equal(value, 0.0)
 
 def test_gram_schmidt():
     for i in (1, 32):
-        b = NumpyVectorArray(np.identity(i, dtype=np.float))
+        b = NumpyVectorSpace.from_data(np.identity(i, dtype=np.float))
         a = gram_schmidt(b)
         assert np.all(almost_equal(b, a))
-    c = NumpyVectorArray([[1.0, 0], [0., 0]])
+    c = NumpyVectorSpace.from_data([[1.0, 0], [0., 0]])
     a = gram_schmidt(c)
     assert (a.data == np.array([[1.0, 0]])).all()
 

--- a/src/pymortests/la.py
+++ b/src/pymortests/la.py
@@ -18,10 +18,11 @@ def test_induced():
     grid = TriaGrid(num_intervals=(10, 10))
     boundary_info = AllDirichletBoundaryInfo(grid)
     product = L2ProductP1(grid, boundary_info)
-    zero = NumpyVectorSpace.from_data(np.zeros(grid.size(2)))
+    zero = product.source.zeros()
     norm = induced_norm(product)
     value = norm(zero)
     np.testing.assert_almost_equal(value, 0.0)
+
 
 def test_gram_schmidt():
     for i in (1, 32):

--- a/src/pymortests/operators.py
+++ b/src/pymortests/operators.py
@@ -127,6 +127,28 @@ def test_apply_adjoint(operator_with_arrays):
         assert np.all(almost_equal(Uind, op.apply_adjoint(V[ind], mu=mu)))
 
 
+def test_apply_adjoint2(operator_with_arrays):
+    op, mu, U, V = operator_with_arrays
+    if not op.linear:
+        return
+    try:
+        op.apply_adjoint(V, mu=mu)
+    except NotImplementedError:
+        return
+    assert np.allclose(V.dot(op.apply(U, mu=mu)), op.apply_adjoint(V, mu=mu).dot(U))
+
+
+def test_T(operator_with_arrays):
+    op, mu, U, V = operator_with_arrays
+    if not op.linear:
+        return
+    try:
+        op.T.apply(V, mu=mu)
+    except NotImplementedError:
+        return
+    assert np.allclose(V.dot(op.apply(U, mu=mu)), op.T.apply(V, mu=mu).dot(U))
+
+
 def test_apply_adjoint_2(operator_with_arrays):
     op, mu, U, V = operator_with_arrays
     if not op.linear:

--- a/src/pymortests/operators.py
+++ b/src/pymortests/operators.py
@@ -31,7 +31,7 @@ def test_selection_op():
         name = "foo"
     )
     x = np.linspace(-1., 1., num=3)
-    vx = NumpyVectorArray(x[:, np.newaxis])
+    vx = p1.source.make_array(x[:, np.newaxis])
     assert np.allclose(p1.apply(vx,mu=0).data, s1.apply(vx,mu=0).data)
 
     s2 = SelectionOperator(
@@ -55,7 +55,7 @@ def test_lincomb_op():
     p12 = p1 + p2
     p0 = p1 - p1
     x = np.linspace(-1., 1., num=3)
-    vx = NumpyVectorArray(x[:, np.newaxis])
+    vx = p1.source.make_array((x[:, np.newaxis]))
     assert np.allclose(p0.apply(vx).data, [0.])
     assert np.allclose(p12.apply(vx).data, (x * x + x)[:, np.newaxis])
     assert np.allclose((p1 * 2.).apply(vx).data, (x * 2.)[:, np.newaxis])
@@ -64,9 +64,9 @@ def test_lincomb_op():
     with pytest.raises(TypeError):
         p2.as_vector()
     p1.as_vector()
-    assert almost_equal(p1.as_vector(), p1.apply(NumpyVectorArray(1.)))
+    assert almost_equal(p1.as_vector(), p1.apply(p1.source.make_array([1.])))
 
-    basis = NumpyVectorArray([1.])
+    basis = p1.source.make_array([1.])
     for p in (p1, p2, p12):
         projected = p.projected(basis, basis)
         pa = projected.apply(vx)
@@ -200,8 +200,8 @@ def test_projected(operator_with_arrays):
     op_UV = op.projected(V, U)
     np.random.seed(4711 + U.dim + len(V))
     coeffs = np.random.random(len(U))
-    X = op_UV.apply(NumpyVectorArray(coeffs, copy=False), mu=mu)
-    Y = NumpyVectorArray(V.dot(op.apply(U.lincomb(coeffs), mu=mu)).T, copy=False)
+    X = op_UV.apply(op_UV.source.make_array(coeffs), mu=mu)
+    Y = op_UV.range.make_array(V.dot(op.apply(U.lincomb(coeffs), mu=mu)).T)
     assert np.all(almost_equal(X, Y))
 
 
@@ -213,7 +213,7 @@ def test_projected_2(operator_with_arrays):
     op_V_U = op_V.projected(None, U)
     op_UV = op.projected(V, U)
     np.random.seed(4711 + U.dim + len(V))
-    W = NumpyVectorArray(np.random.random(len(U)), copy=False)
+    W = op_UV.source.make_array(np.random.random(len(U)))
     Y0 = op_UV.apply(W, mu=mu)
     Y1 = op_U_V.apply(W, mu=mu)
     Y2 = op_V_U.apply(W, mu=mu)
@@ -226,8 +226,8 @@ def test_projected_with_product(operator_with_arrays_and_products):
     op_UV = op.projected(V, U, product=rp)
     np.random.seed(4711 + U.dim + len(V))
     coeffs = np.random.random(len(U))
-    X = op_UV.apply(NumpyVectorArray(coeffs, copy=False), mu=mu)
-    Y = NumpyVectorArray(rp.apply2(op.apply(U.lincomb(coeffs), mu=mu), V), copy=False)
+    X = op_UV.apply(op_UV.source.make_array(coeffs), mu=mu)
+    Y = op_UV.range.make_array(rp.apply2(op.apply(U.lincomb(coeffs), mu=mu), V))
     assert np.all(almost_equal(X, Y))
 
 
@@ -239,7 +239,7 @@ def test_projected_with_product_2(operator_with_arrays_and_products):
     op_V_U = op_V.projected(None, U)
     op_UV = op.projected(V, U, product=rp)
     np.random.seed(4711 + U.dim + len(V))
-    W = NumpyVectorArray(np.random.random(len(U)), copy=False)
+    W = op_UV.source.make_array(np.random.random(len(U)))
     Y0 = op_UV.apply(W, mu=mu)
     Y1 = op_U_V.apply(W, mu=mu)
     Y2 = op_V_U.apply(W, mu=mu)
@@ -278,6 +278,6 @@ def test_restricted(operator_with_arrays):
             rop, source_dofs = op.restricted(components)
         except NotImplementedError:
             return
-        op_U = NumpyVectorArray(op.apply(U, mu=mu).components(components))
-        rop_U = rop.apply(NumpyVectorArray(U.components(source_dofs)), mu=mu)
+        op_U = rop.range.make_array(op.apply(U, mu=mu).components(components))
+        rop_U = rop.apply(rop.source.make_array(U.components(source_dofs)), mu=mu)
         assert np.all(almost_equal(op_U, rop_U))

--- a/src/pymortests/solver.py
+++ b/src/pymortests/solver.py
@@ -9,7 +9,7 @@ import pytest
 import pymor.algorithms.genericsolvers
 from pymor.operators.basic import OperatorBase
 from pymor.operators.numpy import NumpyMatrixOperator, sparse_options, dense_options
-from pymor.vectorarrays.numpy import NumpyVectorSpace, NumpyVectorArray
+from pymor.vectorarrays.numpy import NumpyVectorSpace
 
 
 class GenericOperator(OperatorBase):
@@ -45,20 +45,20 @@ def numpy_sparse_solver(request):
 
 def test_generic_solvers(generic_solver):
     op = GenericOperator(generic_solver)
-    rhs = NumpyVectorArray(np.ones(10))
+    rhs = op.range.make_array(np.ones(10))
     solution = op.apply_inverse(rhs)
     assert ((op.apply(solution) - rhs).l2_norm() / rhs.l2_norm())[0] < 1e-8
 
 
 def test_numpy_dense_solvers(numpy_dense_solver):
     op = NumpyMatrixOperator(np.eye(10) * np.arange(1, 11), solver_options=numpy_dense_solver)
-    rhs = NumpyVectorArray(np.ones(10))
+    rhs = op.range.make_array(np.ones(10))
     solution = op.apply_inverse(rhs)
     assert ((op.apply(solution) - rhs).l2_norm() / rhs.l2_norm())[0] < 1e-8
 
 
 def test_numpy_sparse_solvers(numpy_sparse_solver):
     op = NumpyMatrixOperator(diags([np.arange(1., 11.)], [0]), solver_options=numpy_sparse_solver)
-    rhs = NumpyVectorArray(np.ones(10))
+    rhs = op.range.make_array(np.ones(10))
     solution = op.apply_inverse(rhs)
     assert ((op.apply(solution) - rhs).l2_norm() / rhs.l2_norm())[0] < 1e-8

--- a/src/pymortests/to_matrix.py
+++ b/src/pymortests/to_matrix.py
@@ -12,7 +12,7 @@ from pymor.operators.block import BlockDiagonalOperator
 from pymor.operators.constructions import (AdjointOperator, Concatenation, IdentityOperator, LincombOperator,
                                            VectorArrayOperator)
 from pymor.operators.numpy import NumpyMatrixOperator
-from pymor.vectorarrays.numpy import NumpyVectorArray, NumpyVectorSpace
+from pymor.vectorarrays.numpy import NumpyVectorSpace
 
 
 def test_to_matrix():
@@ -37,7 +37,7 @@ def test_to_matrix():
 
     np.random.seed(0)
     V = np.random.randn(10, 2)
-    Vva = NumpyVectorArray(V.T)
+    Vva = NumpyVectorSpace.make_array(V.T)
     Vop = VectorArrayOperator(Vva)
     assert np.allclose(V, to_matrix(Vop))
     Vop = VectorArrayOperator(Vva, transposed=True)

--- a/src/pymortests/tools.py
+++ b/src/pymortests/tools.py
@@ -15,7 +15,7 @@ from pymor.tools.deprecated import Deprecated
 from pymor.tools.quadratures import GaussQuadratures
 from pymor.tools.floatcmp import float_cmp, float_cmp_all
 from pymor.tools.vtkio import write_vtk
-from pymor.vectorarrays.numpy import NumpyVectorArray
+from pymor.vectorarrays.numpy import NumpyVectorSpace
 from pymor.tools import timing
 
 
@@ -89,7 +89,7 @@ def test_vtkio(rect_or_tria_grid):
     grid = rect_or_tria_grid
     steps = 4
     for dim in range(1, 2):
-        for codim, data in enumerate((NumpyVectorArray(np.zeros((steps, grid.size(c)))) for c in range(grid.dim+1))):
+        for codim, data in enumerate((NumpyVectorSpace.from_data(np.zeros((steps, grid.size(c)))) for c in range(grid.dim+1))):
             with NamedTemporaryFile('wb') as out:
                 if codim == 1:
                     with pytest.raises(NotImplementedError):

--- a/src/pymortests/vectorarray.py
+++ b/src/pymortests/vectorarray.py
@@ -10,7 +10,7 @@ import numpy as np
 
 from pymor.algorithms.basic import almost_equal
 from pymor.core import NUMPY_INDEX_QUIRK
-from pymor.vectorarrays.interfaces import VectorSpace, _INDEXTYPES
+from pymor.vectorarrays.interfaces import VectorSpaceInterface, _INDEXTYPES
 from pymortests.fixtures.vectorarray import \
     (vector_array_without_reserve, vector_array, compatible_vector_array_pair_without_reserve,
      compatible_vector_array_pair, incompatible_vector_array_pair,
@@ -153,8 +153,6 @@ def test_empty(vector_array):
         vector_array.empty(-1)
     for r in (0, 1, 100):
         v = vector_array.empty(reserve=r)
-        assert v.dim == vector_array.dim
-        assert v.subtype == vector_array.subtype
         assert v.space == vector_array.space
         assert len(v) == 0
         if hasattr(v, 'data'):
@@ -167,8 +165,6 @@ def test_zeros(vector_array):
         vector_array.zeros(-1)
     for c in (0, 1, 2, 30):
         v = vector_array.zeros(count=c)
-        assert v.dim == vector_array.dim
-        assert v.subtype == vector_array.subtype
         assert v.space == vector_array.space
         assert len(v) == c
         if min(v.dim, c) > 0:
@@ -184,7 +180,7 @@ def test_from_data(vector_array):
     if hasattr(vector_array, 'data'):
         d = vector_array.data
         try:
-            v = vector_array.from_data(d, vector_array.subtype)
+            v = vector_array.space.from_data(d)
             assert np.allclose(d, v.data)
         except NotImplementedError:
             pass
@@ -201,10 +197,7 @@ def test_shape(vector_array):
 
 def test_space(vector_array):
     v = vector_array
-    assert isinstance(v.space, VectorSpace)
-    assert v.dim == v.space.dim
-    assert v.subtype == v.space.subtype
-    assert type(v) == v.space.type
+    assert isinstance(v.space, VectorSpaceInterface)
     assert v in v.space
 
 
@@ -224,8 +217,7 @@ def test_copy(vector_array):
     for ind in valid_inds(v):
         c = v[ind].copy()
         assert len(c) == v.len_ind(ind)
-        assert c.dim == v.dim
-        assert c.subtype == v.subtype
+        assert c.space == v.space
         assert np.all(almost_equal(c, v[ind]))
         if hasattr(v, 'data'):
             dv = v.data
@@ -271,8 +263,7 @@ def test_append(compatible_vector_array_pair):
             assert np.allclose(c1.data, np.vstack((dv1, indexed(dv2, ind))))
         c1.append(c2[ind], remove_from_other=True)
         assert len(c2) == len(ind_complement_)
-        assert c2.dim == c1.dim
-        assert c2.subtype == c1.subtype
+        assert c2.space == c1.space
         assert len(c1) == len_v1 + 2 * len_ind
         assert np.all(almost_equal(c1[len_v1:len_v1 + len_ind], c1[len_v1 + len_ind:len(c1)]))
         assert np.all(almost_equal(c2, v2[ind_complement_]))
@@ -302,8 +293,7 @@ def test_del(vector_array):
         ind_complement_ = ind_complement(v, ind)
         c = v.copy()
         del c[ind]
-        assert c.dim == v.dim
-        assert c.subtype == v.subtype
+        assert c.space == v.space
         assert len(c) == len(ind_complement_)
         assert np.all(almost_equal(v[ind_complement_], c))
         if hasattr(v, 'data'):
@@ -576,8 +566,7 @@ def test_lincomb_1d(vector_array):
     for ind in valid_inds(v):
         coeffs = np.random.random(v.len_ind(ind))
         lc = v[ind].lincomb(coeffs)
-        assert lc.dim == v.dim
-        assert lc.subtype == v.subtype
+        assert lc.space == v.space
         assert len(lc) == 1
         lc2 = v.zeros()
         for coeff, i in zip(coeffs, ind_to_list(v, ind)):
@@ -592,8 +581,7 @@ def test_lincomb_2d(vector_array):
         for count in (0, 1, 5):
             coeffs = np.random.random((count, v.len_ind(ind)))
             lc = v[ind].lincomb(coeffs)
-            assert lc.dim == v.dim
-            assert lc.subtype == v.subtype
+            assert lc.space == v.space
             assert len(lc) == count
             lc2 = v.empty(reserve=count)
             for coeffs_1d in coeffs:


### PR DESCRIPTION
This pull request contains two major changes to the `VectorSpace` concept:

`VectorSpaces` are now the factories for new `VectorArrays`. Instead of instantiating the array directly, one now writes `space.make_array(obj_to_be_warpped_as_vector_array)`. In particular, to implement a new `VectorArray` own now also subclasses `VectorSpaceInterface`. This new approach has the following benefits:
- VectorSpaces replace the `subtype` concept which was hard to understand by newcomers. In contrast, the idea of a `VectorSpace` which can produce vectors contained in itself should be very natural.
- VectorSpaces can have meaningful attributes (like `dim`) instead of a generic `subtype` attribute. Custom implementations of `__repr__` are easily possible.
- By subclassing an existing `VectorSpace`, one can easily add additional data that is relavant in a given mathematical situation (e.g. the subdomain number for localized model reduction), and this data is then also attached (via the space) to all arrays created from the space.

Second, every `VectorSpace` has now a string `id` attribute that can be used to distinguish mathematically different vector spaces. The currently used default `id` is `'STATE'` for all function spaces and `'SCALARS'` for elements of R^n. In particular, the `range` of functionals and the `source` of vectors are tagged as `'SCALARS'`. The same would apply to multidimensional input or output operators. This in particular allows to detect the 'kind' (#275, #310) of an Operator without any additional effort. As a consequence, the special `functionals` and `vector_operators` dicts of the `Discretizations` can go away. The same applies to the `ss_operators`, `is_operators`, `so_operators` and `io_operators` dicts in @pmli's code.

This pull request is still work in progress. In particular, i haven't updated the documentation yet. Before I proceed with the polish, @andreasbuhr, @pmli, @ftalbrecht, please let me know what you think!