### PR TITLE
Add basic support for visualization in juypter notebooks

### DIFF
--- a/src/pymor/core/config.py
+++ b/src/pymor/core/config.py
@@ -37,6 +37,7 @@ _PACKAGES = {
     'GL': lambda: import_module('OpenGL.GL') and import_module('OpenGL').__version__,
     'IPYTHON': _get_ipython_version,
     'MATPLOTLIB': lambda: import_module('matplotlib').__version__,
+    'IPYWIDGETS': lambda: import_module('ipywidgets').__version__,
     'MPI': lambda: import_module('mpi4py.MPI') and import_module('mpi4py').__version__,
     'NUMPY': lambda: import_module('numpy').__version__,
     'PYAMG': lambda: import_module('pyamg.version').full_version,

--- a/src/pymor/discretizers/cg.py
+++ b/src/pymor/discretizers/cg.py
@@ -13,7 +13,7 @@ from pymor.domaindiscretizers.default import discretize_domain_default
 from pymor.functions.basic import ConstantFunction, LincombFunction
 from pymor.grids.boundaryinfos import EmptyBoundaryInfo
 from pymor.grids.referenceelements import line, triangle, square
-from pymor.gui.qt import PatchVisualizer, Matplotlib1DVisualizer
+from pymor.gui.visualizers import PatchVisualizer, OnedVisualizer
 from pymor.operators.cg import (DiffusionOperatorP1, DiffusionOperatorQ1,
                                 AdvectionOperatorP1, AdvectionOperatorQ1,
                                 L2ProductP1, L2ProductQ1,
@@ -145,7 +145,7 @@ def discretize_stationary_cg(analytical_problem, diameter=None, domain_discretiz
     if grid.reference_element in (triangle, square):
         visualizer = PatchVisualizer(grid=grid, bounding_box=grid.bounding_box(), codim=2)
     elif grid.reference_element is line:
-        visualizer = Matplotlib1DVisualizer(grid=grid, codim=1)
+        visualizer = OnedVisualizer(grid=grid, codim=1)
     else:
         visualizer = None
 

--- a/src/pymor/discretizers/fv.py
+++ b/src/pymor/discretizers/fv.py
@@ -14,7 +14,7 @@ from pymor.discretizations.basic import StationaryDiscretization, InstationaryDi
 from pymor.domaindiscretizers.default import discretize_domain_default
 from pymor.functions.basic import LincombFunction
 from pymor.grids.referenceelements import line, triangle, square
-from pymor.gui.qt import PatchVisualizer, Matplotlib1DVisualizer
+from pymor.gui.visualizers import PatchVisualizer, OnedVisualizer
 from pymor.operators.constructions import LincombOperator, ZeroOperator
 from pymor.operators.numpy import NumpyGenericOperator
 from pymor.operators.fv import (DiffusionOperator, LinearAdvectionLaxFriedrichs, ReactionOperator,
@@ -182,7 +182,7 @@ def discretize_stationary_fv(analytical_problem, diameter=None, domain_discretiz
     if grid.reference_element in (triangle, square):
         visualizer = PatchVisualizer(grid=grid, bounding_box=grid.bounding_box(), codim=0)
     elif grid.reference_element is line:
-        visualizer = Matplotlib1DVisualizer(grid=grid, codim=0)
+        visualizer = OnedVisualizer(grid=grid, codim=0)
     else:
         visualizer = None
 

--- a/src/pymor/gui/jupyter.py
+++ b/src/pymor/gui/jupyter.py
@@ -1,0 +1,117 @@
+# This file is part of the pyMOR project (http://www.pymor.org).
+# Copyright 2013-2016 pyMOR developers and contributors. All rights reserved.
+# License: BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+
+import numpy as np
+
+from pymor.gui.matplotlib import MatplotlibPatchAxes
+from pymor.vectorarrays.interfaces import VectorArrayInterface
+
+
+def visualize_patch(grid, U, bounding_box=([0, 0], [1, 1]), codim=2, title=None, legend=None,
+                    separate_colorbars=False, rescale_colorbars=False, columns=2):
+    """Visualize scalar data associated to a two-dimensional |Grid| as a patch plot.
+
+    The grid's |ReferenceElement| must be the triangle or square. The data can either
+    be attached to the faces or vertices of the grid.
+
+    Parameters
+    ----------
+    grid
+        The underlying |Grid|.
+    U
+        |VectorArray| of the data to visualize. If `len(U) > 1`, the data is visualized
+        as a time series of plots. Alternatively, a tuple of |VectorArrays| can be
+        provided, in which case a subplot is created for each entry of the tuple. The
+        lengths of all arrays have to agree.
+    bounding_box
+        A bounding box in which the grid is contained.
+    codim
+        The codimension of the entities the data in `U` is attached to (either 0 or 2).
+    title
+        Title of the plot.
+    legend
+        Description of the data that is plotted. Most useful if `U` is a tuple in which
+        case `legend` has to be a tuple of strings of the same length.
+    separate_colorbars
+        If `True`, use separate colorbars for each subplot.
+    rescale_colorbars
+        If `True`, rescale colorbars to data in each frame.
+    columns
+        The number of columns in the visualizer GUI in case multiple plots are displayed
+        at the same time.
+    """
+
+    assert isinstance(U, VectorArrayInterface) and hasattr(U, 'data') \
+        or (isinstance(U, tuple) and all(isinstance(u, VectorArrayInterface) and hasattr(u, 'data') for u in U)
+            and all(len(u) == len(U[0]) for u in U))
+    U = (U.data.astype(np.float64, copy=False),) if hasattr(U, 'data') else \
+        tuple(u.data.astype(np.float64, copy=False) for u in U)
+    if isinstance(legend, str):
+        legend = (legend,)
+    assert legend is None or isinstance(legend, tuple) and len(legend) == len(U)
+    if len(U) < 2:
+        columns = 1
+
+    class Plot:
+
+        def __init__(self):
+            if separate_colorbars:
+                if rescale_colorbars:
+                    self.vmins = tuple(np.min(u[0]) for u in U)
+                    self.vmaxs = tuple(np.max(u[0]) for u in U)
+                else:
+                    self.vmins = tuple(np.min(u) for u in U)
+                    self.vmaxs = tuple(np.max(u) for u in U)
+            else:
+                if rescale_colorbars:
+                    self.vmins = (min(np.min(u[0]) for u in U),) * len(U)
+                    self.vmaxs = (max(np.max(u[0]) for u in U),) * len(U)
+                else:
+                    self.vmins = (min(np.min(u) for u in U),) * len(U)
+                    self.vmaxs = (max(np.max(u) for u in U),) * len(U)
+
+            import matplotlib.pyplot as plt
+
+            rows = int(np.ceil(len(U) / columns))
+            self.figure = figure = plt.figure()
+
+            self.plots = plots = []
+            axes = []
+            for i, (vmin, vmax) in enumerate(zip(self.vmins, self.vmaxs)):
+                ax = figure.add_subplot(rows, columns, i+1)
+                axes.append(ax)
+                plots.append(MatplotlibPatchAxes(figure, grid, bounding_box=bounding_box, vmin=vmin, vmax=vmax,
+                                                 codim=codim, colorbar=separate_colorbars))
+                if legend:
+                    ax.set_title(legend[i])
+
+            plt.tight_layout()
+            if not separate_colorbars:
+                figure.colorbar(plots[0].p, ax=axes)
+
+        def set(self, U, ind):
+            if rescale_colorbars:
+                if separate_colorbars:
+                    self.vmins = tuple(np.min(u[ind]) for u in U)
+                    self.vmaxs = tuple(np.max(u[ind]) for u in U)
+                else:
+                    self.vmins = (min(np.min(u[ind]) for u in U),) * len(U)
+                    self.vmaxs = (max(np.max(u[ind]) for u in U),) * len(U)
+
+            for u, plot, vmin, vmax in zip(U, self.plots, self.vmins, self.vmaxs):
+                plot.set(u[ind], vmin=vmin, vmax=vmax)
+
+    plot = Plot()
+    plot.set(U, 0)
+
+    if len(U[0]) > 1:
+
+        from ipywidgets import interact, IntSlider
+
+        def set_time(t):
+            plot.set(U, t)
+
+        interact(set_time, t=IntSlider(min=0, max=len(U[0])-1, step=1, value=0))
+
+    return plot

--- a/src/pymor/gui/jupyter.py
+++ b/src/pymor/gui/jupyter.py
@@ -2,6 +2,15 @@
 # Copyright 2013-2016 pyMOR developers and contributors. All rights reserved.
 # License: BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
 
+"""This module provides plotting support inside the Jupyter notebook.
+
+To use these routines you first have to execute ::
+
+        %matplotlib notebook
+
+inside the given notebook.
+"""
+
 import numpy as np
 
 from pymor.core.config import config

--- a/src/pymor/gui/jupyter.py
+++ b/src/pymor/gui/jupyter.py
@@ -4,6 +4,7 @@
 
 import numpy as np
 
+from pymor.core.config import config
 from pymor.gui.matplotlib import MatplotlibPatchAxes
 from pymor.vectorarrays.interfaces import VectorArrayInterface
 
@@ -43,10 +44,17 @@ def visualize_patch(grid, U, bounding_box=([0, 0], [1, 1]), codim=2, title=None,
     """
 
     assert isinstance(U, VectorArrayInterface) and hasattr(U, 'data') \
-        or (isinstance(U, tuple) and all(isinstance(u, VectorArrayInterface) and hasattr(u, 'data') for u in U)
-            and all(len(u) == len(U[0]) for u in U))
+        or (isinstance(U, tuple) and
+            all(isinstance(u, VectorArrayInterface) and hasattr(u, 'data') for u in U) and
+            all(len(u) == len(U[0]) for u in U))
     U = (U.data.astype(np.float64, copy=False),) if hasattr(U, 'data') else \
         tuple(u.data.astype(np.float64, copy=False) for u in U)
+
+    if not config.HAVE_MATPLOTLIB:
+        raise ImportError('cannot visualize: import of matplotlib failed')
+    if not config.HAVE_IPYWIDGETS and len(U[0]) > 1:
+        raise ImportError('cannot visualize: import of ipywidgets failed')
+
     if isinstance(legend, str):
         legend = (legend,)
     assert legend is None or isinstance(legend, tuple) and len(legend) == len(U)

--- a/src/pymor/gui/matplotlib.py
+++ b/src/pymor/gui/matplotlib.py
@@ -110,25 +110,29 @@ if config.HAVE_QT and config.HAVE_MATPLOTLIB:
             self.setParent(parent)
             self.setMinimumSize(300, 300)
             self.setSizePolicy(QSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding))
+            a = self.figure.gca()
+            if self.codim == 2:
+                self.p = a.tripcolor(self.coordinates[:, 0], self.coordinates[:, 1], self.subentities,
+                                     np.zeros(len(self.coordinates)),
+                                     vmin=self.vmin, vmax=self.vmax, shading='gouraud')
+            else:
+                self.p = a.tripcolor(self.coordinates[:, 0], self.coordinates[:, 1], self.subentities,
+                                     facecolors=np.zeros(len(self.subentities)),
+                                     vmin=self.vmin, vmax=self.vmax, shading='flat')
+            self.figure.colorbar(self.p)
 
         def set(self, U, vmin=None, vmax=None):
             self.vmin = self.vmin if vmin is None else vmin
             self.vmax = self.vmax if vmax is None else vmax
             U = np.array(U)
-            f = self.figure
-            f.clear()
-            a = f.gca()
+            p = self.p
             if self.codim == 2:
-                p = a.tripcolor(self.coordinates[:, 0], self.coordinates[:, 1], self.subentities, U,
-                                vmin=self.vmin, vmax=self.vmax, shading='flat')
+                p.set_array(U)
             elif self.reference_element is triangle:
-                p = a.tripcolor(self.coordinates[:, 0], self.coordinates[:, 1], self.subentities, facecolors=U,
-                                vmin=self.vmin, vmax=self.vmax, shading='flat')
+                p.set_array(U)
             else:
-                p = a.tripcolor(self.coordinates[:, 0], self.coordinates[:, 1], self.subentities,
-                                facecolors=np.tile(U, 2), vmin=self.vmin, vmax=self.vmax, shading='flat')
-
-            self.figure.colorbar(p)
+                p.set_array(np.tile(U, 2))
+            p.set_clim(self.vmin, self.vmax)
             self.draw()
 
 else:

--- a/src/pymor/gui/matplotlib.py
+++ b/src/pymor/gui/matplotlib.py
@@ -5,8 +5,6 @@
 """ This module provides a widgets for displaying plots of
 scalar data assigned to one- and two-dimensional grids using
 :mod:`matplotlib`. This widget is not intended to be used directly.
-Instead, use :meth:`~pymor.gui.qt.visualize_matplotlib_1d` or
-:class:`~pymor.gui.qt.Matplotlib1DVisualizer`.
 """
 
 import numpy as np
@@ -16,7 +14,8 @@ from pymor.core.config import config
 
 class MatplotlibPatchAxes:
 
-    def __init__(self, figure, grid, bounding_box=None, vmin=None, vmax=None, codim=2):
+    def __init__(self, figure, grid, bounding_box=None, vmin=None, vmax=None, codim=2,
+                 colorbar=True):
         assert grid.reference_element in (triangle, square)
         assert grid.dim == 2
         assert codim in (0, 2)
@@ -39,7 +38,8 @@ class MatplotlibPatchAxes:
             self.p = a.tripcolor(self.coordinates[:, 0], self.coordinates[:, 1], self.subentities,
                                  facecolors=np.zeros(len(self.subentities)),
                                  vmin=self.vmin, vmax=self.vmax, shading='flat')
-        figure.colorbar(self.p, ax=a)
+        if colorbar:
+            figure.colorbar(self.p, ax=a)
 
     def set(self, U, vmin=None, vmax=None):
         self.vmin = self.vmin if vmin is None else vmin

--- a/src/pymor/gui/matplotlib.py
+++ b/src/pymor/gui/matplotlib.py
@@ -10,6 +10,8 @@ scalar data assigned to one- and two-dimensional grids using
 import numpy as np
 
 from pymor.core.config import config
+from pymor.grids.constructions import flatten_grid
+from pymor.grids.referenceelements import triangle, square
 
 
 class MatplotlibPatchAxes:
@@ -68,9 +70,7 @@ if config.HAVE_QT and config.HAVE_MATPLOTLIB:
 
     from matplotlib.figure import Figure
 
-    from pymor.grids.constructions import flatten_grid
     from pymor.grids.oned import OnedGrid
-    from pymor.grids.referenceelements import triangle, square
 
     # noinspection PyShadowingNames
     class Matplotlib1DWidget(FigureCanvas):

--- a/src/pymor/gui/visualizers.py
+++ b/src/pymor/gui/visualizers.py
@@ -1,0 +1,152 @@
+# This file is part of the pyMOR project (http://www.pymor.org).
+# Copyright 2013-2016 pyMOR developers and contributors. All rights reserved.
+# License: BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+
+
+from pymor.core.interfaces import BasicInterface
+from pymor.grids.oned import OnedGrid
+from pymor.grids.referenceelements import triangle, square
+from pymor.tools.vtkio import write_vtk
+from pymor.vectorarrays.interfaces import VectorArrayInterface
+
+
+class PatchVisualizer(BasicInterface):
+    """Visualize scalar data associated to a two-dimensional |Grid| as a patch plot.
+
+    The grid's |ReferenceElement| must be the triangle or square. The data can either
+    be attached to the faces or vertices of the grid.
+
+    Parameters
+    ----------
+    grid
+        The underlying |Grid|.
+    bounding_box
+        A bounding box in which the grid is contained.
+    codim
+        The codimension of the entities the data in `U` is attached to (either 0 or 2).
+    backend
+        Plot backend to use ('gl', 'matplotlib', 'jupyter').
+    block
+        If `True`, block execution until the plot window is closed.
+    """
+
+    def __init__(self, grid, bounding_box=([0, 0], [1, 1]), codim=2, backend=None, block=False):
+        assert grid.reference_element in (triangle, square)
+        assert grid.dim == 2
+        assert codim in (0, 2)
+        self.grid = grid
+        self.bounding_box = bounding_box
+        self.codim = codim
+        if backend is None:
+            import sys
+            if 'matplotlib' in sys.modules:
+                matplotlib = sys.modules['matplotlib']
+                if hasattr(matplotlib, 'backends') and matplotlib.backends.backend == 'nbAgg':
+                    backend = 'jupyter'
+        self.backend = backend
+        self.block = block
+
+    def visualize(self, U, discretization, title=None, legend=None, separate_colorbars=False,
+                  rescale_colorbars=False, block=None, filename=None, columns=2):
+        """Visualize the provided data.
+
+        Parameters
+        ----------
+        U
+            |VectorArray| of the data to visualize. If `len(U) > 1`, the data is visualized
+            as a time series of plots. Alternatively, a tuple of |VectorArrays| can be
+            provided, in which case a subplot is created for each entry of the tuple. The
+            lengths of all arrays have to agree.
+        discretization
+            Filled in :meth:`pymor.discretizations.DiscretizationBase.visualize` (ignored).
+        title
+            Title of the plot.
+        legend
+            Description of the data that is plotted. Most useful if `U` is a tuple in which
+            case `legend` has to be a tuple of strings of the same length.
+        separate_colorbars
+            If `True`, use separate colorbars for each subplot.
+        rescale_colorbars
+            If `True`, rescale colorbars to data in each frame.
+        block
+            If `True`, block execution until the plot window is closed. If `None`, use the
+            default provided during instantiation.
+        filename
+            If specified, write the data to a VTK-file using
+            :func:`pymor.tools.vtkio.write_vtk` instead of displaying it.
+        columns
+            The number of columns in the visualizer GUI in case multiple plots are displayed
+            at the same time.
+        """
+        assert isinstance(U, VectorArrayInterface) and hasattr(U, 'data') \
+            or (isinstance(U, tuple) and
+                all(isinstance(u, VectorArrayInterface) and hasattr(u, 'data') for u in U) and
+                all(len(u) == len(U[0]) for u in U))
+        if filename:
+            if not isinstance(U, tuple):
+                write_vtk(self.grid, U, filename, codim=self.codim)
+            else:
+                for i, u in enumerate(U):
+                    write_vtk(self.grid, u, '{}-{}'.format(filename, i), codim=self.codim)
+        else:
+            if self.backend == 'jupyter':
+                from pymor.gui.jupyter import visualize_patch
+                visualize_patch(self.grid, U, bounding_box=self.bounding_box, codim=self.codim, title=title,
+                                legend=legend, separate_colorbars=separate_colorbars,
+                                rescale_colorbars=rescale_colorbars, columns=columns)
+            else:
+                block = self.block if block is None else block
+                from pymor.gui.qt import visualize_patch
+                visualize_patch(self.grid, U, bounding_box=self.bounding_box, codim=self.codim, title=title,
+                                legend=legend, separate_colorbars=separate_colorbars,
+                                rescale_colorbars=rescale_colorbars, backend=self.backend, block=block,
+                                columns=columns)
+
+
+class OnedVisualizer(BasicInterface):
+    """Visualize scalar data associated to a one-dimensional |Grid| as a plot.
+
+    The grid's |ReferenceElement| must be the line. The data can either
+    be attached to the subintervals or vertices of the grid.
+
+    Parameters
+    ----------
+    grid
+        The underlying |Grid|.
+    codim
+        The codimension of the entities the data in `U` is attached to (either 0 or 1).
+    block
+        If `True`, block execution until the plot window is closed.
+    """
+
+    def __init__(self, grid, codim=1, block=False):
+        assert isinstance(grid, OnedGrid)
+        assert codim in (0, 1)
+        self.grid = grid
+        self.codim = codim
+        self.block = block
+
+    def visualize(self, U, discretization, title=None, legend=None, block=None):
+        """Visualize the provided data.
+
+        Parameters
+        ----------
+        U
+            |VectorArray| of the data to visualize. If `len(U) > 1`, the data is visualized
+            as a time series of plots. Alternatively, a tuple of |VectorArrays| can be
+            provided, in which case several plots are made into the same axes. The
+            lengths of all arrays have to agree.
+        discretization
+            Filled in by :meth:`pymor.discretizations.DiscretizationBase.visualize` (ignored).
+        title
+            Title of the plot.
+        legend
+            Description of the data that is plotted. Most useful if `U` is a tuple in which
+            case `legend` has to be a tuple of strings of the same length.
+        block
+            If `True`, block execution until the plot window is closed. If `None`, use the
+            default provided during instantiation.
+        """
+        block = self.block if block is None else block
+        from pymor.gui.qt import visualize_matplotlib_1d
+        visualize_matplotlib_1d(self.grid, U, codim=self.codim, title=title, legend=legend, block=block)

--- a/src/pymordemos/minimal_cpp_demo/demo.py
+++ b/src/pymordemos/minimal_cpp_demo/demo.py
@@ -8,7 +8,7 @@ from pymor.algorithms.pod import pod
 from pymor.algorithms.timestepping import ExplicitEulerTimeStepper
 from pymor.discretizations.basic import InstationaryDiscretization
 from pymor.grids.oned import OnedGrid
-from pymor.gui.qt import Matplotlib1DVisualizer
+from pymor.gui.visualizers import OnedVisualizer
 from pymor.operators.constructions import VectorFunctional, LincombOperator
 from pymor.parameters.functionals import ProjectionParameterFunctional
 from pymor.parameters.spaces import CubicParameterSpace
@@ -38,7 +38,7 @@ def discretize(n, nt, blocks):
 
     # hack together a visualizer ...
     grid = OnedGrid(domain=(0, 1), num_intervals=n)
-    visualizer = Matplotlib1DVisualizer(grid)
+    visualizer = OnedVisualizer(grid)
 
     time_stepper = ExplicitEulerTimeStepper(nt)
     parameter_space = CubicParameterSpace(operator.parameter_type, 0.1, 1)


### PR DESCRIPTION
This pull request adds a matplotlib-based patch visualizer for the jupyter notebook. Performance is relatively bad, but it should be usable enough for tutorial notebooks, etc. @pymor/pymor-devs, please check if this works on your machines. (For testing, you should say `%matplotlib notebook` before using pyMOR.)