### PR TITLE
Fixes for #564

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,11 +2,13 @@
 test = pytest
 [pep8]
 max-line-length = 120
-ignore = E221,E226,E241,E242, W0105, W503, N803, N806
+ignore = E221,E226,E241,E242, E731, E741, W0105, W503, N803, N806
 # E221 multiple spaces before operator
 # E226 missing whitespace around arithmetic operator  [ignored by default]
 # E241 multiple spaces after ':'                      [ignored by default]
 # E242 tab after `,'                                  [ignored by default]
+# E731 do not assign a lambda expression, use a def
+# E741 do not use variables named 'l', 'O', or 'I'
 # W0105 String statement has no effect (we use triple qoted strings as documentation in some files)
 # W503 line break before binary operator
 # N803 argument name should be lowercase (we use single capital letters everywhere for vectorarrays)
@@ -15,7 +17,7 @@ ignore = E221,E226,E241,E242, W0105, W503, N803, N806
 
 [flake8]
 max-line-length = 120
-ignore = E221,E226,E241,E242, W0105, W503, N803, N806
+ignore = E221,E226,E241,E242, E731, E741, W0105, W503, N803, N806
 # The following exclude avoids wrong warnings for unused imports
 exclude = __init__.py
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,7 @@ test = pytest
 
 [pycodestyle]
 max-line-length = 120
+max-doc-length = 100
 ignore = E221,E226,E241,E242, E731, E741, W0105, W503, N803, N806
 # E221 multiple spaces before operator
 # E226 missing whitespace around arithmetic operator  [ignored by default]
@@ -17,6 +18,7 @@ ignore = E221,E226,E241,E242, E731, E741, W0105, W503, N803, N806
 
 [flake8]
 max-line-length = 120
+max-doc-length = 100
 ignore = E221,E226,E241,E242, E731, E741, W0105, W503, N803, N806
 # The following exclude avoids wrong warnings for unused imports
 exclude = __init__.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,7 @@
 [aliases]
 test = pytest
-[pep8]
+
+[pycodestyle]
 max-line-length = 120
 ignore = E221,E226,E241,E242, E731, E741, W0105, W503, N803, N806
 # E221 multiple spaces before operator
@@ -13,7 +14,6 @@ ignore = E221,E226,E241,E242, E731, E741, W0105, W503, N803, N806
 # W503 line break before binary operator
 # N803 argument name should be lowercase (we use single capital letters everywhere for vectorarrays)
 # N806 same for variables in function
-
 
 [flake8]
 max-line-length = 120

--- a/src/pymor/discretizers/fv.py
+++ b/src/pymor/discretizers/fv.py
@@ -140,10 +140,6 @@ def discretize_stationary_fv(analytical_problem, diameter=None, domain_discretiz
         if num_flux == 'lax_friedrichs':
             L += [nonlinear_advection_lax_friedrichs_operator(grid, boundary_info, p.nonlinear_advection,
                                                               dirichlet_data=p.dirichlet_data, lxf_lambda=lxf_lambda)]
-        elif num_flux == 'upwind':
-            L += [nonlinear_advection_upwind_operator(grid, boundary_info, p.nonlinear_advection,
-                                                      p.nonlinear_advection_derivative,
-                                                      dirichlet_data=p.dirichlet_data)]
         elif num_flux == 'engquist_osher':
             L += [nonlinear_advection_engquist_osher_operator(grid, boundary_info, p.nonlinear_advection,
                                                               p.nonlinear_advection_derivative,


### PR DESCRIPTION
Fixes #564.

- ignores pycodestyle errors `E731` and `E741`
- sets `max-doc-line` to 100
- replaces pep8 section with pycodestyle
- removes `nonlinear_advection_upwind_operator`