### PR TITLE
Balancing and interpolation related reductors for SecondOrderSystems

### DIFF
--- a/notebooks/string.ipynb
+++ b/notebooks/string.ipynb
@@ -109,6 +109,7 @@
     "from pymor.reductors.lti import IRKAReductor\n",
     "from pymor.reductors.sobt import (SOBTpReductor, SOBTvReductor, SOBTpvReductor, SOBTvpReductor,\n",
     "                                  SOBTfvReductor, SOBTReductor)\n",
+    "from pymor.reductors.sor_irka import SOR_IRKAReductor\n",
     "\n",
     "import logging\n",
     "logging.getLogger('pymor.algorithms.gram_schmidt.gram_schmidt').setLevel(logging.ERROR)"
@@ -681,6 +682,165 @@
    "source": [
     "fig, ax = SecondOrderSystem.mag_plot(err_bt, w=w)\n",
     "ax.set_title('Bode plot of the BT error system')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Iterative Rational Krylov Algorithm (IRKA)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "r = 10\n",
+    "irka_reductor = IRKAReductor(so_sys.to_lti())\n",
+    "rom_irka = irka_reductor.reduce(r, dist_num=10, conv_crit='rel_H2_dist')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots()\n",
+    "ax.semilogy(irka_reductor.dist, '.-')\n",
+    "ax.set_title('IRKA convergence criterion')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "poles_rom_irka = rom_irka.poles(force_dense=True)\n",
+    "fig, ax = plt.subplots()\n",
+    "ax.plot(poles_rom_irka.real, poles_rom_irka.imag, '.')\n",
+    "ax.set_title(\"IRKA reduced model's poles\")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "err_irka = so_sys.to_lti() - rom_irka\n",
+    "print('H_2-error for the IRKA ROM:     {}'.format(err_irka.norm()))\n",
+    "print('H_inf-error for the IRKA ROM:   {}'.format(err_irka.norm('Hinf')))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = SecondOrderSystem.mag_plot((so_sys, rom_irka), w=w)\n",
+    "ax.set_title('Bode plot of the full and IRKA reduced model')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = SecondOrderSystem.mag_plot(err_irka, w=w)\n",
+    "ax.set_title('Bode plot of the IRKA error system')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Second-Order Iterative Rational Krylov Algorithm (SOR-IRKA)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "r = 10\n",
+    "sor_irka_reductor = SOR_IRKAReductor(so_sys)\n",
+    "rom_sor_irka = sor_irka_reductor.reduce(r, dist_num=10, conv_crit='rel_H2_dist',\n",
+    "                                        irka_options={'tol': 1e-2,\n",
+    "                                                      'dist_num': 10,\n",
+    "                                                      'conv_crit': 'rel_H2_dist'})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots()\n",
+    "ax.semilogy(sor_irka_reductor.dist, '.-')\n",
+    "ax.set_title('SOR-IRKA convergence criterion')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "poles_rom_sor_irka = rom_sor_irka.poles(force_dense=True)\n",
+    "fig, ax = plt.subplots()\n",
+    "ax.plot(poles_rom_sor_irka.real, poles_rom_sor_irka.imag, '.')\n",
+    "ax.set_title(\"SOR-IRKA reduced model's poles\")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "err_sor_irka = so_sys - rom_sor_irka\n",
+    "print('H_2-error for the SOR-IRKA ROM:     {}'.format(err_sor_irka.norm()))\n",
+    "print('H_inf-error for the SOR-IRKA ROM:   {}'.format(err_sor_irka.norm('Hinf')))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = SecondOrderSystem.mag_plot((so_sys, rom_sor_irka), w=w)\n",
+    "ax.set_title('Bode plot of the full and SOR-IRKA reduced model')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = SecondOrderSystem.mag_plot(err_sor_irka, w=w)\n",
+    "ax.set_title('Bode plot of the SOR-IRKA error system')\n",
     "plt.show()"
    ]
   }

--- a/notebooks/string.ipynb
+++ b/notebooks/string.ipynb
@@ -1,0 +1,709 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "This file is part of the pyMOR project (http://www.pymor.org).\n",
+    "Copyright 2013-2017 pyMOR developers and contributors. All rights reserved.\n",
+    "License: BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# String equation example"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Analytic problem formulation\n",
+    "\n",
+    "We consider a vibrating string on the segment $[0, 1]$, fixed on both sides, with input $u$ and output $\\tilde{y}$ in the middle:\n",
+    "$$\n",
+    "\\begin{align*}\n",
+    "    \\partial_{tt} \\xi(z, t)\n",
+    "    + d \\partial_t \\xi(z, t)\n",
+    "    - k \\partial_{zz} \\xi(z, t)\n",
+    "    & = \\delta(z - \\tfrac{1}{2}) u(t), & 0 < z < 1,\\ t > 0, \\\\\n",
+    "    \\partial_z \\xi(0, t) & = 0, & t > 0, \\\\\n",
+    "    \\partial_z \\xi(1, t) & = 0, & t > 0, \\\\\n",
+    "    \\tilde{y}(t) & = \\xi(1/2, t), & t > 0.\n",
+    "\\end{align*}\n",
+    "$$\n",
+    "\n",
+    "## Semidiscretized formulation\n",
+    "\n",
+    "Using the finite volume method on the equidistant mesh $0 = z_1 < z_2 < \\ldots < z_{n + 1} = 1$, where $n = 2 n_2 - 1$, we obtain the semidiscretized formulation:\n",
+    "$$\n",
+    "\\begin{align*}\n",
+    "    \\ddot{x}_i(t)\n",
+    "    + d \\dot{x}_i(t)\n",
+    "    - k \\frac{x_{i - 1}(t) - 2 x_i(t) + x_{i + 1}(t)}{h^2}\n",
+    "    & = \\frac{1}{h} \\delta_{i, n_2} u(t), & i = 1, 2, 3, \\ldots, n - 1, n, \\\\\n",
+    "    x_0(t) & = 0, \\\\\n",
+    "    x_{n + 1}(t) & = 0, \\\\\n",
+    "    y(t) & = x_{n_2}(t),\n",
+    "\\end{align*}\n",
+    "$$\n",
+    "where $h = \\frac{1}{n}$, $x_i(t) \\approx \\int_{z_i}^{z_{i + 1}} \\xi(z, t) \\, \\mathrm{d}z$, and $y(t) \\approx \\tilde{y}(t)$.\n",
+    "\n",
+    "Separating cases $i = 1$ and $i = n$ in the first equation, we find:\n",
+    "$$\n",
+    "\\begin{alignat*}{6}\n",
+    "    \\ddot{x}_1(t)\n",
+    "    + d \\dot{x}_1(t)\n",
+    "    &\n",
+    "    && + 2 k n^2 x_1(t)\n",
+    "    && - k n^2 x_2(t)\n",
+    "    && = 0, \\\\\n",
+    "    \\ddot{x}_i(t)\n",
+    "    + d \\dot{x}_i(t)\n",
+    "    & - k n^2 x_{i - 1}(t)\n",
+    "    && + 2 k n^2 x_i(t)\n",
+    "    && - k n^2 x_{i + 1}(t)\n",
+    "    && = n \\delta_{i, n_2} u(t),\n",
+    "    & i = 2, 3, \\ldots, n - 1, \\\\\n",
+    "    \\ddot{x}_n(t)\n",
+    "    + d \\dot{x}_n(t)\n",
+    "    & - k n^2 x_{n - 1}(t)\n",
+    "    && + 2 k n^2  x_n(t)\n",
+    "    &&\n",
+    "    && = 0, \\\\\n",
+    "    &\n",
+    "    &&\n",
+    "    &&\n",
+    "    & y(t)\n",
+    "    & = x_{n_2}(t).\n",
+    "\\end{alignat*}\n",
+    "$$"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Import modules"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from __future__ import absolute_import, division, print_function\n",
+    "\n",
+    "import numpy as np\n",
+    "import scipy.linalg as spla\n",
+    "import scipy.sparse as sps\n",
+    "import scipy.integrate as spint\n",
+    "import matplotlib.pyplot as plt\n",
+    "%matplotlib inline\n",
+    "\n",
+    "from pymor.discretizations.iosys import SecondOrderSystem\n",
+    "from pymor.reductors.bt import BTReductor\n",
+    "from pymor.reductors.lti import IRKAReductor\n",
+    "from pymor.reductors.sobt import (SOBTpReductor, SOBTvReductor, SOBTpvReductor, SOBTvpReductor,\n",
+    "                                  SOBTfvReductor, SOBTReductor)\n",
+    "\n",
+    "import logging\n",
+    "logging.getLogger('pymor.algorithms.gram_schmidt.gram_schmidt').setLevel(logging.ERROR)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Assemble $M$, $D$, $K$, $B$, $C_p$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "n2 = 50\n",
+    "n = 2 * n2 - 1  # dimension of the system\n",
+    "\n",
+    "d = 10  # damping\n",
+    "k = 1   # stiffness\n",
+    "\n",
+    "M = sps.eye(n, format='csc')\n",
+    "\n",
+    "D = d * sps.eye(n, format='csc')\n",
+    "\n",
+    "K = sps.diags([n * [2 * k * n ** 2],\n",
+    "               (n - 1) * [-k * n ** 2],\n",
+    "               (n - 1) * [-k * n ** 2]],\n",
+    "              [0, -1, 1],\n",
+    "              format='csc')\n",
+    "\n",
+    "B = np.zeros((n, 1))\n",
+    "B[n2 - 1, 0] = n\n",
+    "\n",
+    "Cp = np.zeros((1, n))\n",
+    "Cp[0, n2 - 1] = 1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Second-order system"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "so_sys = SecondOrderSystem.from_matrices(M, D, K, B, Cp)\n",
+    "\n",
+    "print('n = {}'.format(so_sys.n))\n",
+    "print('m = {}'.format(so_sys.m))\n",
+    "print('p = {}'.format(so_sys.p))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "poles = so_sys.poles(force_dense=True)\n",
+    "fig, ax = plt.subplots()\n",
+    "ax.plot(poles.real, poles.imag, '.')\n",
+    "ax.set_title('System poles')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "np.max(poles.real)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "w = np.logspace(-1, 3, 1000)\n",
+    "fig, ax = SecondOrderSystem.mag_plot(so_sys, w=w)\n",
+    "ax.set_title('Bode plot of the full model')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "psv = so_sys.psv()\n",
+    "vsv = so_sys.vsv()\n",
+    "pvsv = so_sys.pvsv()\n",
+    "vpsv = so_sys.vpsv()\n",
+    "fig, ax = plt.subplots(2, 2, figsize=(12, 8), sharey=True)\n",
+    "ax[0, 0].semilogy(range(1, len(psv) + 1), psv, '.-')\n",
+    "ax[0, 0].set_title('Position singular values')\n",
+    "ax[0, 1].semilogy(range(1, len(vsv) + 1), vsv, '.-')\n",
+    "ax[0, 1].set_title('Velocity singular values')\n",
+    "ax[1, 0].semilogy(range(1, len(pvsv) + 1), pvsv, '.-')\n",
+    "ax[1, 0].set_title('Position-velocity singular values')\n",
+    "ax[1, 1].semilogy(range(1, len(vpsv) + 1), vpsv, '.-')\n",
+    "ax[1, 1].set_title('Velocity-position singular values')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print('H_2-norm of the full model:   {}'.format(so_sys.norm()))\n",
+    "print('H_inf-norm of the full model: {}'.format(so_sys.norm('Hinf')))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Position Second-Order Balanced Truncation (SOBTp)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "r = 10\n",
+    "sobtp_reductor = SOBTpReductor(so_sys)\n",
+    "rom_sobtp = sobtp_reductor.reduce(r, projection='bfsr')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "poles_rom_sobtp = rom_sobtp.poles(force_dense=True)\n",
+    "fig, ax = plt.subplots()\n",
+    "ax.plot(poles_rom_sobtp.real, poles_rom_sobtp.imag, '.')\n",
+    "ax.set_title(\"SOBTp reduced model's poles\")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "err_sobtp = so_sys - rom_sobtp\n",
+    "print('H_2-error for the SOBTp ROM:     {}'.format(err_sobtp.norm()))\n",
+    "print('H_inf-error for the SOBTp ROM:   {}'.format(err_sobtp.norm('Hinf')))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = SecondOrderSystem.mag_plot((so_sys, rom_sobtp), w=w)\n",
+    "ax.set_title('Bode plot of the full and SOBTp reduced model')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = SecondOrderSystem.mag_plot(err_sobtp, w=w)\n",
+    "ax.set_title('Bode plot of the SOBTp error system')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Velocity Second-Order Balanced Truncation (SOBTv)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "r = 10\n",
+    "sobtv_reductor = SOBTvReductor(so_sys)\n",
+    "rom_sobtv = sobtv_reductor.reduce(r, projection='bfsr')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "poles_rom_sobtv = rom_sobtv.poles(force_dense=True)\n",
+    "fig, ax = plt.subplots()\n",
+    "ax.plot(poles_rom_sobtv.real, poles_rom_sobtv.imag, '.')\n",
+    "ax.set_title(\"SOBTv reduced model's poles\")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "err_sobtv = so_sys - rom_sobtv\n",
+    "print('H_2-error for the SOBTv ROM:     {}'.format(err_sobtv.norm()))\n",
+    "print('H_inf-error for the SOBTv ROM:   {}'.format(err_sobtv.norm('Hinf')))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = SecondOrderSystem.mag_plot((so_sys, rom_sobtv), w=w)\n",
+    "ax.set_title('Bode plot of the full and SOBTv reduced model')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = SecondOrderSystem.mag_plot(err_sobtv, w=w)\n",
+    "ax.set_title('Bode plot of the SOBTv error system')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Position-Velocity Second-Order Balanced Truncation (SOBTpv)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "r = 10\n",
+    "sobtpv_reductor = SOBTpvReductor(so_sys)\n",
+    "rom_sobtpv = sobtpv_reductor.reduce(r, projection='bfsr')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "poles_rom_sobtpv = rom_sobtpv.poles(force_dense=True)\n",
+    "fig, ax = plt.subplots()\n",
+    "ax.plot(poles_rom_sobtpv.real, poles_rom_sobtpv.imag, '.')\n",
+    "ax.set_title(\"SOBTpv reduced model's poles\")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "err_sobtpv = so_sys - rom_sobtpv\n",
+    "print('H_2-error for the SOBTpv ROM:     {}'.format(err_sobtpv.norm()))\n",
+    "#print('H_inf-error for the SOBTpv ROM:   {}'.format(err_sobtpv.norm('Hinf')))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = SecondOrderSystem.mag_plot((so_sys, rom_sobtpv), w=w)\n",
+    "ax.set_title('Bode plot of the full and SOBTpv reduced model')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = SecondOrderSystem.mag_plot(err_sobtpv, w=w)\n",
+    "ax.set_title('Bode plot of the SOBTpv error system')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Velocity-Position Second-Order Balanced Truncation (SOBTvp)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "r = 10\n",
+    "sobtvp_reductor = SOBTvpReductor(so_sys)\n",
+    "rom_sobtvp = sobtvp_reductor.reduce(r, projection='bfsr')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "poles_rom_sobtvp = rom_sobtvp.poles(force_dense=True)\n",
+    "fig, ax = plt.subplots()\n",
+    "ax.plot(poles_rom_sobtvp.real, poles_rom_sobtvp.imag, '.')\n",
+    "ax.set_title(\"SOBTvp reduced model's poles\")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "err_sobtvp = so_sys - rom_sobtvp\n",
+    "print('H_2-error for the SOBTvp ROM:     {}'.format(err_sobtvp.norm()))\n",
+    "print('H_inf-error for the SOBTvp ROM:   {}'.format(err_sobtvp.norm('Hinf')))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = SecondOrderSystem.mag_plot((so_sys, rom_sobtvp), w=w)\n",
+    "ax.set_title('Bode plot of the full and SOBTvp reduced model')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = SecondOrderSystem.mag_plot(err_sobtvp, w=w)\n",
+    "ax.set_title('Bode plot of the SOBTvp error system')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Free-Velocity Second-Order Balanced Truncation (SOBTfv)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "r = 10\n",
+    "sobtfv_reductor = SOBTfvReductor(so_sys)\n",
+    "rom_sobtfv = sobtfv_reductor.reduce(r, projection='sr')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "poles_rom_sobtfv = rom_sobtfv.poles(force_dense=True)\n",
+    "fig, ax = plt.subplots()\n",
+    "ax.plot(poles_rom_sobtfv.real, poles_rom_sobtfv.imag, '.')\n",
+    "ax.set_title(\"SOBTfv reduced model's poles\")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "err_sobtfv = so_sys - rom_sobtfv\n",
+    "print('H_2-error for the SOBTfv ROM:     {}'.format(err_sobtfv.norm()))\n",
+    "print('H_inf-error for the SOBTfv ROM:   {}'.format(err_sobtfv.norm('Hinf')))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = SecondOrderSystem.mag_plot((so_sys, rom_sobtfv), w=w)\n",
+    "ax.set_title('Bode plot of the full and SOBTfv reduced model')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = SecondOrderSystem.mag_plot(err_sobtfv, w=w)\n",
+    "ax.set_title('Bode plot of the SOBTfv error system')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Second-Order Balanced Truncation (SOBT)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "r = 10\n",
+    "sobt_reductor = SOBTReductor(so_sys)\n",
+    "rom_sobt = sobt_reductor.reduce(r, projection='bfsr')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "poles_rom_sobt = rom_sobt.poles(force_dense=True)\n",
+    "fig, ax = plt.subplots()\n",
+    "ax.plot(poles_rom_sobt.real, poles_rom_sobt.imag, '.')\n",
+    "ax.set_title(\"SOBT reduced model's poles\")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "err_sobt = so_sys - rom_sobt\n",
+    "print('H_2-error for the SOBT ROM:     {}'.format(err_sobt.norm()))\n",
+    "print('H_inf-error for the SOBT ROM:   {}'.format(err_sobt.norm('Hinf')))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = SecondOrderSystem.mag_plot((so_sys, rom_sobt), w=w)\n",
+    "ax.set_title('Bode plot of the full and SOBT reduced model')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = SecondOrderSystem.mag_plot(err_sobt, w=w)\n",
+    "ax.set_title('Bode plot of the SOBT error system')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Balanced Truncation (BT)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "r = 10\n",
+    "bt_reductor = BTReductor(so_sys.to_lti())\n",
+    "rom_bt = bt_reductor.reduce(r, projection='bfsr')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "poles_rom_bt = rom_bt.poles(force_dense=True)\n",
+    "fig, ax = plt.subplots()\n",
+    "ax.plot(poles_rom_bt.real, poles_rom_bt.imag, '.')\n",
+    "ax.set_title(\"BT reduced model's poles\")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "err_bt = so_sys.to_lti() - rom_bt\n",
+    "print('H_2-error for the BT ROM:     {}'.format(err_bt.norm()))\n",
+    "print('H_inf-error for the BT ROM:   {}'.format(err_bt.norm('Hinf')))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = SecondOrderSystem.mag_plot((so_sys, rom_bt), w=w)\n",
+    "ax.set_title('Bode plot of the full and BT reduced model')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = SecondOrderSystem.mag_plot(err_bt, w=w)\n",
+    "ax.set_title('Bode plot of the BT error system')\n",
+    "plt.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}

--- a/src/pymor/discretizations/iosys.py
+++ b/src/pymor/discretizations/iosys.py
@@ -246,11 +246,21 @@ class LTISystem(InputOutputSystem):
         D = D or ZeroOperator(C.range, B.source)
         E = E or IdentityOperator(A.source)
 
-        assert A.linear and A.source == A.range and A.source.id == 'STATE'
-        assert B.linear and B.range == A.source and B.source.id == 'INPUT'
-        assert C.linear and C.source == A.range and C.range.id == 'OUTPUT'
-        assert D.linear and D.source == B.source and D.range == C.range
-        assert E.linear and E.source == E.range == A.source
+        assert A.linear
+        assert A.source == A.range
+        assert A.source.id == 'STATE'
+        assert B.linear
+        assert B.range == A.source
+        assert B.source.id == 'INPUT'
+        assert C.linear
+        assert C.source == A.range
+        assert C.range.id == 'OUTPUT'
+        assert D.linear
+        assert D.source == B.source
+        assert D.range == C.range
+        assert E.linear
+        assert E.source == E.range
+        assert E.source == A.source
         assert cont_time in (True, False)
         assert solver_options is None or solver_options.keys() <= {'lyap', 'ricc'}
 

--- a/src/pymor/discretizations/iosys.py
+++ b/src/pymor/discretizations/iosys.py
@@ -15,7 +15,7 @@ from pymor.core.cache import cached
 from pymor.core.config import config
 from pymor.core.defaults import defaults
 from pymor.discretizations.basic import DiscretizationBase
-from pymor.operators.block import BlockOperator, BlockDiagonalOperator
+from pymor.operators.block import BlockOperator, BlockDiagonalOperator, SecondOrderOperator
 from pymor.operators.constructions import Concatenation, IdentityOperator, LincombOperator, ZeroOperator
 from pymor.operators.numpy import NumpyMatrixOperator
 
@@ -901,10 +901,7 @@ class SecondOrderSystem(InputOutputSystem):
         lti
             |LTISystem| equivalent to the second order system.
         """
-        return LTISystem(A=BlockOperator([[None, IdentityOperator(self.M.source)],
-                                          [self.K * (-1), self.D * (-1)]],
-                                         source_id='STATE',
-                                         range_id='STATE'),
+        return LTISystem(A=SecondOrderOperator(self.D, self.K),
                          B=BlockOperator.vstack((ZeroOperator(self.B.range, self.B.source),
                                                  self.B),
                                                 source_id='INPUT',

--- a/src/pymor/discretizations/iosys.py
+++ b/src/pymor/discretizations/iosys.py
@@ -1048,6 +1048,42 @@ class SecondOrderSystem(InputOutputSystem):
         else:
             raise NotImplementedError("Only 'pcf', 'vcf', 'pof', and 'vof' types are possible.")
 
+    def psv(self):
+        """Position singular values.
+
+        Returns
+        -------
+        One-dimensional |NumPy array| of singular values.
+        """
+        return spla.svdvals(self.gramian('pof').inner(self.gramian('pcf')))
+
+    def vsv(self):
+        """Velocity singular values.
+
+        Returns
+        -------
+        One-dimensional |NumPy array| of singular values.
+        """
+        return spla.svdvals(self.gramian('vof').inner(self.gramian('vcf'), product=self.M))
+
+    def pvsv(self):
+        """Position-velocity singular values.
+
+        Returns
+        -------
+        One-dimensional |NumPy array| of singular values.
+        """
+        return spla.svdvals(self.gramian('vof').inner(self.gramian('pcf'), product=self.M))
+
+    def vpsv(self):
+        """Velocity-position singular values.
+
+        Returns
+        -------
+        One-dimensional |NumPy array| of singular values.
+        """
+        return spla.svdvals(self.gramian('pof').inner(self.gramian('vcf')))
+
     @cached
     def norm(self, name='H2'):
         """Compute a system norm."""

--- a/src/pymor/discretizations/iosys.py
+++ b/src/pymor/discretizations/iosys.py
@@ -15,7 +15,7 @@ from pymor.core.cache import cached
 from pymor.core.config import config
 from pymor.core.defaults import defaults
 from pymor.discretizations.basic import DiscretizationBase
-from pymor.operators.block import BlockOperator, BlockDiagonalOperator, SecondOrderOperator
+from pymor.operators.block import BlockOperator, BlockDiagonalOperator, SecondOrderSystemOperator
 from pymor.operators.constructions import Concatenation, IdentityOperator, LincombOperator, ZeroOperator
 from pymor.operators.numpy import NumpyMatrixOperator
 
@@ -911,7 +911,7 @@ class SecondOrderSystem(InputOutputSystem):
         lti
             |LTISystem| equivalent to the second order system.
         """
-        return LTISystem(A=SecondOrderOperator(self.D, self.K),
+        return LTISystem(A=SecondOrderSystemOperator(self.D, self.K),
                          B=BlockOperator.vstack((ZeroOperator(self.B.range, self.B.source),
                                                  self.B),
                                                 source_id='INPUT',

--- a/src/pymor/discretizations/iosys.py
+++ b/src/pymor/discretizations/iosys.py
@@ -925,6 +925,17 @@ class SecondOrderSystem(InputOutputSystem):
                          cont_time=self.cont_time, cache_region=self.cache_region, solver_options=self.solver_options,
                          estimator=None, visualizer=None, name=self.name + '_first_order')
 
+    @cached
+    def poles(self, force_dense=False):
+        """Compute system poles.
+
+        Parameters
+        ----------
+        force_dense
+            Should `to_matrix` with `format='dense'` be used.
+        """
+        return self.to_lti().poles(force_dense=force_dense)
+
     def eval_tf(self, s):
         """Evaluate the transfer function.
 

--- a/src/pymor/operators/block.py
+++ b/src/pymor/operators/block.py
@@ -227,8 +227,8 @@ class BlockDiagonalOperator(BlockOperator):
     def assemble_lincomb(self, operators, coefficients, solver_options=None, name=None):
         assert operators[0] is self
 
-        # return ShiftedSecondOrderOperator if possible
-        if len(operators) == 2 and isinstance(operators[1], SecondOrderOperator):
+        # return ShiftedSecondOrderSystemOperator if possible
+        if len(operators) == 2 and isinstance(operators[1], SecondOrderSystemOperator):
             return operators[1].assemble_lincomb(operators[::-1], coefficients[::-1],
                                                  solver_options=solver_options, name=name)
 
@@ -255,7 +255,7 @@ class BlockDiagonalOperator(BlockOperator):
             return self.__class__(blocks)
 
 
-class SecondOrderOperator(BlockOperator):
+class SecondOrderSystemOperator(BlockOperator):
     """BlockOperator appearing in SecondOrderSystem.to_lti().
 
     This represents a block operator
@@ -340,11 +340,11 @@ class SecondOrderOperator(BlockOperator):
     def assemble_lincomb(self, operators, coefficients, solver_options=None, name=None):
         assert operators[0] is self
 
-        # return ShiftedSecondOrderOperator if possible
+        # return ShiftedSecondOrderSystemOperator if possible
         if (len(operators) == 2 and isinstance(operators[1], BlockDiagonalOperator) and
                 operators[1].num_source_blocks == 2 and operators[1].num_range_blocks == 2 and
                 isinstance(operators[1]._blocks[0, 0], IdentityOperator)):
-            return ShiftedSecondOrderOperator(operators[1]._blocks[1, 1],
+            return ShiftedSecondOrderSystemOperator(operators[1]._blocks[1, 1],
                                               self.D,
                                               self.K,
                                               coefficients[1],
@@ -369,7 +369,7 @@ class SecondOrderOperator(BlockOperator):
             return BlockOperator(blocks)
 
 
-class ShiftedSecondOrderOperator(BlockOperator):
+class ShiftedSecondOrderSystemOperator(BlockOperator):
     """BlockOperator appearing in second-order systems.
 
     This represents a block operator

--- a/src/pymor/operators/block.py
+++ b/src/pymor/operators/block.py
@@ -447,7 +447,8 @@ class ShiftedSecondOrderSystemOperator(BlockOperator):
         assert V in self.range
         aMmbDV0 = self.M.apply(V.block(0), mu=mu) * self.a - self.D.apply(V.block(0), mu=mu) * self.b
         KV0 = self.K.apply(V.block(0), mu=mu)
-        a2MmabDpb2K = LincombOperator([self.M, self.D, self.K], [self.a ** 2, -self.a * self.b, self.b ** 2])
+        a2MmabDpb2K = LincombOperator([self.M, self.D, self.K],
+                                      [self.a ** 2, -self.a * self.b, self.b ** 2]).assemble(mu=mu)
         a2MmabDpb2KiV1 = a2MmabDpb2K.apply_inverse(V.block(1), mu=mu, least_squares=least_squares)
         U_blocks = [a2MmabDpb2K.apply_inverse(aMmbDV0, mu=mu, least_squares=least_squares) -
                     a2MmabDpb2KiV1 * self.b,
@@ -457,7 +458,8 @@ class ShiftedSecondOrderSystemOperator(BlockOperator):
 
     def apply_inverse_transpose(self, U, mu=None, least_squares=False):
         assert U in self.source
-        a2MmabDpb2K = LincombOperator([self.M, self.D, self.K], [self.a ** 2, -self.a * self.b, self.b ** 2])
+        a2MmabDpb2K = LincombOperator([self.M, self.D, self.K],
+                                      [self.a ** 2, -self.a * self.b, self.b ** 2]).assemble(mu=mu)
         a2MmabDpb2KitU0 = a2MmabDpb2K.apply_inverse_transpose(U.block(0), mu=mu, least_squares=least_squares)
         a2MmabDpb2KitU1 = a2MmabDpb2K.apply_inverse_transpose(U.block(1), mu=mu, least_squares=least_squares)
         V_blocks = [self.M.apply_transpose(a2MmabDpb2KitU0, mu=mu) * self.a -

--- a/src/pymor/operators/block.py
+++ b/src/pymor/operators/block.py
@@ -228,13 +228,9 @@ class BlockDiagonalOperator(BlockOperator):
         assert operators[0] is self
 
         # return ShiftedSecondOrderOperator if possible
-        if (len(operators) == 2 and self.num_source_blocks == 2 and self.num_range_blocks == 2 and
-                isinstance(self._blocks[0, 0], IdentityOperator) and isinstance(operators[1], SecondOrderOperator)):
-            return ShiftedSecondOrderOperator(self._blocks[1, 1],
-                                              operators[1].D,
-                                              operators[1].K,
-                                              coefficients[0],
-                                              coefficients[1])
+        if len(operators) == 2 and isinstance(operators[1], SecondOrderOperator):
+            return operators[1].assemble_lincomb(operators[::-1], coefficients[::-1],
+                                                 solver_options=solver_options, name=name)
 
         # return BlockOperator if not all operators are BlockDiagonalOperators
         if not all(isinstance(op, self.__class__) for op in operators):

--- a/src/pymor/operators/block.py
+++ b/src/pymor/operators/block.py
@@ -433,30 +433,30 @@ class ShiftedSecondOrderOperator(BlockOperator):
 
     def apply(self, U, mu=None):
         assert U in self.source
-        V_blocks = [self.a * U.block(0) + self.b * U.block(1),
-                    -self.b * self.K.apply(U.block(0), mu=mu) +
-                    self.a * self.M.apply(U.block(1), mu=mu) -
-                    self.b * self.D.apply(U.block(1), mu=mu)]
+        V_blocks = [U.block(0) * self.a + U.block(1) * self.b,
+                    self.K.apply(U.block(0), mu=mu) * (-self.b) +
+                    self.M.apply(U.block(1), mu=mu) * self.a -
+                    self.D.apply(U.block(1), mu=mu) * self.b]
         return self.range.make_array(V_blocks)
 
     def apply_transpose(self, V, mu=None):
         assert V in self.range
-        U_blocks = [self.a * V.block(0) - self.b * self.K.apply_transpose(V.block(1), mu=mu),
-                    self.b * V.block(0) +
-                    self.a * self.M.apply_transpose(V.block(1), mu=mu) -
-                    self.b * self.D.apply_transpose(V.block(1), mu=mu)]
+        U_blocks = [V.block(0) * self.a - self.K.apply_transpose(V.block(1), mu=mu) * self.b,
+                    V.block(0) * self.b +
+                    self.M.apply_transpose(V.block(1), mu=mu) * self.a -
+                    self.D.apply_transpose(V.block(1), mu=mu) * self.b]
         return self.source.make_array(U_blocks)
 
     def apply_inverse(self, V, mu=None, least_squares=False):
         assert V in self.range
-        aMmbDV0 = self.a * self.M.apply(V.block(0), mu=mu) - self.b * self.D.apply(V.block(0), mu=mu)
+        aMmbDV0 = self.M.apply(V.block(0), mu=mu) * self.a - self.D.apply(V.block(0), mu=mu) * self.b
         KV0 = self.K.apply(V.block(0), mu=mu)
         a2MmabDpb2K = LincombOperator([self.M, self.D, self.K], [self.a ** 2, -self.a * self.b, self.b ** 2])
         a2MmabDpb2KiV1 = a2MmabDpb2K.apply_inverse(V.block(1), mu=mu, least_squares=least_squares)
         U_blocks = [a2MmabDpb2K.apply_inverse(aMmbDV0, mu=mu, least_squares=least_squares) -
-                    self.b * a2MmabDpb2KiV1,
-                    self.b * a2MmabDpb2K.apply_inverse(KV0, mu=mu, least_squares=least_squares) +
-                    self.a * a2MmabDpb2KiV1]
+                    a2MmabDpb2KiV1 * self.b,
+                    a2MmabDpb2K.apply_inverse(KV0, mu=mu, least_squares=least_squares) * self.b +
+                    a2MmabDpb2KiV1 * self.a]
         return self.source.make_array(U_blocks)
 
     def apply_inverse_transpose(self, U, mu=None, least_squares=False):
@@ -464,10 +464,10 @@ class ShiftedSecondOrderOperator(BlockOperator):
         a2MmabDpb2K = LincombOperator([self.M, self.D, self.K], [self.a ** 2, -self.a * self.b, self.b ** 2])
         a2MmabDpb2KitU0 = a2MmabDpb2K.apply_inverse_transpose(U.block(0), mu=mu, least_squares=least_squares)
         a2MmabDpb2KitU1 = a2MmabDpb2K.apply_inverse_transpose(U.block(1), mu=mu, least_squares=least_squares)
-        V_blocks = [self.a * self.M.apply_transpose(a2MmabDpb2KitU0, mu=mu) -
-                    self.b * self.D.apply_transpose(a2MmabDpb2KitU0, mu=mu) +
-                    self.b * self.K.apply_transpose(a2MmabDpb2KitU1, mu=mu),
-                    -self.b * a2MmabDpb2KitU0 + self.a * a2MmabDpb2KitU1]
+        V_blocks = [self.M.apply_transpose(a2MmabDpb2KitU0, mu=mu) * self.a -
+                    self.D.apply_transpose(a2MmabDpb2KitU0, mu=mu) * self.b +
+                    self.K.apply_transpose(a2MmabDpb2KitU1, mu=mu) * self.b,
+                    -a2MmabDpb2KitU0 * self.b + a2MmabDpb2KitU1 * self.a]
         return self.range.make_array(V_blocks)
 
     def assemble(self, mu=None):

--- a/src/pymor/operators/block.py
+++ b/src/pymor/operators/block.py
@@ -6,7 +6,7 @@
 import numpy as np
 
 from pymor.operators.basic import OperatorBase
-from pymor.operators.constructions import ZeroOperator
+from pymor.operators.constructions import LincombOperator, IdentityOperator, ZeroOperator
 from pymor.operators.interfaces import OperatorInterface
 from pymor.vectorarrays.block import BlockVectorSpace
 
@@ -225,10 +225,19 @@ class BlockDiagonalOperator(BlockOperator):
             return self.__class__(blocks)
 
     def assemble_lincomb(self, operators, coefficients, solver_options=None, name=None):
+        assert operators[0] is self
+
+        # return ShiftedSecondOrderOperator if possible
+        if (len(operators) == 2 and self.num_source_blocks == 2 and self.num_range_blocks == 2 and
+                isinstance(self._blocks[0, 0], IdentityOperator) and isinstance(operators[1], SecondOrderOperator) and
+                coefficients[1] == 1):
+            return ShiftedSecondOrderOperator(self._blocks[1, 1], operators[1].D, operators[1].K, coefficients[0])
+
+        # return BlockOperator if not all operators are BlockDiagonalOperators
         if not all(isinstance(op, self.__class__) for op in operators):
             return super().assemble_lincomb(operators, coefficients, solver_options=solver_options, name=name)
 
-        assert operators[0] is self
+        # return BlockDiagonalOperator
         blocks = np.empty((self.num_source_blocks,), dtype=object)
         if len(operators) > 1:
             for i in range(self.num_source_blocks):
@@ -245,3 +254,224 @@ class BlockDiagonalOperator(BlockOperator):
             for i in range(self.num_source_blocks):
                 blocks[i] = self._blocks[i, i] * c
             return self.__class__(blocks)
+
+
+class SecondOrderOperator(BlockOperator):
+    """BlockOperator appearing in SecondOrderSystem.to_lti().
+
+    This represents a block operator
+
+    .. math::
+        \mathcal{A} =
+        \begin{bmatrix}
+            0 & I \\
+            -K & -D
+        \end{bmatrix},
+
+    which satisfies
+
+    .. math::
+        \mathcal{A}^T &=
+        \begin{bmatrix}
+            0 & -K^T \\
+            I & -D^T
+        \end{bmatrix}, \\
+        \mathcal{A}^{-1} &=
+        \begin{bmatrix}
+            -K^{-1} D & -K^{-1} \\
+            I & 0
+        \end{bmatrix}, \\
+        \mathcal{A}^{-T} &=
+        \begin{bmatrix}
+            -D^T K^{-T} & I \\
+            -K^{-T} & 0
+        \end{bmatrix}.
+
+    Parameters
+    ----------
+    D
+        |Operator|.
+    K
+        |Operator|.
+    """
+
+    def __init__(self, D, K):
+        super().__init__([[None, IdentityOperator(D.source)],
+                          [K * (-1), D * (-1)]])
+        self.D = D
+        self.K = K
+
+    def apply(self, U, mu=None):
+        assert U in self.source
+        V_blocks = [U.block(1),
+                    -self.K.apply(U.block(0), mu=mu) - self.D.apply(U.block(1), mu=mu)]
+        return self.range.make_array(V_blocks)
+
+    def apply_transpose(self, V, mu=None):
+        assert V in self.range
+        U_blocks = [-self.K.apply_transpose(V.block(1), mu=mu),
+                    V.block(0) - self.D.apply_transpose(V.block(1), mu=mu)]
+        return self.source.make_array(U_blocks)
+
+    def apply_inverse(self, V, mu=None, least_squares=False):
+        assert V in self.range
+        U_blocks = [-self.K.apply_inverse(self.D.apply(V.block(0), mu=mu) + V.block(1), mu=mu,
+                                          least_squares=least_squares),
+                    V.block(0)]
+        return self.source.make_array(U_blocks)
+
+    def apply_inverse_transpose(self, U, mu=None, least_squares=False):
+        assert U in self.source
+        KitU0 = self.K.apply_inverse_transpose(U.block(0), mu=mu, least_squares=least_squares)
+        V_blocks = [-self.D.apply_transpose(KitU0, mu=mu) + U.block(1),
+                    -KitU0]
+        return self.range.make_array(V_blocks)
+
+    def assemble(self, mu=None):
+        D = self.D.assemble(mu)
+        K = self.K.assemble(mu)
+        if D == self.D and K == self.K:
+            return self
+        else:
+            return self.__class__(D, K)
+
+    def assemble_lincomb(self, operators, coefficients, solver_options=None, name=None):
+        assert operators[0] is self
+
+        # return ShiftedSecondOrderOperator if possible
+        if (len(operators) == 2 and isinstance(operators[1], BlockDiagonalOperator) and
+                operators[1].num_source_blocks == 2 and operators[1].num_range_blocks == 2 and
+                isinstance(operators[1]._blocks[0, 0], IdentityOperator) and coefficients[0] == 1):
+            return ShiftedSecondOrderOperator(operators[1]._blocks[1, 1], self.D, self.K, coefficients[1])
+
+        # return BlockOperator
+        blocks = np.empty(self._blocks.shape, dtype=object)
+        if len(operators) > 1:
+            for (i, j) in np.ndindex(self._blocks.shape):
+                operators_ij = [op._blocks[i, j] for op in operators]
+                blocks[i, j] = operators_ij[0].assemble_lincomb(operators_ij, coefficients,
+                                                                solver_options=solver_options, name=name)
+                if blocks[i, j] is None:
+                    return None
+            return BlockOperator(blocks)
+        else:
+            c = coefficients[0]
+            if c == 1:
+                return self
+            for (i, j) in np.ndindex(self._blocks.shape):
+                blocks[i, j] = self._blocks[i, j] * c
+            return BlockOperator(blocks)
+
+
+class ShiftedSecondOrderOperator(BlockOperator):
+    """BlockOperator appearing in second-order Lyapunov equation.
+
+    This represents a block operator
+
+    .. math::
+        \mathcal{A} + p \mathcal{E} =
+        \begin{bmatrix}
+            p I & I \\
+            -K & p M - D
+        \end{bmatrix},
+
+    which satisfies
+
+    .. math::
+        (\mathcal{A} + p \mathcal{E})^T &=
+        \begin{bmatrix}
+            p I & -K^T \\
+            I & p M^T - D^T
+        \end{bmatrix}, \\
+        (\mathcal{A} + p \mathcal{E})^{-1} &=
+        \begin{bmatrix}
+            (p^2 M - p D + K)^{-1} (p M - D) & -(p^2 M - p D + K)^{-1} \\
+            (p^2 M - p D + K)^{-1} K & p (p^2 M - p D + K)^{-1}
+        \end{bmatrix}, \\
+        (\mathcal{A} + p \mathcal{E})^{-T} &=
+        \begin{bmatrix}
+            (p M - D)^T (p^2 M - p D + K)^{-T} & K^T (p^2 M - p D + K)^{-T} \\
+            -(p^2 M - p D + K)^{-T} & p (p^2 M - p D + K)^{-T}
+        \end{bmatrix}.
+
+    Parameters
+    ----------
+    M
+        |Operator|.
+    D
+        |Operator|.
+    K
+        |Operator|.
+    p
+        Complex number.
+    """
+
+    def __init__(self, M, D, K, p):
+        super().__init__([[IdentityOperator(M.source) * p, IdentityOperator(M.source)],
+                          [K * (-1), LincombOperator([M, D], [p, -1])]])
+        self.M = M
+        self.D = D
+        self.K = K
+        self.p = p
+
+    def apply(self, U, mu=None):
+        assert U in self.source
+        V_blocks = [self.p * U.block(0) + U.block(1),
+                    -self.K.apply(U.block(0), mu=mu) + self.p * self.M.apply(U.block(1), mu=mu) -
+                    self.D.apply(U.block(1), mu=mu)]
+        return self.range.make_array(V_blocks)
+
+    def apply_transpose(self, V, mu=None):
+        assert V in self.range
+        U_blocks = [self.p * V.block(0) - self.K.apply_transpose(V.block(1), mu=mu),
+                    V.block(0) + self.p * self.M.apply_transpose(V.block(1), mu=mu) -
+                    self.D.apply_transpose(V.block(1), mu=mu)]
+        return self.source.make_array(U_blocks)
+
+    def apply_inverse(self, V, mu=None, least_squares=False):
+        assert V in self.range
+        pMmDV0 = self.p * self.M.apply(V.block(0), mu=mu) - self.D.apply(V.block(0), mu=mu)
+        KV0 = self.K.apply(V.block(0), mu=mu)
+        p2MmpDK = LincombOperator([self.M, self.D, self.K], [self.p ** 2, -self.p, 1])
+        p2MmpDKiV1 = p2MmpDK.apply_inverse(V.block(1), mu=mu, least_squares=least_squares)
+        U_blocks = [p2MmpDK.apply_inverse(pMmDV0, mu=mu, least_squares=least_squares) - p2MmpDKiV1,
+                    p2MmpDK.apply_inverse(KV0, mu=mu, least_squares=least_squares) + self.p * p2MmpDKiV1]
+        return self.source.make_array(U_blocks)
+
+    def apply_inverse_transpose(self, U, mu=None, least_squares=False):
+        assert U in self.source
+        p2MmpDK = LincombOperator([self.M, self.D, self.K], [self.p ** 2, -self.p, 1])
+        p2MmpDKitU0 = p2MmpDK.apply_inverse_transpose(U.block(0), mu=mu, least_squares=least_squares)
+        p2MmpDKitU1 = p2MmpDK.apply_inverse_transpose(U.block(1), mu=mu, least_squares=least_squares)
+        V_blocks = [self.p * self.M.apply_transpose(p2MmpDKitU0, mu=mu) - self.D.apply_transpose(p2MmpDKitU0, mu=mu) +
+                    self.K.apply_transpose(p2MmpDKitU1, mu=mu),
+                    -p2MmpDKitU0 + self.p * p2MmpDKitU1]
+        return self.range.make_array(V_blocks)
+
+    def assemble(self, mu=None):
+        M = self.M.assemble(mu)
+        D = self.D.assemble(mu)
+        K = self.K.assemble(mu)
+        if M == self.M and D == self.D and K == self.K:
+            return self
+        else:
+            return self.__class__(M, D, K, self.p)
+
+    def assemble_lincomb(self, operators, coefficients, solver_options=None, name=None):
+        assert operators[0] is self
+        blocks = np.empty(self._blocks.shape, dtype=object)
+        if len(operators) > 1:
+            for (i, j) in np.ndindex(self._blocks.shape):
+                operators_ij = [op._blocks[i, j] for op in operators]
+                blocks[i, j] = operators_ij[0].assemble_lincomb(operators_ij, coefficients,
+                                                                solver_options=solver_options, name=name)
+                if blocks[i, j] is None:
+                    return None
+            return BlockOperator(blocks)
+        else:
+            c = coefficients[0]
+            if c == 1:
+                return self
+            for (i, j) in np.ndindex(self._blocks.shape):
+                blocks[i, j] = self._blocks[i, j] * c
+            return BlockOperator(blocks)

--- a/src/pymor/reductors/interpolation.py
+++ b/src/pymor/reductors/interpolation.py
@@ -6,6 +6,7 @@ import numpy as np
 
 from pymor.algorithms.arnoldi import arnoldi
 from pymor.algorithms.gram_schmidt import gram_schmidt, gram_schmidt_biorth
+from pymor.discretizations.iosys import LTISystem, SecondOrderSystem, LinearDelaySystem
 from pymor.operators.constructions import LincombOperator
 from pymor.reductors.basic import GenericPGReductor
 
@@ -129,6 +130,7 @@ class LTI_BHIReductor(GenericBHIReductor):
         |LTISystem|.
     """
     def __init__(self, d):
+        assert isinstance(d, LTISystem)
         self.d = d
         self._B_source = d.B.source
         self._C_range = d.C.range
@@ -229,9 +231,10 @@ class SO_BHIReductor(GenericBHIReductor):
         :class:`~pymor.discretizations.iosys.SecondOrderSystem`.
     """
     def __init__(self, d):
+        assert isinstance(d, SecondOrderSystem)
         self.d = d
         self._B_source = d.B.source
-        self._C_range = d.C.range
+        self._C_range = d.Cp.range
         self._K_source = d.K.source
         self._product = d.M
         self._biorthogonal_product = 'M'
@@ -240,7 +243,9 @@ class SO_BHIReductor(GenericBHIReductor):
         return self.d.B.apply(V)
 
     def _C_apply_transpose(self, s, V):
-        return self.d.C.apply_transpose(V)
+        x = self.d.Cp.apply_transpose(V)
+        y = self.d.Cv.apply_transpose(V)
+        return x + y * s
 
     def _K_apply_inverse(self, s, V):
         s2MpsDpK = LincombOperator((self.d.M, self.d.D, self.d.K), (s ** 2, s, 1))
@@ -260,6 +265,7 @@ class DelayBHIReductor(GenericBHIReductor):
         :class:`~pymor.discretizations.iosys.LinearDelaySystem`.
     """
     def __init__(self, d):
+        assert isinstance(d, LinearDelaySystem)
         self.d = d
         self._B_source = d.B.source
         self._C_range = d.C.range

--- a/src/pymor/reductors/interpolation.py
+++ b/src/pymor/reductors/interpolation.py
@@ -34,7 +34,7 @@ class GenericBHIReductor(GenericPGReductor):
         self._C_range = None
         self._K_source = None
         self._product = None
-        self._use_default = None
+        self._biorthogonal_product = None
 
     def _B_apply(self, s, V):
         raise NotImplementedError()
@@ -108,10 +108,10 @@ class GenericBHIReductor(GenericPGReductor):
         if projection == 'orth':
             self.V = gram_schmidt(self.V, atol=0, rtol=0)
             self.W = gram_schmidt(self.W, atol=0, rtol=0)
-            self.use_default = None
+            self.biorthogonal_product = None
         elif projection == 'biorth':
             self.V, self.W = gram_schmidt_biorth(self.V, self.W, product=self._product)
-            self.use_default = self._use_default
+            self.biorthogonal_product = self._biorthogonal_product
 
         rd = super().reduce()
         return rd
@@ -134,7 +134,7 @@ class LTI_BHIReductor(GenericBHIReductor):
         self._C_range = d.C.range
         self._K_source = d.A.source
         self._product = d.E
-        self._use_default = ['E']
+        self._biorthogonal_product = 'E'
 
     def _B_apply(self, s, V):
         return self.d.B.apply(V)
@@ -214,7 +214,7 @@ class LTI_BHIReductor(GenericBHIReductor):
 
         self.V = arnoldi(d.A, d.E, d.B, sigma)
         self.W = arnoldi(d.A, d.E, d.C, sigma, trans=True)
-        self.use_default = None
+        self.biorthogonal_product = None
 
         rd = super(GenericBHIReductor, self).reduce()
         return rd
@@ -234,7 +234,7 @@ class SO_BHIReductor(GenericBHIReductor):
         self._C_range = d.C.range
         self._K_source = d.K.source
         self._product = d.M
-        self._use_default = ['M']
+        self._biorthogonal_product = 'M'
 
     def _B_apply(self, s, V):
         return self.d.B.apply(V)
@@ -265,7 +265,7 @@ class DelayBHIReductor(GenericBHIReductor):
         self._C_range = d.C.range
         self._K_source = d.A.source
         self._product = d.E
-        self._use_default = ['E']
+        self._biorthogonal_product = 'E'
 
     def _B_apply(self, s, V):
         return self.d.B.apply(V)

--- a/src/pymor/reductors/lti.py
+++ b/src/pymor/reductors/lti.py
@@ -348,10 +348,10 @@ class TSIAReductor(GenericPGReductor):
         if projection == 'orth':
             self.V = gram_schmidt(self.V, atol=0, rtol=0)
             self.W = gram_schmidt(self.W, atol=0, rtol=0)
-            self.use_default = None
+            self.biorthogonal_product = None
         elif projection == 'biorth':
             self.V, self.W = gram_schmidt_biorth(self.V, self.W, product=d.E)
-            self.use_default = ['E']
+            self.biorthogonal_product = 'E'
 
         if conv_crit == 'rel_sigma_change':
             sigma_list = (dist_num + 1) * [None]

--- a/src/pymor/reductors/sobt.py
+++ b/src/pymor/reductors/sobt.py
@@ -1,0 +1,544 @@
+# This file is part of the pyMOR project (http://www.pymor.org).
+# Copyright 2013-2017 pyMOR developers and contributors. All rights reserved.
+# License: BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+
+import numpy as np
+import scipy.linalg as spla
+
+from pymor.algorithms.gram_schmidt import gram_schmidt, gram_schmidt_biorth
+from pymor.algorithms.projection import project
+from pymor.discretizations.iosys import SecondOrderSystem
+from pymor.operators.constructions import IdentityOperator
+from pymor.reductors.basic import GenericPGReductor
+from pymor.vectorarrays.numpy import NumpyVectorSpace
+
+
+class SOBTpReductor(GenericPGReductor):
+    """Second-Order Balanced Truncation position reductor.
+
+    .. [RS08] T. Reis and T. Stykel,
+              Balanced truncation model reduction of second-order
+              systems,
+              Math. Comput. Model. Dyn. Syst., 2008, 14(5), 391-406
+
+    Parameters
+    ----------
+    d
+        The system which is to be reduced.
+    """
+    def __init__(self, d):
+        assert isinstance(d, SecondOrderSystem)
+        self.d = d
+        self.V = None
+        self.W = None
+
+    def reduce(self, r, projection='sr'):
+        """Reduce using SOBTp.
+
+        Parameters
+        ----------
+        r
+            Order of the reduced model.
+        projection
+            Projection method used:
+
+                - `'sr'`: square root method (default, since standard in
+                    literature)
+                - `'bfsr'`: balancing-free square root method (avoids
+                    scaling by singular values and orthogonalizes the
+                    projection matrices, which might make it more
+                    accurate than the square root method)
+                - `'biorth'`: like the balancing-free square root
+                    method, except it biorthogonalizes the projection
+                    matrices
+
+        Returns
+        -------
+        rd
+            Reduced system.
+        """
+        assert 0 < r < self.d.n
+        assert projection in ('sr', 'bfsr', 'biorth')
+
+        # compute all necessary Gramian factors
+        pcf = self.d.gramian('pcf')
+        pof = self.d.gramian('pof')
+        vcf = self.d.gramian('vcf')
+        vof = self.d.gramian('vof')
+
+        if r > min([len(pcf), len(pof), len(vcf), len(vof)]):
+            raise ValueError('r needs to be smaller than the sizes of Gramian factors.'
+                             ' Try reducing the tolerance in the low-rank matrix equation solver.')
+
+        # find necessary SVDs
+        _, sp, Vp = spla.svd(pof.inner(pcf))
+        Uv, _, _ = spla.svd(vof.inner(vcf, product=self.d.M))
+        Uv = Uv.T
+
+        # compute projection matrices and find the reduced model
+        self.V = pcf.lincomb(Vp[:r])
+        self.W = vof.lincomb(Uv[:r])
+        if projection == 'sr':
+            alpha = 1 / np.sqrt(sp[:r])
+            self.V.scal(alpha)
+            self.W.scal(alpha)
+            self.biorthogonal_product = None
+        elif projection == 'bfsr':
+            self.V = gram_schmidt(self.V, atol=0, rtol=0)
+            self.W = gram_schmidt(self.W, atol=0, rtol=0)
+            self.biorthogonal_product = None
+        elif projection == 'biorth':
+            self.V, self.W = gram_schmidt_biorth(self.V, self.W, product=self.d.M)
+            self.biorthogonal_product = 'M'
+
+        rd = super().reduce()
+
+        return rd
+
+    extend_source_basis = None
+    extend_range_basis = None
+
+
+class SOBTvReductor(GenericPGReductor):
+    """Second-Order Balanced Truncation velocity reductor.
+
+    .. [RS08] T. Reis and T. Stykel,
+              Balanced truncation model reduction of second-order
+              systems,
+              Math. Comput. Model. Dyn. Syst., 2008, 14(5), 391-406
+
+    Parameters
+    ----------
+    d
+        The system which is to be reduced.
+    """
+    def __init__(self, d):
+        assert isinstance(d, SecondOrderSystem)
+        self.d = d
+        self.V = None
+        self.W = None
+
+    def reduce(self, r, projection='sr'):
+        """Reduce using SOBTv.
+
+        Parameters
+        ----------
+        r
+            Order of the reduced model.
+        projection
+            Projection method used:
+
+                - `'sr'`: square root method (default, since standard in
+                    literature)
+                - `'bfsr'`: balancing-free square root method (avoids
+                    scaling by singular values and orthogonalizes the
+                    projection matrices, which might make it more
+                    accurate than the square root method)
+                - `'biorth'`: like the balancing-free square root
+                    method, except it biorthogonalizes the projection
+                    matrices
+
+        Returns
+        -------
+        rd
+            Reduced system.
+        """
+        assert 0 < r < self.d.n
+        assert projection in ('sr', 'bfsr', 'biorth')
+
+        # compute all necessary Gramian factors
+        vcf = self.d.gramian('vcf')
+        vof = self.d.gramian('vof')
+
+        if r > min([len(vcf), len(vof)]):
+            raise ValueError('r needs to be smaller than the sizes of Gramian factors.'
+                             ' Try reducing the tolerance in the low-rank matrix equation solver.')
+
+        # find necessary SVDs
+        Uv, sv, Vv = spla.svd(vof.inner(vcf, product=self.d.M))
+        Uv = Uv.T
+
+        # compute projection matrices and find the reduced model
+        self.V = vcf.lincomb(Vv[:r])
+        self.W = vof.lincomb(Uv[:r])
+        if projection == 'sr':
+            alpha = 1 / np.sqrt(sv[:r])
+            self.V.scal(alpha)
+            self.W.scal(alpha)
+            self.biorthogonal_product = 'M'
+        elif projection == 'bfsr':
+            self.V = gram_schmidt(self.V, atol=0, rtol=0)
+            self.W = gram_schmidt(self.W, atol=0, rtol=0)
+            self.biorthogonal_product = None
+        elif projection == 'biorth':
+            self.V, self.W = gram_schmidt_biorth(self.V, self.W, product=self.d.M)
+            self.biorthogonal_product = 'M'
+
+        rd = super().reduce()
+
+        return rd
+
+    extend_source_basis = None
+    extend_range_basis = None
+
+
+class SOBTpvReductor(GenericPGReductor):
+    """Second-Order Balanced Truncation position-velocity reductor.
+
+    .. [RS08] T. Reis and T. Stykel,
+              Balanced truncation model reduction of second-order
+              systems,
+              Math. Comput. Model. Dyn. Syst., 2008, 14(5), 391-406
+
+    Parameters
+    ----------
+    d
+        The system which is to be reduced.
+    """
+    def __init__(self, d):
+        assert isinstance(d, SecondOrderSystem)
+        self.d = d
+        self.V = None
+        self.W = None
+
+    def reduce(self, r, projection='sr'):
+        """Reduce using SOBTpv.
+
+        Parameters
+        ----------
+        r
+            Order of the reduced model.
+        projection
+            Projection method used:
+
+                - `'sr'`: square root method (default, since standard in
+                    literature)
+                - `'bfsr'`: balancing-free square root method (avoids
+                    scaling by singular values and orthogonalizes the
+                    projection matrices, which might make it more
+                    accurate than the square root method)
+                - `'biorth'`: like the balancing-free square root
+                    method, except it biorthogonalizes the projection
+                    matrices
+
+        Returns
+        -------
+        rd
+            Reduced system.
+        """
+        assert 0 < r < self.d.n
+        assert projection in ('sr', 'bfsr', 'biorth')
+
+        # compute all necessary Gramian factors
+        pcf = self.d.gramian('pcf')
+        vof = self.d.gramian('vof')
+
+        if r > min([len(pcf), len(vof)]):
+            raise ValueError('r needs to be smaller than the sizes of Gramian factors.'
+                             ' Try reducing the tolerance in the low-rank matrix equation solver.')
+
+        # find necessary SVDs
+        Upv, spv, Vpv = spla.svd(vof.inner(pcf, product=self.d.M))
+        Upv = Upv.T
+
+        # compute projection matrices and find the reduced model
+        self.V = pcf.lincomb(Vpv[:r])
+        self.W = vof.lincomb(Upv[:r])
+        if projection == 'sr':
+            alpha = 1 / np.sqrt(spv[:r])
+            self.V.scal(alpha)
+            self.W.scal(alpha)
+            self.biorthogonal_product = 'M'
+        elif projection == 'bfsr':
+            self.V = gram_schmidt(self.V, atol=0, rtol=0)
+            self.W = gram_schmidt(self.W, atol=0, rtol=0)
+            self.biorthogonal_product = None
+        elif projection == 'biorth':
+            self.V, self.W = gram_schmidt_biorth(self.V, self.W, product=self.d.M)
+            self.biorthogonal_product = 'M'
+
+        rd = super().reduce()
+
+        return rd
+
+    extend_source_basis = None
+    extend_range_basis = None
+
+
+class SOBTvpReductor(GenericPGReductor):
+    """Second-Order Balanced Truncation velocity-position reductor.
+
+    .. [RS08] T. Reis and T. Stykel,
+              Balanced truncation model reduction of second-order
+              systems,
+              Math. Comput. Model. Dyn. Syst., 2008, 14(5), 391-406
+
+    Parameters
+    ----------
+    d
+        The system which is to be reduced.
+    """
+    def __init__(self, d):
+        assert isinstance(d, SecondOrderSystem)
+        self.d = d
+        self.V = None
+        self.W = None
+
+    def reduce(self, r, projection='sr'):
+        """Reduce using SOBTvp.
+
+        Parameters
+        ----------
+        r
+            Order of the reduced model.
+        projection
+            Projection method used:
+
+                - `'sr'`: square root method (default, since standard in
+                    literature)
+                - `'bfsr'`: balancing-free square root method (avoids
+                    scaling by singular values and orthogonalizes the
+                    projection matrices, which might make it more
+                    accurate than the square root method)
+                - `'biorth'`: like the balancing-free square root
+                    method, except it biorthogonalizes the projection
+                    matrices
+
+        Returns
+        -------
+        rd
+            Reduced system.
+        """
+        assert 0 < r < self.d.n
+        assert projection in ('sr', 'bfsr', 'biorth')
+
+        # compute all necessary Gramian factors
+        pof = self.d.gramian('pof')
+        vcf = self.d.gramian('vcf')
+        vof = self.d.gramian('vof')
+
+        if r > min([len(pof), len(vcf), len(vof)]):
+            raise ValueError('r needs to be smaller than the sizes of Gramian factors.'
+                             ' Try reducing the tolerance in the low-rank matrix equation solver.')
+
+        # find necessary SVDs
+        Uv, _, _ = spla.svd(vof.inner(vcf, product=self.d.M))
+        Uv = Uv.T
+        _, svp, Vvp = spla.svd(pof.inner(vcf))
+
+        # compute projection matrices and find the reduced model
+        self.V = vcf.lincomb(Vvp[:r])
+        self.W = vof.lincomb(Uv[:r])
+        if projection == 'sr':
+            alpha = 1 / np.sqrt(svp[:r])
+            self.V.scal(alpha)
+            self.W.scal(alpha)
+            self.biorthogonal_product = None
+        elif projection == 'bfsr':
+            self.V = gram_schmidt(self.V, atol=0, rtol=0)
+            self.W = gram_schmidt(self.W, atol=0, rtol=0)
+            self.biorthogonal_product = None
+        elif projection == 'biorth':
+            self.V, self.W = gram_schmidt_biorth(self.V, self.W, product=self.d.M)
+            self.biorthogonal_product = 'M'
+
+        rd = super().reduce()
+
+        return rd
+
+    extend_source_basis = None
+    extend_range_basis = None
+
+
+class SOBTfvReductor(GenericPGReductor):
+    """Free-velocity Second-Order Balanced Truncation reductor.
+
+    .. [MS96] D. G. Meyer and S. Srinivasan,
+              Balancing and model reduction for second-order form linear
+              systems,
+              IEEE Trans. Automat. Control, 1996, 41, 1632–1644
+
+    Parameters
+    ----------
+    d
+        The system which is to be reduced.
+    """
+    def __init__(self, d):
+        assert isinstance(d, SecondOrderSystem)
+        self.d = d
+        self.V = None
+        self.W = None
+
+    def reduce(self, r, projection='sr'):
+        """Reduce using SOBTfv.
+
+        Parameters
+        ----------
+        r
+            Order of the reduced model.
+        projection
+            Projection method used:
+
+                - `'sr'`: square root method (default, since standard in
+                    literature)
+                - `'bfsr'`: balancing-free square root method (avoids
+                    scaling by singular values and orthogonalizes the
+                    projection matrices, which might make it more
+                    accurate than the square root method)
+                - `'biorth'`: like the balancing-free square root
+                    method, except it biorthogonalizes the projection
+                    matrices
+
+        Returns
+        -------
+        rd
+            Reduced system.
+        """
+        assert 0 < r < self.d.n
+        assert projection in ('sr', 'bfsr', 'biorth')
+
+        # compute all necessary Gramian factors
+        pcf = self.d.gramian('pcf')
+        pof = self.d.gramian('pof')
+
+        if r > min([len(pcf), len(pof)]):
+            raise ValueError('r needs to be smaller than the sizes of Gramian factors.'
+                             ' Try reducing the tolerance in the low-rank matrix equation solver.')
+
+        # find necessary SVDs
+        _, sp, Vp = spla.svd(pof.inner(pcf))
+
+        # compute projection matrices and find the reduced model
+        self.V = pcf.lincomb(Vp[:r])
+        if projection == 'sr':
+            alpha = 1 / np.sqrt(sp[:r])
+            self.V.scal(alpha)
+            self.biorthogonal_product = None
+        elif projection == 'bfsr':
+            self.V = gram_schmidt(self.V, atol=0, rtol=0)
+            self.biorthogonal_product = None
+        elif projection == 'biorth':
+            self.V = gram_schmidt(self.V, product=self.d.M, atol=0, rtol=0)
+            self.biorthogonal_product = 'M'
+
+        self.W = self.V
+
+        rd = super().reduce()
+
+        return rd
+
+    extend_source_basis = None
+    extend_range_basis = None
+
+
+class SOBTReductor():
+    """Second-Order Balanced Truncation reductor.
+
+        - SOBT [CLVV06]_
+
+    .. [CLVV06] Y. Chahlaoui, D. Lemonnier, A. Vandendorpe, P. Van
+                Dooren,
+                Second-order balanced truncation,
+                Linear Algebra and its Applications, 2006, 415(2–3),
+                373-384
+
+    Parameters
+    ----------
+    d
+        The system which is to be reduced.
+    """
+    def __init__(self, d):
+        assert isinstance(d, SecondOrderSystem)
+        self.d = d
+        self.V1 = None
+        self.W1 = None
+        self.V2 = None
+        self.W2 = None
+
+    def reduce(self, r, projection='sr'):
+        """Reduce using SOBT.
+
+        Parameters
+        ----------
+        r
+            Order of the reduced model.
+        projection
+            Projection method used:
+
+                - `'sr'`: square root method
+                - `'bfsr'`: balancing-free square root method
+                - `'biorth'`: biorthogonalization
+
+        Returns
+        -------
+        rd
+            Reduced system.
+        """
+        assert 0 < r < self.d.n
+        assert projection in ('sr', 'bfsr', 'biorth')
+
+        # compute all necessary Gramian factors
+        pcf = self.d.gramian('pcf')
+        pof = self.d.gramian('pof')
+        vcf = self.d.gramian('vcf')
+        vof = self.d.gramian('vof')
+
+        if r > min([len(pcf), len(pof), len(vcf), len(vof)]):
+            raise ValueError('r needs to be smaller than the sizes of Gramian factors.'
+                             ' Try reducing the tolerance in the low-rank matrix equation solver.')
+
+        # find necessary SVDs
+        Up, sp, Vp = spla.svd(pof.inner(pcf))
+        Up = Up.T
+        Uv, sv, Vv = spla.svd(vof.inner(vcf, product=self.d.M))
+        Uv = Uv.T
+
+        # compute projection matrices and find the reduced model
+        self.V1 = pcf.lincomb(Vp[:r])
+        self.W1 = pof.lincomb(Up[:r])
+        self.V2 = vcf.lincomb(Vv[:r])
+        self.W2 = vof.lincomb(Uv[:r])
+        if projection == 'sr':
+            alpha1 = 1 / np.sqrt(sp[:r])
+            self.V1.scal(alpha1)
+            self.W1.scal(alpha1)
+            alpha2 = 1 / np.sqrt(sv[:r])
+            self.V2.scal(alpha2)
+            self.W2.scal(alpha2)
+            W1TV1invW1TV2 = self.W1.inner(self.V2)
+            projected_ops = {'M': IdentityOperator(NumpyVectorSpace(r, id_='STATE'))}
+        elif projection == 'bfsr':
+            self.V1 = gram_schmidt(self.V1, atol=0, rtol=0)
+            self.W1 = gram_schmidt(self.W1, atol=0, rtol=0)
+            self.V2 = gram_schmidt(self.V2, atol=0, rtol=0)
+            self.W2 = gram_schmidt(self.W2, atol=0, rtol=0)
+            W1TV1invW1TV2 = spla.solve(self.W1.inner(self.V1), self.W1.inner(self.V2))
+            projected_ops = {'M': project(self.d.M, range_basis=self.W2, source_basis=self.V2)}
+        elif projection == 'biorth':
+            self.V1, self.W1 = gram_schmidt_biorth(self.V1, self.W1)
+            self.V2, self.W2 = gram_schmidt_biorth(self.V2, self.W2, product=self.d.M)
+            W1TV1invW1TV2 = self.W1.inner(self.V2)
+            projected_ops = {'M': IdentityOperator(NumpyVectorSpace(r, id_='STATE'))}
+
+        projected_ops.update({'D': project(self.d.D,
+                                           range_basis=self.W2,
+                                           source_basis=self.V2),
+                              'K': project(self.d.K,
+                                           range_basis=self.W2,
+                                           source_basis=self.V1.lincomb(W1TV1invW1TV2.T)),
+                              'B': project(self.d.B,
+                                           range_basis=self.W2,
+                                           source_basis=None),
+                              'Cp': project(self.d.Cp,
+                                            range_basis=None,
+                                            source_basis=self.V1.lincomb(W1TV1invW1TV2.T)),
+                              'Cv': project(self.d.Cv,
+                                            range_basis=None,
+                                            source_basis=self.V2)})
+
+        rd = self.d.with_(operators=projected_ops,
+                          visualizer=None, estimator=None,
+                          cache_region=None, name=self.d.name + '_reduced')
+        rd.disable_logging()
+
+        return rd

--- a/src/pymor/reductors/sor_irka.py
+++ b/src/pymor/reductors/sor_irka.py
@@ -1,0 +1,260 @@
+# -*- coding: utf-8 -*-
+# This file is part of the pyMOR project (http://www.pymor.org).
+# Copyright 2013-2017 pyMOR developers and contributors. All rights reserved.
+# License: BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+
+import numpy as np
+import scipy.linalg as spla
+
+from pymor.algorithms.gram_schmidt import gram_schmidt, gram_schmidt_biorth
+from pymor.algorithms.sylvester import solve_sylv_schur
+from pymor.algorithms.to_matrix import to_matrix
+from pymor.core.logger import getLogger
+from pymor.discretizations.iosys import SecondOrderSystem
+from pymor.operators.constructions import IdentityOperator
+from pymor.reductors.basic import GenericPGReductor
+from pymor.reductors.interpolation import SO_BHIReductor
+from pymor.reductors.lti import IRKAReductor
+
+
+class SOR_IRKAReductor(GenericPGReductor):
+    """SOR-IRKA reductor.
+
+    Parameters
+    ----------
+    d
+        SecondOrderSystem.
+    """
+    def __init__(self, d):
+        assert isinstance(d, SecondOrderSystem)
+        self.d = d
+
+    def reduce(self, r, sigma=None, b=None, c=None, tol=1e-4, maxit=100, dist_num=1, force_sigma_in_rhp=False,
+               projection='orth', use_arnoldi=False, conv_crit='rel_sigma_change', compute_errors=False,
+               irka_options=None):
+        """Reduce using SOR-IRKA.
+
+        It uses IRKA as the intermediate reductor, to reduce from 2r poles to r.
+
+        .. [W12] S. Wyatt,
+                 Issues in Interpolatory Model Reduction: Inexact Solves,
+                 Second Order Systems and DAEs,
+                 PhD thesis, Virginia Tech, 2012
+
+        Parameters
+        ----------
+        r
+            Order of the reduced order model.
+        sigma
+            Initial interpolation points (closed under conjugation),
+            list of length `r`.
+
+            If `None`, interpolation points are log-spaced between 0.1
+            and 10.
+        b
+            Initial right tangential directions, |VectorArray| of length
+            `r` from `d.B.source`.
+
+            If `None`, `b` is chosen with all ones.
+        c
+            Initial left tangential directions, |VectorArray| of length
+            `r` from `d.C.range`.
+
+            If `None`, `c` is chosen with all ones.
+        tol
+            Tolerance for the largest change in interpolation points.
+        maxit
+            Maximum number of iterations.
+        dist_num
+            Number of past iterations to compare the current iteration.
+            Larger number can avoid occasional cyclic behaviour of IRKA.
+        force_sigma_in_rhp
+            If 'False`, new interpolation are reflections of reduced
+            order model's poles. Otherwise, they are always in the right
+            half-plane.
+        projection
+            Projection method:
+
+                - `'orth'`: projection matrices are orthogonalized with
+                    respect to the Euclidean inner product
+                - `'biorth'`: projection matrices are biorthogolized
+                    with respect to the M product
+        conv_crit
+            Convergence criterion:
+
+                - `'rel_sigma_change'`: relative change in interpolation
+                  points
+                - `'subspace_sin'`: maximum of sines of Petrov-Galerkin
+                  subspaces
+                - `'rel_H2_dist'`: relative :math:`\mathcal{H}_2`
+                  distance of reduced order models
+        compute_errors
+            Should the relative :math:`\mathcal{H}_2`-errors of
+            intermediate reduced order models be computed.
+
+            .. warning::
+                Computing :math:`\mathcal{H}_2`-errors is expensive. Use
+                this option only if necessary.
+        irka_options
+            Dict of options for IRKAReductor.reduce.
+
+        Returns
+        -------
+        rd
+            Reduced |LTISystem| model.
+        """
+        d = self.d
+        if not d.cont_time:
+            raise NotImplementedError
+        assert 0 < r < d.n
+        assert sigma is None or len(sigma) == r
+        assert b is None or b in d.B.source and len(b) == r
+        assert c is None or c in d.C.range and len(c) == r
+        assert dist_num >= 1
+        assert projection in ('orth', 'biorth')
+        assert conv_crit in ('rel_sigma_change', 'subspace_sin', 'rel_H2_dist')
+        assert irka_options is None or isinstance(irka_options, dict)
+        if not irka_options:
+            irka_options = {}
+
+        logger = getLogger('pymor.reductors.sor_irka.SOR_IRKAReductor.reduce')
+        logger.info('Starting SOR-IRKA')
+
+        # basic choice for initial interpolation points and tangential
+        # directions
+        if sigma is None:
+            sigma = np.logspace(-1, 1, r)
+        if b is None:
+            b = d.B.source.from_data(np.ones((r, d.m)))
+        if c is None:
+            c = d.Cp.range.from_data(np.ones((r, d.p)))
+
+        if compute_errors:
+            logger.info('iter | conv. criterion | rel. H_2-error')
+            logger.info('-----+-----------------+----------------')
+        else:
+            logger.info('iter | conv. criterion')
+            logger.info('-----+----------------')
+
+        self.dist = []
+        self.sigmas = [np.array(sigma)]
+        self.R = [b]
+        self.L = [c]
+        self.errors = [] if compute_errors else None
+        interp_reductor = SO_BHIReductor(d)
+        # main loop
+        for it in range(maxit):
+            # interpolatory reduced order model
+            rd = interp_reductor.reduce(sigma, b, c, projection=projection)
+
+            if compute_errors:
+                err = d - rd
+                try:
+                    rel_H2_err = err.norm() / d.norm()
+                except:
+                    rel_H2_err = np.inf
+                self.errors.append(rel_H2_err)
+
+            # reduction to a system with r poles
+            with logger.block('Intermediate reduction ...'):
+                irka_reductor = IRKAReductor(rd.to_lti())
+                rd_r = irka_reductor.reduce(r, **irka_options)
+
+            # new interpolation points
+            if isinstance(rd_r.E, IdentityOperator):
+                sigma, Y, X = spla.eig(to_matrix(rd_r.A, format='dense'), left=True, right=True)
+            else:
+                sigma, Y, X = spla.eig(to_matrix(rd_r.A, format='dense'), to_matrix(rd_r.E, format='dense'),
+                                       left=True, right=True)
+            if force_sigma_in_rhp:
+                sigma = np.array([np.abs(s.real) + s.imag * 1j for s in sigma])
+            else:
+                sigma *= -1
+            self.sigmas.append(sigma)
+
+            # new tangential directions
+            Y = rd_r.B.range.make_array(Y.conj().T)
+            X = rd_r.C.source.make_array(X.T)
+            b = rd_r.B.apply_transpose(Y).block(0)
+            c = rd_r.C.apply(X).block(0)
+            self.R.append(b)
+            self.L.append(c)
+
+            # compute convergence criterion
+            if conv_crit == 'rel_sigma_change':
+                dist = spla.norm((self.sigmas[-2] - self.sigmas[-1]) / self.sigmas[-2], ord=np.inf)
+                for i in range(2, min(dist_num + 1, len(self.sigmas))):
+                    dist2 = spla.norm((self.sigmas[-i - 1] - self.sigmas[-1]) / self.sigmas[-i - 1], ord=np.inf)
+                    dist = min(dist, dist2)
+                self.dist.append(dist)
+            elif conv_crit == 'subspace_sin':
+                if it == 0:
+                    V_list = (dist_num + 1) * [None]
+                    W_list = (dist_num + 1) * [None]
+                    V_list[0] = interp_reductor.V
+                    W_list[0] = interp_reductor.W
+                    self.dist.append(1)
+                else:
+                    for i in range(1, dist_num + 1):
+                        V_list[-i] = V_list[-i - 1]
+                        W_list[-i] = W_list[-i - 1]
+                    V_list[0] = interp_reductor.V
+                    W_list[0] = interp_reductor.W
+                    # TODO: replace with SVD when it becomes possible
+                    sinV = np.sqrt(np.max(spla.eigvalsh((V_list[0] -
+                                                         V_list[1].lincomb(V_list[0].inner(V_list[1]))).gramian())))
+                    sinW = np.sqrt(np.max(spla.eigvalsh((W_list[0] -
+                                                         W_list[1].lincomb(W_list[0].inner(W_list[1]))).gramian())))
+                    dist = max(sinV, sinW)
+                    for i in range(2, dist_num + 1):
+                        if V_list[i] is None:
+                            break
+                        sinV = np.sqrt(np.max(spla.eigvalsh((V_list[0] -
+                                                             V_list[i].lincomb(V_list[0].inner(V_list[i]))).gramian())))
+                        sinW = np.sqrt(np.max(spla.eigvalsh((W_list[0] -
+                                                             W_list[i].lincomb(W_list[0].inner(W_list[i]))).gramian())))
+                        dist = min(dist, max(sinV, sinW))
+                    self.dist.append(dist)
+            elif conv_crit == 'rel_H2_dist':
+                if it == 0:
+                    rd_list = (dist_num + 1) * [None]
+                    rd_list[0] = rd
+                    self.dist.append(np.inf)
+                else:
+                    for i in range(1, dist_num + 1):
+                        rd_list[-i] = rd_list[-i - 1]
+                    rd_list[0] = rd
+                    rd_diff = rd_list[1] - rd_list[0]
+                    try:
+                        rel_H2_dist = rd_diff.norm() / rd_list[1].norm()
+                    except:
+                        rel_H2_dist = np.inf
+                    for i in range(2, dist_num + 1):
+                        if rd_list[i] is None:
+                            break
+                        rd_diff2 = rd_list[i] - rd_list[0]
+                        try:
+                            rel_H2_dist2 = rd_diff2.norm() / rd_list[i].norm()
+                        except:
+                            rel_H2_dist2 = np.inf
+                        rel_H2_dist = min(rel_H2_dist, rel_H2_dist2)
+                    self.dist.append(rel_H2_dist)
+
+            if compute_errors:
+                logger.info('{:4d} | {:15.9e} | {:15.9e}'.format(it + 1, self.dist[-1], rel_H2_err))
+            else:
+                logger.info('{:4d} | {:15.9e}'.format(it + 1, self.dist[-1]))
+
+            # check if convergence criterion is satisfied
+            if self.dist[-1] < tol:
+                break
+
+        # final reduced order model
+        rd = interp_reductor.reduce(sigma, b, c, projection=projection)
+        self.V = interp_reductor.V
+        self.W = interp_reductor.W
+
+        return rd
+
+    extend_source_basis = None
+    extend_range_basis = None

--- a/src/pymor/reductors/sor_irka.py
+++ b/src/pymor/reductors/sor_irka.py
@@ -125,9 +125,9 @@ class SOR_IRKAReductor(GenericPGReductor):
         if sigma is None:
             sigma = np.logspace(-1, 1, r)
         if b is None:
-            b = d.B.source.from_data(np.ones((r, d.m)))
+            b = d.B.source.from_numpy(np.ones((r, d.m)))
         if c is None:
-            c = d.Cp.range.from_data(np.ones((r, d.p)))
+            c = d.Cp.range.from_numpy(np.ones((r, d.p)))
 
         if compute_errors:
             logger.info('iter | conv. criterion | rel. H_2-error')


### PR DESCRIPTION
New reductors:
- `SOBT`, `SOBTp`, `SOBTv`, `SOBTpv`, `SOBTvp`, `SOBTfv` (balancing-related reductors for second order systems)
- `SOR-IRKA` (`IRKA`-inspired reductor for second order systems, the version where the intermediate reductor is `IRKA`)

Demo:
- Jupyter notebook `string.ipynb` demonstrating the above methods

Misc:
- added `SecondOrderOperator` and `ShiftedSecondOrderOperator` such that the generic solver (LGMRES) is not used
- fixed a few bugs in `VectorArrayOperator`
- made `GenericRBReductor` and `GenericPGReductor` more similar concerning `orthogonal_product`
- made `as_source_array` and `as_range_array` for `VectorArrayOperator` work for vectorarrays from `BlockVectorSpace`