### PR TITLE
Update intro docs for pymor-0.5

### DIFF
--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -7,21 +7,31 @@ Getting started
 Installation
 ------------
 
-Before trying out pyMOR, you need to install it. We provide packages for Ubuntu
-via our PPA::
+pyMOR can be easily installed via `pip`::
 
-        sudo apt-add-repository ppa:pymor/stable
-        sudo apt-get update
-        sudo apt-get install python-pymor python-pymor-demos python-pymor-doc
+        pip install --upgrade pip  # make sure that pip is reasonably new
+        pip install pymor[full]
 
-Daily snapshots can be installed by using the ``pymor/daily`` PPA instead of
-``pymor/stable``. The current release can also be installed via
-`pip <http://pip-installer.org>`_. Please take a look at our
-`README <https://github.com/pymor/pymor#installation-via-pip>`_ file for
-further details. The
-`README <https://github.com/pymor/pymor#setting-up-an-environment-for-pymor-development>`_
-also contains instructions for setting up a development environment for working
-on pyMOR itself.
+For Linux we provide binary wheels, so no further system packages should
+be required. The following optional packages must be installed separately::
+
+        # for support of MPI distributed models and parallelization of
+        # greedy algorithms (requires MPI development headers)
+        pip install mpi4py 
+
+        # dense matrix equation solver for system-theoretic MOR methods,
+        # required for H-infinity norm calculation (requires OpenBLAS headers)
+        pip install slycot
+
+        # sparse matrix equation solver for system-theoretic MOR methods
+        # (other backends available)
+        open https://www.mpi-magdeburg.mpg.de/projects/mess
+        # download and install pymess wheel for your architecture
+
+We recommend installation of pyMOR in a `virtual environment <http://www.virtualenv.org/>`_.
+Please take a look at our `README <https://github.com/pymor/pymor#installation-via-pip>`_
+file for more detailed installation instructions and a guide to setup a
+development environment for working on pyMOR itself.
 
 
 Trying it out
@@ -30,8 +40,7 @@ Trying it out
 While we consider pyMOR mainly as a library for building MOR applications, we
 ship a few example scripts. These can be found in the ``src/pymordemos``
 directory of the source repository.  Try launching one of
-them using the ``pymor-demo`` script contained in the ``python-pymor-demos``
-package::
+them using the ``pymor-demo`` script::
 
     pymor-demo thermalblock --plot-err --plot-solutions 3 2 3 32
 
@@ -39,10 +48,9 @@ The demo scripts can also be launched directly from the source tree::
 
     ./thermalblock.py --plot-err --plot-solutions 3 2 3 32
 
-This will solve and reduce the so called thermal block problem using
-the reduced basis method with a greedy basis generation algorithm.
-The thermal block problem consists in solving the stationary diffusion
-problem ::
+This will reduce the so called thermal block problem using the reduced basis
+method with a greedy basis generation algorithm. The thermal block problem
+consists in solving the stationary heat equation ::
 
     - ∇ ⋅ [ d(x, μ) ∇ u(x, μ) ] = 1     for x in Ω
                       u(x, μ)   = 0     for x in ∂Ω
@@ -133,10 +141,10 @@ a :class:`~pymor.analyticalproblems.elliptic.StationaryProblem`, we can use
 a predifined *discretizer* to do the work for us. In this case, we use
 :func:`~pymor.discretizers.cg.discretize_stationary_cg`:
 
->>> d, d_data = discretize_stationary_cg(p, diameter=1. / 100.)
+>>> d, d_data = discretize_stationary_cg(p, diameter=1./100.)
 
 ``d`` is the |StationaryDiscretization| which has been created for us,
-whereas ``d_data`` contains some additional data, in this case the |Grid|
+whereas ``d_data`` contains some additional data, in particular the |Grid|
 and the |BoundaryInfo| which have been created during discretization. We
 can have a look at the grid,
 
@@ -146,8 +154,7 @@ x0-intervals: 100, x1-intervals: 100
 elements: 40000, edges: 60200, vertices: 20201
 
 and, as always, we can display its class documentation using
-``help(d_data['grid'])``, or in the case of IPython
-``d_data['grid']?``.
+``help(d_data['grid'])``.
 
 Let's solve the thermal block problem and visualize the solution:
 
@@ -167,7 +174,7 @@ have a look:
 {diffusion: (2, 3)}
 
 This tells us, that the |Parameter| which
-`~pymor.discretizations.interfaces.DiscretizationInterface.solve` expects
+:meth:`~pymor.discretizations.interfaces.DiscretizationInterface.solve` expects
 should be a dictionary with one key ``'diffusion'`` whose value is a
 |NumPy array| of shape ``(2, 3)``, corresponding to the block structure of
 the problem. However, by using the 
@@ -176,15 +183,15 @@ smart enough to correctly parse the input ``[1.0, 0.1, 0.3, 0.1, 0.2, 1.0]``.
 
 Next we want to use the :func:`~pymor.algorithms.greedy.greedy` algorithm
 to reduce the problem. For this we need to choose a reductor which will keep
-track of the reduced basis and perform the actual RB-projection. We will
+track of the reduced basis and perform the actual RB-projection. We will use
 :class:`~pymor.reductors.coercive.CoerciveRBReductor`, which will
 also assemble an error estimator to estimate the reduction error. This
 will significantly speed up the basis generation, as we will only need to
 solve the high-dimensional problem for those parameters in the training set
 which are actually selected for basis extension. To control the condition of
 the reduced system matrix, we must ensure that the generated basis is
-orthonormal w.r.t. the H1-product on the solution space. For this we pass
-the :attr:`h1_product` attribute of the discretization as inner product to
+orthonormal w.r.t. the H1_0-product on the solution space. For this we pass
+the :attr:`h1_0_semi_product` attribute of the discretization as inner product to
 the reductor, which will also use it for computing the Riesz representatives
 required for error estimation. Moreover, we have to provide
 the reductor with a |ParameterFunctional| which computes a lower bound for
@@ -192,7 +199,7 @@ the coercivity of the problem for a given parameter.
 
 >>> reductor = CoerciveRBReductor(
 ...     d, 
-...     product=d.h1_product,
+...     product=d.h1_0_semi_product,
 ...     coercivity_estimator=ExpressionParameterFunctional('min(diffusion)', d.parameter_type)
 ... )
 
@@ -210,37 +217,38 @@ Now we start the basis generation:
 >>> greedy_data = greedy(d, reductor, samples,
 ...                      use_estimator=True,
 ...                      max_extensions=32)
-02:44 greedy: Started greedy search on 4096 samples
-02:44 greedy: Reducing ...
-02:44 |   CoerciveRBReductor: RB projection ...
-02:44 |   CoerciveRBReductor: Assembling error estimator ...
-02:44 |   |   ResidualReductor: Estimating residual range ...
-02:44 |   |   |   estimate_image_hierarchical: Estimating image for basis vector -1 ...
-02:44 |   |   |   estimate_image_hierarchical: Orthonormalizing ...
-02:44 |   |   ResidualReductor: Projecting residual operator ...
-02:44 greedy: Estimating errors ...
-02:45 greedy: Maximum error after 0 extensions: 9.867369536289422 (mu = {diffusion: [0.1, 0.1, 0.1, 0.1, 0.1, 0.1]})
-02:45 greedy: Computing solution snapshot for mu = {diffusion: [0.1, 0.1, 0.1, 0.1, 0.1, 0.1]} ...
-02:45 |   StationaryDiscretization: Solving ThermalBlock((3, 2))_CG for {diffusion: [0.1, 0.1, 0.1, 0.1, 0.1, 0.1]} ...
-02:45 greedy: Extending basis with solution snapshot ...
+16:52 greedy: Started greedy search on 4096 samples
+16:52 greedy: Reducing ...
+16:52 |   CoerciveRBReductor: RB projection ...
+16:52 |   CoerciveRBReductor: Assembling error estimator ...
+16:52 |   |   ResidualReductor: Estimating residual range ...
+16:52 |   |   |   estimate_image_hierarchical: Estimating image for basis vector -1 ...
+16:52 |   |   |   estimate_image_hierarchical: Orthonormalizing ...
+16:52 |   |   ResidualReductor: Projecting residual operator ...
+16:52 greedy: Estimating errors ...
+16:55 greedy: Maximum error after 0 extensions: 1.8745731821515579 (mu = {diffusion: [0.1, 0.1, 0.1, 0.1, 0.1, 0.1]})
+16:55 greedy: Computing solution snapshot for mu = {diffusion: [0.1, 0.1, 0.1, 0.1, 0.1, 0.1]} ...
+16:55 |   StationaryDiscretization: Solving ThermalBlock((3, 2))_CG for {diffusion: [0.1, 0.1, 0.1, 0.1, 0.1, 0.1]} ...
+16:55 greedy: Extending basis with solution snapshot ...
                  ...
                  ...
-04:01 greedy: Maximum number of 32 extensions reached.
-04:01 greedy: Reducing once more ...
-04:01 |   CoerciveRBReductor: RB projection ...
-04:01 |   CoerciveRBReductor: Assembling error estimator ...
-04:01 |   |   ResidualReductor: Estimating residual range ...
-04:01 |   |   |   estimate_image_hierarchical: Estimating image for basis vector 31 ...
-04:01 |   |   |   estimate_image_hierarchical: Orthonormalizing ...
-04:01 |   |   |   |   gram_schmidt: Removing vector 179 of norm 2.969681043318627e-15
-04:01 |   |   |   |   gram_schmidt: Orthonormalizing vector 180 again
-04:01 |   |   |   |   gram_schmidt: Orthonormalizing vector 181 again
-04:01 |   |   |   |   gram_schmidt: Orthonormalizing vector 182 again
-04:02 |   |   |   |   gram_schmidt: Orthonormalizing vector 183 again
-04:02 |   |   |   |   gram_schmidt: Orthonormalizing vector 184 again
-04:02 |   |   |   |   gram_schmidt: Orthonormalizing vector 185 again
-04:02 |   |   ResidualReductor: Projecting residual operator ...
-04:02 greedy: Greedy search took 78.39375972747803 seconds
+18:57 greedy: Maximum number of 32 extensions reached.
+18:57 greedy: Reducing once more ...
+18:57 |   CoerciveRBReductor: RB projection ...
+18:57 |   CoerciveRBReductor: Assembling error estimator ...
+18:57 |   |   ResidualReductor: Estimating residual range ...
+18:57 |   |   |   estimate_image_hierarchical: Estimating image for basis vector 31 ...
+18:57 |   |   |   estimate_image_hierarchical: Orthonormalizing ...
+18:57 |   |   |   |   gram_schmidt: Removing vector 180 of norm 1.7588304501544013e-15
+18:57 |   |   |   |   gram_schmidt: Orthonormalizing vector 181 again
+18:57 |   |   |   |   gram_schmidt: Orthonormalizing vector 182 again
+18:57 |   |   |   |   gram_schmidt: Orthonormalizing vector 183 again
+18:58 |   |   |   |   gram_schmidt: Orthonormalizing vector 184 again
+18:58 |   |   |   |   gram_schmidt: Orthonormalizing vector 185 again
+18:58 |   |   |   |   gram_schmidt: Orthonormalizing vector 186 again
+18:58 |   |   ResidualReductor: Projecting residual operator ...
+18:58 greedy: Greedy search took 126.14163041114807 seconds
+                 
 
 The ``max_extensions`` parameter defines how many basis vectors we want to
 obtain. ``greedy_data`` is a dictionary containing various data that has
@@ -270,9 +278,9 @@ the H1-product. For this we use the :meth:`~pymor.operators.interfaces.OperatorI
 method:
 
 >>> import numpy as np
->>> gram_matrix = RB.gramian(d.h1_product)
+>>> gram_matrix = reductor.RB.gramian(d.h1_0_semi_product)
 >>> print(np.max(np.abs(gram_matrix - np.eye(32))))
-5.86218898944e-14
+3.0088616060491846e-14
 
 Looks good! We can now solve the reduced model for the same parameter as above.
 The result is a vector of coefficients w.r.t. the reduced basis, which is
@@ -297,23 +305,24 @@ Finally we compute the reduction error and display the reduced solution along wi
 the detailed solution and the error:
 
 >>> ERR = U - U_red
->>> print(ERR.norm(d.h1_product))
-[ 0.00944595]
+>>> print(ERR.norm(d.h1_0_semi_product))
+[0.00473238]
 >>> d.visualize((U, U_red, ERR),
 ...             legend=('Detailed', 'Reduced', 'Error'),
 ...             separate_colorbars=True)
 
 We can nicely observe that, as expected, the error is maximized along the
-jumps of the diffusion coeffient.
+jumps of the diffusion coefficient.
+
 
 Learning more
 -------------
 
 As a next step, you should read our :ref:`technical_overview` which discusses the
 most important concepts and design decisions behind pyMOR. After that
-you should be fit to delve into the reference documentation.
+you should be ready to delve into the reference documentation.
 
 Should you have any problems regarding pyMOR, questions or
-`feature requests <https://github.com/pymor/pymor/issues>`_, do not hestitate
+`feature requests <https://github.com/pymor/pymor/issues>`_, do not hesitate
 to contact us at our
 `mailing list <http://listserv.uni-muenster.de/mailman/listinfo/pymor-dev>`_!

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -3,13 +3,14 @@ pyMOR - Model Order Reduction with python
 #########################################
 
 `pyMOR <http://pymor.org>`_ is a software library for building model order
-reduction applications with the Python programming language.  Its main focus
-lies on the application of reduced basis methods to parameterized partial
-differential equations.  All algorithms in pyMOR are formulated in terms of
-abstract interfaces for seamless integration with external high-dimensional PDE
-solvers.  Moreover, pure Python implementations of finite element and finite
-volume discretizations using the `NumPy/SciPy <http://scipy.org>`_ scientific
-computing stack are provided for getting started quickly.
+reduction applications with the Python programming language. Implemented
+algorithms include reduced basis methods for parametric linear and non-linear
+problems, as well as system-theoretic methods such as balanced truncation or
+IRKA.  All algorithms in pyMOR are formulated in terms of abstract interfaces
+for seamless integration with external PDE solver packages.  Moreover, pure
+Python implementations of finite element and finite volume discretizations
+using the `NumPy/SciPy <http://scipy.org>`_ scientific computing stack are
+provided for getting started quickly.
 
 
 .. toctree::

--- a/docs/source/substitutions.py
+++ b/docs/source/substitutions.py
@@ -103,6 +103,7 @@ common = '''
 .. |Parameter| replace:: :class:`~pymor.parameters.base.Parameter`
 .. |Parameters| replace:: :class:`Parameters <pymor.parameters.base.Parameter>`
 .. |Parametric| replace:: :class:`~pymor.parameters.base.Parametric`
+.. |parametric| replace:: :attr:`~pymor.parameters.base.Parametric.parametric`
 
 .. |LTISystem| replace:: :class:`~pymor.discretizations.iosys.LTISystem`
 .. |LTISystems| replace:: :class:`LTISystems <pymor.discretizations.iosys.LTISystem>`
@@ -126,8 +127,10 @@ common = '''
 .. |solver_options| replace:: :attr:`~pymor.operators.interfaces.OperatorInterface.solver_options`
 
 .. |RuleTable| replace:: :class:`~pymor.algorithms.rules.RuleTable`
+.. |RuleTables| replace:: :class:`RuleTables <pymor.algorithms.rules.RuleTable>`
 .. |rule| replace:: :class:`~pymor.algorithms.rules.rule`
 .. |rules| replace:: :class:`rules <pymor.algorithms.rules.rule>`
+.. |project| replace:: :func:`~pymor.algorithms.projection.project`
 
 '''
 

--- a/docs/source/substitutions.py
+++ b/docs/source/substitutions.py
@@ -42,6 +42,8 @@ interfaces = '''
 .. |RemoteObjects| replace:: :class:`RemoteObjects <pymor.parallel.interfaces.RemoteObjectInterface>`
 .. |VectorArrays| replace:: :class:`VectorArrays <pymor.vectorarrays.interfaces.VectorArrayInterface>`
 .. |VectorArray| replace:: :class:`VectorArray <pymor.vectorarrays.interfaces.VectorArrayInterface>`
+.. |VectorSpace| replace:: :class:`VectorSpace <pymor.vectorarrays.interfaces.VectorSpaceInterface>`
+.. |VectorSpaces| replace:: :class:`VectorSpaces <pymor.vectorarrays.interfaces.VectorSpaceInterface>`
 .. |WorkerPool| replace:: :class:`WorkerPool <pymor.parallel.interfaces.WorkerPoolInterface>`
 .. |WorkerPools| replace:: :class:`WorkerPools <pymor.parallel.interfaces.WorkerPoolInterface>`
 
@@ -89,8 +91,6 @@ common = '''
 .. |EmpiricalInterpolatedOperator| replace:: :class:`~pymor.operators.ei.EmpiricalInterpolatedOperator`
 .. |EmpiricalInterpolatedOperators| replace:: :class:`EmpiricalInterpolatedOperators <pymor.operators.ei.EmpiricalInterpolatedOperator>`
 .. |Concatenation| replace:: :class:`~pymor.operators.constructions.Concatenation`
-.. |VectorSpace| replace:: :class:`~pymor.vectorarrays.interfaces.VectorSpaceInterface`
-.. |VectorSpaces| replace:: :class:`VectorSpaces <pymor.vectorarrays.interfaces.VectorSpaceInterface>`
 .. |NumpyVectorSpace| replace:: :func:`~pymor.vectorarrays.numpy.NumpyVectorSpace`
 .. |NumpyVectorSpaces| replace:: :func:`NumpyVectorSpaces <pymor.vectorarrays.numpy.NumpyVectorSpace>`
 

--- a/docs/source/technical_overview.rst
+++ b/docs/source/technical_overview.rst
@@ -311,6 +311,48 @@ writing code of the following form::
 See the :mod:`~pymor.core.defaults` module for more information.
 
 
+RuleTables
+----------
+
+Many algorithms in pyMOR can be seen as transformations acting on trees of
+|Operators|. One example is the structure-preserving (Petrov-)Galerkin
+projection of |Operators| performed by the |project| method. For instance, a
+|LincombOperator| is projected by replacing all its children (the |Operators|
+forming the affine decomposition) with projected |Operators|.
+
+During development of pyMOR, it turned out that using inheritance for selecting
+the action to be taken to project a specific operator (i.e. single dispatch
+based on the class of the to-be-projected |Operator|) is not sufficiently
+flexible. With pyMOR 0.5 we have introduced algorithms which are based on
+|RuleTables| instead of inheritance. A |RuleTable| is simply an ordered list of
+:class:`rules <pymor.algorithms.rules.rule>`, i.e. pairs of conditions to match
+with corresponding actions. When a |RuleTable| is :meth:`applied
+<pymor.algorithms.rules.RuleTable.apply>` to an object (e.g. an |Operator|),
+the action associated with the first matching rule in the table is executed. As
+part of the action, the |RuleTable| can be easily :meth:`applied recursively
+<pymor.algorithms.rules.RuleTable.apply_children>` to the children of the given
+object.
+
+This approach has several advantages over an inheritance-based model:
+
+- Rules can match based on the class of the object, but also on more general
+  conditions, i.e. the name of the |Operator| or being linear and non-|parametric|.
+
+- The entire mathematical algorithm can be specified in a single file even when the
+  definition of the possible classes the algorithm can be applied to is scattered
+  over various files.
+
+- The precedence of rules is directly apparent from the definition of the |RuleTable|.
+
+- Generic rules (e.g. the projection of a linear non-|parametric| |Operator| by simply
+  applying the basis) can be easily scheduled to take precedence over more specific
+  rules.
+
+- Users can implement or modify |RuleTables| without modification of the classes
+  shipped with pyMOR.
+
+
+
 The Reduction Process
 ---------------------
 

--- a/docs/source/technical_overview.rst
+++ b/docs/source/technical_overview.rst
@@ -12,17 +12,18 @@ operating on objects of the following types:
 
 |VectorArrays|
     Vector arrays are ordered collections of vectors. Each vector of the array
-    must be of the same |dimension|. Subsets of vectors can be
-    |copied| to a new array, |appended| to an existing array or |removed| from the
-    array. Basic linear algebra operations can be performed on the vectors of the
+    must be of the same |dimension|. Vectors can be |copied| to a new array,
+    |appended| to an existing array or |removed| from the array. Basic linear
+    algebra operations can be performed on the vectors of the
     array: vectors can be |scaled| in-place, the BLAS |axpy| operation is
     supported and |inner products| between vectors can be formed. Linear
     combinations of vectors can be formed using the |lincomb| method. Moreover,
     various norms can be computed and selected |dofs| of the vectors can
     be extracted for :mod:`empirical interpolation <pymor.algorithms.ei>`.
-    To act on subsets of vectors of an array, arrays can be |indexed|, returning
-    a new |VectorArray| which acts as a view onto the respective vectors in the
-    original array. As a convenience, many of Python's math operators are
+    To act on subsets of vectors of an array, arrays can be |indexed| with an
+    integer, a list of integers or a slice, in each case returning a new
+    |VectorArray| which acts as a modifiable view onto the respective vectors in
+    the original array. As a convenience, many of Python's math operators are
     implemented in terms of the interface methods.
 
     Note that there is not the notion of a single vector in pyMOR. The main
@@ -40,9 +41,9 @@ operating on objects of the following types:
 
     Associated to each vector array is a |VectorSpace| which acts as a
     factory for new arrays of a given type.  New vector arrays can be created
-    from their associated the |zeros| and |empty| methods. To wrap the raw
-    objects of the underlying linear algebra backend into a new |VectorArray|,
-    |make_array| is used.
+    using the |zeros| and |empty| methods. To wrap the raw objects of the
+    underlying linear algebra backend into a new |VectorArray|, |make_array|
+    is used.
 
     The data needed to define a new |VectorSpace| largely depends on the
     implementation of the underlying backend. For |NumpyVectorSpace|, the
@@ -122,8 +123,8 @@ operating on objects of the following types:
 
     Apart from describing the discrete problem, discretizations also implement
     algorithms for |solving| the given problem, returning |VectorArrays|
-    with space |solution_space|. The solution can be |cached|, s.t.
-    subsequent solving of the problem for the same parameters reduces to
+    from the |solution_space|. The solution can be |cached|, s.t.
+    subsequent solving of the problem for the same parameter reduces to
     looking up the solution in pyMOR's cache.
 
     While special discretization classes may be implemented which make use of
@@ -136,8 +137,9 @@ operating on objects of the following types:
     discretizations found in :mod:`pymor.discretizations.basic`.
 
     Discretizations can also implement |estimate| and |visualize| methods to
-    estimate the discretization error of a computed solution and create graphic
-    representations of |VectorArrays| from the |solution_space|.
+    estimate the discretization or model reduction error of a computed solution
+    and create graphic representations of |VectorArrays| from the
+    |solution_space|.
 
     .. |cached|           replace:: :mod:`cached <pymor.core.cache>`
     .. |estimate|         replace:: :meth:`~pymor.discretizations.interfaces.DiscretizationInterface.estimate`
@@ -243,9 +245,12 @@ structures which can be used to quickly add features to the high-dimensional
 code without any recompilation. A minimal example for such an integration using
 `pybindgen <https://code.google.com/p/pybindgen>`_ can be found in the
 ``src/pymordemos/minimal_cpp_demo`` directory of the pyMOR repository.
-The `dune-pymor <https://github.com/pymor/dune-pymor>`_ repository contains
-experimental bindings for the `DUNE <http://dune-project.org>`_ software
-framework.
+Bindings for `FEnicS <https://fenicsproject.org>`_ and
+`NGSolve <https://ngsolve.org>`_ packages are available in the 
+:mod:`bindings.fenics <pymor.bindings.fenics>` and
+:mod:`bindings.ngsolve <pymor.bindings.ngsolve>` modules.
+The `pymor-deal.II <https://github.com/pymor/pymor-deal.II>`_ repository contains
+experimental bindings for `deal.II <https://dealii.org>`_.
 
 
 Parameters
@@ -265,7 +270,7 @@ expected shapes.
 The |ParameterType| of a |Parametric| object is determined by the class
 implementor during `__init__` via a call to
 :meth:`~pymor.parameters.base.Parametric.build_parameter_type`, which can be
-used, to infer the |ParameterType| from the |ParameterTypes| of objects the
+used to infer the |ParameterType| from the |ParameterTypes| of objects the
 given object depends upon. I.e. an |Operator| implementing the L2-product with
 some |Function| will inherit the |ParameterType| of the |Function|.
 
@@ -288,10 +293,11 @@ decorator::
         ...
 
 Default values can be changed by calling :func:`~pymor.core.defaults.set_defaults`.
-A configuration file with all defaults defined in pyMOR can be obtained with
-:func:`~pymor.core.defaults.write_defaults_to_file`. This file can then be loaded,
-either programmatically or automatically by setting the ``PYMOR_DEFAULTS`` environment
-variable.
+By calling :func:`~pymor.core.defaults.print_defaults` a summary of all defaults
+in pyMOR and their values can be printed. A configuration file with all defaults
+can be obtained with :func:`~pymor.core.defaults.write_defaults_to_file`. This file can
+then be loaded, either programmatically or automatically by setting the
+``PYMOR_DEFAULTS`` environment variable.
 
 As an additional feature, if ``None`` is passed as value for a function argument
 which is a default, its default value is used instead of ``None``. This allows


### PR DESCRIPTION
This PR includes some fixes and updates to pyMOR intro documentation to make it ready for the 0.5 release.

- I have made the general description of pyMOR less RB-centric.
- I have updated the installation instruction based on the assumption that we will remove mpi4py and slycot from the extras.
- There is now an intro to RuleTables.

Fixes #506.