### PR TITLE
[models.iosys] remove space id handling except for factory methods

### DIFF
--- a/src/pymor/models/basic.py
+++ b/src/pymor/models/basic.py
@@ -290,10 +290,6 @@ class InstationaryModel(ModelBase):
 
         if not all(op.linear for op in [A, B, C, E]):
             raise ValueError('Operators not linear.')
-        if A.source.id == B.source.id:
-            raise ValueError('State space must have different id than input space.')
-        if A.source.id == C.range.id:
-            raise ValueError('State space must have different id than output space.')
 
         from pymor.models.iosys import LTIModel
         return LTIModel(A, B, C, E=E, visualizer=self.visualizer)


### PR DESCRIPTION
As suggested in #609, I have removed most `VectorSpace` id code from `models.iosys`. What remains is the ability to assign space ids when loading matrices from disk.