### PR TITLE
Output functionals in CG discretizations

### DIFF
--- a/src/pymor/analyticalproblems/elliptic.py
+++ b/src/pymor/analyticalproblems/elliptic.py
@@ -6,6 +6,7 @@
 import numpy as np
 
 from pymor.core.interfaces import ImmutableInterface
+from pymor.tools.frozendict import FrozenDict
 
 
 class StationaryProblem(ImmutableInterface):
@@ -45,6 +46,16 @@ class StationaryProblem(ImmutableInterface):
         |Function| providing the Neumann boundary values.
     robin_data
         Tuple of two |Functions| providing the Robin parameter and boundary values.
+    functionals
+        `Dict` of additional functionals to assemble. Each value must be a tuple
+        of the form `(functional_type, data)` where `functional_type` is a string
+        defining the type of functional to assemble and `data` is a |Function| holding
+        the corresponding coefficient function. Currently implemented `functional_types`
+        are:
+
+            :l2:            Evaluate the l2-product with the given data function.
+            :l2_boundary:   Evaluate the l2-product with the given data function
+                            on the boundary.
     parameter_space
         |ParameterSpace| for the problem.
     name
@@ -64,13 +75,14 @@ class StationaryProblem(ImmutableInterface):
     dirichlet_data
     neumann_data
     robin_data
+    functionals
     """
 
     def __init__(self, domain,
                  rhs=None, diffusion=None,
                  advection=None, nonlinear_advection=None, nonlinear_advection_derivative=None,
                  reaction=None, nonlinear_reaction=None, nonlinear_reaction_derivative=None,
-                 dirichlet_data=None, neumann_data=None, robin_data=None,
+                 dirichlet_data=None, neumann_data=None, robin_data=None, functionals=None,
                  parameter_space=None, name=None):
 
         assert rhs is None \
@@ -97,6 +109,9 @@ class StationaryProblem(ImmutableInterface):
         assert robin_data is None \
             or (isinstance(robin_data, tuple) and len(robin_data) == 2 and
                 np.all([f.dim_domain == domain.dim and f.shape_range == () for f in robin_data]))
+        assert functionals is None \
+            or all(isinstance(v, tuple) and len(v) == 2 and v[0] in ('l2', 'l2_boundary') and
+                   v[1].dim_domain == domain.dim and v[1].shape_range == () for v in functionals.values())
 
         self.domain = domain
         self.rhs = rhs
@@ -110,5 +125,6 @@ class StationaryProblem(ImmutableInterface):
         self.dirichlet_data = dirichlet_data
         self.neumann_data = neumann_data
         self.robin_data = robin_data
+        self.functionals = FrozenDict(functionals) if functionals is not None else None
         self.parameter_space = parameter_space
         self.name = name

--- a/src/pymor/discretizers/cg.py
+++ b/src/pymor/discretizers/cg.py
@@ -177,9 +177,19 @@ def discretize_stationary_cg(analytical_problem, diameter=None, domain_discretiz
                 'h1_0_semi': h1_0_semi_product,
                 'l2_0': l2_0_product}
 
+    # assemble additionals functionals
+    if p.functionals:
+        if any(v[0] not in ('l2', 'l2_boundary') for v in p.functionals.values()):
+            raise NotImplementedError
+        functionals = {k + '_functional': (L2Functional(grid, v[1], dirichlet_clear_dofs=False).H if v[0] == 'l2' else
+                                           BoundaryL2Functional(grid, v[1], dirichlet_clear_dofs=False).H)
+                       for k, v in p.functionals.items()}
+    else:
+        functionals = None
+
     parameter_space = p.parameter_space if hasattr(p, 'parameter_space') else None
 
-    d  = StationaryDiscretization(L, F, products=products, visualizer=visualizer,
+    d  = StationaryDiscretization(L, F, operators=functionals, products=products, visualizer=visualizer,
                                   parameter_space=parameter_space, name='{}_CG'.format(p.name))
 
     data = {'grid': grid, 'boundary_info': boundary_info}

--- a/src/pymor/discretizers/fv.py
+++ b/src/pymor/discretizers/fv.py
@@ -86,6 +86,8 @@ def discretize_stationary_fv(analytical_problem, diameter=None, domain_discretiz
 
     if analytical_problem.robin_data is not None:
         raise NotImplementedError
+    if p.functionals:
+        raise NotImplementedError
 
     if grid is None:
         domain_discretizer = domain_discretizer or discretize_domain_default

--- a/src/pymor/grids/interfaces.py
+++ b/src/pymor/grids/interfaces.py
@@ -365,22 +365,17 @@ class BoundaryInfoInterface(CacheableInterface):
         return self.mask('robin', codim)
 
     @cached
-    def _dirichlet_boundaries(self, codim):
-        return np.where(self.dirichlet_mask(codim))[0].astype('int32')
+    def _boundaries(self, boundary_type, codim):
+        return np.where(self.mask(boundary_type, codim))[0].astype('int32')
+
+    def boundaries(self, boundary_type, codim):
+        return self._boundaries(boundary_type, codim)
 
     def dirichlet_boundaries(self, codim):
-        return self._dirichlet_boundaries(codim)
-
-    @cached
-    def _neumann_boundaries(self, codim):
-        return np.where(self.neumann_mask(codim))[0].astype('int32')
+        return self._boundaries('dirichlet', codim)
 
     def neumann_boundaries(self, codim):
-        return self._neumann_boundaries(codim)
-
-    @cached
-    def _robin_boundaries(self, codim):
-        return np.where(self.robin_mask(codim))[0].astype('int32')
+        return self._boundaries('neumann', codim)
 
     def robin_boundaries(self, codim):
-        return self._robin_boundaries(codim)
+        return self._boundaries('robin', codim)

--- a/src/pymor/operators/numpy.py
+++ b/src/pymor/operators/numpy.py
@@ -112,7 +112,7 @@ class NumpyMatrixBasedOperator(OperatorBase):
     @property
     def H(self):
         if not self.parametric:
-            return self.assemble().T
+            return self.assemble().H
         else:
             return super().H
 

--- a/src/pymortests/function.py
+++ b/src/pymortests/function.py
@@ -52,8 +52,6 @@ def test_lincomb_function():
                 assert np.allclose(mul(x), [0.0])
         with pytest.raises(AssertionError):
             zero + ConstantFunction(dim_domain=steps + 1)
-        with pytest.raises(AssertionError):
-            zero * ConstantFunction(dim_domain=steps)
     with pytest.raises(AssertionError):
         ConstantFunction(dim_domain=0)
 


### PR DESCRIPTION
This PR adds support for assembling arbitrary l2 output functionals (on the interior or the boundary) for cg discretizations:

- `InstationaryProblem` gets an additional `functionals` attribute to specify output functionals.
- Assembly of these functionals is only implemented for CG. FV is still missing.
- In `pymor.operators.cg`, the boundary treatment is moved to `BoundaryL2ProductFunctionalP/Q1` which handles the assembly of dirichlet / neumann or arbitrary boundary l2 functionals. `BoundaryDirichletFunctional` is used for enforcing dirichlet constraints.

Additionally:
- A small fix for `NumpyMatrixBasedOperator.H`.
- `Functions` can now be multiplied, yielding a `ProductFunction`.