### PR TITLE
Fixing flake8 W605

### DIFF
--- a/versioneer.py
+++ b/versioneer.py
@@ -418,7 +418,7 @@ def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False,
     return stdout, p.returncode
 
 
-LONG_VERSION_PY['git'] = '''
+LONG_VERSION_PY['git'] = r'''
 # This file helps to compute a version number in source trees obtained from
 # git-archive tarball (such as those provided by githubs download-from-tag
 # feature). Distribution tarballs (built by setup.py sdist) and build


### PR DESCRIPTION
Before the fix:

```bash
$ flake8 | grep W605
./versioneer.py:941:-13592: W605 invalid escape sequence '\s'
./versioneer.py:941:-13408: W605 invalid escape sequence '\s'
./versioneer.py:941:-13228: W605 invalid escape sequence '\s'
./versioneer.py:941:-11196: W605 invalid escape sequence '\d'
./versioneer.py:941:-8162: W605 invalid escape sequence '\d'
./src/pymor/core/logger.py:97:14: W605 invalid escape sequence '\-'
./src/pymor/core/logger.py:104:22: W605 invalid escape sequence '\ '
./src/pymor/grids/tria.py:48:-1615: W605 invalid escape sequence '\ '
./src/pymor/grids/tria.py:48:-1593: W605 invalid escape sequence '\ '
./src/pymor/grids/tria.py:48:-1483: W605 invalid escape sequence '\ '
./src/pymor/grids/tria.py:48:-1461: W605 invalid escape sequence '\ '
./src/pymor/grids/tria.py:48:-1351: W605 invalid escape sequence '\ '
./src/pymor/grids/tria.py:48:-1329: W605 invalid escape sequence '\ '
./src/pymor/grids/tria.py:48:-1219: W605 invalid escape sequence '\ '
./src/pymor/grids/tria.py:48:-1197: W605 invalid escape sequence '\ '
./src/pymor/grids/tria.py:48:-1111: W605 invalid escape sequence '\ '
./src/pymor/grids/tria.py:48:-1089: W605 invalid escape sequence '\ '
./src/pymor/grids/tria.py:48:-979: W605 invalid escape sequence '\ '
./src/pymor/grids/tria.py:48:-957: W605 invalid escape sequence '\ '
./src/pymor/grids/tria.py:48:-847: W605 invalid escape sequence '\ '
./src/pymor/grids/tria.py:48:-825: W605 invalid escape sequence '\ '
./src/pymor/grids/tria.py:48:-715: W605 invalid escape sequence '\ '
./src/pymor/grids/tria.py:48:-693: W605 invalid escape sequence '\ '
./src/pymor/reductors/bt.py:180:-121: W605 invalid escape sequence '\m'
./src/pymor/reductors/bt.py:180:-109: W605 invalid escape sequence '\i'
./src/pymor/reductors/interpolation.py:32:-279: W605 invalid escape sequence '\m'
./src/pymor/reductors/interpolation.py:32:-264: W605 invalid escape sequence '\m'
./src/pymor/reductors/interpolation.py:32:-240: W605 invalid escape sequence '\m'
```