### PR TITLE
[travis] fix deploy stage check

### DIFF
--- a/.ci/travis/travis.yml
+++ b/.ci/travis/travis.yml
@@ -67,7 +67,7 @@ jobs:
     env: PYTEST_MARKER="MPI" DOCKER_TAG="3.7"
 
   - stage: deploy
-    if: type IS push # this seems to be ignored
+    if: type = push
     script: 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then ./.ci/travis/deploy.bash ; fi'
     # overwrite other global/matrix settings
     before_script: true


### PR DESCRIPTION
Without this fix, builds on travis are not started due to the invalid condition "type IS push". According to [this document](https://docs.travis-ci.com/user/conditions-v1) it has to be "type = push".

@renemilk, you may want to take a look, but I will merge now to get travis running again.