### PR TITLE
Rename system attributes n, m, p

### DIFF
--- a/notebooks/heat.ipynb
+++ b/notebooks/heat.ipynb
@@ -135,9 +135,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print('n = {}'.format(lti.n))\n",
-    "print('m = {}'.format(lti.m))\n",
-    "print('p = {}'.format(lti.p))"
+    "print('order of the model = {}'.format(lti.order))\n",
+    "print('number of inputs   = {}'.format(lti.input_dim))\n",
+    "print('number of outputs  = {}'.format(lti.output_dim))"
    ]
   },
   {

--- a/notebooks/string.ipynb
+++ b/notebooks/string.ipynb
@@ -162,9 +162,9 @@
    "source": [
     "so_sys = SecondOrderModel.from_matrices(M, E, K, B, Cp)\n",
     "\n",
-    "print('n = {}'.format(so_sys.n))\n",
-    "print('m = {}'.format(so_sys.m))\n",
-    "print('p = {}'.format(so_sys.p))"
+    "print('order of the model = {}'.format(so_sys.order))\n",
+    "print('number of inputs   = {}'.format(so_sys.input_dim))\n",
+    "print('number of outputs  = {}'.format(so_sys.output_dim))"
    ]
   },
   {

--- a/src/pymor/reductors/bt.py
+++ b/src/pymor/reductors/bt.py
@@ -76,7 +76,7 @@ class GenericBTReductor(BasicInterface):
             Reduced system.
         """
         assert r is not None or tol is not None
-        assert r is None or 0 < r < self.fom.n
+        assert r is None or 0 < r < self.fom.order
         assert projection in ('sr', 'bfsr', 'biorth')
 
         cf, of = self.gramians()
@@ -185,15 +185,18 @@ class BRBTReductor(GenericBTReductor):
         self.solver_options = solver_options
 
     def gramians(self):
-        A = self.fom.A
-        B = self.fom.B
-        C = self.fom.C
-        E = self.fom.E if not isinstance(self.fom.E, IdentityOperator) else None
+        fom = self.fom
+        A = fom.A
+        B = fom.B
+        C = fom.C
+        E = fom.E if not isinstance(fom.E, IdentityOperator) else None
         options = self.solver_options
 
-        cf = solve_pos_ricc_lrcf(A, E, B.as_range_array(), C.as_source_array(), R=self.gamma**2 * np.eye(C.range.dim),
+        cf = solve_pos_ricc_lrcf(A, E, B.as_range_array(), C.as_source_array(),
+                                 R=self.gamma**2 * np.eye(fom.output_dim),
                                  trans=False, options=options)
-        of = solve_pos_ricc_lrcf(A, E, B.as_range_array(), C.as_source_array(), R=self.gamma**2 * np.eye(B.source.dim),
+        of = solve_pos_ricc_lrcf(A, E, B.as_range_array(), C.as_source_array(),
+                                 R=self.gamma**2 * np.eye(fom.input_dim),
                                  trans=True, options=options)
         return cf, of
 

--- a/src/pymor/reductors/h2.py
+++ b/src/pymor/reductors/h2.py
@@ -28,7 +28,8 @@ class IRKAReductor(BasicInterface):
         self.fom = fom
 
     def reduce(self, r, sigma=None, b=None, c=None, rom0=None, tol=1e-4, maxit=100, num_prev=1,
-               force_sigma_in_rhp=False, projection='orth', use_arnoldi=False, conv_crit='sigma', compute_errors=False):
+               force_sigma_in_rhp=False, projection='orth', use_arnoldi=False, conv_crit='sigma',
+               compute_errors=False):
         r"""Reduce using IRKA.
 
         See [GAB08]_ (Algorithm 4.1) and [ABG10]_ (Algorithm 1).
@@ -113,7 +114,7 @@ class IRKAReductor(BasicInterface):
         fom = self.fom
         if not fom.cont_time:
             raise NotImplementedError
-        assert 0 < r < fom.n
+        assert 0 < r < fom.order
         assert isinstance(num_prev, int) and num_prev >= 1
         assert projection in ('orth', 'biorth')
         assert conv_crit in ('sigma', 'h2')
@@ -124,7 +125,7 @@ class IRKAReductor(BasicInterface):
         assert c is None or isinstance(c, int) or c in fom.C.range and len(c) == r
         assert (rom0 is None
                 or isinstance(rom0, LTIModel)
-                and rom0.n == r and rom0.B.source == fom.B.source and rom0.C.range == fom.C.range)
+                and rom0.order == r and rom0.B.source == fom.B.source and rom0.C.range == fom.C.range)
         assert sigma is None or rom0 is None
         assert b is None or rom0 is None
         assert c is None or rom0 is None
@@ -138,15 +139,15 @@ class IRKAReductor(BasicInterface):
                 np.random.seed(sigma)
                 sigma = np.abs(np.random.randn(r))
             if b is None:
-                b = fom.B.source.from_numpy(np.ones((r, fom.m)))
+                b = fom.B.source.from_numpy(np.ones((r, fom.input_dim)))
             elif isinstance(b, int):
                 np.random.seed(b)
-                b = fom.B.source.from_numpy(np.random.randn(r, fom.m))
+                b = fom.B.source.from_numpy(np.random.randn(r, fom.input_dim))
             if c is None:
-                c = fom.C.range.from_numpy(np.ones((r, fom.p)))
+                c = fom.C.range.from_numpy(np.ones((r, fom.output_dim)))
             elif isinstance(c, int):
                 np.random.seed(c)
-                c = fom.C.range.from_numpy(np.random.randn(r, fom.p))
+                c = fom.C.range.from_numpy(np.random.randn(r, fom.output_dim))
 
         # being logging
         self.logger.info('Starting IRKA')
@@ -284,8 +285,8 @@ class TSIAReductor(BasicInterface):
         """
         fom = self.fom
         assert isinstance(rom0, LTIModel) and rom0.B.source == fom.B.source and rom0.C.range == fom.C.range
-        r = rom0.n
-        assert 0 < r < fom.n
+        r = rom0.order
+        assert 0 < r < fom.order
         assert isinstance(num_prev, int) and num_prev >= 1
         assert projection in ('orth', 'biorth')
         assert conv_crit in ('sigma', 'h2')
@@ -374,8 +375,8 @@ class TF_IRKAReductor(BasicInterface):
     def __init__(self, fom):
         self.fom = fom
 
-    def reduce(self, r, sigma=None, b=None, c=None, rom0=None, tol=1e-4, maxit=100, num_prev=1, force_sigma_in_rhp=False,
-               conv_crit='sigma'):
+    def reduce(self, r, sigma=None, b=None, c=None, rom0=None, tol=1e-4, maxit=100, num_prev=1,
+               force_sigma_in_rhp=False, conv_crit='sigma'):
         r"""Reduce using TF-IRKA.
 
         Parameters
@@ -446,9 +447,9 @@ class TF_IRKAReductor(BasicInterface):
 
         # initial interpolation points and tangential directions
         assert sigma is None or isinstance(sigma, int) or len(sigma) == r
-        assert b is None or isinstance(b, int) or isinstance(b, np.ndarray) and b.shape == (fom.m, r)
-        assert c is None or isinstance(c, int) or isinstance(c, np.ndarray) and c.shape == (fom.p, r)
-        assert rom0 is None or rom0.n == r and rom0.B.source.dim == fom.m and rom0.C.range.dim == fom.p
+        assert b is None or isinstance(b, int) or isinstance(b, np.ndarray) and b.shape == (fom.input_dim, r)
+        assert c is None or isinstance(c, int) or isinstance(c, np.ndarray) and c.shape == (fom.output_dim, r)
+        assert rom0 is None or rom0.order == r and rom0.input_dim == fom.input_dim and rom0.output_dim == fom.output_dim
         assert sigma is None or rom0 is None
         assert b is None or rom0 is None
         assert c is None or rom0 is None
@@ -464,15 +465,15 @@ class TF_IRKAReductor(BasicInterface):
                 np.random.seed(sigma)
                 sigma = np.abs(np.random.randn(r))
             if b is None:
-                b = np.ones((fom.m, r))
+                b = np.ones((fom.input_dim, r))
             elif isinstance(b, int):
                 np.random.seed(b)
-                b = np.random.randn(fom.m, r)
+                b = np.random.randn(fom.input_dim, r)
             if c is None:
-                c = np.ones((fom.p, r))
+                c = np.ones((fom.output_dim, r))
             elif isinstance(c, int):
                 np.random.seed(c)
-                c = np.random.randn(fom.p, r)
+                c = np.random.randn(fom.output_dim, r)
 
         # begin logging
         self.logger.info('Starting TF-IRKA')

--- a/src/pymor/reductors/interpolation.py
+++ b/src/pymor/reductors/interpolation.py
@@ -183,7 +183,7 @@ class LTI_BHIReductor(GenericBHIReductor):
         rom
             Reduced model.
         """
-        if use_arnoldi and self.fom.m == 1 and self.fom.p == 1:
+        if use_arnoldi and self.fom.input_dim == 1 and self.fom.output_dim == 1:
             return self.reduce_arnoldi(sigma, b, c)
         else:
             return super().reduce(sigma, b, c, projection=projection)
@@ -209,7 +209,7 @@ class LTI_BHIReductor(GenericBHIReductor):
             Reduced |LTIModel| model.
         """
         fom = self.fom
-        assert fom.m == 1 and fom.p == 1
+        assert fom.input_dim == 1 and fom.output_dim == 1
         r = len(sigma)
         assert b in fom.B.source and len(b) == r
         assert c in fom.C.range and len(c) == r
@@ -304,10 +304,10 @@ class TFInterpReductor(BasicInterface):
             length `r`.
         b
             Right tangential directions, |NumPy array| of shape
-            `(fom.m, r)`.
+            `(fom.input_dim, r)`.
         c
             Left tangential directions, |NumPy array| of shape
-            `(fom.p, r)`.
+            `(fom.output_dim, r)`.
 
         Returns
         -------
@@ -316,8 +316,8 @@ class TFInterpReductor(BasicInterface):
         """
         fom = self.fom
         r = len(sigma)
-        assert isinstance(b, np.ndarray) and b.shape == (fom.m, r)
-        assert isinstance(c, np.ndarray) and c.shape == (fom.p, r)
+        assert isinstance(b, np.ndarray) and b.shape == (fom.input_dim, r)
+        assert isinstance(c, np.ndarray) and c.shape == (fom.output_dim, r)
 
         # rescale tangential directions (to avoid overflow or underflow)
         if b.shape[0] > 1:
@@ -334,8 +334,8 @@ class TFInterpReductor(BasicInterface):
         # matrices of the interpolatory LTI system
         Er = np.empty((r, r), dtype=complex)
         Ar = np.empty((r, r), dtype=complex)
-        Br = np.empty((r, fom.m), dtype=complex)
-        Cr = np.empty((fom.p, r), dtype=complex)
+        Br = np.empty((r, fom.input_dim), dtype=complex)
+        Cr = np.empty((fom.output_dim, r), dtype=complex)
 
         Hs = [fom.eval_tf(s) for s in sigma]
         dHs = [fom.eval_dtf(s) for s in sigma]

--- a/src/pymor/reductors/sobt.py
+++ b/src/pymor/reductors/sobt.py
@@ -61,7 +61,7 @@ class GenericSOBTpvReductor(BasicInterface):
         rom
             Reduced system.
         """
-        assert 0 < r < self.fom.n
+        assert 0 < r < self.fom.order
         assert projection in ('sr', 'bfsr', 'biorth')
 
         # compute all necessary Gramian factors
@@ -225,7 +225,7 @@ class SOBTfvReductor(BasicInterface):
         rom
             Reduced system.
         """
-        assert 0 < r < self.fom.n
+        assert 0 < r < self.fom.order
         assert projection in ('sr', 'bfsr', 'biorth')
 
         # compute all necessary Gramian factors
@@ -305,7 +305,7 @@ class SOBTReductor(BasicInterface):
         rom
             Reduced system.
         """
-        assert 0 < r < self.fom.n
+        assert 0 < r < self.fom.order
         assert projection in ('sr', 'bfsr', 'biorth')
 
         # compute all necessary Gramian factors

--- a/src/pymor/reductors/sor_irka.py
+++ b/src/pymor/reductors/sor_irka.py
@@ -22,9 +22,9 @@ class SOR_IRKAReductor(BasicInterface):
         assert isinstance(fom, SecondOrderModel)
         self.fom = fom
 
-    def reduce(self, r, sigma=None, b=None, c=None, rom0=None, tol=1e-4, maxit=100, num_prev=1, force_sigma_in_rhp=False,
-               projection='orth', use_arnoldi=False, conv_crit='sigma', compute_errors=False,
-               irka_options=None):
+    def reduce(self, r, sigma=None, b=None, c=None, rom0=None, tol=1e-4, maxit=100, num_prev=1,
+               force_sigma_in_rhp=False, projection='orth', use_arnoldi=False, conv_crit='sigma',
+               compute_errors=False, irka_options=None):
         r"""Reduce using SOR-IRKA.
 
         It uses IRKA as the intermediate reductor, to reduce from 2r to
@@ -109,7 +109,7 @@ class SOR_IRKAReductor(BasicInterface):
         fom = self.fom
         if not fom.cont_time:
             raise NotImplementedError
-        assert 0 < r < fom.n
+        assert 0 < r < fom.order
         assert isinstance(num_prev, int) and num_prev >= 1
         assert projection in ('orth', 'biorth')
         assert conv_crit in ('sigma', 'h2')
@@ -123,7 +123,7 @@ class SOR_IRKAReductor(BasicInterface):
         assert c is None or isinstance(c, int) or c in fom.Cp.range and len(c) == r
         assert (rom0 is None
                 or isinstance(rom0, SecondOrderModel)
-                and rom0.n == r and rom0.B.source == fom.B.source and rom0.Cp.range == fom.Cp.range)
+                and rom0.order == r and rom0.B.source == fom.B.source and rom0.Cp.range == fom.Cp.range)
         assert sigma is None or rom0 is None
         assert b is None or rom0 is None
         assert c is None or rom0 is None
@@ -140,15 +140,15 @@ class SOR_IRKAReductor(BasicInterface):
                 np.random.seed(sigma)
                 sigma = np.abs(np.random.randn(r))
             if b is None:
-                b = fom.B.source.from_numpy(np.ones((r, fom.m)))
+                b = fom.B.source.from_numpy(np.ones((r, fom.input_dim)))
             elif isinstance(b, int):
                 np.random.seed(b)
-                b = fom.B.source.from_numpy(np.random.randn(r, fom.m))
+                b = fom.B.source.from_numpy(np.random.randn(r, fom.input_dim))
             if c is None:
-                c = fom.Cp.range.from_numpy(np.ones((r, fom.p)))
+                c = fom.Cp.range.from_numpy(np.ones((r, fom.output_dim)))
             elif isinstance(c, int):
                 np.random.seed(c)
-                c = fom.Cp.range.from_numpy(np.random.randn(r, fom.p))
+                c = fom.Cp.range.from_numpy(np.random.randn(r, fom.output_dim))
 
         # begin logging
         self.logger.info('Starting SOR-IRKA')

--- a/src/pymordemos/delay.py
+++ b/src/pymordemos/delay.py
@@ -59,7 +59,7 @@ if __name__ == '__main__':
 
     nt = 1000
     t = np.linspace(0, 4, nt)
-    x_old = np.zeros(rom.n)
+    x_old = np.zeros(rom.order)
     y = np.zeros(nt)
     for i in range(1, nt):
         h = t[i] - t[i - 1]
@@ -87,7 +87,7 @@ if __name__ == '__main__':
     B_ss = rom_ss.B.matrix
     C_ss = rom_ss.C.matrix
 
-    x_ss_old = np.zeros(rom_ss.n)
+    x_ss_old = np.zeros(rom_ss.order)
     y_ss = np.zeros(nt)
     for i in range(1, nt):
         h = t[i] - t[i - 1]

--- a/src/pymordemos/heat.py
+++ b/src/pymordemos/heat.py
@@ -58,9 +58,9 @@ if __name__ == '__main__':
 
     lti = fom.to_lti()
 
-    print(f'n = {lti.n}')
-    print(f'm = {lti.m}')
-    print(f'p = {lti.p}')
+    print(f'order of the model = {lti.order}')
+    print(f'number of inputs   = {lti.input_dim}')
+    print(f'number of outputs  = {lti.output_dim}')
 
     # System poles
     poles = lti.poles()

--- a/src/pymordemos/string_equation.py
+++ b/src/pymordemos/string_equation.py
@@ -55,9 +55,9 @@ if __name__ == '__main__':
     # Second-order system
     so_sys = SecondOrderModel.from_matrices(M, E, K, B, Cp)
 
-    print(f'n = {so_sys.n}')
-    print(f'm = {so_sys.m}')
-    print(f'p = {so_sys.p}')
+    print(f'order of the model = {so_sys.order}')
+    print(f'number of inputs   = {so_sys.input_dim}')
+    print(f'number of outputs  = {so_sys.output_dim}')
 
     poles = so_sys.poles()
     fig, ax = plt.subplots()


### PR DESCRIPTION
Renaming is as follows:
- `n` -> `order`
- `m` -> `input_dim`
- `p` -> `output_dim`

Other suggestions are welcome. `order` is used in places related to quadrature. Maybe shortening `input_dim` and `output_dim` would be good, e.g., `in_dim` and `out_dim`. Or replacing `input_dim` and `output_dim` with an attribute `shape = (m.output_space.dim, m.input_space.dim)`.