### PR TITLE
Moving arithmetic operators from InputStateOutputModel

### DIFF
--- a/notebooks/heat.ipynb
+++ b/notebooks/heat.ipynb
@@ -692,18 +692,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "tf_sys_w = tf_sys.bode(w)\n",
-    "lti_w = lti.bode(w)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "tf_lti_diff = tf_sys - lti\n",
     "fig, ax = plt.subplots()\n",
-    "ax.loglog(w, spla.norm(tf_sys_w - lti_w, axis=(1, 2)))\n",
+    "tf_lti_diff.mag_plot(w, ax=ax)\n",
     "ax.set_title('Distance between PDE and discretized transfer function')\n",
     "plt.show()"
    ]
@@ -734,7 +725,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dist_H2_int, dist_int_err = spint.quad(lambda w: spla.norm(tf_sys.eval_tf(w * 1j) - lti.eval_tf(w * 1j)) ** 2,\n",
+    "dist_h2_int, dist_int_err = spint.quad(lambda w: spla.norm(tf_lti_diff.eval_tf(w * 1j)) ** 2,\n",
     "                                       -np.inf, np.inf, epsabs=1e-16)\n",
     "print((dist_H2_int, dist_int_err))"
    ]
@@ -778,8 +769,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "error_H2, error_int_err = spint.quad(lambda w: spla.norm(tf_sys.eval_tf(w * 1j) -\n",
-    "                                                         rom_tf_irka.eval_tf(w * 1j)) ** 2,\n",
+    "err_tf_irka = tf_sys - rom_tf_irka\n",
+    "error_h2, error_int_err = spint.quad(lambda w: spla.norm(err_tf_irka.eval_tf(w * 1j)) ** 2,\n",
     "                                     -np.inf, np.inf, epsabs=1e-16)\n",
     "print((error_H2, error_int_err))"
    ]
@@ -799,8 +790,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "error_irka_H2, error_irka_int_err = spint.quad(lambda w: spla.norm(tf_sys.eval_tf(w * 1j) -\n",
-    "                                                                   rom_irka.eval_tf(w * 1j)) ** 2,\n",
+    "err_irka_tf = tf_sys - rom_irka\n",
+    "error_irka_h2, error_irka_int_err = spint.quad(lambda w: spla.norm(err_irka_tf.eval_tf(w * 1j)) ** 2,\n",
     "                                               -np.inf, np.inf, epsabs=1e-16)\n",
     "print((error_irka_H2, error_irka_int_err))"
    ]

--- a/notebooks/string.ipynb
+++ b/notebooks/string.ipynb
@@ -678,7 +678,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "err_bt = so_sys.to_lti() - rom_bt\n",
+    "err_bt = so_sys - rom_bt\n",
     "print('H_2-error for the BT ROM:    {:e}'.format(err_bt.h2_norm()))\n",
     "if config.HAVE_SLYCOT:\n",
     "    print('H_inf-error for the BT ROM:  {:e}'.format(err_bt.hinf_norm()))\n",
@@ -761,7 +761,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "err_irka = so_sys.to_lti() - rom_irka\n",
+    "err_irka = so_sys - rom_irka\n",
     "print('H_2-error for the IRKA ROM:    {:e}'.format(err_irka.h2_norm()))\n",
     "if config.HAVE_SLYCOT:\n",
     "    print('H_inf-error for the IRKA ROM:  {:e}'.format(err_irka.hinf_norm()))\n",

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -880,6 +880,61 @@ class TransferFunction(InputOutputModel):
     def eval_dtf(self, s):
         return self.dtf(s)
 
+    def __add__(self, other):
+        assert isinstance(other, InputOutputModel)
+        assert self.cont_time == other.cont_time
+        assert self.input_space == other.input_space
+        assert self.output_space == other.output_space
+
+        H = lambda s: self.eval_tf(s) + other.eval_tf(s)
+        dH = lambda s: self.eval_dtf(s) + other.eval_dtf(s)
+        return self.with_(H=H, dH=dH)
+
+    __radd__ = __add__
+
+    def __sub__(self, other):
+        assert isinstance(other, InputOutputModel)
+        assert self.cont_time == other.cont_time
+        assert self.input_space == other.input_space
+        assert self.output_space == other.output_space
+
+        H = lambda s: self.eval_tf(s) - other.eval_tf(s)
+        dH = lambda s: self.eval_dtf(s) - other.eval_dtf(s)
+        return self.with_(H=H, dH=dH)
+
+    def __rsub__(self, other):
+        assert isinstance(other, InputOutputModel)
+        assert self.cont_time == other.cont_time
+        assert self.input_space == other.input_space
+        assert self.output_space == other.output_space
+
+        H = lambda s: other.eval_tf(s) - self.eval_tf(s)
+        dH = lambda s: other.eval_dtf(s) - self.eval_dtf(s)
+        return self.with_(H=H, dH=dH)
+
+    def __neg__(self):
+        H = lambda s: -self.eval_tf(s)
+        dH = lambda s: -self.eval_dtf(s)
+        return self.with_(H=H, dH=dH)
+
+    def __mul__(self, other):
+        assert isinstance(other, InputOutputModel)
+        assert self.cont_time == other.cont_time
+        assert self.input_space == other.output_space
+
+        H = lambda s: self.eval_tf(s) @ other.eval_tf(s)
+        dH = lambda s: self.eval_dtf(s) @ other.eval_dtf(s)
+        return self.with_(H=H, dH=dH)
+
+    def __rmul__(self, other):
+        assert isinstance(other, InputOutputModel)
+        assert self.cont_time == other.cont_time
+        assert self.output_space == other.input_space
+
+        H = lambda s: other.eval_tf(s) @ self.eval_tf(s)
+        dH = lambda s: other.eval_dtf(s) @ self.eval_dtf(s)
+        return self.with_(H=H, dH=dH)
+
 
 class SecondOrderModel(InputStateOutputModel):
     r"""Class for linear second order systems.

--- a/src/pymor/reductors/interpolation.py
+++ b/src/pymor/reductors/interpolation.py
@@ -369,4 +369,5 @@ class TFInterpReductor(BasicInterface):
         Br = (T.dot(Br)).real
         Cr = (Cr.dot(T.conj().T)).real
 
-        return LTIModel.from_matrices(Ar, Br, Cr, D=None, E=Er, cont_time=fom.cont_time)
+        return LTIModel.from_matrices(Ar, Br, Cr, D=None, E=Er, cont_time=fom.cont_time,
+                                      input_id=fom.input_space.id, output_id=fom.output_space.id)

--- a/src/pymordemos/delay.py
+++ b/src/pymordemos/delay.py
@@ -50,6 +50,12 @@ if __name__ == '__main__':
     tf.mag_plot(w, ax=ax)
     rom.mag_plot(w, ax=ax, linestyle='dashed')
     ax.set_title('Magnitude Bode plots of the full and reduced model')
+    plt.show()
+
+    fig, ax = plt.subplots()
+    (tf - rom).mag_plot(w, ax=ax)
+    ax.set_title('Magnitude Bode plots of the error system')
+    plt.show()
 
     # step response
     E = rom.E.matrix

--- a/src/pymordemos/string_equation.py
+++ b/src/pymordemos/string_equation.py
@@ -263,7 +263,7 @@ if __name__ == '__main__':
     ax.set_title("BT reduced model's poles")
     plt.show()
 
-    err_bt = so_sys.to_lti() - rom_bt
+    err_bt = so_sys - rom_bt
     print(f'H_2-error for the BT ROM:    {err_bt.h2_norm():e}')
     compute_hinf_norm('H_inf-error for the BT ROM:  {:e}', err_bt)
     print(f'Hankel-error for the BT ROM: {err_bt.hankel_norm():e}')
@@ -295,7 +295,7 @@ if __name__ == '__main__':
     ax.set_title("IRKA reduced model's poles")
     plt.show()
 
-    err_irka = so_sys.to_lti() - rom_irka
+    err_irka = so_sys - rom_irka
     print(f'H_2-error for the IRKA ROM:    {err_irka.h2_norm():e}')
     compute_hinf_norm('H_inf-error for the IRKA ROM:  {:e}', err_irka)
     print(f'Hankel-error for the IRKA ROM: {err_irka.hankel_norm():e}')


### PR DESCRIPTION
This moves the generic `__add__`, `__neg__` and `__sub__` from `InputStateOutputModel` to `LTIModel`, `TransferFunction`, and `SecondOrderModel`. (Those should be added to other system classes after resolving #580.)

The motivation was to allow, e.g. `lti + tf` and `lti + so`, without making `InputStateOutputModel` even more convoluted. As a benefit, this removes the requirement that the `input_space`, `state_space` and `output_space` are different. There is quite some code repetition, which I'm not sure how to remove in a nice way.

The `__sub__` now does not depend on `__neg__` so that it can check if the two `D` operators are the same. (It is good for `fom - rom` to have the explicit zero `D` term when `rom` is obtained from `fom` by projection.)

This PR also adds `__mul__` to `TransferFunction` and `SecondOrderModel`.

The operations are built such that `LTIModel` knows only about itself, `TransferFunction` works with any model with `eval_tf` and `eval_dtf` attributes, and `SecondOrderModel` knows about `LTIModel`.

Related to #399 and #391.