### PR TITLE
Type promotion

### DIFF
--- a/src/pymor/operators/block.py
+++ b/src/pymor/operators/block.py
@@ -139,9 +139,9 @@ class BlockOperator(OperatorBase):
                     return None
             return self.__class__(blocks)
         else:
-            if coefficients[0] == 1:
+            c = coefficients[0]
+            if c == 1:
                 return self
-            c = coefficients[0].real if coefficients[0].imag == 0 else coefficients[0]
             for (i, j) in np.ndindex(self._blocks.shape):
                 blocks[i, j] = self._blocks[i, j] * c
             return self.__class__(blocks)
@@ -224,9 +224,9 @@ class BlockDiagonalOperator(BlockOperator):
                     return None
             return self.__class__(blocks)
         else:
-            if coefficients[0] == 1:
+            c = coefficients[0]
+            if c == 1:
                 return self
-            c = coefficients[0].real if coefficients[0].imag == 0 else coefficients[0]
             for i in range(self.num_source_blocks):
                 blocks[i] = self._blocks[i, i] * c
             return self.__class__(blocks)

--- a/src/pymor/operators/block.py
+++ b/src/pymor/operators/block.py
@@ -167,34 +167,24 @@ class BlockDiagonalOperator(BlockOperator):
 
     def apply(self, U, mu=None):
         assert U in self.source
-
         V_blocks = [self._blocks[i, i].apply(U.block(i), mu=mu) for i in range(self.num_range_blocks)]
-
         return self.range.make_array(V_blocks)
 
     def apply_transpose(self, V, mu=None):
         assert V in self.range
-
         U_blocks = [self._blocks[i, i].apply_transpose(V.block(i), mu=mu) for i in range(self.num_source_blocks)]
-
-        U = self.source.make_array(U_blocks)
-
-        return U
+        return self.source.make_array(U_blocks)
 
     def apply_inverse(self, V, mu=None, least_squares=False):
         assert V in self.range
-
         U_blocks = [self._blocks[i, i].apply_inverse(V.block(i), mu=mu, least_squares=least_squares)
                     for i in range(self.num_source_blocks)]
-
         return self.source.make_array(U_blocks)
 
     def apply_inverse_transpose(self, U, mu=None, least_squares=False):
         assert U in self.source
-
         V_blocks = [self._blocks[i, i].apply_inverse_transpose(U.block(i), mu=mu, least_squares=least_squares)
                     for i in range(self.num_source_blocks)]
-
         return self.range.make_array(V_blocks)
 
     def assemble(self, mu=None):

--- a/src/pymor/operators/constructions.py
+++ b/src/pymor/operators/constructions.py
@@ -141,7 +141,6 @@ class LincombOperator(OperatorBase):
                 return self.assemble().apply_transpose(V)
         elif self._try_assemble:
             return self.assemble().apply_transpose(V)
-
         coeffs = self.evaluate_coefficients(mu)
         R = self.operators[0].apply_transpose(V, mu=mu)
         R.scal(coeffs[0])
@@ -1165,7 +1164,7 @@ class InducedNorm(ImmutableInterface, Parametric):
         self.build_parameter_type(product)
 
     def __call__(self, U, mu=None):
-        norm_squared = self.product.pairwise_apply2(U, U, mu=mu)
+        norm_squared = self.product.pairwise_apply2(U, U, mu=mu).real
         if self.tol > 0:
             norm_squared = np.where(np.logical_and(0 > norm_squared, norm_squared > - self.tol),
                                     0, norm_squared)

--- a/src/pymor/operators/numpy.py
+++ b/src/pymor/operators/numpy.py
@@ -400,16 +400,13 @@ class NumpyMatrixOperator(NumpyMatrixBasedOperator):
 
         common_mat_dtype = reduce(np.promote_types,
                                   (op._matrix.dtype for op in operators if hasattr(op, '_matrix')))
-        common_coef_dtype = reduce(np.promote_types, (type(c.real if c.imag == 0 else c) for c in coefficients))
+        common_coef_dtype = reduce(np.promote_types, (type(c) for c in coefficients))
         common_dtype = np.promote_types(common_mat_dtype, common_coef_dtype)
 
         if coefficients[0] == 1:
             matrix = operators[0]._matrix.astype(common_dtype)
         else:
-            if coefficients[0].imag == 0:
-                matrix = operators[0]._matrix * coefficients[0].real
-            else:
-                matrix = operators[0]._matrix * coefficients[0]
+            matrix = operators[0]._matrix * coefficients[0]
             if matrix.dtype != common_dtype:
                 matrix = matrix.astype(common_dtype)
 
@@ -434,11 +431,6 @@ class NumpyMatrixOperator(NumpyMatrixBasedOperator):
                     matrix -= op._matrix
                 except NotImplementedError:
                     matrix = matrix - op._matrix
-            elif c.imag == 0:
-                try:
-                    matrix += (op._matrix * c.real)
-                except NotImplementedError:
-                    matrix = matrix + (op._matrix * c.real)
             else:
                 try:
                     matrix += (op._matrix * c)

--- a/src/pymor/vectorarrays/block.py
+++ b/src/pymor/vectorarrays/block.py
@@ -3,6 +3,7 @@
 # Copyright 2013-2016 pyMOR developers and contributors. All rights reserved.
 # License: BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
 
+from functools import reduce
 from numbers import Number
 import numpy as np
 
@@ -84,7 +85,8 @@ class BlockVectorArray(VectorArrayInterface):
         assert other in self.space
         dots = [block.dot(other_block) for block, other_block in zip(self._blocks, other._blocks)]
         assert all([dot.shape == dots[0].shape for dot in dots])
-        ret = np.zeros(dots[0].shape)
+        common_dtype = reduce(np.promote_types, (dot.dtype for dot in dots))
+        ret = np.zeros(dots[0].shape, dtype=common_dtype)
         for dot in dots:
             ret += dot
         return ret
@@ -94,7 +96,8 @@ class BlockVectorArray(VectorArrayInterface):
         dots = [block.pairwise_dot(other_block)
                 for block, other_block in zip(self._blocks, other._blocks)]
         assert all([dot.shape == dots[0].shape for dot in dots])
-        ret = np.zeros(dots[0].shape)
+        common_dtype = reduce(np.promote_types, (dot.dtype for dot in dots))
+        ret = np.zeros(dots[0].shape, dtype=common_dtype)
         for dot in dots:
             ret += dot
         return ret

--- a/src/pymor/vectorarrays/block.py
+++ b/src/pymor/vectorarrays/block.py
@@ -31,6 +31,14 @@ class BlockVectorArray(VectorArrayInterface):
     def data(self):
         return np.hstack([block.data for block in self._blocks])
 
+    @property
+    def real(self):
+        return BlockVectorArray([block.real for block in self._blocks], self.space)
+
+    @property
+    def imag(self):
+        return BlockVectorArray([block.imag for block in self._blocks], self.space)
+
     def block(self, ind):
         """
         Returns a copy of each block (no slicing).

--- a/src/pymor/vectorarrays/constructions.py
+++ b/src/pymor/vectorarrays/constructions.py
@@ -4,7 +4,7 @@
 
 
 def cat_arrays(vector_arrays):
-    """Return a new |VectorArray| which a concatenation of the arrays in `vector_arrays`."""
+    """Return a new |VectorArray| which is a concatenation of the arrays in `vector_arrays`."""
     vector_arrays = list(vector_arrays)
     total_length = sum(map(len, vector_arrays))
     cated_arrays = vector_arrays[0].empty(reserve=total_length)

--- a/src/pymor/vectorarrays/numpy.py
+++ b/src/pymor/vectorarrays/numpy.py
@@ -42,11 +42,11 @@ class NumpyVectorArray(VectorArrayInterface):
 
     @property
     def real(self):
-        return NumpyVectorArray(self._array[:self._len].real.copy(), self.space)
+        return NumpyVectorArray(self.data.real.copy(), self.space)
 
     @property
     def imag(self):
-        return NumpyVectorArray(self._array[:self._len].imag, self.space)
+        return NumpyVectorArray(self.data.imag.copy(), self.space)
 
     def __len__(self):
         return self._len

--- a/src/pymor/vectorarrays/numpy.py
+++ b/src/pymor/vectorarrays/numpy.py
@@ -281,6 +281,10 @@ class NumpyVectorArray(VectorArrayInterface):
         assert self.dim == other.dim
         if self._refcount[0] > 1:
             self._deep_copy()
+        other_dtype = other.base._array.dtype if other.is_view else other._array.dtype
+        common_dtype = np.promote_types(self._array.dtype, other_dtype)
+        if self._array.dtype != common_dtype:
+            self._array = self._array.astype(common_dtype)
         self._array[:self._len] += other.base._array[other.ind] if other.is_view else other._array[:other._len]
         return self
 
@@ -296,6 +300,10 @@ class NumpyVectorArray(VectorArrayInterface):
         assert self.dim == other.dim
         if self._refcount[0] > 1:
             self._deep_copy()
+        other_dtype = other.base._array.dtype if other.is_view else other._array.dtype
+        common_dtype = np.promote_types(self._array.dtype, other_dtype)
+        if self._array.dtype != common_dtype:
+            self._array = self._array.astype(common_dtype)
         self._array[:self._len] -= other.base._array[other.ind] if other.is_view else other._array[:other._len]
         return self
 
@@ -309,6 +317,10 @@ class NumpyVectorArray(VectorArrayInterface):
             or isinstance(other, np.ndarray) and other.shape == (len(self),)
         if self._refcount[0] > 1:
             self._deep_copy()
+        other_dtype = other.dtype if isinstance(other, np.ndarray) else type(other)
+        common_dtype = np.promote_types(self._array.dtype, other_dtype)
+        if self._array.dtype != common_dtype:
+            self._array = self._array.astype(common_dtype)
         self._array[:self._len] *= other
         return self
 

--- a/src/pymor/vectorarrays/numpy.py
+++ b/src/pymor/vectorarrays/numpy.py
@@ -475,7 +475,6 @@ class NumpyVectorArrayView(NumpyVectorArray):
 
     def l2_norm2(self):
         return self.base.l2_norm2(_ind=self.ind)
-        pass
 
     def sup_norm(self):
         return self.base.sup_norm(_ind=self.ind)

--- a/src/pymor/vectorarrays/numpy.py
+++ b/src/pymor/vectorarrays/numpy.py
@@ -499,6 +499,10 @@ class NumpyVectorArrayView(NumpyVectorArray):
         assert self.base.check_ind_unique(self.ind)
         if self.base._refcount[0] > 1:
             self._deep_copy()
+        other_dtype = other.base._array.dtype if other.is_view else other._array.dtype
+        common_dtype = np.promote_types(self.base._array.dtype, other_dtype)
+        if self.base._array.dtype != common_dtype:
+            self.base._array = self.base._array.astype(common_dtype)
         self.base.array[self.ind] += other.base._array[other.ind] if other.is_view else other._array[:other._len]
         return self
 
@@ -515,6 +519,10 @@ class NumpyVectorArrayView(NumpyVectorArray):
         assert self.base.check_ind_unique(self.ind)
         if self.base._refcount[0] > 1:
             self._deep_copy()
+        other_dtype = other.base._array.dtype if other.is_view else other._array.dtype
+        common_dtype = np.promote_types(self.base._array.dtype, other_dtype)
+        if self.base._array.dtype != common_dtype:
+            self.base._array = self.base._array.astype(common_dtype)
         self.base._array[self.ind] -= other.base._array[other.ind] if other.is_view else other._array[:other._len]
         return self
 
@@ -529,6 +537,10 @@ class NumpyVectorArrayView(NumpyVectorArray):
         assert self.base.check_ind_unique(self.ind)
         if self.base._refcount[0] > 1:
             self._deep_copy()
+        other_dtype = other.dtype if isinstance(other, np.ndarray) else type(other)
+        common_dtype = np.promote_types(self.base._array.dtype, other_dtype)
+        if self.base._array.dtype != common_dtype:
+            self.base._array = self.base._array.astype(common_dtype)
         self.base._array[self.ind] *= other
         return self
 

--- a/src/pymortests/complex_values.py
+++ b/src/pymortests/complex_values.py
@@ -24,7 +24,7 @@ def test_complex():
     # assemble_lincomb
     assert not np.iscomplexobj(Aop.assemble_lincomb((Iop, Bop), (1, 1))._matrix)
     assert not np.iscomplexobj(Aop.assemble_lincomb((Aop, Bop), (1, 1))._matrix)
-    assert not np.iscomplexobj(Aop.assemble_lincomb((Aop, Bop), (1 + 0j, 1 + 0j))._matrix)
+    assert np.iscomplexobj(Aop.assemble_lincomb((Aop, Bop), (1 + 0j, 1 + 0j))._matrix)
     assert np.iscomplexobj(Aop.assemble_lincomb((Aop, Bop), (1j, 1))._matrix)
     assert np.iscomplexobj(Aop.assemble_lincomb((Bop, Aop), (1, 1j))._matrix)
 


### PR DESCRIPTION
This pull request is to enable automatic type promotion and correct handling of complex types. This is as discussed in #333, except unlike there, I decided not to include special handling when imaginary part is zero. The main reason is that I noticed that such conditions can be handled in "higher-level" functions (e.g. reductors). Also, it just seems like too much work to do it in all "lower-level" function (e.g. operator and vectorarray methods)...

So far, I only made some changes in `vectorarrays` and `operators`. @pymor/pymor-devs @andreasbuhr, please check the changes, and see if additional changes are necessary.

Besides `vectorarrays` and `operators`, I noticed one thing in `algorithms` which should be changed. In [line 341 in `algorithms/genericsolvers.py`](https://github.com/pymor/pymor/blob/ffbff4046faef7d731857b585be727cbcd3ca64a/src/pymor/algorithms/genericsolvers.py#L341), the assignment doesn't work for complex numbers. Do we want to touch LGMRES code?

I haven't noticed any other `ComplexWarning`s or `TypeError`s (like in #333), but in future, we should probably include tests with complex data (and mixtures or float and complex data). Is this something easy to enable in the current testing framework?

There is also a general question of handling complex numbers, like in `dot` (see #259). Should this be a separate pull request?