### PR TITLE
[NumpyMatrixOperator] rename '_matrix' attribute to 'matrix'

### DIFF
--- a/src/pymor/algorithms/error.py
+++ b/src/pymor/algorithms/error.py
@@ -351,7 +351,7 @@ def _compute_errors(mu, d, reductor, estimator, error_norms, condition, custom, 
                 e = e[0] if hasattr(e, '__len__') else e
                 errors[i_norm, i_N] = e
         if condition:
-            conditions[i_N] = np.linalg.cond(rd.operator.assemble(mu)._matrix) if N > 0 else 0.
+            conditions[i_N] = np.linalg.cond(rd.operator.assemble(mu).matrix) if N > 0 else 0.
         for i_custom, cust in enumerate(custom):
             c = cust(rd=rd,
                      d=d,

--- a/src/pymor/algorithms/projection.py
+++ b/src/pymor/algorithms/projection.py
@@ -270,7 +270,7 @@ class ProjectToSubbasisRules(RuleTable):
     @match_class(NumpyMatrixOperator)
     def action_NumpyMatrixOperator(self, op):
         # copy instead of just slicing the matrix to ensure contiguous memory
-        return NumpyMatrixOperator(op._matrix[:self.dim_range, :self.dim_source].copy(),
+        return NumpyMatrixOperator(op.matrix[:self.dim_range, :self.dim_source].copy(),
                                    source_id=op.source.id,
                                    range_id=op.range.id,
                                    solver_options=op.solver_options,

--- a/src/pymor/algorithms/to_matrix.py
+++ b/src/pymor/algorithms/to_matrix.py
@@ -51,17 +51,17 @@ class ToMatrixRules(RuleTable):
     def action_NumpyMatrixOperator(self, op):
         format = self.format
         if format is None:
-            return op._matrix
+            return op.matrix
         elif format == 'dense':
             if not op.sparse:
-                return op._matrix
+                return op.matrix
             else:
-                return op._matrix.toarray()
+                return op.matrix.toarray()
         else:
             if not op.sparse:
-                return getattr(sps, format + '_matrix')(op._matrix)
+                return getattr(sps, format + '_matrix')(op.matrix)
             else:
-                return op._matrix.asformat(format)
+                return op.matrix.asformat(format)
 
     @match_class(BlockOperator)
     def action_BlockOperator(self, op):

--- a/src/pymor/bindings/pyamg.py
+++ b/src/pymor/bindings/pyamg.py
@@ -181,7 +181,7 @@ if config.HAVE_PYAMG:
         assert V in op.range
 
         if isinstance(op, NumpyMatrixOperator):
-            matrix = op._matrix
+            matrix = op.matrix
         else:
             from pymor.algorithms.to_matrix import to_matrix
             matrix = to_matrix(op)

--- a/src/pymor/bindings/scipy.py
+++ b/src/pymor/bindings/scipy.py
@@ -178,7 +178,7 @@ def apply_inverse(op, V, options=None, least_squares=False, check_finite=True,
     assert V in op.range
 
     if isinstance(op, NumpyMatrixOperator):
-        matrix = op._matrix
+        matrix = op.matrix
     else:
         from pymor.algorithms.to_matrix import to_matrix
         matrix = to_matrix(op)

--- a/src/pymor/discretizers/disk.py
+++ b/src/pymor/discretizers/disk.py
@@ -139,8 +139,8 @@ def discretize_stationary_from_disk(parameter_file):
         expr = rhs_vec[i][1]
         parameter_functional = ExpressionParameterFunctional(expr, parameter_type=parameter_type)
         op = NumpyMatrixOperator.from_file(path, source_id='STATE')
-        assert isinstance(op._matrix, np.ndarray)
-        op = op.with_(matrix=op._matrix.reshape((1, -1)))
+        assert isinstance(op.matrix, np.ndarray)
+        op = op.with_(matrix=op.matrix.reshape((1, -1)))
         rhs_operators.append(op)
         rhs_functionals.append(parameter_functional)
 
@@ -277,8 +277,8 @@ def discretize_instationary_from_disk(parameter_file, T=None, steps=None, u0=Non
         expr = rhs_vec[i][1]
         parameter_functional = ExpressionParameterFunctional(expr, parameter_type=parameter_type)
         op = NumpyMatrixOperator.from_file(path, source_id='STATE')
-        assert isinstance(op._matrix, np.ndarray)
-        op = op.with_(matrix=op._matrix.reshape((1, -1)))
+        assert isinstance(op.matrix, np.ndarray)
+        op = op.with_(matrix=op.matrix.reshape((1, -1)))
         rhs_operators.append(op)
         rhs_functionals.append(parameter_functional)
 
@@ -293,8 +293,8 @@ def discretize_instationary_from_disk(parameter_file, T=None, steps=None, u0=Non
         u_0 = config.items('initial-solution')
         path = os.path.join(base_path, u_0[0][1])
         op = NumpyMatrixOperator.from_file(path, range_id='STATE')
-        assert isinstance(op._matrix, np.ndarray)
-        u0 = op.with_(matrix=op._matrix.reshape((-1, 1)))
+        assert isinstance(op.matrix, np.ndarray)
+        u0 = op.with_(matrix=op.matrix.reshape((-1, 1)))
 
     # get products if given
     if 'products' in config.sections():

--- a/src/pymor/operators/numpy.py
+++ b/src/pymor/operators/numpy.py
@@ -169,7 +169,7 @@ class NumpyMatrixBasedOperator(OperatorBase):
             The |Parameter| to assemble the to be exported matrix for.
         """
         assert output_format in {'matlab', 'matrixmarket'}
-        matrix = self.assemble(mu)._matrix
+        matrix = self.assemble(mu).matrix
         matrix_name = matrix_name or self.name
         if output_format is 'matlab':
             savemat(filename, {matrix_name: matrix})
@@ -196,7 +196,7 @@ class NumpyMatrixOperator(NumpyMatrixBasedOperator):
         self.range = NumpyVectorSpace(matrix.shape[0], range_id)
         self.solver_options = solver_options
         self.name = name
-        self._matrix = matrix
+        self.matrix = matrix
         self.source_id = source_id
         self.range_id = range_id
         self.sparse = issparse(matrix)
@@ -212,7 +212,7 @@ class NumpyMatrixOperator(NumpyMatrixBasedOperator):
     def T(self):
         options = {'inverse': self.solver_options.get('inverse_transpose'),
                    'inverse_transpose': self.solver_options.get('inverse')} if self.solver_options else None
-        return self.with_(matrix=self._matrix.T, source_id=self.range_id, range_id=self.source_id,
+        return self.with_(matrix=self.matrix.T, source_id=self.range_id, range_id=self.source_id,
                           solver_options=options, name=self.name + '_transposed')
 
     def _assemble(self, mu=None):
@@ -222,18 +222,18 @@ class NumpyMatrixOperator(NumpyMatrixBasedOperator):
         return self
 
     def as_range_array(self, mu=None):
-        return self.range.make_array(self._matrix.T.copy())
+        return self.range.make_array(self.matrix.T.copy())
 
     def as_source_array(self, mu=None):
-        return self.source.make_array(self._matrix.copy())
+        return self.source.make_array(self.matrix.copy())
 
     def apply(self, U, mu=None):
         assert U in self.source
-        return self.range.make_array(self._matrix.dot(U.data.T).T)
+        return self.range.make_array(self.matrix.dot(U.data.T).T)
 
     def apply_transpose(self, V, mu=None):
         assert V in self.range
-        return self.source.make_array(self._matrix.T.dot(V.data.T).T)
+        return self.source.make_array(self.matrix.T.dot(V.data.T).T)
 
     @defaults('check_finite', 'default_sparse_solver_backend',
               qualname='pymor.operators.numpy.NumpyMatrixOperator.apply_inverse')
@@ -309,13 +309,13 @@ class NumpyMatrixOperator(NumpyMatrixBasedOperator):
         else:
             if least_squares:
                 try:
-                    R, _, _, _ = np.linalg.lstsq(self._matrix, V.data.T)
+                    R, _, _, _ = np.linalg.lstsq(self.matrix, V.data.T)
                 except np.linalg.LinAlgError as e:
                     raise InversionError('{}: {}'.format(str(type(e)), str(e)))
                 R = R.T
             else:
                 try:
-                    R = np.linalg.solve(self._matrix, V.data.T).T
+                    R = np.linalg.solve(self.matrix, V.data.T).T
                 except np.linalg.LinAlgError as e:
                     raise InversionError('{}: {}'.format(str(type(e)), str(e)))
 
@@ -327,7 +327,7 @@ class NumpyMatrixOperator(NumpyMatrixBasedOperator):
 
     def apply_inverse_transpose(self, U, mu=None, least_squares=False):
         options = {'inverse': self.solver_options.get('inverse_transpose') if self.solver_options else None}
-        transpose_op = NumpyMatrixOperator(self._matrix.T, source_id=self.range.id, range_id=self.source.id,
+        transpose_op = NumpyMatrixOperator(self.matrix.T, source_id=self.range.id, range_id=self.source.id,
                                            solver_options=options)
         return transpose_op.apply_inverse(U, mu=mu, least_squares=least_squares)
 
@@ -336,14 +336,14 @@ class NumpyMatrixOperator(NumpyMatrixBasedOperator):
             return None
 
         common_mat_dtype = reduce(np.promote_types,
-                                  (op._matrix.dtype for op in operators if hasattr(op, '_matrix')))
+                                  (op.matrix.dtype for op in operators if hasattr(op, 'matrix')))
         common_coef_dtype = reduce(np.promote_types, (type(c) for c in coefficients))
         common_dtype = np.promote_types(common_mat_dtype, common_coef_dtype)
 
         if coefficients[0] == 1:
-            matrix = operators[0]._matrix.astype(common_dtype)
+            matrix = operators[0].matrix.astype(common_dtype)
         else:
-            matrix = operators[0]._matrix * coefficients[0]
+            matrix = operators[0].matrix * coefficients[0]
             if matrix.dtype != common_dtype:
                 matrix = matrix.astype(common_dtype)
 
@@ -360,25 +360,25 @@ class NumpyMatrixOperator(NumpyMatrixBasedOperator):
                     matrix += (np.eye(matrix.shape[0]) * c)
             elif c == 1:
                 try:
-                    matrix += op._matrix
+                    matrix += op.matrix
                 except NotImplementedError:
-                    matrix = matrix + op._matrix
+                    matrix = matrix + op.matrix
             elif c == -1:
                 try:
-                    matrix -= op._matrix
+                    matrix -= op.matrix
                 except NotImplementedError:
-                    matrix = matrix - op._matrix
+                    matrix = matrix - op.matrix
             else:
                 try:
-                    matrix += (op._matrix * c)
+                    matrix += (op.matrix * c)
                 except NotImplementedError:
-                    matrix = matrix + (op._matrix * c)
+                    matrix = matrix + (op.matrix * c)
         return NumpyMatrixOperator(matrix,
                                    source_id=self.source.id,
                                    range_id=self.range.id,
                                    solver_options=solver_options)
 
     def __getstate__(self):
-        if hasattr(self._matrix, 'factorization'):  # remove unplicklable SuperLU factorization
-            del self._matrix.factorization
+        if hasattr(self.matrix, 'factorization'):  # remove unplicklable SuperLU factorization
+            del self.matrix.factorization
         return self.__dict__

--- a/src/pymor/playground/discretizers/numpylistvectorarray.py
+++ b/src/pymor/playground/discretizers/numpylistvectorarray.py
@@ -22,7 +22,7 @@ def convert_to_numpy_list_vector_array(d):
         elif not op.parametric:
             op = op.assemble()
             if isinstance(op, NumpyMatrixOperator):
-                return NumpyListVectorArrayMatrixOperator(op._matrix,
+                return NumpyListVectorArrayMatrixOperator(op.matrix,
                                                           source_id=op.source.id, range_id=op.range.id,
                                                           name=op.name)
             else:

--- a/src/pymor/playground/operators/numpy.py
+++ b/src/pymor/playground/operators/numpy.py
@@ -37,7 +37,7 @@ class NumpyListVectorArrayMatrixOperator(NumpyMatrixOperator):
             V = super().apply(U, mu=mu)
             return self.range.from_data(V.data)
 
-        V = [self._matrix.dot(v._array) for v in U._list]
+        V = [self.matrix.dot(v._array) for v in U._list]
 
         if self.functional:
             return self.range.make_array(np.array(V)) if len(V) > 0 else self.range.empty()
@@ -57,7 +57,7 @@ class NumpyListVectorArrayMatrixOperator(NumpyMatrixOperator):
             else:
                 raise InversionError
 
-        op = NumpyMatrixOperator(self._matrix, solver_options=self.solver_options)
+        op = NumpyMatrixOperator(self.matrix, solver_options=self.solver_options)
 
         return self.source.make_array([op.apply_inverse(NumpyVectorSpace.make_array(v._array),
                                                         least_squares=least_squares).data.ravel()
@@ -65,16 +65,16 @@ class NumpyListVectorArrayMatrixOperator(NumpyMatrixOperator):
 
     def as_range_array(self, mu=None):
         assert not self.sparse
-        return self.range.make_array(list(self._matrix.T.copy()))
+        return self.range.make_array(list(self.matrix.T.copy()))
 
     def as_source_array(self, mu=None):
         assert not self.sparse
-        return self.source.make_array(list(self._matrix.copy()))
+        return self.source.make_array(list(self.matrix.copy()))
 
     def assemble_lincomb(self, operators, coefficients, solver_options=None, name=None):
         lincomb = super().assemble_lincomb(operators, coefficients)
         if lincomb is None:
             return None
         else:
-            return NumpyListVectorArrayMatrixOperator(lincomb._matrix, source_id=self.source.id, range_id=self.range.id,
+            return NumpyListVectorArrayMatrixOperator(lincomb.matrix, source_id=self.source.id, range_id=self.range.id,
                                                       solver_options=solver_options, name=name)

--- a/src/pymor/reductors/coercive.py
+++ b/src/pymor/reductors/coercive.py
@@ -263,6 +263,6 @@ class SimpleCoerciveRBEstimator(ImmutableInterface):
 
         indices = np.concatenate((np.arange(cr),
                                  ((np.arange(co)*old_dim)[..., np.newaxis] + np.arange(dim)).ravel() + cr))
-        matrix = self.estimator_matrix._matrix[indices, :][:, indices]
+        matrix = self.estimator_matrix.matrix[indices, :][:, indices]
 
         return SimpleCoerciveRBEstimator(NumpyMatrixOperator(matrix), self.coercivity_estimator)

--- a/src/pymortests/complex_values.py
+++ b/src/pymortests/complex_values.py
@@ -22,11 +22,11 @@ def test_complex():
     Cva = NumpyVectorSpace.from_data(C)
 
     # assemble_lincomb
-    assert not np.iscomplexobj(Aop.assemble_lincomb((Iop, Bop), (1, 1))._matrix)
-    assert not np.iscomplexobj(Aop.assemble_lincomb((Aop, Bop), (1, 1))._matrix)
-    assert np.iscomplexobj(Aop.assemble_lincomb((Aop, Bop), (1 + 0j, 1 + 0j))._matrix)
-    assert np.iscomplexobj(Aop.assemble_lincomb((Aop, Bop), (1j, 1))._matrix)
-    assert np.iscomplexobj(Aop.assemble_lincomb((Bop, Aop), (1, 1j))._matrix)
+    assert not np.iscomplexobj(Aop.assemble_lincomb((Iop, Bop), (1, 1)).matrix)
+    assert not np.iscomplexobj(Aop.assemble_lincomb((Aop, Bop), (1, 1)).matrix)
+    assert np.iscomplexobj(Aop.assemble_lincomb((Aop, Bop), (1 + 0j, 1 + 0j)).matrix)
+    assert np.iscomplexobj(Aop.assemble_lincomb((Aop, Bop), (1j, 1)).matrix)
+    assert np.iscomplexobj(Aop.assemble_lincomb((Bop, Aop), (1, 1j)).matrix)
 
     # apply_inverse
     assert not np.iscomplexobj(Aop.apply_inverse(Cva).data)

--- a/src/pymortests/fixtures/operator.py
+++ b/src/pymortests/fixtures/operator.py
@@ -361,7 +361,7 @@ def unpicklable_misc_operator_with_arrays_and_products_factory(n):
     if n == 0:
         from pymor.operators.numpy import NumpyGenericOperator
         op, _, U, V, sp, rp = numpy_matrix_operator_with_arrays_and_products_factory(100, 20, 4, 3, n)
-        mat = op._matrix
+        mat = op.matrix
         op2 = NumpyGenericOperator(mapping=lambda U: mat.dot(U.T).T, transpose_mapping=lambda U: mat.T.dot(U.T).T,
                                    dim_source=100, dim_range=20, linear=True)
         return op2, _, U, V, sp, rp


### PR DESCRIPTION
Subclasses of `ImmutableInterface` should have equally-named attributes for their `__init__` attributes. Otherwise a custom `with_` implementation is needed. (Right now, `NumpyMatrixOperator._with` is broken.) Also, you often need access to the `matrix` attribute in interactive work, and tab completion will not show private attributes.

Any objections, @pymor/pymor-devs?