### PR TITLE
fix #439

### DIFF
--- a/src/pymor/operators/constructions.py
+++ b/src/pymor/operators/constructions.py
@@ -121,7 +121,7 @@ class LincombOperator(OperatorBase):
         return R
 
     def assemble(self, mu=None):
-        operators = tuple(op.assemble(mu) for op in self.operators)
+        operators = [op.assemble(mu) for op in self.operators]
         coefficients = self.evaluate_coefficients(mu)
         op = operators[0].assemble_lincomb(operators, coefficients, solver_options=self.solver_options,
                                            name=self.name + '_assembled')
@@ -400,7 +400,7 @@ class IdentityOperator(OperatorBase):
             assert all(op.source == operators[0].source for op in operators)
             return IdentityOperator(operators[0].source, name=name) * sum(coefficients)
         else:
-            return operators[1].assemble_lincomb(operators[1:] + (operators[0],),
+            return operators[1].assemble_lincomb(operators[1:] + [operators[0]],
                                                  coefficients[1:] + [coefficients[0]],
                                                  solver_options=solver_options, name=name)
 

--- a/src/pymortests/complex_values.py
+++ b/src/pymortests/complex_values.py
@@ -22,16 +22,16 @@ def test_complex():
     Cva = NumpyVectorSpace.from_data(C)
 
     # assemble_lincomb
-    assert not np.iscomplexobj(Aop.assemble_lincomb((Iop, Bop), (1, 1)).matrix)
-    assert not np.iscomplexobj(Aop.assemble_lincomb((Aop, Bop), (1, 1)).matrix)
-    assert np.iscomplexobj(Aop.assemble_lincomb((Aop, Bop), (1 + 0j, 1 + 0j)).matrix)
-    assert np.iscomplexobj(Aop.assemble_lincomb((Aop, Bop), (1j, 1)).matrix)
-    assert np.iscomplexobj(Aop.assemble_lincomb((Bop, Aop), (1, 1j)).matrix)
+    assert not np.iscomplexobj(Aop.assemble_lincomb([Iop, Bop], [1, 1]).matrix)
+    assert not np.iscomplexobj(Aop.assemble_lincomb([Aop, Bop], [1, 1]).matrix)
+    assert np.iscomplexobj(Aop.assemble_lincomb([Aop, Bop], [1 + 0j, 1 + 0j]).matrix)
+    assert np.iscomplexobj(Aop.assemble_lincomb([Aop, Bop], [1j, 1]).matrix)
+    assert np.iscomplexobj(Aop.assemble_lincomb([Bop, Aop], [1, 1j]).matrix)
 
     # apply_inverse
     assert not np.iscomplexobj(Aop.apply_inverse(Cva).data)
     assert np.iscomplexobj((Aop * 1j).apply_inverse(Cva).data)
-    assert np.iscomplexobj(Aop.assemble_lincomb((Aop, Bop), (1, 1j)).apply_inverse(Cva).data)
+    assert np.iscomplexobj(Aop.assemble_lincomb([Aop, Bop], [1, 1j]).apply_inverse(Cva).data)
     assert np.iscomplexobj(Aop.apply_inverse(Cva * 1j).data)
 
     # append


### PR DESCRIPTION
This fixes issue #439 by ensuring that the `operators` argument of `assemble_lincomb` is always passed a list.