### PR TITLE
Rewire versioning scheme

### DIFF
--- a/.ci/travis/deploy.bash
+++ b/.ci/travis/deploy.bash
@@ -7,8 +7,10 @@ REPODIR=${HOME}/wheels
 PYMOR_ROOT="$(cd "$(dirname ${BASH_SOURCE[0]})" ; cd ../../ ; pwd -P )"
 cd "${PYMOR_ROOT}"
 
-# sed -i -e 's;style\ \=\ pep440;style\ \=\ ci_wheel_builder;g' setup.cfg
-
+TAG=${DRONE_TAG:-${TRAVIS_TAG}}
+if [[ "x${TAG}" == "x" ]] ; then
+    sed -i -e 's;style\ \=\ pep440;style\ \=\ ci_wheel_builder;g' setup.cfg
+fi
 rm -rf ~/.ssh
 
 ./.ci/travis/init_sshkey.bash "${encrypted_a599472c800f_key}" "${encrypted_a599472c800f_iv}" \

--- a/.ci/travis/deploy.bash
+++ b/.ci/travis/deploy.bash
@@ -7,7 +7,7 @@ REPODIR=${HOME}/wheels
 PYMOR_ROOT="$(cd "$(dirname ${BASH_SOURCE[0]})" ; cd ../../ ; pwd -P )"
 cd "${PYMOR_ROOT}"
 
-sed -i -e 's;style\ \=\ pep440;style\ \=\ ci_wheel_builder;g' setup.cfg
+# sed -i -e 's;style\ \=\ pep440;style\ \=\ ci_wheel_builder;g' setup.cfg
 
 rm -rf ~/.ssh
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ ignore =
 
 [versioneer]
 VCS = git
-style = ci_wheel_builder
+style = pep440
 versionfile_source = src/pymor/version.py
 # this is mandatory for the processed version.py to end up in .whl
 versionfile_build = pymor/version.py


### PR DESCRIPTION
This makes pymor use the PEP440 scheme for building releases from git tags
and our custom epoch+tag-distance for other push builds.