### PR TITLE
Add automatic format option in to_matrix

### DIFF
--- a/src/pymor/algorithms/to_matrix.py
+++ b/src/pymor/algorithms/to_matrix.py
@@ -17,15 +17,17 @@ from pymor.operators.numpy import NumpyMatrixOperator
 
 
 def to_matrix(op, format=None, mu=None):
-    """Transfrom construction of NumpyMatrixOperators to NumPy or SciPy array
+    """Transform construction of Operators to matrix
 
     Parameters
     ----------
     op
         Operator.
     format
-        Format of the resulting |SciPy spmatrix|.
-        If `None`, a dense format is used.
+        Format of the resulting matrix: |NumPy array| if 'dense',
+        otherwise the appropriate |SciPy spmatrix|.
+        If `None`, a choice between dense and sparse format is
+        automatically made.
     mu
         |Parameter|.
 
@@ -34,65 +36,66 @@ def to_matrix(op, format=None, mu=None):
     res
         Equivalent matrix.
     """
-    assert format is None or format in ('bsr', 'coo', 'csc', 'csr', 'dia', 'dok', 'lil')
+    assert format is None or format in ('dense', 'bsr', 'coo', 'csc', 'csr', 'dia', 'dok', 'lil')
     op = op.assemble(mu)
-    mapping = {
-        'bsr': sps.bsr_matrix,
-        'coo': sps.coo_matrix,
-        'csc': sps.csc_matrix,
-        'csr': sps.csr_matrix,
-        'dia': sps.dia_matrix,
-        'dok': sps.dok_matrix,
-        'lil': sps.lil_matrix
-    }
-    return ToMatrixRules.apply(op, format, mapping, mu)
+    return ToMatrixRules.apply(op, format, mu)
 
 
 class ToMatrixRules(RuleTable):
 
     @match_class(NumpyMatrixOperator)
-    def action_NumpyMatrixOperator(self, op, format, mapping, mu):
+    def action_NumpyMatrixOperator(self, op, format, mu):
         if format is None:
+            return op._matrix
+        elif format == 'dense':
             if not op.sparse:
                 return op._matrix
             else:
                 return op._matrix.toarray()
         else:
-            return mapping[format](op._matrix)
+            if not op.sparse:
+                return getattr(sps, format + '_matrix')(op._matrix)
+            else:
+                return op._matrix.asformat(format)
 
     @match_class(BlockOperator)
-    def action_BlockOperator(self, op, format, mapping, mu):
+    def action_BlockOperator(self, op, format, mu):
         op_blocks = op._blocks
         mat_blocks = [[] for i in range(op.num_range_blocks)]
+        is_dense = True
         for i in range(op.num_range_blocks):
             for j in range(op.num_source_blocks):
-                if op_blocks[i, j] is None:
-                    if format is None:
-                        mat_blocks[i].append(np.zeros((op.range.subspaces[i].dim, op.source.subspaces[j].dim)))
-                    else:
-                        mat_blocks[i].append(None)
-                else:
-                    mat_blocks[i].append(self.apply(op_blocks[i, j], format, mapping, mu))
-        if format is None:
-            return np.bmat(mat_blocks)
+                mat_ij = self.apply(op_blocks[i, j], format, mu)
+                if sps.issparse(mat_ij):
+                    is_dense = False
+                mat_blocks[i].append(mat_ij)
+        if format is None and is_dense or format == 'dense':
+            return np.asarray(np.bmat(mat_blocks))
         else:
             return sps.bmat(mat_blocks, format=format)
 
     @match_class(AdjointOperator)
-    def action_AdjointOperator(self, op, format, mapping, mu):
-        res = self.apply(op.operator, format, mapping, mu).T
+    def action_AdjointOperator(self, op, format, mu):
+        res = self.apply(op.operator, format, mu).T
         if op.range_product is not None:
-            res = res.dot(self.apply(op.range_product, format, mapping, mu))
-        if op.source_product is not None:
-            if format is None:
-                res = spla.solve(self.apply(op.source_product, format, mapping, mu), res)
+            range_product = self.apply(op.range_product, format, mu)
+            if format is None and not sps.issparse(res) and sps.issparse(range_product):
+                res = range_product.T.dot(res.T).T
             else:
-                res = spsla.spsolve(self.apply(op.source_product, format, mapping, mu), res)
+                res = res.dot(range_product)
+        if op.source_product is not None:
+            source_product = self.apply(op.source_product, format, mu)
+            if not sps.issparse(source_product):
+                res = spla.solve(source_product, res)
+            else:
+                res = spsla.spsolve(source_product, res)
+        if format is not None and format != 'dense':
+            res = getattr(sps, format + '_matrix')(res)
         return res
 
     @match_class(ComponentProjection)
-    def action_ComponentProjection(self, op, format, mapping, mu):
-        if format is None:
+    def action_ComponentProjection(self, op, format, mu):
+        if format == 'dense':
             res = np.zeros((op.range.dim, op.source.dim))
             for i, j in enumerate(op.components):
                 res[i, j] = 1
@@ -101,38 +104,45 @@ class ToMatrixRules(RuleTable):
             i = np.arange(op.range.dim)
             j = op.components
             res = sps.coo_matrix((data, (i, j)), shape=(op.range.dim, op.source.dim))
-            res = res.asformat(format)
+            res = res.asformat(format if format else 'csc')
         return res
 
     @match_class(Concatenation)
-    def action_Concatenation(self, op, format, mapping, mu):
-        return self.apply(op.second, format, mapping, mu).dot(self.apply(op.first, format, mapping, mu))
+    def action_Concatenation(self, op, format, mu):
+        first = self.apply(op.first, format, mu)
+        second = self.apply(op.second, format, mu)
+        if format is None and not sps.issparse(second) and sps.issparse(first):
+            return first.T.dot(second.T).T
+        else:
+            return second.dot(first)
 
     @match_class(IdentityOperator)
-    def action_IdentityOperator(self, op, format, mapping, mu):
-        if format is None:
+    def action_IdentityOperator(self, op, format, mu):
+        if format == 'dense':
             return np.eye(op.source.dim)
         else:
-            return sps.eye(op.source.dim, format=format)
+            return sps.eye(op.source.dim, format=format if format else 'csc')
 
     @match_class(LincombOperator)
-    def action_LincombOperator(self, op, format, mapping, mu):
+    def action_LincombOperator(self, op, format, mu):
         op_coefficients = op.evaluate_coefficients(mu)
-        res = op_coefficients[0] * self.apply(op.operators[0], format, mapping, mu)
+        res = op_coefficients[0] * self.apply(op.operators[0], format, mu)
         for i in range(1, len(op.operators)):
-            res = res + op_coefficients[i] * self.apply(op.operators[i], format, mapping, mu)
+            res = res + op_coefficients[i] * self.apply(op.operators[i], format, mu)
         return res
 
     @match_class(VectorArrayOperator)
-    def action_VectorArrayOperator(self, op, format, mapping, mu):
+    def action_VectorArrayOperator(self, op, format, mu):
         res = op._array.data if op.transposed else op._array.data.T
-        if format is not None:
-            res = mapping[format](res)
+        if format is not None and format != 'dense':
+            res = getattr(sps, format + '_matrix')(res)
         return res
 
     @match_class(ZeroOperator)
-    def action_ZeroOperator(self, op, format, mapping, mu):
+    def action_ZeroOperator(self, op, format, mu):
         if format is None:
+            return sps.csc_matrix((op.range.dim, op.source.dim))
+        elif format == 'dense':
             return np.zeros((op.range.dim, op.source.dim))
         else:
-            return mapping[format]((op.range.dim, op.source.dim))
+            return getattr(sps, format + '_matrix')((op.range.dim, op.source.dim))

--- a/src/pymortests/to_matrix.py
+++ b/src/pymortests/to_matrix.py
@@ -5,40 +5,219 @@
 from __future__ import absolute_import, division, print_function
 
 import numpy as np
+import scipy.linalg as spla
 import scipy.sparse as sps
 
 from pymor.algorithms.to_matrix import to_matrix
-from pymor.operators.block import BlockDiagonalOperator
-from pymor.operators.constructions import (AdjointOperator, Concatenation, IdentityOperator, LincombOperator,
-                                           VectorArrayOperator)
+from pymor.operators.block import BlockOperator, BlockDiagonalOperator
+from pymor.operators.constructions import (AdjointOperator, Concatenation, ComponentProjection, IdentityOperator,
+                                           LincombOperator, VectorArrayOperator, ZeroOperator)
 from pymor.operators.numpy import NumpyMatrixOperator
 from pymor.vectorarrays.numpy import NumpyVectorSpace
 
 
-def test_to_matrix():
+def assert_type_and_allclose(A, Aop, default_format):
+    if default_format == 'dense':
+        assert isinstance(to_matrix(Aop), np.ndarray)
+        assert np.allclose(A, to_matrix(Aop))
+    elif default_format == 'sparse':
+        assert sps.issparse(to_matrix(Aop))
+        assert np.allclose(A, to_matrix(Aop).toarray())
+    else:
+        assert getattr(sps, 'isspmatrix_' + default_format)(to_matrix(Aop))
+        assert np.allclose(A, to_matrix(Aop).toarray())
+
+    assert isinstance(to_matrix(Aop, format='dense'), np.ndarray)
+    assert np.allclose(A, to_matrix(Aop, format='dense'))
+
+    assert sps.isspmatrix_csr(to_matrix(Aop, format='csr'))
+    assert np.allclose(A, to_matrix(Aop, format='csr').toarray())
+
+
+def test_to_matrix_NumpyMatrixOperator():
     np.random.seed(0)
     A = np.random.randn(2, 2)
-    B = np.random.randn(3, 3)
-    C = np.random.randn(3, 3)
 
-    X = np.bmat([[np.eye(2) + A, np.zeros((2, 3))], [np.zeros((3, 2)), B.dot(C.T)]])
+    Aop = NumpyMatrixOperator(A)
+    assert_type_and_allclose(A, Aop, 'dense')
 
-    C = sps.csc_matrix(C)
+    Aop = NumpyMatrixOperator(sps.csc_matrix(A))
+    assert_type_and_allclose(A, Aop, 'csc')
+
+
+def test_to_matrix_BlockOperator():
+    np.random.seed(0)
+    A11 = np.random.randn(2, 2)
+    A12 = np.random.randn(2, 3)
+    A21 = np.random.randn(3, 2)
+    A22 = np.random.randn(3, 3)
+    B = np.asarray(np.bmat([[A11, A12], [A21, A22]]))
+
+    A11op = NumpyMatrixOperator(A11)
+    A12op = NumpyMatrixOperator(A12)
+    A21op = NumpyMatrixOperator(A21)
+    A22op = NumpyMatrixOperator(A22)
+    Bop = BlockOperator([[A11op, A12op], [A21op, A22op]])
+    assert_type_and_allclose(B, Bop, 'dense')
+
+    A11op = NumpyMatrixOperator(sps.csc_matrix(A11))
+    A12op = NumpyMatrixOperator(A12)
+    A21op = NumpyMatrixOperator(A21)
+    A22op = NumpyMatrixOperator(A22)
+    Bop = BlockOperator([[A11op, A12op], [A21op, A22op]])
+    assert_type_and_allclose(B, Bop, 'sparse')
+
+
+def test_to_matrix_BlockDiagonalOperator():
+    np.random.seed(0)
+    A1 = np.random.randn(2, 2)
+    A2 = np.random.randn(3, 3)
+    B = np.asarray(np.bmat([[A1, np.zeros((2, 3))],
+                            [np.zeros((3, 2)), A2]]))
+
+    A1op = NumpyMatrixOperator(A1)
+    A2op = NumpyMatrixOperator(A2)
+    Bop = BlockDiagonalOperator([A1op, A2op])
+    assert_type_and_allclose(B, Bop, 'sparse')
+
+    A1op = NumpyMatrixOperator(sps.csc_matrix(A1))
+    A2op = NumpyMatrixOperator(A2)
+    Bop = BlockDiagonalOperator([A1op, A2op])
+    assert_type_and_allclose(B, Bop, 'sparse')
+
+
+def test_to_matrix_AdjointOperator():
+    np.random.seed(0)
+    A = np.random.randn(2, 2)
+    S = np.random.randn(2, 2)
+    S = S.dot(S.T)
+    R = np.random.randn(2, 2)
+    R = R.dot(R.T)
+
+    Aop = NumpyMatrixOperator(A)
+    Aadj = AdjointOperator(Aop)
+    assert_type_and_allclose(A.T, Aadj, 'dense')
+
+    Aop = NumpyMatrixOperator(sps.csc_matrix(A))
+    Aadj = AdjointOperator(Aop)
+    assert_type_and_allclose(A.T, Aadj, 'sparse')
+
+    Aop = NumpyMatrixOperator(A)
+    Sop = NumpyMatrixOperator(S)
+    Rop = NumpyMatrixOperator(R)
+    Aadj = AdjointOperator(Aop, source_product=Sop, range_product=Rop)
+    assert_type_and_allclose(spla.solve(S, A.T.dot(R)), Aadj, 'dense')
+
+    Aop = NumpyMatrixOperator(sps.csc_matrix(A))
+    Sop = NumpyMatrixOperator(S)
+    Rop = NumpyMatrixOperator(R)
+    Aadj = AdjointOperator(Aop, source_product=Sop, range_product=Rop)
+    assert_type_and_allclose(spla.solve(S, A.T.dot(R)), Aadj, 'dense')
+
+    Aop = NumpyMatrixOperator(A)
+    Sop = NumpyMatrixOperator(S)
+    Rop = NumpyMatrixOperator(sps.csc_matrix(R))
+    Aadj = AdjointOperator(Aop, source_product=Sop, range_product=Rop)
+    assert_type_and_allclose(spla.solve(S, A.T.dot(R)), Aadj, 'dense')
+
+    Aop = NumpyMatrixOperator(sps.csc_matrix(A))
+    Sop = NumpyMatrixOperator(sps.csc_matrix(S))
+    Rop = NumpyMatrixOperator(sps.csc_matrix(R))
+    Aadj = AdjointOperator(Aop, source_product=Sop, range_product=Rop)
+    assert_type_and_allclose(spla.solve(S, A.T.dot(R)), Aadj, 'sparse')
+
+
+def test_to_matrix_ComponentProjection():
+    components = np.array([0, 1, 2, 4, 8])
+    n = 10
+    A = np.zeros((len(components), n))
+    A[range(len(components)), components] = 1
+
+    source = NumpyVectorSpace(n)
+    Aop = ComponentProjection(components, source)
+    assert_type_and_allclose(A, Aop, 'sparse')
+
+
+def test_to_matrix_Concatenation():
+    np.random.seed(0)
+    A = np.random.randn(2, 3)
+    B = np.random.randn(3, 4)
+    C = A.dot(B)
 
     Aop = NumpyMatrixOperator(A)
     Bop = NumpyMatrixOperator(B)
-    Cop = NumpyMatrixOperator(C)
+    Cop = Concatenation(Aop, Bop)
+    assert_type_and_allclose(C, Cop, 'dense')
 
-    Xop = BlockDiagonalOperator([LincombOperator([IdentityOperator(NumpyVectorSpace(2)), Aop],
-                                                 [1, 1]), Concatenation(Bop, AdjointOperator(Cop))])
+    Aop = NumpyMatrixOperator(sps.csc_matrix(A))
+    Bop = NumpyMatrixOperator(B)
+    Cop = Concatenation(Aop, Bop)
+    assert_type_and_allclose(C, Cop, 'dense')
 
-    assert np.allclose(X, to_matrix(Xop))
-    assert np.allclose(X, to_matrix(Xop, format='csr').toarray())
+    Aop = NumpyMatrixOperator(A)
+    Bop = NumpyMatrixOperator(sps.csc_matrix(B))
+    Cop = Concatenation(Aop, Bop)
+    assert_type_and_allclose(C, Cop, 'dense')
 
+    Aop = NumpyMatrixOperator(sps.csc_matrix(A))
+    Bop = NumpyMatrixOperator(sps.csc_matrix(B))
+    Cop = Concatenation(Aop, Bop)
+    assert_type_and_allclose(A, Aop, 'sparse')
+
+
+def test_to_matrix_IdentityOperator():
+    n = 3
+    I = np.eye(n)
+
+    Iop = IdentityOperator(NumpyVectorSpace(n))
+    assert_type_and_allclose(I, Iop, 'sparse')
+
+
+def test_to_matrix_LincombOperator():
+    np.random.seed(0)
+    A = np.random.randn(3, 3)
+    B = np.random.randn(3, 2)
+    a = np.random.randn()
+    b = np.random.randn()
+    C = a * A + b * B.dot(B.T)
+
+    Aop = NumpyMatrixOperator(A)
+    Bop = NumpyMatrixOperator(B)
+    Cop = LincombOperator([Aop, Concatenation(Bop, Bop.T)], [a, b])
+    assert_type_and_allclose(C, Cop, 'dense')
+
+    Aop = NumpyMatrixOperator(sps.csc_matrix(A))
+    Bop = NumpyMatrixOperator(B)
+    Cop = LincombOperator([Aop, Concatenation(Bop, Bop.T)], [a, b])
+    assert_type_and_allclose(C, Cop, 'dense')
+
+    Aop = NumpyMatrixOperator(A)
+    Bop = NumpyMatrixOperator(sps.csc_matrix(B))
+    Cop = LincombOperator([Aop, Concatenation(Bop, Bop.T)], [a, b])
+    assert_type_and_allclose(C, Cop, 'dense')
+
+    Aop = NumpyMatrixOperator(sps.csc_matrix(A))
+    Bop = NumpyMatrixOperator(sps.csc_matrix(B))
+    Cop = LincombOperator([Aop, Concatenation(Bop, Bop.T)], [a, b])
+    assert_type_and_allclose(C, Cop, 'sparse')
+
+
+def test_to_matrix_VectorArrayOperator():
     np.random.seed(0)
     V = np.random.randn(10, 2)
+
     Vva = NumpyVectorSpace.make_array(V.T)
     Vop = VectorArrayOperator(Vva)
-    assert np.allclose(V, to_matrix(Vop))
+    assert_type_and_allclose(V, Vop, 'dense')
+
     Vop = VectorArrayOperator(Vva, transposed=True)
-    assert np.allclose(V, to_matrix(Vop).T)
+    assert_type_and_allclose(V.T, Vop, 'dense')
+
+
+def test_to_matrix_ZeroOperator():
+    n = 3
+    m = 4
+    Z = np.zeros((n, m))
+
+    Zop = ZeroOperator(NumpyVectorSpace(m), NumpyVectorSpace(n))
+    assert_type_and_allclose(Z, Zop, 'sparse')


### PR DESCRIPTION
Changes:
- `format=None` now does automatic format decision and `format='dense'` forces dense format
- `getattr` is used instead of the `mapping` dictionary
- `to_matrix` test is more extensive