### PR TITLE
Setup extras

### DIFF
--- a/.ci/travis/run_travis_builders.py
+++ b/.ci/travis/run_travis_builders.py
@@ -38,13 +38,13 @@ def _run_config(tm, clone_dir, commit):
             print(lg.decode())
 
 
-docker_tags = ['2.7', ]
-pytest_marker = [ "PIP_ONLY", ]
+docker_tags = ['2.7', '3.4', '3.5', '3.6']
+pytest_marker = ["None", 'PIP_ONLY', 'MPI']
 commit = subprocess.check_output(['git', 'rev-parse', 'HEAD']).decode().strip()
-
+variations = list(product(docker_tags, pytest_marker)) + [('3.6', 'NUMPY')]
 with TemporaryDirectory() as clone_tmp:
     clone_dir = os.path.join(clone_tmp, 'pymor')
     subprocess.check_call(['git', 'clone', os.getcwd(), clone_dir])
     run_configs = partial(_run_config, clone_dir=clone_dir, commit=commit)
-    for tm in product(docker_tags, pytest_marker):
+    for tm in variations:
         run_configs(tm)

--- a/.ci/travis/script.bash
+++ b/.ci/travis/script.bash
@@ -32,6 +32,8 @@ if [ "${PYTEST_MARKER}" == "PIP_ONLY" ] ; then
     if [[ "${TRAVIS_PULL_REQUEST}" == "false" ]] ; then
       sudo pip install git+https://github.com/${TRAVIS_REPO_SLUG}.git@${TRAVIS_COMMIT}
       sudo pip uninstall -y pymor
+      sudo pip install git+https://github.com/${TRAVIS_REPO_SLUG}.git@${TRAVIS_COMMIT}#egg=pymor[full]
+      sudo pip uninstall -y pymor
     fi
     python setup.py sdist -d ${SDIST_DIR}/ --format=gztar
     check-manifest -p python ${PWD}

--- a/dependencies.py
+++ b/dependencies.py
@@ -59,6 +59,25 @@ def strip_markers(name):
     return name
 
 
+def extras():
+    import pkg_resources
+    import itertools
+    def _ex(name):
+        # no environment specifiers or wheel URI etc are allowed in extras
+        name = strip_markers(name)
+        try:
+            next(pkg_resources.parse_requirements(name))
+        except pkg_resources.RequirementParseError:
+            name = import_names[name]
+        return name
+
+    full = [_ex(f) for f in set(itertools.chain(doc_requires, tests_require, install_suggests.keys()))]
+    return {
+        'full':  full,
+        'travis':  travis_requires,
+    }
+
+
 def missing(names):
     for name in names:
         stripped_name = strip_markers(name)

--- a/dependencies.py
+++ b/dependencies.py
@@ -71,7 +71,26 @@ def extras():
             name = import_names[name]
         return name
 
-    full = [_ex(f) for f in set(itertools.chain(doc_requires, tests_require, install_suggests.keys()))]
+    def _candidates():
+        # skip those which aren't needed in our current environment (py ver, platform)
+        for pkg in set(itertools.chain(doc_requires, tests_require, install_suggests.keys())):
+            try:
+                marker = next(pkg_resources.parse_requirements(pkg)).marker
+                if marker is None or marker.evaluate():
+                    yield pkg
+            except pkg_resources.RequirementParseError:
+                # try to fake a package to get the marker parsed
+                clean = _ex(pkg)
+                stripped = strip_markers(pkg)
+                fake_pkg = 'pip ' + pkg.replace(stripped, '')
+                try:
+                    marker = next(pkg_resources.parse_requirements(fake_pkg)).marker
+                    if marker is None or marker.evaluate():
+                        yield pkg
+                except pkg_resources.RequirementParseError:
+                    continue
+
+    full = [_ex(f) for f in _candidates()]
     return {
         'full':  full,
         'travis':  travis_requires,

--- a/setup.py
+++ b/setup.py
@@ -208,6 +208,7 @@ def setup_package():
         setup_requires=setup_requires,
         tests_require=tests_require,
         install_requires=install_requires,
+        extras_require = dependencies.extras(),
         classifiers=['Development Status :: 4 - Beta',
                      'License :: OSI Approved :: BSD License',
                      'Programming Language :: Python :: 2.7',


### PR DESCRIPTION
In theory you can now do 
```
pip install git+https://github.com/pymor/pymor@setup_extras#egg=pymor[full]
```
in practice this has problems with Qt. As in either it fails the install because pip cannot locate a wheel for pyside, or it might only install Qt.py but not PyQt. It's weird. This'll be tricky to impossible to solve because:
 - no environment specifiers or wheel URI etc are allowed in extras (or install_requires, etc.)
 - this is considered 'good': https://caremad.io/posts/2013/07/setup-vs-requirement/
 - https://www.python.org/dev/peps/pep-0426/ is _still_ in draft
 - whether setuptools' dependency_links feature is used in any given install scenario is unclear (and probably too brittle to use anyway)

Ideas welcome.