### PR TITLE
Switch debianization to python 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ If you use pyMOR for academic work, please consider citing our
 
 	R. Milk, S. Rave, F. Schindler
 	pyMOR - Generic Algorithms and Interfaces for Model Order Reduction
-	SIAM J. Sci. Comput., 38(5), pp. S194–S216
+	SIAM J. Sci. Comput., 38(5), pp. S194-S216
 
 
 Distribution Packages

--- a/README.txt
+++ b/README.txt
@@ -56,7 +56,7 @@ publication:
 
     R. Milk, S. Rave, F. Schindler
     pyMOR - Generic Algorithms and Interfaces for Model Order Reduction
-    SIAM J. Sci. Comput., 38(5), pp. S194–S216
+    SIAM J. Sci. Comput., 38(5), pp. S194-S216
 
 Distribution Packages
 ---------------------

--- a/debian/README.source
+++ b/debian/README.source
@@ -1,9 +1,0 @@
-pymor-base for Debian
----------------------
-
-<this file describes information about the source package, see Debian policy
-manual section 4.14. You WILL either need to modify or delete this file>
-
-
-
-

--- a/debian/control
+++ b/debian/control
@@ -2,68 +2,24 @@ Source: pymor
 Section: math
 Priority: extra
 Maintainer: Rene Milk <rene.milk@uni-muenster.de>
-Build-Depends: debhelper (>= 8.0.0), python-pip, python-virtualenv, python-numpy,
-  python-scipy, python-pytest, python-pyside, python-setuptools,
-  cython, python-sphinx, python-sympy, python-matplotlib,
-  python-opengl, python-docopt, python-evtk,
-  python-dev, python3, dh-make, python3-pytest-cov, python-pytest-cov,
-  python-docutils, texlive-latex-extra, dvipng,
+Build-Depends: debhelper (>= 8.0.0),
+  python3, dh-make, python3-pytest-cov,
+  texlive-latex-extra, dvipng,
   python3-scipy, python3-pytest, python3-pyside, python3-setuptools,
   cython3, python3-sphinx, python3-sympy, python3-matplotlib,
-  python3-opengl, python-docopt, python3-evtk, python-3to2,
+  python3-opengl, python3-evtk,
   python3-dev, python3-pip, python3-virtualenv, python3-numpy,
-  python3-docutils, python-pytest-runner,  python3-pytest-runner
+  python3-docutils, python3-pytest-runner
 Standards-Version: 3.9.4
 Homepage: http://pymor.org
 #Vcs-Git: git://git.debian.org/collab-maint/pymor-base.git
 Vcs-Browser: https://github.com/pymor/pymor/tree/0.4.x
 
-Package: python-pymor
-Architecture: any
-Depends: ${misc:Depends}, ${python:Depends}, ${shlibs:Depends},
-  python-pip, python-virtualenv, python-numpy,
-  python-scipy, python-pytest, python-pyside,
-  cython, python-matplotlib, python-opengl, python-3to2,
-  python-docopt, python-evtk, python-pytest-runner,
-  python-dev, python, python-mpi4py, mpi-default-dev
-Suggests: python-pymor-doc
-Description: makes pyMOR importable system-wide + dependency tracking
-  pyMOR is a software library developed at the University of Münster for building model order reduction applications
-  with the Python programming language. Its main focus lies on the application of reduced basis methods to
-  parameterized partial differential equations. All algorithms in pyMOR are formulated in terms of abstract interfaces
-  for seamless integration with external high-dimensional PDE solvers. Moreover, pure Python implementations of finite
-  element and finite volume discretizations using the NumPy/SciPy scientific computing stack are provided for getting
-  started quickly.
-
-Package: python-pymor-demos
-Architecture: any
-Depends: ${misc:Depends}, ${shlibs:Depends}, ${python:Depends} , python, python-pymor, ipython, python-tk, python-matplotlib, python-opengl
-Suggests: python-pymor-doc
-Description: makes all included demos launchable via "pymor-demo" script
-  pyMOR is a software library developed at the University of Münster for building model order reduction applications
-  with the Python programming language. Its main focus lies on the application of reduced basis methods to
-  parameterized partial differential equations. All algorithms in pyMOR are formulated in terms of abstract interfaces
-  for seamless integration with external high-dimensional PDE solvers. Moreover, pure Python implementations of finite
-  element and finite volume discretizations using the NumPy/SciPy scientific computing stack are provided for getting
-  started quickly.
-
-Package: python-pymor-doc
-Architecture: all
-Section: doc
-Depends: ${misc:Depends}, python-sphinx, ${sphinxdoc:Depends}
-Description: auto-generated sphinx-html documenttaion for python-pymor
-  pyMOR is a software library developed at the University of Münster for building model order reduction applications
-  with the Python programming language. Its main focus lies on the application of reduced basis methods to
-  parameterized partial differential equations. All algorithms in pyMOR are formulated in terms of abstract interfaces
-  for seamless integration with external high-dimensional PDE solvers. Moreover, pure Python implementations of finite
-  element and finite volume discretizations using the NumPy/SciPy scientific computing stack are provided for getting
-  started quickly.
-
 Package: python3-pymor
 Architecture: any
 Depends: ${misc:Depends}, ${python:Depends}, ${shlibs:Depends},
   python3-pip, python3-virtualenv, python3-numpy,
-  python3-scipy, python-pytest, python3-pyside,
+  python3-scipy, python3-pyside, python3-setuptools,
   cython3, python3-matplotlib, python3-opengl,
   python3-docopt, python3-evtk, python3-pytest-runner,
   python3-dev, python3, python3-mpi4py, mpi-default-dev

--- a/debian/control
+++ b/debian/control
@@ -1,25 +1,30 @@
 Source: pymor
 Section: math
 Priority: extra
-Maintainer: Rene Milk <rene.milk@uni-muenster.de>  
+Maintainer: Rene Milk <rene.milk@uni-muenster.de>
 Build-Depends: debhelper (>= 8.0.0), python-pip, python-virtualenv, python-numpy,
   python-scipy, python-pytest, python-pyside, python-setuptools,
   cython, python-sphinx, python-sympy, python-matplotlib,
-  python-opengl, python-docopt, python-pyevtk,
-  python-dev, python3, dh-make,
-  python-docutils, texlive-latex-extra, dvipng
+  python-opengl, python-docopt, python-evtk,
+  python-dev, python3, dh-make, python3-pytest-cov, python-pytest-cov,
+  python-docutils, texlive-latex-extra, dvipng,
+  python3-scipy, python3-pytest, python3-pyside, python3-setuptools,
+  cython3, python3-sphinx, python3-sympy, python3-matplotlib,
+  python3-opengl, python-docopt, python3-evtk, python-3to2,
+  python3-dev, python3-pip, python3-virtualenv, python3-numpy,
+  python3-docutils, python-pytest-runner,  python3-pytest-runner
 Standards-Version: 3.9.4
 Homepage: http://pymor.org
 #Vcs-Git: git://git.debian.org/collab-maint/pymor-base.git
-Vcs-Browser: https://github.com/pymor/pymor/tree/0.2.x
+Vcs-Browser: https://github.com/pymor/pymor/tree/0.4.x
 
 Package: python-pymor
 Architecture: any
 Depends: ${misc:Depends}, ${python:Depends}, ${shlibs:Depends},
   python-pip, python-virtualenv, python-numpy,
   python-scipy, python-pytest, python-pyside,
-  cython, python-matplotlib, python-opengl,
-  python-docopt, python-pyevtk,
+  cython, python-matplotlib, python-opengl, python-3to2,
+  python-docopt, python-evtk, python-pytest-runner,
   python-dev, python, python-mpi4py, mpi-default-dev
 Suggests: python-pymor-doc
 Description: makes pyMOR importable system-wide + dependency tracking
@@ -32,7 +37,7 @@ Description: makes pyMOR importable system-wide + dependency tracking
 
 Package: python-pymor-demos
 Architecture: any
-Depends: ${misc:Depends}, ${shlibs:Depends}, python, python-pymor, ipython, python-tk, python-matplotlib, python-opengl
+Depends: ${misc:Depends}, ${shlibs:Depends}, ${python:Depends} , python, python-pymor, ipython, python-tk, python-matplotlib, python-opengl
 Suggests: python-pymor-doc
 Description: makes all included demos launchable via "pymor-demo" script
   pyMOR is a software library developed at the University of Münster for building model order reduction applications
@@ -41,7 +46,7 @@ Description: makes all included demos launchable via "pymor-demo" script
   for seamless integration with external high-dimensional PDE solvers. Moreover, pure Python implementations of finite
   element and finite volume discretizations using the NumPy/SciPy scientific computing stack are provided for getting
   started quickly.
- 
+
 Package: python-pymor-doc
 Architecture: all
 Section: doc
@@ -53,4 +58,45 @@ Description: auto-generated sphinx-html documenttaion for python-pymor
   for seamless integration with external high-dimensional PDE solvers. Moreover, pure Python implementations of finite
   element and finite volume discretizations using the NumPy/SciPy scientific computing stack are provided for getting
   started quickly.
- 
+
+Package: python3-pymor
+Architecture: any
+Depends: ${misc:Depends}, ${python:Depends}, ${shlibs:Depends},
+  python3-pip, python3-virtualenv, python3-numpy,
+  python3-scipy, python-pytest, python3-pyside,
+  cython3, python3-matplotlib, python3-opengl,
+  python3-docopt, python3-evtk, python3-pytest-runner,
+  python3-dev, python3, python3-mpi4py, mpi-default-dev
+Suggests: python3-pymor-doc
+Description: makes pyMOR importable system-wide + dependency tracking
+  pyMOR is a software library developed at the University of Münster for building model order reduction applications
+  with the Python programming language. Its main focus lies on the application of reduced basis methods to
+  parameterized partial differential equations. All algorithms in pyMOR are formulated in terms of abstract interfaces
+  for seamless integration with external high-dimensional PDE solvers. Moreover, pure Python implementations of finite
+  element and finite volume discretizations using the NumPy/SciPy scientific computing stack are provided for getting
+  started quickly.
+
+Package: python3-pymor-demos
+Architecture: any
+Depends: ${misc:Depends}, ${shlibs:Depends}, ${python:Depends}, python3, python3-pymor, ipython3, python3-tk, python3-matplotlib,
+  python3-opengl
+Suggests: python3-pymor-doc
+Description: makes all included demos launchable via "pymor-demo" script
+  pyMOR is a software library developed at the University of Münster for building model order reduction applications
+  with the Python programming language. Its main focus lies on the application of reduced basis methods to
+  parameterized partial differential equations. All algorithms in pyMOR are formulated in terms of abstract interfaces
+  for seamless integration with external high-dimensional PDE solvers. Moreover, pure Python implementations of finite
+  element and finite volume discretizations using the NumPy/SciPy scientific computing stack are provided for getting
+  started quickly.
+
+Package: python3-pymor-doc
+Architecture: all
+Section: doc
+Depends: ${misc:Depends}, python3-sphinx, ${sphinxdoc:Depends}
+Description: auto-generated sphinx-html documenttaion for python-pymor
+  pyMOR is a software library developed at the University of Münster for building model order reduction applications
+  with the Python programming language. Its main focus lies on the application of reduced basis methods to
+  parameterized partial differential equations. All algorithms in pyMOR are formulated in terms of abstract interfaces
+  for seamless integration with external high-dimensional PDE solvers. Moreover, pure Python implementations of finite
+  element and finite volume discretizations using the NumPy/SciPy scientific computing stack are provided for getting
+  started quickly.

--- a/debian/control
+++ b/debian/control
@@ -17,7 +17,7 @@ Vcs-Browser: https://github.com/pymor/pymor/tree/0.4.x
 
 Package: python3-pymor
 Architecture: any
-Depends: ${misc:Depends}, ${python:Depends}, ${shlibs:Depends},
+Depends: ${misc:Depends},  ${shlibs:Depends},
   python3-pip, python3-virtualenv, python3-numpy,
   python3-scipy, python3-pyside, python3-setuptools,
   cython3, python3-matplotlib, python3-opengl,
@@ -34,7 +34,7 @@ Description: makes pyMOR importable system-wide + dependency tracking
 
 Package: python3-pymor-demos
 Architecture: any
-Depends: ${misc:Depends}, ${shlibs:Depends}, ${python:Depends}, python3, python3-pymor, ipython3, python3-tk, python3-matplotlib,
+Depends: ${misc:Depends}, ${shlibs:Depends},  python3, python3-pymor, ipython3, python3-tk, python3-matplotlib,
   python3-opengl
 Suggests: python3-pymor-doc
 Description: makes all included demos launchable via "pymor-demo" script

--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Build-Depends: debhelper (>= 8.0.0),
   cython3, python3-sphinx, python3-sympy, python3-matplotlib,
   python3-opengl, python3-evtk,
   python3-dev, python3-pip, python3-virtualenv, python3-numpy,
-  python3-docutils, python3-pytest-runner
+  python3-docutils, python3-pytest-runner (>= 2.9)
 Standards-Version: 3.9.4
 Homepage: http://pymor.org
 #Vcs-Git: git://git.debian.org/collab-maint/pymor-base.git
@@ -21,7 +21,7 @@ Depends: ${misc:Depends},  ${shlibs:Depends},
   python3-pip, python3-virtualenv, python3-numpy,
   python3-scipy, python3-pyside, python3-setuptools,
   cython3, python3-matplotlib, python3-opengl,
-  python3-docopt, python3-evtk, python3-pytest-runner,
+  python3-docopt, python3-evtk, python3-pytest-runner (>= 2.9),
   python3-dev, python3, python3-mpi4py, mpi-default-dev
 Suggests: python3-pymor-doc
 Description: makes pyMOR importable system-wide + dependency tracking

--- a/debian/python-pymor-demos.install
+++ b/debian/python-pymor-demos.install
@@ -1,3 +1,0 @@
-src/pymordemos/ usr/share/pymor-demos/src
-debian/pymor/usr/lib/python2.7/dist-packages/pymordemos usr/lib/python2.7/dist-packages/
-debian/pymor/usr/bin/pymor-demo usr/bin

--- a/debian/python-pymor-doc.docs
+++ b/debian/python-pymor-doc.docs
@@ -1,1 +1,0 @@
-build/sphinx

--- a/debian/python-pymor.install
+++ b/debian/python-pymor.install
@@ -1,4 +1,0 @@
-debian/pymor/usr/lib/python2.7/dist-packages/pymor usr/lib/python2.7/dist-packages/
-debian/pymor/usr/lib/python2.7/dist-packages/pymor*.egg-info usr/lib/python2.7/dist-packages/
-src/pymor/ usr/share/pymor-base/src
-

--- a/debian/python3-pymor-demos.install
+++ b/debian/python3-pymor-demos.install
@@ -1,0 +1,3 @@
+src/pymordemos/ usr/share/pymor-demos/src
+usr/lib/python3*/dist-packages/pymordemos
+usr/bin/pymor-demo

--- a/debian/python3-pymor-demos.lintian-overrides
+++ b/debian/python3-pymor-demos.lintian-overrides
@@ -1,0 +1,2 @@
+# ignore due to false positives (lintian bug 805597)
+python3-pymor-demos binary: python-script-but-no-python-dep

--- a/debian/python3-pymor.install
+++ b/debian/python3-pymor.install
@@ -1,0 +1,3 @@
+usr/lib/python3*/dist-packages/pymor
+src/pymor/ usr/share/pymor-base/src
+

--- a/debian/rules
+++ b/debian/rules
@@ -1,11 +1,11 @@
 #!/usr/bin/make -f
 # -*- makefile -*-
 
-PY2VERS=$(shell pyversions -vr debian/control)
+PY2VERS=
 PY3VERS=$(shell py3versions -vr)
-PYDEF=$(shell pyversions -dv)
+PYDEF=
 PY3DEF=$(shell py3versions -dv)
-PYLIBPATH := $(shell python -c "from distutils.command.build import build ; from distutils.core import Distribution ; b = build(Distribution()) ; b.finalize_options() ; print b.build_platlib")
+PYLIBPATH := $(shell python3 -c "from distutils.command.build import build ; from distutils.core import Distribution ; b = build(Distribution()) ; b.finalize_options() ; print b.build_platlib")
 
 # Uncomment this to turn on verbose mode.
 export DH_VERBOSE=1
@@ -16,21 +16,21 @@ import sys,sysconfig
 print("build/lib.{}-{}.{}".format(sysconfig.get_platform(), *sys.version_info[:2]))
 endef
 
-builddir := $(shell python -c '$(buildscript)')
+builddir := $(shell python3 -c '$(buildscript)')
 
 export PYMOR_DEB_VERSION=$(shell dpkg-parsechangelog | sed -n -e 's/^Version: //p')
 
 %:
-	dh $@ --with sphinxdoc,python3,python2 --buildsystem=pybuild
+	dh $@ --with sphinxdoc,python3 --buildsystem=pybuild
 
 override_dh_auto_install:
-	python setup.py install --root=debian/pymor --install-layout=deb
+	python3 setup.py install --root=debian/pymor --install-layout=deb
 	dh_auto_install
 
 override_dh_auto_build:
 	dh_auto_build
-	python setup.py build
-	PYTHONPATH=$(builddir) http_proxy='127.0.0.1:9' READTHEDOCS=True python setup.py build_sphinx -b html
+	python3 setup.py build
+	PYTHONPATH=$(builddir) http_proxy='127.0.0.1:9' READTHEDOCS=True python3 setup.py build_sphinx -b html
 
 override_dh_sphinxdoc-arch:
 

--- a/debian/rules
+++ b/debian/rules
@@ -21,7 +21,7 @@ builddir := $(shell python -c '$(buildscript)')
 export PYMOR_DEB_VERSION=$(shell dpkg-parsechangelog | sed -n -e 's/^Version: //p')
 
 %:
-	dh $@ --with sphinxdoc,python2
+	dh $@ --with sphinxdoc,python3,python2 --buildsystem=pybuild
 
 override_dh_auto_install:
 	python setup.py install --root=debian/pymor --install-layout=deb

--- a/debian/rules
+++ b/debian/rules
@@ -1,15 +1,9 @@
 #!/usr/bin/make -f
 # -*- makefile -*-
 
-PY2VERS=
-PY3VERS=$(shell py3versions -vr)
-PYDEF=
-PY3DEF=$(shell py3versions -dv)
-PYLIBPATH := $(shell python3 -c "from distutils.command.build import build ; from distutils.core import Distribution ; b = build(Distribution()) ; b.finalize_options() ; print b.build_platlib")
-
 # Uncomment this to turn on verbose mode.
-export DH_VERBOSE=1
-export DH_OPTIONS=-v
+#export DH_VERBOSE=1
+#export DH_OPTIONS=-v
 
 define buildscript
 import sys,sysconfig

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,6 @@ ignore =
 VCS = git
 style = pep440
 versionfile_source = src/pymor/version.py
-versionfile_build = pymor/version.py
 tag_prefix = ''
 
 [tool:pytest]

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ ignore = E221,E226,E241,E242, W0105, N803, N806
 # E221 multiple spaces before operator
 # E226 missing whitespace around arithmetic operator  [ignored by default]
 # E241 multiple spaces after ':'                      [ignored by default]
-# E242 tab after ‘,’                                  [ignored by default]
+# E242 tab after `,'                                  [ignored by default]
 # W0105 String statement has no effect (we use triple qoted strings as documentation in some files)
 # N803 argument name should be lowercase (we use single capital letters everywhere for vectorarrays)
 # N806 same for variables in function

--- a/versioneer.py
+++ b/versioneer.py
@@ -340,7 +340,8 @@ def get_config_from_root(root):
     # the top of versioneer.py for instructions on writing your setup.cfg .
     setup_cfg = os.path.join(root, "setup.cfg")
     parser = configparser.SafeConfigParser()
-    parser.read(setup_cfg)
+    with open(setup_cfg, "r") as f:
+        parser.readfp(f)
     VCS = parser.get("versioneer", "VCS")  # mandatory
 
     def get(parser, name):


### PR DESCRIPTION
Switch all packages to use python 3 only. I dropped python 2 because I wasn't able to reliably delay the lib3to2 source transformation until the entire python 3 build was complete. This resulted in transformed sources being installed into the python 3 dirs, which resulted in an unusable installation. 