### PR TITLE
Residual bugfix [0.4.x]

### DIFF
--- a/src/pymor/algorithms/image.py
+++ b/src/pymor/algorithms/image.py
@@ -104,7 +104,7 @@ def estimate_image(operators=(), vectors=(),
             for o in op.operators:
                 collect_vector_ranges(o, image)
         elif isinstance(op, AdjointOperator):
-            if op.source not in image_space:
+            if op.source != image_space:
                 raise ImageCollectionError(op)  # Not implemented
             operator = Concatenation(op.range_product, op.operator) if op.range_product else op.operator
             collect_operator_ranges(operator, NumpyVectorArray(np.ones(1)), image)

--- a/src/pymor/reductors/residual.py
+++ b/src/pymor/reductors/residual.py
@@ -177,7 +177,10 @@ class NonProjectedResidualOperator(ResidualOperator):
                 inversel2 = np.nan_to_num(inversel2)
                 return R_riesz * (np.sqrt(R_riesz.dot(R)) * inversel2)[0]
             else:
-                return R * (np.sqrt(self.product.pairwise_apply2(R, R)) / R.l2_norm())[0]
+                # divide by norm, except when norm is zero:
+                inversel2 = 1./R.l2_norm()
+                inversel2 = np.nan_to_num(inversel2)
+                return R * (np.sqrt(self.product.pairwise_apply2(R, R)) * inversel2)[0]
         else:
             return R
 

--- a/src/pymor/reductors/residual.py
+++ b/src/pymor/reductors/residual.py
@@ -171,7 +171,11 @@ class NonProjectedResidualOperator(ResidualOperator):
         if self.product:
             if self.rhs_is_functional:
                 R_riesz = self.product.apply_inverse(R)
-                return R_riesz * (np.sqrt(R_riesz.dot(R)) / R_riesz.l2_norm())[0]
+
+                # divide by norm, except when norm is zero:
+                inversel2 = 1./R_riesz.l2_norm()
+                inversel2 = np.nan_to_num(inversel2)
+                return R_riesz * (np.sqrt(R_riesz.dot(R)) * inversel2)[0]
             else:
                 return R * (np.sqrt(self.product.pairwise_apply2(R, R)) / R.l2_norm())[0]
         else:


### PR DESCRIPTION
fix two bugs:

Riesz representative calculation was broken in NonProjectedResidualOperator if the residual was zero. This resulted in a division by zero and thereby nan entries.

estimate_image was broken for an adjoint of a concatenation operator.

Both fixed here.