### PR TITLE
[sys-mor] moving Gramians from LTISystem to reductors

### DIFF
--- a/notebooks/heat.ipynb
+++ b/notebooks/heat.ipynb
@@ -171,7 +171,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "hsv = lti.hsv\n",
+    "hsv = lti.hsv()\n",
     "fig, ax = plt.subplots()\n",
     "ax.semilogy(range(1, len(hsv) + 1), hsv, '.-')\n",
     "ax.set_title('Hankel singular values')\n",

--- a/notebooks/heat.ipynb
+++ b/notebooks/heat.ipynb
@@ -80,7 +80,7 @@
     "%matplotlib inline\n",
     "\n",
     "from pymor.discretizations.iosys import LTISystem, TransferFunction\n",
-    "from pymor.reductors.bt import BTReductor\n",
+    "from pymor.reductors.bt import BTReductor, LQGBTReductor, BRBTReductor\n",
     "from pymor.reductors.lti import IRKAReductor, TSIAReductor\n",
     "from pymor.reductors.tf import TF_IRKAReductor\n",
     "\n",
@@ -238,6 +238,112 @@
    "source": [
     "fig, ax = LTISystem.mag_plot(err_bt, w=w)\n",
     "ax.set_title('Bode plot of the BT error system')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## LQG Balanced Truncation (LQGBT)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "r = 5\n",
+    "lqgbt_reductor = LQGBTReductor(lti)\n",
+    "rom_lqgbt = lqgbt_reductor.reduce(r, tol=1e-5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print('H_2-norm of the LQGBT ROM:       {}'.format(rom_lqgbt.norm()))\n",
+    "print('H_inf-norm of the LQGBT ROM:     {}'.format(rom_lqgbt.norm('Hinf')))\n",
+    "err_lqgbt = lti - rom_lqgbt\n",
+    "print('H_2-error for the LQGBT ROM:     {}'.format(err_lqgbt.norm()))\n",
+    "print('H_inf-error for the LQGBT ROM:   {}'.format(err_lqgbt.norm('Hinf')))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = LTISystem.mag_plot((lti, rom_lqgbt), w=w)\n",
+    "ax.set_title('Bode plot of the full and LQGBT reduced model')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = LTISystem.mag_plot(err_lqgbt, w=w)\n",
+    "ax.set_title('Bode plot of the LQGBT error system')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Bounded Real Balanced Truncation (BRBT)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "r = 5\n",
+    "brbt_reductor = BRBTReductor(lti, 1)\n",
+    "rom_brbt = brbt_reductor.reduce(r, tol=1e-5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print('H_2-norm of the BRBT ROM:       {}'.format(rom_brbt.norm()))\n",
+    "print('H_inf-norm of the BRBT ROM:     {}'.format(rom_brbt.norm('Hinf')))\n",
+    "err_brbt = lti - rom_brbt\n",
+    "print('H_2-error for the BRBT ROM:     {}'.format(err_brbt.norm()))\n",
+    "print('H_inf-error for the BRBT ROM:   {}'.format(err_brbt.norm('Hinf')))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = LTISystem.mag_plot((lti, rom_brbt), w=w)\n",
+    "ax.set_title('Bode plot of the full and BRBT reduced model')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = LTISystem.mag_plot(err_brbt, w=w)\n",
+    "ax.set_title('Bode plot of the BRBT error system')\n",
     "plt.show()"
    ]
   },

--- a/notebooks/heat.ipynb
+++ b/notebooks/heat.ipynb
@@ -171,9 +171,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sv = lti.sv_U_V('lyap')[0]\n",
+    "hsv = lti.hsv\n",
     "fig, ax = plt.subplots()\n",
-    "ax.semilogy(range(1, len(sv) + 1), sv, '.-')\n",
+    "ax.semilogy(range(1, len(hsv) + 1), hsv, '.-')\n",
     "ax.set_title('Hankel singular values')\n",
     "plt.show()"
    ]
@@ -308,7 +308,7 @@
    "outputs": [],
    "source": [
     "r = 5\n",
-    "brbt_reductor = BRBTReductor(lti, 1)\n",
+    "brbt_reductor = BRBTReductor(lti, 0.34)\n",
     "rom_brbt = brbt_reductor.reduce(r, tol=1e-5)"
    ]
   },

--- a/src/pymor/discretizations/iosys.py
+++ b/src/pymor/discretizations/iosys.py
@@ -575,7 +575,7 @@ class LTISystem(InputOutputSystem):
             raise NotImplementedError("Only 'cf' and 'of' types are possible.")
 
     @cached
-    def _sv_U_V(self):
+    def _hsv_U_V(self):
         """Compute Hankel singular values and vectors.
 
         Returns
@@ -602,7 +602,7 @@ class LTISystem(InputOutputSystem):
         sv
             One-dimensional |NumPy array| of singular values.
         """
-        return self._sv_U_V()[0]
+        return self._hsv_U_V()[0]
 
     @property
     def hsU(self):
@@ -613,7 +613,7 @@ class LTISystem(InputOutputSystem):
         Uh
             |NumPy array| of left singluar vectors.
         """
-        return self._sv_U_V()[1]
+        return self._hsv_U_V()[1]
 
     @property
     def hsV(self):
@@ -624,7 +624,7 @@ class LTISystem(InputOutputSystem):
         Vh
             |NumPy array| of right singluar vectors.
         """
-        return self._sv_U_V()[2]
+        return self._hsv_U_V()[2]
 
     @cached
     def norm(self, name='H2'):

--- a/src/pymor/discretizations/iosys.py
+++ b/src/pymor/discretizations/iosys.py
@@ -593,7 +593,6 @@ class LTISystem(InputOutputSystem):
         U, hsv, Vh = spla.svd(self.E.apply2(of, cf))
         return hsv, U.T, Vh
 
-    @property
     def hsv(self):
         """Hankel singular values.
 
@@ -604,7 +603,6 @@ class LTISystem(InputOutputSystem):
         """
         return self._hsv_U_V()[0]
 
-    @property
     def hsU(self):
         """Left Hankel singular vectors.
 
@@ -615,7 +613,6 @@ class LTISystem(InputOutputSystem):
         """
         return self._hsv_U_V()[1]
 
-    @property
     def hsV(self):
         """Right Hankel singular vectors.
 

--- a/src/pymor/reductors/bt.py
+++ b/src/pymor/reductors/bt.py
@@ -2,9 +2,16 @@
 # Copyright 2013-2017 pyMOR developers and contributors. All rights reserved.
 # License: BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
 
+from functools import partial
+
 import numpy as np
+import scipy.linalg as spla
 
 from pymor.algorithms.gram_schmidt import gram_schmidt, gram_schmidt_biorth
+from pymor.core.config import config
+from pymor.core.defaults import defaults
+from pymor.discretizations.iosys import _DEFAULT_ME_SOLVER_BACKEND
+from pymor.operators.constructions import IdentityOperator
 from pymor.reductors.basic import GenericPGReductor
 
 
@@ -24,12 +31,11 @@ class GenericBTReductor(GenericPGReductor):
 
     def _compute_gramians(self):
         """Returns low-rank factors of Gramians."""
-        self.cf = self.d.gramian(self.typ, 'cf')
-        self.of = self.d.gramian(self.typ, 'of')
+        raise NotImplementedError()
 
     def _compute_sv_U_V(self):
         """Returns singular values and vectors."""
-        self.sv, self.sU, self.sV = self.d.sv_U_V(self.typ)
+        raise NotImplementedError()
 
     def _compute_error_bounds(self):
         """Returns error bounds for all possible reduced orders."""
@@ -77,7 +83,7 @@ class GenericBTReductor(GenericPGReductor):
             r = r_tol if r is None else min([r, r_tol])
 
         if r > min([len(self.cf), len(self.of)]):
-            raise ValueError('r needs to be smaller than the sizes of Gramian factors.' +
+            raise ValueError('r needs to be smaller than the sizes of Gramian factors.'
                              ' Try reducing the tolerance in the low-rank matrix equation solver.')
 
         # compute projection matrices and find the reduced model
@@ -121,6 +127,13 @@ class BTReductor(GenericBTReductor):
         super().__init__(d)
         self.typ = 'lyap'
 
+    def _compute_gramians(self):
+        self.cf = self.d.gramian(self.typ, 'cf')
+        self.of = self.d.gramian(self.typ, 'of')
+
+    def _compute_sv_U_V(self):
+        self.sv, self.sU, self.sV = self.d.sv_U_V(self.typ)
+
     def _compute_error_bounds(self):
         self.bounds = 2 * self.sv[:0:-1].cumsum()[::-1]
 
@@ -141,12 +154,46 @@ class LQGBTReductor(GenericBTReductor):
     d
         The system which is to be reduced.
     """
-    def __init__(self, d):
+    def __init__(self, d, solver_options=None):
         super().__init__(d)
-        self.typ = 'lqg'
+        self.solver_options = solver_options
+
+    @defaults('default_solver_backend', qualname='pymor.reductors.bt.LQGBTReductor._ricc_solver')
+    def _ricc_solver(self, default_solver_backend=_DEFAULT_ME_SOLVER_BACKEND):
+        options = self.solver_options.get('ricc') if self.solver_options else None
+        if options:
+            solver = options if isinstance(options, str) else options['type']
+            backend = solver.split('_')[0]
+        else:
+            backend = default_solver_backend
+        if backend == 'scipy':
+            from pymor.bindings.scipy import solve_ricc as solve_ricc_impl
+        elif backend == 'slycot':
+            from pymor.bindings.slycot import solve_ricc as solve_ricc_impl
+        elif backend == 'pymess':
+            from pymor.bindings.pymess import solve_ricc as solve_ricc_impl
+        else:
+            raise NotImplementedError
+        return partial(solve_ricc_impl, options=options)
+
+    def _compute_gramians(self):
+        A = self.d.A
+        B = self.d.B
+        C = self.d.C
+        E = self.d.E if not isinstance(self.d.E, IdentityOperator) else None
+
+        self.cf = self._ricc_solver()(A, E=E, B=B, C=C, trans=True)
+        self.of = self._ricc_solver()(A, E=E, B=B, C=C, trans=False)
+
+    def _compute_sv_U_V(self):
+        U, sv, Vh = spla.svd(self.d.E.apply2(self.of, self.cf))
+        self.sv, self.sU, self.sV = sv, U.T, Vh
 
     def _compute_error_bounds(self):
         self.bounds = 2 * (self.sv[:0:-1] / np.sqrt(1 + self.sv[:0:-1] ** 2)).cumsum()[::-1]
+
+
+_DEFAULT_BR_SOLVER_BACKEND = 'slycot' if config.HAVE_SLYCOT else 'scipy'
 
 
 class BRBTReductor(GenericBTReductor):
@@ -165,10 +212,41 @@ class BRBTReductor(GenericBTReductor):
     gamma
         Upper bound for the :math:`\mathcal{H}_\infty`-norm.
     """
-    def __init__(self, d, gamma):
+    def __init__(self, d, gamma, solver_options=None):
         super().__init__(d)
-        self.typ = ('br', gamma)
         self.gamma = gamma
+        self.solver_options = solver_options
 
-    def _compute_error_bounds(self, sv):
-        self.bounds = 2 * self.gamma * self.sv[:0:-1].cumsum()[::-1]
+    @defaults('default_solver_backend', qualname='pymor.reductors.bt.BRBTReductor._ricc_solver')
+    def _ricc_solver(self, default_solver_backend=_DEFAULT_BR_SOLVER_BACKEND):
+        options = self.solver_options.get('ricc') if self.solver_options else None
+        if options:
+            solver = options if isinstance(options, str) else options['type']
+            backend = solver.split('_')[0]
+        else:
+            backend = default_solver_backend
+        if backend == 'scipy':
+            from pymor.bindings.scipy import solve_ricc as solve_ricc_impl
+        elif backend == 'slycot':
+            from pymor.bindings.slycot import solve_ricc as solve_ricc_impl
+        elif backend == 'pymess':
+            from pymor.bindings.pymess import solve_ricc as solve_ricc_impl
+        else:
+            raise NotImplementedError
+        return partial(solve_ricc_impl, options=options)
+
+    def _compute_gramians(self):
+        A = self.d.A
+        B = self.d.B
+        C = self.d.C
+        E = self.d.E if not isinstance(self.d.E, IdentityOperator) else None
+
+        self.cf = self._ricc_solver()(A, E=E, B=B, C=C, R=IdentityOperator(C.range) * (-self.gamma ** 2), trans=True)
+        self.of = self._ricc_solver()(A, E=E, B=B, C=C, R=IdentityOperator(B.source) * (-self.gamma ** 2), trans=False)
+
+    def _compute_sv_U_V(self):
+        U, sv, Vh = spla.svd(self.d.E.apply2(self.of, self.cf))
+        self.sv, self.sU, self.sV = sv, U.T, Vh
+
+    def _compute_error_bounds(self):
+        self.bounds = 2 * self.sv[:0:-1].cumsum()[::-1]

--- a/src/pymor/reductors/bt.py
+++ b/src/pymor/reductors/bt.py
@@ -35,7 +35,8 @@ class GenericBTReductor(GenericPGReductor):
 
     def _compute_sv_U_V(self):
         """Returns singular values and vectors."""
-        raise NotImplementedError()
+        U, sv, Vh = spla.svd(self.d.E.apply2(self.of, self.cf))
+        self.sv, self.sU, self.sV = sv, U.T, Vh
 
     def _compute_error_bounds(self):
         """Returns error bounds for all possible reduced orders."""
@@ -125,14 +126,10 @@ class BTReductor(GenericBTReductor):
     """
     def __init__(self, d):
         super().__init__(d)
-        self.typ = 'lyap'
 
     def _compute_gramians(self):
-        self.cf = self.d.gramian(self.typ, 'cf')
-        self.of = self.d.gramian(self.typ, 'of')
-
-    def _compute_sv_U_V(self):
-        self.sv, self.sU, self.sV = self.d.sv_U_V(self.typ)
+        self.cf = self.d.gramian('cf')
+        self.of = self.d.gramian('of')
 
     def _compute_error_bounds(self):
         self.bounds = 2 * self.sv[:0:-1].cumsum()[::-1]
@@ -184,10 +181,6 @@ class LQGBTReductor(GenericBTReductor):
 
         self.cf = self._ricc_solver()(A, E=E, B=B, C=C, trans=True)
         self.of = self._ricc_solver()(A, E=E, B=B, C=C, trans=False)
-
-    def _compute_sv_U_V(self):
-        U, sv, Vh = spla.svd(self.d.E.apply2(self.of, self.cf))
-        self.sv, self.sU, self.sV = sv, U.T, Vh
 
     def _compute_error_bounds(self):
         self.bounds = 2 * (self.sv[:0:-1] / np.sqrt(1 + self.sv[:0:-1] ** 2)).cumsum()[::-1]
@@ -243,10 +236,6 @@ class BRBTReductor(GenericBTReductor):
 
         self.cf = self._ricc_solver()(A, E=E, B=B, C=C, R=IdentityOperator(C.range) * (-self.gamma ** 2), trans=True)
         self.of = self._ricc_solver()(A, E=E, B=B, C=C, R=IdentityOperator(B.source) * (-self.gamma ** 2), trans=False)
-
-    def _compute_sv_U_V(self):
-        U, sv, Vh = spla.svd(self.d.E.apply2(self.of, self.cf))
-        self.sv, self.sU, self.sV = sv, U.T, Vh
 
     def _compute_error_bounds(self):
         self.bounds = 2 * self.sv[:0:-1].cumsum()[::-1]

--- a/src/pymordemos/heat.py
+++ b/src/pymordemos/heat.py
@@ -75,9 +75,9 @@ if __name__ == '__main__':
     plt.show()
 
     # Hankel singular values
-    sv = lti.sv_U_V('lyap')[0]
+    hsv = lti.hsv
     fig, ax = plt.subplots()
-    ax.semilogy(range(1, len(sv) + 1), sv, '.-')
+    ax.semilogy(range(1, len(hsv) + 1), hsv, '.-')
     ax.set_title('Hankel singular values')
     plt.show()
 

--- a/src/pymordemos/heat.py
+++ b/src/pymordemos/heat.py
@@ -75,7 +75,7 @@ if __name__ == '__main__':
     plt.show()
 
     # Hankel singular values
-    hsv = lti.hsv
+    hsv = lti.hsv()
     fig, ax = plt.subplots()
     ax.semilogy(range(1, len(hsv) + 1), hsv, '.-')
     ax.set_title('Hankel singular values')


### PR DESCRIPTION
This PR moves LQG and BR Gramians from `LTISystem` to reductors. Thus:
- `LTISystem.gramian` only computes standard (Lyapunov) Gramians,
- `solver_options` in `LTISystem` now only refers to the Lyapunov equations,
- `LQGBTReductor` and `BRBTReductor` have their own `solver_options` for LQG/BR Riccati equations,
- `BTReductor` still uses `LTISystem.gramian`.

Additionally:
- `notebook/heat.ipynb` now also demonstrates LQGBT and BRBT,
- `LTISystem.sv_U_V` was replaced by `LTISystem._hsv_U_V`, `LTISystem.hsv`, `LTISystem.hsU`, and `LTISystem.hsV`, since now it only computes Hankel singular values and vectors,
- `LTISystem.hsv`, `LTISystem.hsU`, and `LTISystem.hsV` are a properties for ease of use.
