### PR TITLE
use packaging.version to improve version handling

### DIFF
--- a/src/pymor/bindings/scipy.py
+++ b/src/pymor/bindings/scipy.py
@@ -5,6 +5,7 @@
 
 
 import numpy as np
+from packaging.version import Version
 import scipy.version
 from scipy.sparse.linalg import bicgstab, spsolve, splu, spilu, lgmres, lsqr, LinearOperator
 
@@ -221,7 +222,7 @@ def apply_inverse(op, V, options=None, least_squares=False, check_finite=True,
                 if not np.can_cast(V.dtype, fdtype, casting='safe'):
                     del matrix.factorization
 
-            if list(map(int, scipy.version.version.split('.'))) >= [0, 14, 0]:
+            if Version(scipy.version.version) >= Version('0.14'):
                 if hasattr(matrix, 'factorization'):
                     # we may use a complex factorization of a real matrix to
                     # apply it to a real vector. In that case, we downcast

--- a/src/pymor/core/config.py
+++ b/src/pymor/core/config.py
@@ -15,11 +15,7 @@ def _can_import(module):
 
 def _get_fenics_version():
     import dolfin as df
-    version = list(map(int, df.__version__.split('.')[0:3]))
-    if version[:2] != [1, 6]:
-        import warnings
-        warnings.warn('FEniCS support has only been tested with dolfin 1.6.')
-    return version
+    return df.__version__
 
 
 def is_windows_platform():

--- a/src/pymor/vectorarrays/interfaces.py
+++ b/src/pymor/vectorarrays/interfaces.py
@@ -6,17 +6,14 @@
 from numbers import Number
 import sys
 
+from packaging.version import Version
 import numpy as np
 
 from pymor.core.config import config
 from pymor.core.interfaces import BasicInterface, ImmutableInterface, abstractmethod
 
 
-def _numpy_version_older(version_tuple):
-    np_tuple = tuple(int(p) for p in np.__version__.split('.')[:3])
-    return np_tuple < version_tuple
-
-_INDEXTYPES = (Number,) if not _numpy_version_older((1, 9)) else (Number, np.intp)
+_INDEXTYPES = (Number,) if Version(np.__version__) >= Version('1.9') else (Number, np.intp)
 
 
 class VectorArrayInterface(BasicInterface):


### PR DESCRIPTION
also, remove FEniCS version warning. (Until now, we didn't
have any issues with newer FEniCS versions breaking things.)