### PR TITLE
Simplify Reductors and Models

### DIFF
--- a/notebooks/delay.ipynb
+++ b/notebooks/delay.ipynb
@@ -1,0 +1,227 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "This file is part of the pyMOR project (http://www.pymor.org).\n",
+    "Copyright 2013-2019 pyMOR developers and contributors. All rights reserved.\n",
+    "License: BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Create heat equation model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import scipy.linalg as spla\n",
+    "import scipy.sparse as sps\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "from pymor.basic import *\n",
+    "from pymor.models.iosys import LinearDelayModel\n",
+    "from pymor.reductors.interpolation import DelayBHIReductor, TFInterpReductor"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "p = InstationaryProblem(\n",
+    "    StationaryProblem(\n",
+    "        domain=LineDomain([0.,1.], left='robin', right='robin'),\n",
+    "        diffusion=ConstantFunction(1., 1),\n",
+    "        robin_data=(ConstantFunction(1., 1), ExpressionFunction('(x[...,0] < 1e-10) * 1.', 1)),\n",
+    "        functionals={'output': ('l2_boundary', ExpressionFunction('(x[...,0] > (1 - 1e-10)) * 1.', 1))}\n",
+    "    ),\n",
+    "    ConstantFunction(0., 1),\n",
+    "    T=3.\n",
+    ")\n",
+    "\n",
+    "fom, _ = discretize_instationary_cg(p, diameter=1/100, nt=100)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lti = fom.to_lti()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Add delayed feedback from output to input"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tau = 1.\n",
+    "g = 5.\n",
+    "Atau = sps.coo_matrix(([g], ([0], [lti.order - 1])), (lti.order, lti.order)).tocsc()\n",
+    "Atau = NumpyMatrixOperator(Atau, source_id=lti.state_space.id, range_id=lti.state_space.id)\n",
+    "td_lti = LinearDelayModel(lti.A, (Atau,), (tau,), lti.B, lti.C, E=lti.E)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots()\n",
+    "w = np.logspace(-1, 2.5, 500)\n",
+    "td_lti.mag_plot(w, ax=ax)\n",
+    "ax.set_title('Bode magnitude plot of the FOM')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Unstructured Hermite interpolation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "interp = TFInterpReductor(td_lti)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "r = 3\n",
+    "sigma = np.logspace(0, 1, r)\n",
+    "sigma = np.concatenate((1j * sigma, -1j * sigma))\n",
+    "b = td_lti.input_space.from_numpy(np.ones((2 * r, td_lti.input_dim)))\n",
+    "c = td_lti.output_space.from_numpy(np.ones((2 * r, td_lti.output_dim)))\n",
+    "\n",
+    "rom = interp.reduce(sigma, b.to_numpy().T, c.to_numpy().T)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots()\n",
+    "td_lti.mag_plot(w, ax=ax)\n",
+    "rom.mag_plot(w, ax=ax)\n",
+    "ax.set_title('Bode magnitude plot of the FOM and ROM')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots()\n",
+    "ax.loglog(w, spla.norm(td_lti.bode(w) - rom.bode(w), axis=(1, 2)))\n",
+    "ax.set_title('Bode magnitude plot of the error')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Delay-preserving reduction by Hermite interpolation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "delay_interp = DelayBHIReductor(td_lti)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "td_rom = delay_interp.reduce(sigma, b, c)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots()\n",
+    "td_lti.mag_plot(w, ax=ax)\n",
+    "rom.mag_plot(w, ax=ax)\n",
+    "td_rom.mag_plot(w, ax=ax)\n",
+    "ax.set_title('Bode magnitude plot of the FOM and ROMs')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots()\n",
+    "ax.loglog(w, spla.norm(td_lti.bode(w) - rom.bode(w), axis=(1, 2)), 'tab:orange')\n",
+    "ax.loglog(w, spla.norm(td_lti.bode(w) - td_rom.bode(w), axis=(1, 2)), 'tab:green')\n",
+    "ax.set_title('Bode magnitude plot of the errors')\n",
+    "plt.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/src/pymor/algorithms/ei.py
+++ b/src/pymor/algorithms/ei.py
@@ -294,7 +294,7 @@ def interpolate_operators(fom, operator_names, parameter_sample, error_norm=None
     assert alg in ('ei_greedy', 'deim')
     logger = getLogger('pymor.algorithms.ei.interpolate_operators')
     with RemoteObjectManager() as rom:
-        operators = [fom.operators[operator_name] for operator_name in operator_names]
+        operators = [getattr(fom, operator_name) for operator_name in operator_names]
         with logger.block('Computing operator evaluations on solution snapshots ...'):
             if pool:
                 logger.info(f'Using pool of {len(pool)} workers for parallel evaluation')
@@ -329,9 +329,7 @@ def interpolate_operators(fom, operator_names, parameter_sample, error_norm=None
 
     ei_operators = {name: EmpiricalInterpolatedOperator(operator, dofs, basis, triangular=(alg == 'ei_greedy'))
                     for name, operator in zip(operator_names, operators)}
-    operators_dict = fom.operators.copy()
-    operators_dict.update(ei_operators)
-    eim = fom.with_(operators=operators_dict, name=f'{fom.name}_ei')
+    eim = fom.with_(name=f'{fom.name}_ei', **ei_operators)
 
     data.update({'dofs': dofs, 'basis': basis})
     return eim, data

--- a/src/pymor/algorithms/error.py
+++ b/src/pymor/algorithms/error.py
@@ -337,7 +337,7 @@ def _compute_errors(mu, fom, reductor, estimator, error_norms, condition, custom
             norms[i_norm] = n
 
     for i_N, N in enumerate(basis_sizes):
-        rom = reductor.reduce(dim=N)
+        rom = reductor.reduce(dims={k: N for k in reductor.bases})
         u = rom.solve(mu)
         if estimator:
             e = rom.estimate(u, mu)

--- a/src/pymor/basic.py
+++ b/src/pymor/basic.py
@@ -67,7 +67,7 @@ from pymor.parameters.functionals import (ProjectionParameterFunctional, Generic
                                           ExpressionParameterFunctional)
 from pymor.parameters.spaces import CubicParameterSpace
 
-from pymor.reductors.basic import GenericRBReductor
+from pymor.reductors.basic import StationaryRBReductor, InstationaryRBReductor, LTIPGReductor, SOLTIPGReductor
 from pymor.reductors.bt import BTReductor, LQGBTReductor, BRBTReductor
 from pymor.reductors.coercive import CoerciveRBReductor, SimpleCoerciveRBReductor
 from pymor.reductors.h2 import IRKAReductor, TSIAReductor, TF_IRKAReductor

--- a/src/pymor/discretizers/cg.py
+++ b/src/pymor/discretizers/cg.py
@@ -194,7 +194,7 @@ def discretize_stationary_cg(analytical_problem, diameter=None, domain_discretiz
 
     parameter_space = p.parameter_space if hasattr(p, 'parameter_space') else None
 
-    m  = StationaryModel(L, F, operators=functionals, products=products, visualizer=visualizer,
+    m  = StationaryModel(L, F, outputs=functionals, products=products, visualizer=visualizer,
                          parameter_space=parameter_space, name=f'{p.name}_CG')
 
     data = {'grid': grid, 'boundary_info': boundary_info}
@@ -284,7 +284,7 @@ def discretize_instationary_cg(analytical_problem, diameter=None, domain_discret
 
     m = InstationaryModel(operator=m.operator, rhs=m.rhs, mass=mass, initial_data=I, T=p.T,
                           products=m.products,
-                          operators={k: v for k, v in m.operators.items() if not k in {'operator', 'rhs'}},
+                          outputs=m.outputs,
                           time_stepper=time_stepper,
                           parameter_space=p.parameter_space,
                           visualizer=m.visualizer,

--- a/src/pymor/models/basic.py
+++ b/src/pymor/models/basic.py
@@ -74,12 +74,12 @@ class StationaryModel(ModelBase):
     rhs
         The vector F. Either a |VectorArray| of length 1 or a vector-like
         |Operator|.
+    outputs
+        A dict of additional output |Functionals| associated with the model.
     products
         A dict of inner product |Operators| defined on the discrete space the
         problem is posed on. For each product a corresponding norm
         is added as a method of the model.
-    operators
-        A dict of additional |Operators| associated with the model.
     parameter_space
         The |ParameterSpace| for which the discrete problem is posed.
     estimator
@@ -104,8 +104,8 @@ class StationaryModel(ModelBase):
         The |Operator| L. The same as `operators['operator']`.
     rhs
         The right-hand side F. The same as `operators['rhs']`.
-    operators
-        Dict of all |Operators| appearing in the model.
+    outputs
+        Dict of all output |Functionals|.
     products
         Dict of all product |Operators| associated with the model.
     """
@@ -174,12 +174,12 @@ class InstationaryModel(ModelBase):
     num_values
         The number of returned vectors of the solution trajectory. If `None`, each
         intermediate vector that is calculated is returned.
+    outputs
+        A dict of additional output |Functionals| associated with the model.
     products
         A dict of product |Operators| defined on the discrete space the
         problem is posed on. For each product a corresponding norm
         is added as a method of the model.
-    operators
-        A dict of additional |Operators| associated with the model.
     parameter_space
         The |ParameterSpace| for which the discrete problem is posed.
     estimator
@@ -213,8 +213,8 @@ class InstationaryModel(ModelBase):
         The mass operator M. The same as `operators['mass']`.
     time_stepper
         The provided :class:`time-stepper <pymor.algorithms.timestepping.TimeStepperInterface>`.
-    operators
-        Dict of all |Operators| appearing in the model.
+    outputs
+        Dict of all output |Functionals|.
     products
         Dict of all product |Operators| associated with the model.
     """
@@ -279,8 +279,10 @@ class InstationaryModel(ModelBase):
             None                   -> D
             self.mass              -> E
         """
-        if len(self.outputs) != 1:
-            raise NotImplementedError
+        if len(self.outputs) == 0:
+            raise ValueError('No outputs defined.')
+        if len(self.outputs) > 1:
+            raise NotImplementedError('Only one output supported.')
         A = - self.operator
         B = self.rhs
         C = next(iter(self.outputs.values()))

--- a/src/pymor/models/basic.py
+++ b/src/pymor/models/basic.py
@@ -251,15 +251,9 @@ class InstationaryModel(ModelBase):
         self.outputs = FrozenDict(outputs or {})
         self.build_parameter_type(self.initial_data, self.operator, self.rhs, self.mass, provides={'_t': 0})
         self.parameter_space = parameter_space
-        if hasattr(time_stepper, 'nt'):
-            self.add_with_arguments = self.add_with_arguments | {'time_stepper_nt'}
 
-    def with_(self, **kwargs):
-        assert set(kwargs.keys()) <= self.with_arguments
-        assert 'time_stepper_nt' not in kwargs or 'time_stepper' not in kwargs
-        if 'time_stepper_nt' in kwargs:
-            kwargs['time_stepper'] = self.time_stepper.with_(nt=kwargs.pop('time_stepper_nt'))
-        return super().with_(**kwargs)
+    def with_time_stepper(self, **kwargs):
+        return self.with_(time_stepper=self.time_stepper.with_(**kwargs))
 
     def _solve(self, mu=None):
         mu = self.parse_parameter(mu).copy()

--- a/src/pymor/models/interfaces.py
+++ b/src/pymor/models/interfaces.py
@@ -24,8 +24,6 @@ class ModelInterface(CacheableInterface, Parametric):
         `True` if the model describes a linear problem.
     operators
         Dictionary of all |Operators| contained in the model
-        (see :class:`~pymor.reductors.basic.GenericRBReductor` for a usage
-        example).
     products
         Same as |Operators| but for inner product operators associated with the
         model.

--- a/src/pymor/models/interfaces.py
+++ b/src/pymor/models/interfaces.py
@@ -22,16 +22,12 @@ class ModelInterface(CacheableInterface, Parametric):
         |VectorSpace| of the |VectorArrays| returned by :meth:`solve`.
     linear
         `True` if the model describes a linear problem.
-    operators
-        Dictionary of all |Operators| contained in the model
     products
-        Same as |Operators| but for inner product operators associated with the
-        model.
+        Dict of inner product operators associated with the model.
     """
 
     solution_space = None
     linear = False
-    operators = dict()
     products = dict()
 
     @abstractmethod

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -24,10 +24,10 @@ class InputOutputModel(ModelBase):
     """Base class for input-output systems."""
 
     def __init__(self, input_space, output_space, cont_time=True,
-                 cache_region='memory', name=None, **kwargs):
+                 estimator=None, visualizer=None, cache_region='memory', name=None):
         self.input_space = input_space
         self.output_space = output_space
-        super().__init__(cache_region=cache_region, name=name, **kwargs)
+        super().__init__(estimator=estimator, visualizer=visualizer, cache_region=cache_region, name=name)
         self.cont_time = cont_time
 
     @property
@@ -120,12 +120,12 @@ class InputStateOutputModel(InputOutputModel):
     """Base class for input-output systems with state space."""
 
     def __init__(self, input_space, state_space, output_space, cont_time=True,
-                 cache_region='memory', name=None, **kwargs):
+                 estimator=None, visualizer=None, cache_region='memory', name=None):
         # ensure that state_space can be distinguished from input and output space
         # ensure that ids are different to make sure that also reduced spaces can be differentiated
         assert state_space.id != input_space.id and state_space.id != output_space.id
         super().__init__(input_space, output_space, cont_time=cont_time,
-                         cache_region=cache_region, name=name, **kwargs)
+                         estimator=estimator, visualizer=visualizer, cache_region=cache_region, name=name)
         self.state_space = state_space
 
     @property
@@ -203,8 +203,6 @@ class LTIModel(InputStateOutputModel):
         Dict of all |Operators| appearing in the model.
     """
 
-    special_operators = frozenset({'A', 'B', 'C', 'D', 'E'})
-
     def __init__(self, A, B, C, D=None, E=None, cont_time=True,
                  solver_options=None, estimator=None, visualizer=None,
                  cache_region='memory', name=None):
@@ -229,9 +227,13 @@ class LTIModel(InputStateOutputModel):
 
         super().__init__(B.source, A.source, C.range, cont_time=cont_time,
                          estimator=estimator, visualizer=visualizer,
-                         cache_region=cache_region, name=name,
-                         A=A, B=B, C=C, D=D, E=E)
+                         cache_region=cache_region, name=name)
 
+        self.A = A
+        self.B = B
+        self.C = C
+        self.D = D
+        self.E = E
         self.solution_space = A.source
         self.solver_options = solver_options
 
@@ -1030,8 +1032,6 @@ class SecondOrderModel(InputStateOutputModel):
         Dictionary of all |Operators| contained in the model.
     """
 
-    special_operators = frozenset({'M', 'E', 'K', 'B', 'Cp', 'Cv', 'D'})
-
     def __init__(self, M, E, K, B, Cp, Cv=None, D=None, cont_time=True,
                  solver_options=None, estimator=None, visualizer=None,
                  cache_region='memory', name=None):
@@ -1050,9 +1050,14 @@ class SecondOrderModel(InputStateOutputModel):
 
         super().__init__(B.source, M.source, Cp.range, cont_time=cont_time,
                          estimator=estimator, visualizer=visualizer,
-                         cache_region=cache_region, name=name,
-                         M=M, E=E, K=K, B=B, Cp=Cp, Cv=Cv, D=D)
-
+                         cache_region=cache_region, name=name)
+        self.M = M
+        self.E = E
+        self.K = K
+        self.B = B
+        self.Cp = Cp
+        self.Cv = Cv
+        self.D = D
         self.solution_space = M.source
         self.solver_options = solver_options
 
@@ -1611,8 +1616,6 @@ class LinearDelayModel(InputStateOutputModel):
         Dict of all |Operators| appearing in the model.
     """
 
-    special_operators = frozenset({'A', 'Ad', 'B', 'C', 'D', 'E'})
-
     def __init__(self, A, Ad, tau, B, C, D=None, E=None, cont_time=True,
                  estimator=None, visualizer=None,
                  cache_region='memory', name=None):
@@ -1632,9 +1635,14 @@ class LinearDelayModel(InputStateOutputModel):
 
         super().__init__(B.source, A.source, C.range, cont_time=cont_time,
                          estimator=estimator, visualizer=visualizer,
-                         cache_region=cache_region, name=name,
-                         A=A, Ad=Ad, B=B, C=C, D=D, E=E)
+                         cache_region=cache_region, name=name)
 
+        self.A = A
+        self.Ad = Ad
+        self.B = B
+        self.C = C
+        self.D = D
+        self.E = E
         self.solution_space = A.source
         self.tau = tau
         self.q = len(Ad)
@@ -1815,8 +1823,6 @@ class LinearStochasticModel(InputStateOutputModel):
         Dictionary of all |Operators| contained in the model.
     """
 
-    special_operators = frozenset({'A', 'As', 'B', 'C', 'D', 'E'})
-
     def __init__(self, A, As, B, C, D=None, E=None, cont_time=True,
                  estimator=None, visualizer=None,
                  cache_region='memory', name=None):
@@ -1835,9 +1841,14 @@ class LinearStochasticModel(InputStateOutputModel):
 
         super().__init__(B.source, A.source, C.range, cont_time=cont_time,
                          estimator=estimator, visualizer=visualizer,
-                         cache_region=cache_region, name=name,
-                         A=A, As=As, B=B, C=C, D=D, E=E)
+                         cache_region=cache_region, name=name)
 
+        self.A = A
+        self.As = As
+        self.B = B
+        self.C = C
+        self.D = D
+        self.E = E
         self.solution_space = A.source
         self.q = len(As)
 
@@ -1929,8 +1940,6 @@ class BilinearModel(InputStateOutputModel):
         Dictionary of all |Operators| contained in the model.
     """
 
-    special_operators = frozenset({'A', 'N', 'B', 'C', 'D', 'E'})
-
     def __init__(self, A, N, B, C, D, E=None, cont_time=True,
                  estimator=None, visualizer=None,
                  cache_region='memory', name=None):
@@ -1949,8 +1958,13 @@ class BilinearModel(InputStateOutputModel):
 
         super().__init__(B.source, C.range, state_space=A.source, cont_time=cont_time,
                          estimator=estimator, visualizer=visualizer,
-                         cache_region=cache_region, name=name,
-                         A=A, N=N, B=B, C=C, D=D, E=E)
+                         cache_region=cache_region, name=name)
 
+        self.A = A
+        self.N = N
+        self.B = B
+        self.C = C
+        self.D = D
+        self.E = E
         self.solution_space = A.source
         self.linear = False

--- a/src/pymor/reductors/basic.py
+++ b/src/pymor/reductors/basic.py
@@ -69,12 +69,20 @@ class ProjectionBasedReductor(BasicInterface):
     def _reduce(self):
         with self.logger.block('Operator projection ...'):
             projected_operators = self.project_operators()
-        with self.logger.block('Assembling error estimator ...'):
-            estimator = self.assemble_estimator()
+
+        # ensure that no logging output is generated for estimator assembly in case there is
+        # no estimator to assemble
+        if self.assemble_estimator.__func__ is not ProjectionBasedReductor.assemble_estimator:
+            with self.logger.block('Assembling error estimator ...'):
+                estimator = self.assemble_estimator()
+        else:
+            estimator = None
+
         with self.logger.block('Building ROM ...'):
             rom = self.build_rom(projected_operators, estimator)
             rom = rom.with_(name=f'{self.fom.name}_reduced')
             rom.disable_logging()
+
         return rom
 
     def _reduce_to_subbasis(self, dims):

--- a/src/pymor/reductors/basic.py
+++ b/src/pymor/reductors/basic.py
@@ -2,289 +2,310 @@
 # Copyright 2013-2019 pyMOR developers and contributors. All rights reserved.
 # License: BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
 
+from numbers import Number
+
 import numpy as np
 
 from pymor.algorithms.basic import almost_equal
 from pymor.algorithms.gram_schmidt import gram_schmidt
 from pymor.algorithms.pod import pod
 from pymor.algorithms.projection import project, project_to_subbasis
-from pymor.core.exceptions import ExtensionError
-from pymor.core.interfaces import BasicInterface
-from pymor.operators.constructions import IdentityOperator, Concatenation, InverseOperator
+from pymor.core.defaults import defaults
+from pymor.core.exceptions import ExtensionError, AccuracyError
+from pymor.core.interfaces import BasicInterface, abstractmethod
+from pymor.models.basic import StationaryModel, InstationaryModel
+from pymor.models.iosys import LTIModel, SecondOrderModel
 from pymor.operators.numpy import NumpyMatrixOperator
-from pymor.vectorarrays.numpy import NumpyVectorSpace
+from pymor.operators.constructions import Concatenation, InverseOperator
 
 
-class GenericRBReductor(BasicInterface):
-    """Generic reduced basis reductor.
-
-    Replaces each |Operator| of the given |Model| with the Galerkin
-    projection onto the span of the given reduced basis.
+class ProjectionBasedReductor(BasicInterface):
+    """Generic projection based reductor.
 
     Parameters
     ----------
-    fom
-        The |Model| which is to be reduced.
-    RB
-        |VectorArray| containing the reduced basis on which to project.
-    basis_is_orthonormal
-        If `RB` is specified, indicate whether or not the basis is orthonormal
-        w.r.t. `product`.
-    vector_ranged_operators
-        List of keys in `fom.operators` for which the corresponding |Operator|
-        should be orthogonally projected (i.e. operators which map to vectors in
-        contrast to bilinear forms which map to functionals).
-    product
-        Inner product for the orthonormalization of `RB` and the projection of the
-        |Operators| given by `vector_ranged_operators`.
+    bases
+        A dict of |VectorArrays| of basis vectors.
+    products
+        A dict of inner product `Operators` w.r.t. which the bases are orthonormalized
     """
 
-    def __init__(self, fom, RB=None, basis_is_orthonormal=None,
-                 vector_ranged_operators=('initial_data',), product=None):
-        if RB is not None and basis_is_orthonormal is None:
-            raise ValueError('Please specify is given basis is orthonormal using basis_is_orthonormal.')
-        if RB is None and basis_is_orthonormal is None:
-            basis_is_orthonormal = True
+    @defaults('check_orthonormality', 'check_tol')
+    def __init__(self, fom, bases, products={}, check_orthonormality=True, check_tol=1e-3):
+        assert products.keys() <= bases.keys()
         self.fom = fom
-        self.RB = fom.solution_space.empty() if RB is None else RB
-        assert self.RB in fom.solution_space
-        self.basis_is_orthonormal = basis_is_orthonormal
-        self.vector_ranged_operators = vector_ranged_operators
-        self.product = product
+        self.bases = dict(bases)
+        self.products = dict(products)
+        self.check_orthonormality = check_orthonormality
+        self.check_tol = check_tol
         self._last_rom = None
 
-    def reduce(self, dim=None):
-        """Perform the reduced basis projection.
+        if check_orthonormality:
+            for basis in bases:
+                self._check_orthonormality(basis)
 
-        Parameters
-        ----------
-        dim
-            If specified, the desired reduced state dimension. Must not be larger than the
-            current reduced basis dimension.
+    def reduce(self, dims=None):
+        if dims is None:
+            dims = {k: len(v) for k, v in self.bases.items()}
+        if isinstance(dims, Number):
+            dims = {k: dims for k in self.bases}
+        if set(dims.keys()) != set(self.bases.keys()):
+            raise ValueError(f'Must specify dimensions for {set(self.bases.keys())}')
+        for k, d in dims.items():
+            if d < 0:
+                raise ValueError(f'Reduced state dimension must be larger than zero {k}')
+            if d > len(self.bases[k]):
+                raise ValueError(f'Specified reduced state dimension larger than reduced basis {k}')
 
-        Returns
-        -------
-        The reduced |Model|.
-        """
-        if dim is None:
-            dim = len(self.RB)
-        if dim > len(self.RB):
-            raise ValueError('Specified reduced state dimension larger than reduced basis')
-        if self._last_rom is None or dim > self._last_rom.solution_space.dim:
+        if self._last_rom is None or any(dims[b] > self._last_rom_dims[b] for b in dims):
             self._last_rom = self._reduce()
-        if dim == self._last_rom.solution_space.dim:
+            self._last_rom_dims = dict(dims)
+
+        if dims == self._last_rom_dims:
             return self._last_rom
         else:
-            return self._reduce_to_subbasis(dim)
+            return self._reduce_to_subbasis(dims)
 
     def _reduce(self):
+        with self.logger.block('Operator projection ...'):
+            projected_operators = self.project_operators()
+        with self.logger.block('Assembling error estimator ...'):
+            estimator = self.assemble_estimator()
+        with self.logger.block('Building ROM ...'):
+            rom = self.build_rom(projected_operators, estimator)
+            rom = rom.with_(name=f'{self.fom.name}_reduced')
+            rom.disable_logging()
+        return rom
 
+    def _reduce_to_subbasis(self, dims):
+        projected_operators = self.project_operators_to_subbasis(dims)
+        estimator = self.assemble_estimator_for_subbasis(dims)
+        rom = self.build_rom(projected_operators, estimator)
+        rom = rom.with_(name=f'{self.fom.name}_reduced')
+        rom.disable_logging()
+        return rom
+
+    @abstractmethod
+    def project_operators(self):
+        pass
+
+    def assemble_estimator(self):
+        return None
+
+    @abstractmethod
+    def build_rom(self, projected_operators, estimator):
+        pass
+
+    def project_operators_to_subbasis(self, dims):
+        raise NotImplementedError
+
+    def assemble_estimator_for_subbasis(self, dims):
+        return None
+
+    def reconstruct(self, u, basis='RB'):
+        """Reconstruct high-dimensional vector from reduced vector `u`."""
+        return self.bases[basis][:u.dim].lincomb(u.to_numpy())
+
+    def extend_basis(self, U, basis='RB', method='gram_schmidt', pod_modes=1, pod_orthonormalize=True, copy_U=True):
+        basis_length = len(self.bases[basis])
+
+        extend_basis(U, self.bases[basis], self.products.get(basis), method=method, pod_modes=pod_modes,
+                     pod_orthonormalize=pod_orthonormalize,
+                     copy_U=copy_U)
+
+        self._check_orthonormality(basis, basis_length)
+
+    def _check_orthonormality(self, basis, offset=0):
+        if not self.check_orthonormality or basis not in self.products:
+            return
+
+        U = self.bases[basis]
+        product = self.products.get(basis, None)
+        error_matrix = U[offset:].inner(U, product)
+        error_matrix[:len(U) - offset, offset:] -= np.eye(len(U) - offset)
+        if error_matrix.size > 0:
+            err = np.max(np.abs(error_matrix))
+            if err >= self.check_tol:
+                raise AccuracyError(f"result not orthogonal (max err={err})")
+
+
+class StationaryRBReductor(ProjectionBasedReductor):
+    def __init__(self, fom, RB=None, product=None, check_orthonormality=None, check_tol=None):
+        assert isinstance(fom, StationaryModel)
+        RB = fom.solution_space.empty() if RB is None else RB
+        assert RB in fom.solution_space
+        super().__init__(fom, {'RB': RB}, {'RB': product},
+                         check_orthonormality=check_orthonormality, check_tol=check_tol)
+
+    def project_operators(self):
         fom = self.fom
-        RB = self.RB
+        RB = self.bases['RB']
+        projected_operators = {'operator': project(fom.operator, RB, RB),
+                               'rhs':      project(fom.rhs, RB, None),
+                               'products': {k: project(v, RB, RB) for k, v in fom.products.items()}}
+        return projected_operators
 
-        if any(k in self.vector_ranged_operators for k in fom.operators) and not self.basis_is_orthonormal:
-            projection_matrix = RB.inner(RB, self.product)
+    def project_operators_to_subbasis(self, dims):
+        rom = self._last_rom
+        dim = dims['RB']
+        projected_operators = {'operator': project_to_subbasis(rom.operator, dim, dim),
+                               'rhs':      project_to_subbasis(rom.rhs, dim, None),
+                               'products': {k: project_to_subbasis(v, dim, dim) for k, v in rom.products.items()}}
+        return projected_operators
+
+    def build_rom(self, projected_operators, estimator):
+        return StationaryModel(parameter_space=self.fom.parameter_space, estimator=estimator, **projected_operators)
+
+
+class InstationaryRBReductor(ProjectionBasedReductor):
+    def __init__(self, fom, RB=None, product=None, initial_data_product=None, product_is_mass=False,
+                 check_orthonormality=None, check_tol=None):
+        assert isinstance(fom, InstationaryModel)
+        RB = fom.solution_space.empty() if RB is None else RB
+        assert RB in fom.solution_space
+        super().__init__(fom, {'RB': RB}, {'RB': product},
+                         check_orthonormality=check_orthonormality, check_tol=check_tol)
+        self.initial_data_product = initial_data_product or product
+        self.product_is_mass = product_is_mass
+
+    def project_operators(self):
+        fom = self.fom
+        RB = self.bases['RB']
+        product = self.products['RB']
+
+        if self.initial_data_product != product:
+            # TODO there should be functionality for this somewhere else
+            projection_matrix = RB.gramian(self.initial_data_product)
             projection_op = NumpyMatrixOperator(projection_matrix, source_id=RB.space.id, range_id=RB.space.id)
             inverse_projection_op = InverseOperator(projection_op, 'inverse_projection_op')
-
-        def project_operator(k, op):
-            if op is self.product and self.basis_is_orthonormal:
-                return IdentityOperator(NumpyVectorSpace(len(RB), RB.space.id), name=op.name)
-            elif k in self.vector_ranged_operators:
-                assert RB in op.range
-                pop = project(op, range_basis=RB, source_basis=RB if RB in op.source else None, product=self.product)
-                if not self.basis_is_orthonormal:
-                    return Concatenation([inverse_projection_op, pop])
-                else:
-                    return pop
-            else:
-                return project(op,
-                               range_basis=RB if RB in op.range else None,
-                               source_basis=RB if RB in op.source else None)
-
-        projected_operators = {k: project_operator(k, op) if op else None for k, op in fom.operators.items()}
-
-        projected_products = {k: project_operator(k, p) for k, p in fom.products.items()}
-
-        rom = fom.with_(operators=projected_operators, products=projected_products,
-                        visualizer=None, estimator=None,
-                        cache_region=None, name=fom.name + '_reduced')
-        rom.disable_logging()
-
-        return rom
-
-    def _reduce_to_subbasis(self, dim):
-        rom = self._last_rom
-
-        def project_operator(k, op):
-            if k in self.vector_ranged_operators and not self.basis_is_orthonormal:
-                assert (isinstance(op, Concatenation) and len(op.operators) == 2
-                        and op.operators[0].name == 'inverse_projection_op')
-                pop = project_to_subbasis(op.operators[1],
-                                          dim_range=dim,
-                                          dim_source=dim if op.source == rom.solution_space else None)
-                inverse_projection_op = InverseOperator(
-                    project_to_subbasis(op.operators[0].operator, dim_range=dim, dim_source=dim),
-                    name='inverse_projection_op'
-                )
-                return Concatenation([inverse_projection_op, pop])
-            else:
-                return project_to_subbasis(op,
-                                           dim_range=dim if op.range == rom.solution_space else None,
-                                           dim_source=dim if op.source == rom.solution_space else None)
-
-        projected_operators = {k: project_operator(k, op) if op else None for k, op in rom.operators.items()}
-
-        projected_products = {k: project_operator(k, op) for k, op in rom.products.items()}
-
-        if rom.estimator:
-            estimator = rom.estimator.restricted_to_subbasis(dim, m=rom)
+            pid = project(fom.initial_data, range_basis=RB, source_basis=None, product=self.initial_data_product)
+            projected_initial_data = Concatenation([inverse_projection_op, pid])
         else:
-            estimator = None
+            projected_initial_data = project(fom.initial_data, range_basis=RB, source_basis=None,
+                                             product=product)
 
-        rrom = rom.with_(operators=projected_operators, products=projected_products, estimator=estimator,
-                         visualizer=None, name=rom.name + '_reduced_to_subbasis')
+        projected_operators = {'mass':         (None if fom.mass is None or self.product_is_mass else
+                                                project(fom.mass, RB, RB)),
+                               'operator':     project(fom.operator, RB, RB),
+                               'rhs':          project(fom.rhs, RB, None) if fom.rhs is not None else None,
+                               'initial_data': projected_initial_data,
+                               'products':     {k: project(v, RB, RB) for k, v in fom.products.items()}}
 
-        return rrom
+        return projected_operators
 
-    def reconstruct(self, u):
-        """Reconstruct high-dimensional vector from reduced vector `u`."""
-        return self.RB[:u.dim].lincomb(u.to_numpy())
+    def project_operators_to_subbasis(self, dims):
+        rom = self._last_rom
+        dim = dims['RB']
+        product = self.products['RB']
 
-    def extend_basis(self, U, method='gram_schmidt', pod_modes=1, pod_orthonormalize=True, orthonormal=None,
-                     copy_U=True):
-        """Extend basis by new vectors.
+        if self.initial_data_product != product:
+            # TODO there should be functionality for this somewhere else
+            pop = project_to_subbasis(rom.initial_data.operators[1], dim_range=dim, dim_source=None)
+            inverse_projection_op = InverseOperator(
+                project_to_subbasis(rom.initial_data.operators[0].operator, dim_range=dim, dim_source=dim),
+                name='inverse_projection_op'
+            )
+            projected_initial_data = Concatenation([inverse_projection_op, pop])
+        else:
+            projected_initial_data = project_to_subbasis(rom.initial_data, dim_range=dim, dim_source=None)
 
-        Parameters
-        ----------
-        U
-            |VectorArray| containing the new basis vectors.
-        method
-            Basis extension method to use. The following methods are available:
+        projected_operators = {'mass':     (None if rom.mass is None or self.product_is_mass else
+                                            project_to_subbasis(rom.mass, dim, dim)),
+                               'operator': project_to_subbasis(rom.operator, dim, dim),
+                               'rhs':      project_to_subbasis(rom.rhs, dim, None) if rom.rhs is not None else None,
+                               'initial_data': projected_initial_data,
+                               'products': {k: project_to_subbasis(v, dim, dim) for k, v in rom.products.items()}}
+        return projected_operators
 
-                :trivial:      Vectors in `U` are appended to the basis. Duplicate vectors
-                               in the sense of :func:`~pymor.algorithms.basic.almost_equal`
-                               are removed.
-                :gram_schmidt: New basis vectors are orthonormalized w.r.t. to the old
-                               basis using the :func:`~pymor.algorithms.gram_schmidt.gram_schmidt`
-                               algorithm.
-                :pod:          Append the first POD modes of the defects of the projections
-                               of the vectors in U onto the existing basis
-                               (e.g. for use in POD-Greedy algorithm).
-
-            .. warning::
-                In case of the `'gram_schmidt'` and `'pod'` extension methods, the existing reduced
-                basis is assumed to be orthonormal w.r.t. the given inner product.
-
-        pod_modes
-            In case `method == 'pod'`, the number of POD modes that shall be appended to
-            the basis.
-        pod_orthonormalize
-            If `True` and `method == 'pod'`, re-orthonormalize the new basis vectors obtained
-            by the POD in order to improve numerical accuracy.
-        orthonormal
-            If `method == 'trivial'`, set this to `True` to indicate that the basis will remain
-            orthonormal after extending.
-        copy_U
-            If `copy_U` is `False`, the new basis vectors might be removed from `U`.
-
-        Raises
-        ------
-        ExtensionError
-            Raised when the selected extension method does not yield a basis of increased
-            dimension.
-        """
-        assert method == 'trivial' or orthonormal is None
-        extend_basis(self.RB, U, self.product, method=method, pod_modes=pod_modes,
-                     pod_orthonormalize=pod_orthonormalize, copy_U=copy_U)
-        if method == 'trivial' and not orthonormal:
-            self.basis_is_orthonormal = False
+    def build_rom(self, projected_operators, estimator):
+        fom = self.fom
+        return InstationaryModel(T=fom.T, time_stepper=fom.time_stepper, num_values=fom.num_values,
+                                 parameter_space=self.fom.parameter_space, estimator=estimator, **projected_operators)
 
 
-class GenericPGReductor(BasicInterface):
-    """Generic Petrov-Galerkin reductor.
+class LTIPGReductor(ProjectionBasedReductor):
+    def __init__(self, fom, W, V, E_biorthonormal=False):
+        assert isinstance(fom, LTIModel)
+        super().__init__(fom, {'W': W, 'V': V})
+        self.E_biorthonormal = E_biorthonormal
 
-    Replaces each |Operator| of the given |Model| with the projection
-    onto the span of the given projection matrices.
+    def project_operators(self):
+        fom = self.fom
+        W = self.bases['W']
+        V = self.bases['V']
+        projected_operators = {'A': project(fom.A, W, V),
+                               'B': project(fom.B, W, None),
+                               'C': project(fom.C, None, V),
+                               'D': fom.D,
+                               'E': None if self.E_biorthonormal else project(fom.E, W, V)}
+        return projected_operators
 
-    Parameters
-    ----------
-    fom
-        The |Model| which is to be reduced.
-    W
-        |VectorArray| containing the left projection matrix.
-    V
-        |VectorArray| containing the right projection matrix.
-    bases_are_biorthonormal
-        Indicate whether or not V and W are biorthonormal w.r.t. `product`.
-    vector_ranged_operators
-        List of keys in `fom.operators` for which the corresponding |Operator|
-        should be biorthogonally projected (i.e. operators which map to vectors in
-        contrast to bilinear forms which map to functionals).
-    product
-        Inner product for the projection of the |Operators| given by
-        `vector_ranged_operators`.
-    """
+    def project_operators_to_subbasis(self, dims):
+        if dims['W'] != dims['V']:
+            raise ValueError
+        rom = self._last_rom
+        dim = dims['V']
+        projected_operators = {'A': project_to_subbasis(rom.A, dim, dim),
+                               'B': project_to_subbasis(rom.B, dim, None),
+                               'C': project_to_subbasis(rom.C, None, dim),
+                               'D': rom.D,
+                               'E': None if self.E_biorthonormal else project_to_subbasis(rom.E, dim, dim)}
+        return projected_operators
 
-    def __init__(self, fom, W, V, bases_are_biorthonormal, vector_ranged_operators=('initial_data',), product=None):
-        assert V in fom.solution_space
-        assert product is None or (W in product.range and V in product.source)
-        self.fom = fom
-        self.V = V
-        self.W = W
-        self.bases_are_biorthonormal = bases_are_biorthonormal
-        self.vector_ranged_operators = vector_ranged_operators
-        self.product = product
+    def build_rom(self, projected_operators, estimator):
+        return LTIModel(estimator=estimator, **projected_operators)
 
-    def reduce(self):
-        """Perform the Petrov-Galerkin projection.
+    def extend_basis(self, **kwargs):
+        raise NotImplementedError
 
-        Returns
-        -------
-        The reduced |Model|.
-        """
-        fom, V, W = self.fom, self.V, self.W
-        product = self.product
-
-        if any(k in self.vector_ranged_operators for k in fom.operators) and not self.bases_are_biorthonormal:
-            projection_matrix = W.inner(V, product)
-            projection_op = NumpyMatrixOperator(projection_matrix, source_id=V.space.id, range_id=W.space.id)
-            inverse_projection_op = InverseOperator(projection_op, 'inverse_projection_op')
-
-        def project_operator(k, op):
-            if not op:
-                return None
-            if k is product and self.bases_are_biorthonormal:
-                if V.space.id != W.space.id:
-                    raise NotImplementedError
-                return IdentityOperator(NumpyVectorSpace(len(V), V.space.id))
-            elif k in self.vector_ranged_operators:
-                assert W in op.range
-                pop = project(op, range_basis=W, source_basis=V if V in op.source else None, product=product)
-                if not self.bases_are_biorthonormal:
-                    return Concatenation([inverse_projection_op, pop])
-                else:
-                    return pop
-            else:
-                return project(op,
-                               range_basis=W if W in op.range else None,
-                               source_basis=V if V in op.source else None)
-
-        projected_ops = {k: project_operator(k, op) for k, op in fom.operators.items()}
-
-        rom = fom.with_(operators=projected_ops,
-                        visualizer=None, estimator=None,
-                        cache_region=None, name=fom.name + '_reduced')
-        rom.disable_logging()
-
-        return rom
-
-    def reconstruct(self, u):
-        """Reconstruct high-dimensional vector from reduced vector `u`."""
-        return self.V[:u.dim].lincomb(u.to_numpy())
+    def reconstruct(self, u, basis='V'):
+        return super().reconstruct(u, basis)
 
 
-def extend_basis(basis, U, product=None, method='gram_schmidt', pod_modes=1, pod_orthonormalize=True, copy_U=True):
+class SOLTIPGReductor(ProjectionBasedReductor):
+    def __init__(self, fom, W, V, M_biorthonormal=False):
+        assert isinstance(fom, SecondOrderModel)
+        super().__init__(fom, {'W': W, 'V': V})
+        self.M_biorthonormal = M_biorthonormal
+
+    def project_operators(self):
+        fom = self.fom
+        W = self.bases['W']
+        V = self.bases['V']
+        projected_operators = {'M':  None if self.M_biorthonormal else project(fom.M, W, V),
+                               'E':  project(fom.E, W, V),
+                               'K':  project(fom.K, W, V),
+                               'B':  project(fom.B, W, None),
+                               'Cp': project(fom.Cp, None, V),
+                               'Cv': project(fom.Cv, None, V),
+                               'D':  fom.D}
+        return projected_operators
+
+    def project_operators_to_subbasis(self, dims):
+        if dims['W'] != dims['V']:
+            raise ValueError
+        rom = self._last_rom
+        dim = dims['V']
+        projected_operators = {'M':  None if self.M_biorthonormal else project_to_subbasis(rom.M, dim, dim),
+                               'E':  project_to_subbasis(rom.E, dim, dim),
+                               'K':  project_to_subbasis(rom.K, dim, dim),
+                               'B':  project_to_subbasis(rom.B, dim, None),
+                               'Cp': project_to_subbasis(rom.C, None, dim),
+                               'Cv': project_to_subbasis(rom.C, None, dim),
+                               'D':  rom.D}
+        return projected_operators
+
+    def build_rom(self, projected_operators, estimator):
+        return SecondOrderModel(estimator=estimator, **projected_operators)
+
+    def extend_basis(self, **kwargs):
+        raise NotImplementedError
+
+    def reconstruct(self, u, basis='V'):
+        return super().reconstruct(u, basis)
+
+
+def extend_basis(U, basis, product=None, method='gram_schmidt', pod_modes=1, pod_orthonormalize=True, copy_U=True):
     assert method in ('trivial', 'gram_schmidt', 'pod')
 
     basis_length = len(basis)
@@ -298,14 +319,14 @@ def extend_basis(basis, U, product=None, method='gram_schmidt', pod_modes=1, pod
                      remove_from_other=(not copy_U))
     elif method == 'gram_schmidt':
         basis.append(U, remove_from_other=(not copy_U))
-        gram_schmidt(basis, offset=basis_length, product=product, copy=False)
+        gram_schmidt(basis, offset=basis_length, product=product, copy=False, check=False)
     elif method == 'pod':
         U_proj_err = U - basis.lincomb(U.inner(basis, product))
 
         basis.append(pod(U_proj_err, modes=pod_modes, product=product, orthonormalize=False)[0])
 
         if pod_orthonormalize:
-            gram_schmidt(basis, offset=basis_length, product=product, copy=False)
+            gram_schmidt(basis, offset=basis_length, product=product, copy=False, check=False)
 
     if len(basis) <= basis_length:
         raise ExtensionError

--- a/src/pymor/reductors/basic.py
+++ b/src/pymor/reductors/basic.py
@@ -142,7 +142,8 @@ class StationaryRBReductor(ProjectionBasedReductor):
         RB = self.bases['RB']
         projected_operators = {'operator': project(fom.operator, RB, RB),
                                'rhs':      project(fom.rhs, RB, None),
-                               'products': {k: project(v, RB, RB) for k, v in fom.products.items()}}
+                               'products': {k: project(v, RB, RB) for k, v in fom.products.items()},
+                               'outputs':  {k: project(v, None, RB) for k, v in fom.outputs.items()}}
         return projected_operators
 
     def project_operators_to_subbasis(self, dims):
@@ -150,7 +151,8 @@ class StationaryRBReductor(ProjectionBasedReductor):
         dim = dims['RB']
         projected_operators = {'operator': project_to_subbasis(rom.operator, dim, dim),
                                'rhs':      project_to_subbasis(rom.rhs, dim, None),
-                               'products': {k: project_to_subbasis(v, dim, dim) for k, v in rom.products.items()}}
+                               'products': {k: project_to_subbasis(v, dim, dim) for k, v in rom.products.items()},
+                               'outputs':  {k: project_to_subbasis(v, None, dim) for k, v in rom.outputs.items()}}
         return projected_operators
 
     def build_rom(self, projected_operators, estimator):
@@ -189,7 +191,8 @@ class InstationaryRBReductor(ProjectionBasedReductor):
                                'operator':     project(fom.operator, RB, RB),
                                'rhs':          project(fom.rhs, RB, None) if fom.rhs is not None else None,
                                'initial_data': projected_initial_data,
-                               'products':     {k: project(v, RB, RB) for k, v in fom.products.items()}}
+                               'products':     {k: project(v, RB, RB) for k, v in fom.products.items()},
+                               'outputs':      {k: project(v, None, RB) for k, v in fom.outputs.items()}}
 
         return projected_operators
 
@@ -214,7 +217,8 @@ class InstationaryRBReductor(ProjectionBasedReductor):
                                'operator': project_to_subbasis(rom.operator, dim, dim),
                                'rhs':      project_to_subbasis(rom.rhs, dim, None) if rom.rhs is not None else None,
                                'initial_data': projected_initial_data,
-                               'products': {k: project_to_subbasis(v, dim, dim) for k, v in rom.products.items()}}
+                               'products': {k: project_to_subbasis(v, dim, dim) for k, v in rom.products.items()},
+                               'outputs':  {k: project_to_subbasis(v, None, dim) for k, v in rom.outputs.items()}}
         return projected_operators
 
     def build_rom(self, projected_operators, estimator):

--- a/src/pymor/reductors/basic.py
+++ b/src/pymor/reductors/basic.py
@@ -24,10 +24,21 @@ class ProjectionBasedReductor(BasicInterface):
 
     Parameters
     ----------
+    fom
+        The full order |Model| to reduce.
     bases
         A dict of |VectorArrays| of basis vectors.
     products
-        A dict of inner product `Operators` w.r.t. which the bases are orthonormalized
+        A dict of inner product |Operators| w.r.t. which the corresponding bases are
+        orthonormalized. A value of `None` corresponds to orthonormalization of the
+        basis w.r.t. the Euclidean inner product.
+    check_orthonormality
+        If `True`, check if bases which have a corresponding entry in the `products`
+        dict are orthonormal w.r.t. the given inner product. After each
+        :meth:`basis extension <extend_basis>`, orthonormality is checked again.
+    check_tol
+        If `check_orthonormality` is `True`, the numerical tolerance with which the checks
+        are performed.
     """
 
     @defaults('check_orthonormality', 'check_tol')
@@ -138,6 +149,22 @@ class ProjectionBasedReductor(BasicInterface):
 
 
 class StationaryRBReductor(ProjectionBasedReductor):
+    """Galerkin projection of a |StationaryModel|.
+
+    Parameters
+    ----------
+    fom
+        The full order |Model| to reduce.
+    RB
+        The basis of the reduced space onto which to project. If `None` an empty basis is used.
+    product
+        Inner product |Operator| w.r.t. which `RB` is orthonormalized. If `None`, the Euclidean
+        inner product is used.
+    check_orthonormality
+        See :class:`ProjectionBasedReductor`.
+    check_tol
+        See :class:`ProjectionBasedReductor`.
+    """
     def __init__(self, fom, RB=None, product=None, check_orthonormality=None, check_tol=None):
         assert isinstance(fom, StationaryModel)
         RB = fom.solution_space.empty() if RB is None else RB
@@ -168,6 +195,28 @@ class StationaryRBReductor(ProjectionBasedReductor):
 
 
 class InstationaryRBReductor(ProjectionBasedReductor):
+    """Galerkin projection of an |InstationaryModel|.
+
+    Parameters
+    ----------
+    fom
+        The full order |Model| to reduce.
+    RB
+        The basis of the reduced space onto which to project. If `None` an empty basis is used.
+    product
+        Inner product |Operator| w.r.t. which `RB` is orthonormalized. If `None`, the
+        the Euclidean inner product is used.
+    initial_data_product
+        Inner product |Operator| w.r.t. which the `initial_data` of `fom` is orthogonally projected. 
+        If `None`, the Euclidean inner product is used.
+    product_is_mass
+        If `True`, no mass matrix for the reduced |Model| is assembled.  Set to `True` if `RB` is
+        orthonormal w.r.t. the `mass` matrix of `fom`.
+    check_orthonormality
+        See :class:`ProjectionBasedReductor`.
+    check_tol
+        See :class:`ProjectionBasedReductor`.
+    """
     def __init__(self, fom, RB=None, product=None, initial_data_product=None, product_is_mass=False,
                  check_orthonormality=None, check_tol=None):
         assert isinstance(fom, InstationaryModel)
@@ -236,6 +285,20 @@ class InstationaryRBReductor(ProjectionBasedReductor):
 
 
 class LTIPGReductor(ProjectionBasedReductor):
+    """Petrov-Galerkin projection of an |LTIModel|.
+
+    Parameters
+    ----------
+    fom
+        The full order |Model| to reduce.
+    W
+        The basis of the test space.
+    V
+        The basis of the ansatz space.
+    E_biorthonormal
+        If `True`, no `E` matrix will be assembled for the reduced |Model|.
+        Set to `True` if `W` and `V` are biorthonormal w.r.t. `fom.E`.
+    """
     def __init__(self, fom, W, V, E_biorthonormal=False):
         assert isinstance(fom, LTIModel)
         super().__init__(fom, {'W': W, 'V': V})
@@ -275,6 +338,20 @@ class LTIPGReductor(ProjectionBasedReductor):
 
 
 class SOLTIPGReductor(ProjectionBasedReductor):
+    """Petrov-Galerkin projection of an |SOLTIModel|.
+
+    Parameters
+    ----------
+    fom
+        The full order |Model| to reduce.
+    W
+        The basis of the test space.
+    V
+        The basis of the ansatz space.
+    E_biorthonormal
+        If `True`, no `E` matrix will be assembled for the reduced |Model|.
+        Set to `True` if `W` and `V` are biorthonormal w.r.t. `fom.E`.
+    """
     def __init__(self, fom, W, V, M_biorthonormal=False):
         assert isinstance(fom, SecondOrderModel)
         super().__init__(fom, {'W': W, 'V': V})
@@ -318,6 +395,20 @@ class SOLTIPGReductor(ProjectionBasedReductor):
 
 
 class DelayLTIPGReductor(ProjectionBasedReductor):
+    """Petrov-Galerkin projection of an |DelayLTIModel|.
+
+    Parameters
+    ----------
+    fom
+        The full order |Model| to reduce.
+    W
+        The basis of the test space.
+    V
+        The basis of the ansatz space.
+    E_biorthonormal
+        If `True`, no `E` matrix will be assembled for the reduced |Model|.
+        Set to `True` if `W` and `V` are biorthonormal w.r.t. `fom.E`.
+    """
     def __init__(self, fom, W, V, E_biorthonormal=False):
         assert isinstance(fom, LinearDelayModel)
         super().__init__(fom, {'W': W, 'V': V})

--- a/src/pymor/reductors/basic.py
+++ b/src/pymor/reductors/basic.py
@@ -14,7 +14,7 @@ from pymor.core.defaults import defaults
 from pymor.core.exceptions import ExtensionError, AccuracyError
 from pymor.core.interfaces import BasicInterface, abstractmethod
 from pymor.models.basic import StationaryModel, InstationaryModel
-from pymor.models.iosys import LTIModel, SecondOrderModel
+from pymor.models.iosys import LTIModel, SecondOrderModel, LinearDelayModel
 from pymor.operators.numpy import NumpyMatrixOperator
 from pymor.operators.constructions import Concatenation, InverseOperator
 
@@ -309,6 +309,47 @@ class SOLTIPGReductor(ProjectionBasedReductor):
 
     def build_rom(self, projected_operators, estimator):
         return SecondOrderModel(estimator=estimator, **projected_operators)
+
+    def extend_basis(self, **kwargs):
+        raise NotImplementedError
+
+    def reconstruct(self, u, basis='V'):
+        return super().reconstruct(u, basis)
+
+
+class DelayLTIPGReductor(ProjectionBasedReductor):
+    def __init__(self, fom, W, V, E_biorthonormal=False):
+        assert isinstance(fom, LinearDelayModel)
+        super().__init__(fom, {'W': W, 'V': V})
+        self.E_biorthonormal = E_biorthonormal
+
+    def project_operators(self):
+        fom = self.fom
+        W = self.bases['W']
+        V = self.bases['V']
+        projected_operators = {'A': project(fom.A, W, V),
+                               'Ad': tuple(project(op, W, V) for op in fom.Ad),
+                               'B': project(fom.B, W, None),
+                               'C': project(fom.C, None, V),
+                               'D': fom.D,
+                               'E': None if self.E_biorthonormal else project(fom.E, W, V)}
+        return projected_operators
+
+    def project_operators_to_subbasis(self, dims):
+        if dims['W'] != dims['V']:
+            raise ValueError
+        rom = self._last_rom
+        dim = dims['V']
+        projected_operators = {'A': project_to_subbasis(rom.A, dim, dim),
+                               'Ad': tuple(project_to_subbasis(op, dim, dim) for op in rom.Ad),
+                               'B': project_to_subbasis(rom.B, dim, None),
+                               'C': project_to_subbasis(rom.C, None, dim),
+                               'D': rom.D,
+                               'E': None if self.E_biorthonormal else project_to_subbasis(rom.E, dim, dim)}
+        return projected_operators
+
+    def build_rom(self, projected_operators, estimator):
+        return LinearDelayModel(tau=self.fom.tau, estimator=estimator, **projected_operators)
 
     def extend_basis(self, **kwargs):
         raise NotImplementedError

--- a/src/pymor/reductors/bt.py
+++ b/src/pymor/reductors/bt.py
@@ -10,7 +10,7 @@ from pymor.algorithms.riccati import solve_ricc_lrcf, solve_pos_ricc_lrcf
 from pymor.core.interfaces import BasicInterface
 from pymor.models.iosys import LTIModel
 from pymor.operators.constructions import IdentityOperator
-from pymor.reductors.basic import GenericPGReductor
+from pymor.reductors.basic import LTIPGReductor
 
 
 class GenericBTReductor(BasicInterface):
@@ -104,8 +104,7 @@ class GenericBTReductor(BasicInterface):
         elif projection == 'biorth':
             self.V, self.W = gram_schmidt_biorth(self.V, self.W, product=self.fom.E)
 
-        self.pg_reductor = GenericPGReductor(self.fom, self.W, self.V, projection in ('sr', 'biorth'),
-                                             product=self.fom.E)
+        self.pg_reductor = LTIPGReductor(self.fom, self.W, self.V, projection in ('sr', 'biorth'))
         rom = self.pg_reductor.reduce()
 
         return rom

--- a/src/pymor/reductors/coercive.py
+++ b/src/pymor/reductors/coercive.py
@@ -114,7 +114,7 @@ class SimpleCoerciveRBReductor(StationaryRBReductor):
 
     def __init__(self, fom, RB=None, product=None, coercivity_estimator=None,
                  check_orthonormality=None, check_tol=None):
-        assert fom.linear
+        assert fom.operator.linear and fom.rhs.linear
         assert isinstance(fom.operator, LincombOperator)
         assert all(not op.parametric for op in fom.operator.operators)
         if fom.rhs.parametric:

--- a/src/pymor/reductors/h2.py
+++ b/src/pymor/reductors/h2.py
@@ -11,7 +11,7 @@ from pymor.algorithms.to_matrix import to_matrix
 from pymor.core.interfaces import BasicInterface
 from pymor.models.iosys import LTIModel
 from pymor.operators.constructions import IdentityOperator
-from pymor.reductors.basic import GenericPGReductor
+from pymor.reductors.basic import LTIPGReductor
 from pymor.reductors.interpolation import LTI_BHIReductor, TFInterpReductor
 
 
@@ -454,7 +454,7 @@ class OneSidedIRKAReductor(BasicInterface):
         else:
             self.V = gram_schmidt(W, atol=0, rtol=0, product=None if projection == 'orth' else fom.E)
 
-        self.pg_reductor = GenericPGReductor(fom, self.V, self.V, projection == 'Eorth', product=fom.E)
+        self.pg_reductor = LTIPGReductor(fom, self.V, self.V, projection == 'Eorth')
 
     def reconstruct(self, u):
         """Reconstruct high-dimensional vector from reduced vector `u`."""
@@ -596,7 +596,7 @@ class TSIAReductor(BasicInterface):
         elif projection == 'biorth':
             self.V, self.W = gram_schmidt_biorth(self.V, self.W, product=fom.E)
 
-        self.pg_reductor = GenericPGReductor(fom, self.W, self.V, projection == 'biorth', product=fom.E)
+        self.pg_reductor = LTIPGReductor(fom, self.W, self.V, projection == 'biorth')
 
     def reconstruct(self, u):
         """Reconstruct high-dimensional vector from reduced vector `u`."""

--- a/src/pymor/reductors/interpolation.py
+++ b/src/pymor/reductors/interpolation.py
@@ -10,7 +10,7 @@ from pymor.algorithms.gram_schmidt import gram_schmidt, gram_schmidt_biorth
 from pymor.core.interfaces import BasicInterface
 from pymor.models.iosys import LTIModel, SecondOrderModel, LinearDelayModel
 from pymor.operators.constructions import LincombOperator
-from pymor.reductors.basic import LTIPGReductor, SOLTIPGReductor
+from pymor.reductors.basic import LTIPGReductor, SOLTIPGReductor, DelayLTIPGReductor
 
 
 class GenericBHIReductor(BasicInterface):
@@ -268,6 +268,9 @@ class DelayBHIReductor(GenericBHIReductor):
     fom
         :class:`~pymor.models.iosys.LinearDelayModel`.
     """
+
+    PGReductor = DelayLTIPGReductor
+
     def __init__(self, fom):
         assert isinstance(fom, LinearDelayModel)
         self.fom = fom

--- a/src/pymor/reductors/interpolation.py
+++ b/src/pymor/reductors/interpolation.py
@@ -10,7 +10,7 @@ from pymor.algorithms.gram_schmidt import gram_schmidt, gram_schmidt_biorth
 from pymor.core.interfaces import BasicInterface
 from pymor.models.iosys import LTIModel, SecondOrderModel, LinearDelayModel
 from pymor.operators.constructions import LincombOperator
-from pymor.reductors.basic import GenericPGReductor
+from pymor.reductors.basic import LTIPGReductor, SOLTIPGReductor
 
 
 class GenericBHIReductor(BasicInterface):
@@ -30,6 +30,9 @@ class GenericBHIReductor(BasicInterface):
     fom
         Model.
     """
+
+    PGReductor = None
+
     def __init__(self, fom):
         self.fom = fom
         self._product = None
@@ -115,7 +118,7 @@ class GenericBHIReductor(BasicInterface):
         elif projection == 'biorth':
             self.V, self.W = gram_schmidt_biorth(self.V, self.W, product=self._product)
 
-        self.pg_reductor = GenericPGReductor(self.fom, self.W, self.V, projection == 'biorth', product=self._product)
+        self.pg_reductor = self.PGReductor(self.fom, self.W, self.V, projection == 'biorth')
 
         rom = self.pg_reductor.reduce()
         return rom
@@ -133,6 +136,9 @@ class LTI_BHIReductor(GenericBHIReductor):
     fom
         |LTIModel|.
     """
+
+    PGReductor = LTIPGReductor
+
     def __init__(self, fom):
         assert isinstance(fom, LTIModel)
         self.fom = fom
@@ -229,6 +235,9 @@ class SO_BHIReductor(GenericBHIReductor):
     fom
         :class:`~pymor.models.iosys.SecondOrderModel`.
     """
+
+    PGReductor = SOLTIPGReductor
+
     def __init__(self, fom):
         assert isinstance(fom, SecondOrderModel)
         self.fom = fom

--- a/src/pymor/reductors/sobt.py
+++ b/src/pymor/reductors/sobt.py
@@ -10,7 +10,7 @@ from pymor.algorithms.projection import project
 from pymor.core.interfaces import BasicInterface
 from pymor.models.iosys import SecondOrderModel
 from pymor.operators.constructions import IdentityOperator
-from pymor.reductors.basic import GenericPGReductor
+from pymor.reductors.basic import SOLTIPGReductor
 from pymor.vectorarrays.numpy import NumpyVectorSpace
 
 
@@ -82,7 +82,7 @@ class GenericSOBTpvReductor(BasicInterface):
         elif projection == 'biorth':
             self.V, self.W = gram_schmidt_biorth(self.V, self.W, product=self.fom.M)
 
-        self.pg_reductor = GenericPGReductor(self.fom, self.W, self.V, projection == 'biorth', product=self.fom.M)
+        self.pg_reductor = SOLTIPGReductor(self.fom, self.W, self.V, projection == 'biorth')
 
         rom = self.pg_reductor.reduce()
 
@@ -253,7 +253,7 @@ class SOBTfvReductor(BasicInterface):
 
         self.W = self.V
 
-        self.pg_reductor = GenericPGReductor(self.fom, self.W, self.V, projection == 'biorth', product=self.fom.M)
+        self.pg_reductor = SOLTIPGReductor(self.fom, self.W, self.V, projection == 'biorth')
 
         rom = self.pg_reductor.reduce()
 
@@ -366,9 +366,7 @@ class SOBTReductor(BasicInterface):
                                             range_basis=None,
                                             source_basis=self.V2)})
 
-        rom = self.fom.with_(operators=projected_ops,
-                             visualizer=None, estimator=None,
-                             cache_region=None, name=self.fom.name + '_reduced')
+        rom = SecondOrderModel(name=self.fom.name + '_reduced', **projected_ops)
         rom.disable_logging()
 
         return rom

--- a/src/pymordemos/analyze_pickle.py
+++ b/src/pymordemos/analyze_pickle.py
@@ -197,7 +197,7 @@ def analyze_pickle_convergence(args):
     T_SOLVES = []
     T_ESTS = []
     for N in dims:
-        rom = reductor.reduce(dim=N)
+        rom = reductor.reduce(N)
         print(f'N = {N:3} ', end='')
         us = []
         print('solve ', end='')

--- a/src/pymordemos/burgers_ei.py
+++ b/src/pymordemos/burgers_ei.py
@@ -93,7 +93,7 @@ from pymor.discretizers.fv import discretize_instationary_fv
 from pymor.grids.rect import RectGrid
 from pymor.grids.tria import TriaGrid
 from pymor.parallel.default import new_parallel_pool
-from pymor.reductors.basic import GenericRBReductor
+from pymor.reductors.basic import InstationaryRBReductor
 
 
 def main(args):
@@ -191,7 +191,7 @@ def main(args):
 
     print('RB generation ...')
 
-    reductor = GenericRBReductor(eim)
+    reductor = InstationaryRBReductor(eim)
 
     greedy_data = greedy(fom, reductor, fom.parameter_space.sample_uniformly(args['SNAPSHOTS']),
                          use_estimator=False, error_norm=lambda U: np.max(fom.l2_norm(U)),
@@ -227,7 +227,7 @@ def main(args):
         return l2_err_max, mumax
     error_analysis = np.frompyfunc(error_analysis, 2, 2)
 
-    real_rb_size = len(reductor.RB)
+    real_rb_size = len(reductor.bases['RB'])
     real_cb_size = len(ei_data['basis'])
     if args['--plot-error-landscape']:
         N_count = min(real_rb_size - 1, args['--plot-error-landscape-N'])

--- a/src/pymordemos/parabolic_mor.py
+++ b/src/pymordemos/parabolic_mor.py
@@ -219,7 +219,7 @@ def reduce_pod(fom, reductor, snapshots, basis_size):
         snapshots.append(fom.solve(mu))
 
     basis, singular_values = pod(snapshots, modes=basis_size, product=fom.h1_0_semi_product)
-    reductor.extend_basis(basis, 'trivial', orthonormal=True)
+    reductor.extend_basis(basis, method='trivial')
 
     rom = reductor.reduce()
 

--- a/src/pymordemos/thermalblock.py
+++ b/src/pymordemos/thermalblock.py
@@ -127,10 +127,12 @@ def main(args):
 
     if args['--reductor'] == 'residual_basis':
         from pymor.reductors.coercive import CoerciveRBReductor
-        reductor = CoerciveRBReductor(fom, product=product, coercivity_estimator=coercivity_estimator)
+        reductor = CoerciveRBReductor(fom, product=product, coercivity_estimator=coercivity_estimator,
+                                      check_orthonormality=False)
     elif args['--reductor'] == 'traditional':
         from pymor.reductors.coercive import SimpleCoerciveRBReductor
-        reductor = SimpleCoerciveRBReductor(fom, product=product, coercivity_estimator=coercivity_estimator)
+        reductor = SimpleCoerciveRBReductor(fom, product=product, coercivity_estimator=coercivity_estimator,
+                                            check_orthonormality=False)
     else:
         assert False  # this should never happen
 
@@ -369,7 +371,7 @@ def reduce_naive(fom, reductor, basis_size):
     training_set = fom.parameter_space.sample_randomly(basis_size)
 
     for mu in training_set:
-        reductor.extend_basis(fom.solve(mu), 'trivial')
+        reductor.extend_basis(fom.solve(mu), method='trivial')
 
     rom = reductor.reduce()
 
@@ -453,10 +455,10 @@ def reduce_pod(fom, reductor, snapshots_per_block, basis_size):
         snapshots.append(fom.solve(mu))
 
     print('Performing POD ...')
-    basis, singular_values = pod(snapshots, modes=basis_size, product=reductor.product)
+    basis, singular_values = pod(snapshots, modes=basis_size, product=reductor.products['RB'])
 
     print('Reducing ...')
-    reductor.extend_basis(basis, 'trivial')
+    reductor.extend_basis(basis, method='trivial')
     rom = reductor.reduce()
 
     elapsed_time = time.time() - tic

--- a/src/pymordemos/thermalblock_simple.py
+++ b/src/pymordemos/thermalblock_simple.py
@@ -230,7 +230,7 @@ def reduce_naive(fom, reductor, basis_size):
     training_set = fom.parameter_space.sample_randomly(basis_size)
 
     for mu in training_set:
-        reductor.extend_basis(fom.solve(mu), 'trivial')
+        reductor.extend_basis(fom.solve(mu), method='trivial')
 
     rom = reductor.reduce()
 
@@ -271,7 +271,7 @@ def reduce_pod(fom, reductor, snapshots, basis_size):
         snapshots.append(fom.solve(mu))
 
     basis, singular_values = pod(snapshots, modes=basis_size, product=reductor.product)
-    reductor.extend_basis(basis, 'trivial')
+    reductor.extend_basis(basis, method='trivial')
 
     rom = reductor.reduce()
 
@@ -308,7 +308,8 @@ def main():
     # select reduction algorithm with error estimator
     #################################################
     coercivity_estimator = ExpressionParameterFunctional('min(diffusion)', fom.parameter_type)
-    reductor = CoerciveRBReductor(fom, product=fom.h1_0_semi_product, coercivity_estimator=coercivity_estimator)
+    reductor = CoerciveRBReductor(fom, product=fom.h1_0_semi_product, coercivity_estimator=coercivity_estimator,
+                                  check_orthonormality=False)
 
     # generate reduced model
     ########################


### PR DESCRIPTION
This is non-functional code to give the @pymor/pymor-devs an idea of what I have in mind for the future Reductor design. It's probably more helpful to look at the new `reductors/basic.py` instead of looking at the diff. Comments welcome ..

As you can see, I have decided to completely remove the projection code from the base class. My impression was that there were too many corner cases to take care of and it might be clearer to explicitly write down the projections.

Fixes #587 when finished.