### PR TITLE
[VectorArrays] rename VectorInterface.components -> VectorInterface.dofs

### DIFF
--- a/docs/source/technical_overview.rst
+++ b/docs/source/technical_overview.rst
@@ -18,7 +18,7 @@ operating on objects of the following types:
     array: vectors can be |scaled| in-place, the BLAS |axpy| operation is
     supported and |inner products| between vectors can be formed. Linear
     combinations of vectors can be formed using the |lincomb| method. Moreover,
-    various norms can be computed and selected |components| of the vectors can
+    various norms can be computed and selected |dofs| of the vectors can
     be extracted for :mod:`empirical interpolation <pymor.algorithms.ei>`.
     To act on subsets of vectors of an array, arrays can be |indexed|, returning
     a new |VectorArray| which acts as a view onto the respective vectors in the
@@ -59,7 +59,7 @@ operating on objects of the following types:
     .. |apply|            replace:: :meth:`~pymor.operators.interfaces.OperatorInterface.apply`
     .. |appended|         replace:: :meth:`appended <pymor.vectorarrays.interfaces.VectorArrayInterface.append>`
     .. |axpy|             replace:: :meth:`~pymor.vectorarrays.interfaces.VectorArrayInterface.axpy`
-    .. |components|       replace:: :meth:`~pymor.vectorarrays.interfaces.VectorArrayInterface.components`
+    .. |dofs|             replace:: :meth:`~pymor.vectorarrays.interfaces.VectorArrayInterface.dofs`
     .. |copied|           replace:: :meth:`copied <pymor.vectorarrays.interfaces.VectorArrayInterface.copy>`
     .. |dimension|        replace:: :attr:`dimension <pymor.vectorarrays.interfaces.VectorArrayInterface.dim>`
     .. |empty|            replace:: :meth:`~pymor.vectorarrays.interfaces.VectorSpaceInterface.empty`

--- a/src/pymor/algorithms/ei.py
+++ b/src/pymor/algorithms/ei.py
@@ -123,7 +123,7 @@ def ei_greedy(U, error_norm=None, atol=None, rtol=None, max_interpolation_dofs=N
         if new_dof in interpolation_dofs:
             logger.info('DOF {} selected twice for interplation! Stopping extension loop.'.format(new_dof))
             break
-        new_dof_value = new_vec.components([new_dof])[0, 0]
+        new_dof_value = new_vec.dofs([new_dof])[0, 0]
         if new_dof_value == 0.:
             logger.info('DOF {} selected for interpolation has zero maximum error! Stopping extension loop.'
                         .format(new_dof))
@@ -134,13 +134,13 @@ def ei_greedy(U, error_norm=None, atol=None, rtol=None, max_interpolation_dofs=N
         max_errs.append(max_err)
 
         # update U and ERR
-        new_dof_values = U.components([new_dof])
+        new_dof_values = U.dofs([new_dof])
         U.axpy(-new_dof_values[:, 0], new_vec)
         errs = ERR.l2_norm() if error_norm is None else error_norm(ERR)
         max_err_ind = np.argmax(errs)
         max_err = errs[max_err_ind]
 
-    interpolation_matrix = collateral_basis.components(interpolation_dofs).T
+    interpolation_matrix = collateral_basis.dofs(interpolation_dofs).T
     triangularity_errors = np.abs(interpolation_matrix - np.tril(interpolation_matrix))
     for d in range(1, len(interpolation_matrix) + 1):
         triangularity_errs.append(np.max(triangularity_errors[:d, :d]))
@@ -203,7 +203,7 @@ def deim(U, modes=None, error_norm=None, product=None):
 
         if len(interpolation_dofs) > 0:
             coefficients = np.linalg.solve(interpolation_matrix,
-                                           collateral_basis[i].components(interpolation_dofs).T).T
+                                           collateral_basis[i].dofs(interpolation_dofs).T).T
             U_interpolated = collateral_basis[:len(interpolation_dofs)].lincomb(coefficients)
             ERR = collateral_basis[i].copy()
             ERR -= U_interpolated
@@ -222,7 +222,7 @@ def deim(U, modes=None, error_norm=None, product=None):
             break
 
         interpolation_dofs = np.hstack((interpolation_dofs, new_dof))
-        interpolation_matrix = collateral_basis[:len(interpolation_dofs)].components(interpolation_dofs).T
+        interpolation_matrix = collateral_basis[:len(interpolation_dofs)].dofs(interpolation_dofs).T
         errs.append(err)
 
         logger.info('')
@@ -369,7 +369,7 @@ def _parallel_ei_greedy(U, pool, error_norm=None, atol=None, rtol=None, max_inte
             if new_dof in interpolation_dofs:
                 logger.info('DOF {} selected twice for interplation! Stopping extension loop.'.format(new_dof))
                 break
-            new_dof_value = new_vec.components([new_dof])[0, 0]
+            new_dof_value = new_vec.dofs([new_dof])[0, 0]
             if new_dof_value == 0.:
                 logger.info('DOF {} selected for interpolation has zero maximum error! Stopping extension loop.'
                             .format(new_dof))
@@ -383,7 +383,7 @@ def _parallel_ei_greedy(U, pool, error_norm=None, atol=None, rtol=None, max_inte
             max_err_ind = np.argmax(errs)
             max_err = errs[max_err_ind]
 
-    interpolation_matrix = collateral_basis.components(interpolation_dofs).T
+    interpolation_matrix = collateral_basis.dofs(interpolation_dofs).T
     triangularity_errors = np.abs(interpolation_matrix - np.tril(interpolation_matrix))
     for d in range(1, len(interpolation_matrix) + 1):
         triangularity_errs.append(np.max(triangularity_errors[:d, :d]))
@@ -420,7 +420,7 @@ def _parallel_ei_greedy_update(new_vec=None, new_dof=None, data=None):
     U = data['U']
     error_norm = data['error_norm']
 
-    new_dof_values = U.components([new_dof])
+    new_dof_values = U.dofs([new_dof])
     U.axpy(-new_dof_values[:, 0], new_vec)
 
     errs = U.l2_norm() if error_norm is None else error_norm(U)

--- a/src/pymor/algorithms/genericsolvers.py
+++ b/src/pymor/algorithms/genericsolvers.py
@@ -538,7 +538,7 @@ def lsqr(A, b, damp=0.0, atol=1e-8, btol=1e-8, conlim=1e8,
         print(head1, head2)
         test1 = 1
         test2 = alfa / beta
-        str1 = '%6g %12.5e' % (itn, x.components([0])[0])
+        str1 = '%6g %12.5e' % (itn, x.dofs([0])[0])
         str2 = ' %10.3e %10.3e' % (r1norm, r2norm)
         str3 = '  %8.1e %8.1e' % (test1, test2)
         print(str1, str2, str3)
@@ -676,7 +676,7 @@ def lsqr(A, b, damp=0.0, atol=1e-8, btol=1e-8, conlim=1e8,
 
         if prnt:
             if show:
-                str1 = '%6g %12.5e' % (itn, x.components([0])[0])
+                str1 = '%6g %12.5e' % (itn, x.dofs([0])[0])
                 str2 = ' %10.3e %10.3e' % (r1norm, r2norm)
                 str3 = '  %8.1e %8.1e' % (test1, test2)
                 str4 = ' %8.1e %8.1e' % (anorm, acond)
@@ -824,7 +824,7 @@ def lsmr(A, b, damp=0.0, atol=1e-6, btol=1e-6, conlim=1e8,
         print(hdg1, hdg2)
         test1 = 1
         test2 = alpha / beta
-        str1 = '%6g %12.5e' % (itn, x.components([0])[0])
+        str1 = '%6g %12.5e' % (itn, x.dofs([0])[0])
         str2 = ' %10.3e %10.3e' % (normr, normar)
         str3 = '  %8.1e %8.1e' % (test1, test2)
         print(''.join([str1, str2, str3]))
@@ -970,7 +970,7 @@ def lsmr(A, b, damp=0.0, atol=1e-6, btol=1e-6, conlim=1e8,
                     print(' ')
                     print(hdg1, hdg2)
                 pcount = pcount + 1
-                str1 = '%6g %12.5e' % (itn, x.components([0])[0])
+                str1 = '%6g %12.5e' % (itn, x.dofs([0])[0])
                 str2 = ' %10.3e %10.3e' % (normr, normar)
                 str3 = '  %8.1e %8.1e' % (test1, test2)
                 str4 = ' %8.1e %8.1e' % (normA, condA)

--- a/src/pymor/algorithms/projection.py
+++ b/src/pymor/algorithms/projection.py
@@ -188,7 +188,7 @@ class ProjectRules(RuleTable):
                 projected_collateral_basis = op.collateral_basis
 
             return ProjectedEmpiciralInterpolatedOperator(op.restricted_operator, op.interpolation_matrix,
-                                                          NumpyVectorSpace.make_array(source_basis.components(op.source_dofs)),
+                                                          NumpyVectorSpace.make_array(source_basis.dofs(op.source_dofs)),
                                                           projected_collateral_basis, op.triangular,
                                                           op.source.id, None, op.name)
 

--- a/src/pymor/bindings/fenics.py
+++ b/src/pymor/bindings/fenics.py
@@ -58,14 +58,14 @@ if config.HAVE_FENICS:
         def sup_norm(self):
             return self.impl.norm('linf')
 
-        def components(self, component_indices):
-            component_indices = np.array(component_indices, dtype=np.intc)
-            if len(component_indices) == 0:
+        def dofs(self, dof_indices):
+            dof_indices = np.array(dof_indices, dtype=np.intc)
+            if len(dof_indices) == 0:
                 return np.array([], dtype=np.intc)
-            assert 0 <= np.min(component_indices)
-            assert np.max(component_indices) < self.impl.size()
+            assert 0 <= np.min(dof_indices)
+            assert np.max(dof_indices) < self.impl.size()
             x = df.Vector()
-            self.impl.gather(x, component_indices)
+            self.impl.gather(x, dof_indices)
             return x.array()
 
         def amax(self):

--- a/src/pymor/bindings/ngsolve.py
+++ b/src/pymor/bindings/ngsolve.py
@@ -55,8 +55,8 @@ if config.HAVE_NGSOLVE:
         def l2_norm2(self):
             return self.impl.vec.Norm() ** 2
 
-        def components(self, component_indices):
-            return self.data[component_indices]
+        def dofs(self, dof_indices):
+            return self.data[dof_indices]
 
         def amax(self):
             A = np.abs(self.data)

--- a/src/pymor/operators/constructions.py
+++ b/src/pymor/operators/constructions.py
@@ -245,7 +245,7 @@ class ComponentProjection(OperatorBase):
 
     def apply(self, U, mu=None):
         assert U in self.source
-        return self.range.make_array(U.components(self.components))
+        return self.range.make_array(U.dofs(self.components))
 
     def restricted(self, dofs):
         assert all(0 <= c < self.range.dim for c in dofs)
@@ -348,7 +348,7 @@ class ConstantOperator(OperatorBase):
 
     def restricted(self, dofs):
         assert all(0 <= c < self.range.dim for c in dofs)
-        restricted_value = NumpyVectorSpace.make_array(self._value.components(dofs))
+        restricted_value = NumpyVectorSpace.make_array(self._value.dofs(dofs))
         return ConstantOperator(restricted_value, NumpyVectorSpace(len(dofs))), dofs
 
 
@@ -498,7 +498,7 @@ class VectorArrayOperator(OperatorBase):
     def restricted(self, dofs):
         assert all(0 <= c < self.range.dim for c in dofs)
         if not self.transposed:
-            restricted_value = NumpyVectorSpace.make_array(self._array.components(dofs))
+            restricted_value = NumpyVectorSpace.make_array(self._array.dofs(dofs))
             return VectorArrayOperator(restricted_value, False), np.arange(self.source.dim, dtype=np.int32)
         else:
             raise NotImplementedError

--- a/src/pymor/operators/ei.py
+++ b/src/pymor/operators/ei.py
@@ -80,7 +80,7 @@ class EmpiricalInterpolatedOperator(OperatorBase):
             except NotImplementedError:
                 self.logger.warning('Operator has no "restricted" method. The full operator will be evaluated.')
                 self.operator = operator
-            interpolation_matrix = collateral_basis.components(interpolation_dofs).T
+            interpolation_matrix = collateral_basis.dofs(interpolation_dofs).T
             self.interpolation_matrix = interpolation_matrix
             self.collateral_basis = collateral_basis.copy()
 
@@ -90,10 +90,10 @@ class EmpiricalInterpolatedOperator(OperatorBase):
             return self.range.zeros(len(U))
 
         if hasattr(self, 'restricted_operator'):
-            U_components = NumpyVectorSpace.make_array(U.components(self.source_dofs))
-            AU = self.restricted_operator.apply(U_components, mu=mu)
+            U_dofs = NumpyVectorSpace.make_array(U.dofs(self.source_dofs))
+            AU = self.restricted_operator.apply(U_dofs, mu=mu)
         else:
-            AU = NumpyVectorSpace.make_array(self.operator.apply(U, mu=mu).components(self.interpolation_dofs))
+            AU = NumpyVectorSpace.make_array(self.operator.apply(U, mu=mu).dofs(self.interpolation_dofs))
         try:
             if self.triangular:
                 interpolation_coefficients = solve_triangular(self.interpolation_matrix, AU.data.T,
@@ -121,8 +121,8 @@ class EmpiricalInterpolatedOperator(OperatorBase):
                                                  solver_options=options, name=self.name + '_jacobian')
         else:
             restricted_source = self.restricted_operator.source
-            U_components = restricted_source.make_array(U.components(self.source_dofs))
-            JU = self.restricted_operator.jacobian(U_components, mu=mu) \
+            U_dofs = restricted_source.make_array(U.dofs(self.source_dofs))
+            JU = self.restricted_operator.jacobian(U_dofs, mu=mu) \
                                          .apply(restricted_source.make_array(np.eye(len(self.source_dofs))))
             try:
                 if self.triangular:
@@ -161,8 +161,8 @@ class ProjectedEmpiciralInterpolatedOperator(OperatorBase):
 
     def apply(self, U, mu=None):
         mu = self.parse_parameter(mu)
-        U_components = self.source_basis_dofs.lincomb(U.data)
-        AU = self.restricted_operator.apply(U_components, mu=mu)
+        U_dofs = self.source_basis_dofs.lincomb(U.data)
+        AU = self.restricted_operator.apply(U_dofs, mu=mu)
         try:
             if self.triangular:
                 interpolation_coefficients = solve_triangular(self.interpolation_matrix, AU.data.T,
@@ -183,8 +183,8 @@ class ProjectedEmpiciralInterpolatedOperator(OperatorBase):
                                        source_id=self.source.id, range_id=self.range.id,
                                        name=self.name + '_jacobian')
 
-        U_components = self.source_basis_dofs.lincomb(U.data[0])
-        J = self.restricted_operator.jacobian(U_components, mu=mu).apply(self.source_basis_dofs)
+        U_dofs = self.source_basis_dofs.lincomb(U.data[0])
+        J = self.restricted_operator.jacobian(U_dofs, mu=mu).apply(self.source_basis_dofs)
         try:
             if self.triangular:
                 interpolation_coefficients = solve_triangular(self.interpolation_matrix, J.data.T,

--- a/src/pymor/operators/interfaces.py
+++ b/src/pymor/operators/interfaces.py
@@ -393,8 +393,8 @@ class OperatorInterface(ImmutableInterface, Parametric):
         operator along with an array `source_dofs` such that for any
         |VectorArray| `U` in `self.source` the following is true::
 
-            self.apply(U, mu).components(dofs)
-                == restricted_op.apply(NumpyVectorArray(U.components(source_dofs)), mu))
+            self.apply(U, mu).dofs(dofs)
+                == restricted_op.apply(NumpyVectorArray(U.dofs(source_dofs)), mu))
 
         Such an operator is mainly useful for
         :class:`empirical interpolation <pymor.operators.ei.EmpiricalInterpolatedOperator>`

--- a/src/pymor/vectorarrays/block.py
+++ b/src/pymor/vectorarrays/block.py
@@ -126,18 +126,18 @@ class BlockVectorArray(VectorArrayInterface):
     def sup_norm(self):
         return np.max(np.array([block.sup_norm() for block in self._blocks]), axis=0)
 
-    def components(self, component_indices):
-        component_indices = np.array(component_indices)
-        if not len(component_indices):
+    def dofs(self, dof_indices):
+        dof_indices = np.array(dof_indices)
+        if not len(dof_indices):
             return np.zeros((len(self), 0))
 
         self._compute_bins()
-        block_inds = np.digitize(component_indices, self._bins) - 1
-        component_indices -= self._bins[block_inds]
+        block_inds = np.digitize(dof_indices, self._bins) - 1
+        dof_indices -= self._bins[block_inds]
         block_inds = self._bin_map[block_inds]
         blocks = self._blocks
-        return np.array([blocks[bi].components([ci])[:, 0]
-                         for bi, ci in zip(block_inds, component_indices)]).T
+        return np.array([blocks[bi].dofs([ci])[:, 0]
+                         for bi, ci in zip(block_inds, dof_indices)]).T
 
     def amax(self):
         self._compute_bins()

--- a/src/pymor/vectorarrays/interfaces.py
+++ b/src/pymor/vectorarrays/interfaces.py
@@ -364,34 +364,33 @@ class VectorArrayInterface(BasicInterface):
             return max_val
 
     @abstractmethod
-    def components(self, component_indices):
-        """Extract components of the vectors contained in the array.
+    def dofs(self, dof_indices):
+        """Extract DOFs of the vectors contained in the array.
 
         Parameters
         ----------
-        component_indices
-            List or 1D |NumPy array| of indices of the vector components that are to
-            be returned.
+        dof_indices
+            List or 1D |NumPy array| of indices of the DOFs that are to be returned.
 
         Returns
         -------
-        A |NumPy array| `result` such that `result[i, j]` is the `component_indices[j]`-th
-        component of the `i`-th vector of the array.
+        A |NumPy array| `result` such that `result[i, j]` is the `dof_indices[j]`-th
+        DOF of the `i`-th vector of the array.
         """
         pass
 
     @abstractmethod
     def amax(self):
-        """The maximum absolute value of the vectors contained in the array.
+        """The maximum absolute value of the DOFs contained in the array.
 
         Returns
         -------
         max_ind
-            |NumPy array| containing for each vector an index at which the maximum is
+            |NumPy array| containing for each vector a DOF index at which the maximum is
             attained.
         max_val
             |NumPy array| containing for each vector the maximum absolute value of its
-            components.
+            DOFs.
         """
         pass
 

--- a/src/pymor/vectorarrays/list.py
+++ b/src/pymor/vectorarrays/list.py
@@ -50,7 +50,7 @@ class VectorInterface(BasicInterface):
         return max_val
 
     @abstractmethod
-    def components(self, component_indices):
+    def dofs(self, dof_indices):
         pass
 
     @abstractmethod
@@ -194,8 +194,8 @@ class NumpyVector(CopyOnWriteVector):
     def l2_norm2(self):
         return np.sum((self._array * self._array.conj()).real)
 
-    def components(self, component_indices):
-        return self._array[component_indices]
+    def dofs(self, dof_indices):
+        return self._array[dof_indices]
 
     def amax(self):
         A = np.abs(self._array)
@@ -362,17 +362,17 @@ class ListVectorArray(VectorArrayInterface):
         else:
             return np.array([v.sup_norm() for v in self._list])
 
-    def components(self, component_indices):
-        assert isinstance(component_indices, list) and (len(component_indices) == 0 or min(component_indices) >= 0) \
-            or (isinstance(component_indices, np.ndarray) and component_indices.ndim == 1
-                and (len(component_indices) == 0 or np.min(component_indices) >= 0))
+    def dofs(self, dof_indices):
+        assert isinstance(dof_indices, list) and (len(dof_indices) == 0 or min(dof_indices) >= 0) \
+            or (isinstance(dof_indices, np.ndarray) and dof_indices.ndim == 1
+                and (len(dof_indices) == 0 or np.min(dof_indices) >= 0))
 
-        R = np.empty((len(self), len(component_indices)))
+        R = np.empty((len(self), len(dof_indices)))
 
-        assert len(self) > 0 or len(component_indices) == 0 or max(component_indices) < self.dim
+        assert len(self) > 0 or len(dof_indices) == 0 or max(dof_indices) < self.dim
 
         for k, v in enumerate(self._list):
-            R[k] = v.components(component_indices)
+            R[k] = v.dofs(dof_indices)
 
         return R
 

--- a/src/pymor/vectorarrays/numpy.py
+++ b/src/pymor/vectorarrays/numpy.py
@@ -216,29 +216,29 @@ class NumpyVectorArray(VectorArrayInterface):
             _, max_val = self.amax(_ind=_ind)
             return max_val
 
-    def components(self, component_indices, *, _ind=None):
+    def dofs(self, dof_indices, *, _ind=None):
         if _ind is None:
             _ind = slice(0, self._len)
-        assert isinstance(component_indices, list) and (len(component_indices) == 0 or min(component_indices) >= 0) \
-            or (isinstance(component_indices, np.ndarray) and component_indices.ndim == 1
-                and (len(component_indices) == 0 or np.min(component_indices) >= 0))
+        assert isinstance(dof_indices, list) and (len(dof_indices) == 0 or min(dof_indices) >= 0) \
+            or (isinstance(dof_indices, np.ndarray) and dof_indices.ndim == 1
+                and (len(dof_indices) == 0 or np.min(dof_indices) >= 0))
         # NumPy 1.9 is quite permissive when indexing arrays of size 0, so we have to add the
         # following check:
         assert self._len > 0 \
-            or (isinstance(component_indices, list)
-                and (len(component_indices) == 0 or max(component_indices) < self.dim)) \
-            or (isinstance(component_indices, np.ndarray) and component_indices.ndim == 1
-                and (len(component_indices) == 0 or np.max(component_indices) < self.dim))
+            or (isinstance(dof_indices, list)
+                and (len(dof_indices) == 0 or max(dof_indices) < self.dim)) \
+            or (isinstance(dof_indices, np.ndarray) and dof_indices.ndim == 1
+                and (len(dof_indices) == 0 or np.max(dof_indices) < self.dim))
 
         if NUMPY_INDEX_QUIRK and (self._len == 0 or self.dim == 0):
-            assert isinstance(component_indices, list) \
-                and (len(component_indices) == 0 or max(component_indices) < self.dim) \
-                or isinstance(component_indices, np.ndarray) \
-                and component_indices.ndim == 1 \
-                and (len(component_indices) == 0 or np.max(component_indices) < self.dim)
-            return np.zeros((self.len_ind(_ind), len(component_indices)))
+            assert isinstance(dof_indices, list) \
+                and (len(dof_indices) == 0 or max(dof_indices) < self.dim) \
+                or isinstance(dof_indices, np.ndarray) \
+                and dof_indices.ndim == 1 \
+                and (len(dof_indices) == 0 or np.max(dof_indices) < self.dim)
+            return np.zeros((self.len_ind(_ind), len(dof_indices)))
 
-        return self._array[:, component_indices][_ind, :]
+        return self._array[:, dof_indices][_ind, :]
 
     def amax(self, *, _ind=None):
         if _ind is None:
@@ -479,8 +479,8 @@ class NumpyVectorArrayView(NumpyVectorArray):
     def sup_norm(self):
         return self.base.sup_norm(_ind=self.ind)
 
-    def components(self, component_indices):
-        return self.base.components(component_indices, _ind=self.ind)
+    def dofs(self, dof_indices):
+        return self.base.dofs(dof_indices, _ind=self.ind)
 
     def amax(self):
         return self.base.amax(_ind=self.ind)

--- a/src/pymordemos/minimal_cpp_demo/wrapper.py
+++ b/src/pymordemos/minimal_cpp_demo/wrapper.py
@@ -48,7 +48,7 @@ class WrappedVector(CopyOnWriteVector):
     def sup_norm(self):
         raise NotImplementedError
 
-    def components(self, component_indices):
+    def dofs(self, dof_indices):
         raise NotImplementedError
 
     def amax(self):

--- a/src/pymortests/operators.py
+++ b/src/pymortests/operators.py
@@ -280,13 +280,13 @@ def test_restricted(operator_with_arrays):
         return
     np.random.seed(4711 + U.dim)
     for num in [0, 1, 3, 7]:
-        components = np.random.randint(0, op.range.dim, num)
+        dofs = np.random.randint(0, op.range.dim, num)
         try:
-            rop, source_dofs = op.restricted(components)
+            rop, source_dofs = op.restricted(dofs)
         except NotImplementedError:
             return
-        op_U = rop.range.make_array(op.apply(U, mu=mu).components(components))
-        rop_U = rop.apply(rop.source.make_array(U.components(source_dofs)), mu=mu)
+        op_U = rop.range.make_array(op.apply(U, mu=mu).dofs(dofs))
+        rop_U = rop.apply(rop.source.make_array(U.dofs(source_dofs)), mu=mu)
         assert np.all(almost_equal(op_U, rop_U))
 
 

--- a/src/pymortests/to_matrix.py
+++ b/src/pymortests/to_matrix.py
@@ -128,13 +128,13 @@ def test_to_matrix_AdjointOperator():
 
 
 def test_to_matrix_ComponentProjection():
-    components = np.array([0, 1, 2, 4, 8])
+    dofs = np.array([0, 1, 2, 4, 8])
     n = 10
-    A = np.zeros((len(components), n))
-    A[range(len(components)), components] = 1
+    A = np.zeros((len(dofs), n))
+    A[range(len(dofs)), dofs] = 1
 
     source = NumpyVectorSpace(n)
-    Aop = ComponentProjection(components, source)
+    Aop = ComponentProjection(dofs, source)
     assert_type_and_allclose(A, Aop, 'sparse')
 
 

--- a/src/pymortests/vectorarray.py
+++ b/src/pymortests/vectorarray.py
@@ -667,52 +667,52 @@ def test_sup_norm(vector_array):
         assert np.allclose(c[ind].sup_norm(), 0)
 
 
-def test_components(vector_array):
+def test_dofs(vector_array):
     v = vector_array
     np.random.seed(len(v) + 24 + v.dim)
     for ind in valid_inds(v):
         c = v.copy()
-        comp = c[ind].components(np.array([], dtype=np.int))
-        assert isinstance(comp, np.ndarray)
-        assert comp.shape == (v.len_ind(ind), 0)
+        dofs = c[ind].dofs(np.array([], dtype=np.int))
+        assert isinstance(dofs, np.ndarray)
+        assert dofs.shape == (v.len_ind(ind), 0)
 
         c = v.copy()
-        comp = c[ind].components([])
-        assert isinstance(comp, np.ndarray)
-        assert comp.shape == (v.len_ind(ind), 0)
+        dofs = c[ind].dofs([])
+        assert isinstance(dofs, np.ndarray)
+        assert dofs.shape == (v.len_ind(ind), 0)
 
         if v.dim > 0:
             for count in (1, 5, 10):
                 c_ind = np.random.randint(0, v.dim, count)
                 c = v.copy()
-                comp = c[ind].components(c_ind)
-                assert comp.shape == (v.len_ind(ind), count)
+                dofs = c[ind].dofs(c_ind)
+                assert dofs.shape == (v.len_ind(ind), count)
                 c = v.copy()
-                comp2 = c[ind].components(list(c_ind))
-                assert np.all(comp == comp2)
+                dofs2 = c[ind].dofs(list(c_ind))
+                assert np.all(dofs == dofs2)
                 c = v.copy()
                 c.scal(3.)
-                comp2 = c[ind].components(c_ind)
-                assert np.allclose(comp * 3, comp2)
+                dofs2 = c[ind].dofs(c_ind)
+                assert np.allclose(dofs * 3, dofs2)
                 c = v.copy()
-                comp2 = c[ind].components(np.hstack((c_ind, c_ind)))
-                assert np.all(comp2 == np.hstack((comp, comp)))
+                dofs2 = c[ind].dofs(np.hstack((c_ind, c_ind)))
+                assert np.all(dofs2 == np.hstack((dofs, dofs)))
                 if hasattr(v, 'data'):
-                    assert np.all(comp == indexed(v.data, ind)[:, c_ind])
+                    assert np.all(dofs == indexed(v.data, ind)[:, c_ind])
 
 
-def test_components_wrong_component_indices(vector_array):
+def test_components_wrong_dof_indices(vector_array):
     v = vector_array
     np.random.seed(len(v) + 24 + v.dim)
     for ind in valid_inds(v):
         with pytest.raises(Exception):
-            v[ind].components(None)
+            v[ind].dofs(None)
         with pytest.raises(Exception):
-            v[ind].components(1)
+            v[ind].dofs(1)
         with pytest.raises(Exception):
-            v[ind].components(np.array([-1]))
+            v[ind].dofs(np.array([-1]))
         with pytest.raises(Exception):
-            v[ind].components(np.array([v.dim]))
+            v[ind].dofs(np.array([v.dim]))
 
 
 def test_amax(vector_array):
@@ -723,7 +723,7 @@ def test_amax(vector_array):
         max_inds, max_vals = v[ind].amax()
         assert np.allclose(np.abs(max_vals), v[ind].sup_norm())
         for i, max_ind, max_val in zip(ind_to_list(v, ind), max_inds, max_vals):
-            assert np.allclose(max_val, v[[i]].components([max_ind]))
+            assert np.allclose(max_val, v[[i]].dofs([max_ind]))
 
 
 # def test_amax_zero_dim(zero_dimensional_vector_space):


### PR DESCRIPTION
`components` always was a slightly awkward name. Moreover, we want to use `component` in the future to extract `VectorArrays` associated with subspaces of a given system `VectorSpace`.