### PR TITLE
Build wheels that can install without --pre

### DIFF
--- a/.ci/travis/deploy.bash
+++ b/.ci/travis/deploy.bash
@@ -7,12 +7,14 @@ REPODIR=${HOME}/wheels
 PYMOR_ROOT="$(cd "$(dirname ${BASH_SOURCE[0]})" ; cd ../../ ; pwd -P )"
 cd "${PYMOR_ROOT}"
 
+sed -i -e 's;style\ \=\ pep440;style\ \=\ ci_wheel_builder;g' setup.cfg
+
 rm -rf ~/.ssh
-ls -l ${PYMOR_ROOT}/.ci/travis/wheels.deploy.key.rsa.enc
 
 ./.ci/travis/init_sshkey.bash "${encrypted_a599472c800f_key}" "${encrypted_a599472c800f_iv}" \
     ${PYMOR_ROOT}/.ci/travis/wheels.deploy.key
 
+set -x
 mkdir -p ${BUILDER_WHEELHOUSE}
 git clone git@github.com:pymor/wheels.pymor.org ${REPODIR}
 for py in 2.7 3.5 3.6 ; do

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ ignore =
 
 [versioneer]
 VCS = git
-style = pep440
+style = ci_wheel_builder
 versionfile_source = src/pymor/version.py
 # this is mandatory for the processed version.py to end up in .whl
 versionfile_build = pymor/version.py

--- a/versioneer.py
+++ b/versioneer.py
@@ -1258,6 +1258,26 @@ def render_pep440(pieces):
     return rendered
 
 
+def render_ci_wheel_builder(pieces):
+    """Build up non-release wheel version, pep440 compliant"
+
+    Our goal: EPOCH!BUILD_NUMBER+TAG.DISTANCE.gHEX
+
+    Exceptions:
+    1: no tags. git_describe was just HEX. 0+untagged.DISTANCE.gHEX[.dirty]
+    """
+    ci_build = str(os.environ.get('TRAVIS_BUILD_ID', 1))
+    if pieces["closest-tag"]:
+        rendered = '999!{}+{}'.format(ci_build, pieces["closest-tag"])
+        if pieces["distance"] or pieces["dirty"]:
+            rendered += ".%d.g%s" % (pieces["distance"], pieces["short"])
+    else:
+        # exception #1
+        rendered = "0+untagged.%d.g%s" % (pieces["distance"],
+                                          pieces["short"])
+    return rendered
+
+
 def render_pep440_pre(pieces):
     """TAG[.post.devDISTANCE] -- No -dirty.
 
@@ -1387,6 +1407,8 @@ def render(pieces, style):
         rendered = render_git_describe(pieces)
     elif style == "git-describe-long":
         rendered = render_git_describe_long(pieces)
+    elif style == "ci_wheel_builder":
+        rendered = render_ci_wheel_builder(pieces)
     else:
         raise ValueError("unknown style '%s'" % style)
 


### PR DESCRIPTION
See https://wheels.pymor.org/branches/wheel_versioning/index.html
Non-release/tag wheels names now carry an epoch version to make them newer than everything else, as far as pip is concerned. To make this work with branches, wheels.pymor.org now has an index per branch dir instead of listing everything on the root index. 
I've also dropped the 'dirty' suffix from the local version part because every wheel will now de birty due to me changing the versioning routine in setup.cfg in the deploy step. I thought doing that change explicitly this way instead of having it being controlled via an environment variable setting was somewhat safer.