### PR TITLE
[pymor-demo] prevent RuntimeWarning due to already loaded module

### DIFF
--- a/src/pymor-demo
+++ b/src/pymor-demo
@@ -13,7 +13,6 @@ import sys
 import runpy
 import argparse
 import functools
-import sys
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Launcher script for all available pyMOR demos.',
@@ -33,6 +32,12 @@ if __name__ == '__main__':
             short = module_name[len('pymordemos.'):]
             modules.append(module_name)
             shorts.append(short)
+
+            # unload module to prevent runpy warning
+            assert sys.getrefcount(foo) == 4, (module_name, sys.getrefcount(foo))
+            del foo
+            del sys.modules[module_name]
+            del sys.modules['pymordemos'][short]
         except (TypeError, ImportError):
             pass
 


### PR DESCRIPTION
Without this fix I am getting the following warning on Python 3.5:

```
/usr/lib/python3.5/runpy.py:125: RuntimeWarning: 'pymordemos.thermalblock' found in sys.modules after import of package 'pymordemos', but prior to execution of 'pymordemos.thermalblock'; this may result in unpredictable behaviour
  warn(RuntimeWarning(msg))
```