### PR TITLE
Implement VectorArrayInterface.ones and VectorArrayInterface.full

### DIFF
--- a/src/pymor/bindings/fenics.py
+++ b/src/pymor/bindings/fenics.py
@@ -120,6 +120,11 @@ if config.HAVE_FENICS:
             impl = df.Function(self.V).vector()
             return FenicsVector(impl)
 
+        def full_vector(self, value):
+            impl = df.Function(self.V).vector()
+            impl += value
+            return FenicsVector(impl)
+
         def make_vector(self, obj):
             return FenicsVector(obj)
 

--- a/src/pymor/bindings/ngsolve.py
+++ b/src/pymor/bindings/ngsolve.py
@@ -99,6 +99,11 @@ if config.HAVE_NGSOLVE:
         def make_vector(self, obj):
             return NGSolveVector(obj)
 
+        def vector_from_numpy(self, data, ensure_copy=False):
+            v = self.zero_vector()
+            v.to_numpy()[:] = data
+            return v
+
     class NGSolveMatrixOperator(OperatorBase):
         """Wraps a NGSolve matrix as an |Operator|."""
 

--- a/src/pymor/reductors/h2.py
+++ b/src/pymor/reductors/h2.py
@@ -139,12 +139,12 @@ class IRKAReductor(BasicInterface):
                 np.random.seed(sigma)
                 sigma = np.abs(np.random.randn(r))
             if b is None:
-                b = fom.B.source.from_numpy(np.ones((r, fom.input_dim)))
+                b = fom.B.source.ones(r)
             elif isinstance(b, int):
                 np.random.seed(b)
                 b = fom.B.source.from_numpy(np.random.randn(r, fom.input_dim))
             if c is None:
-                c = fom.C.range.from_numpy(np.ones((r, fom.output_dim)))
+                c = fom.C.range.ones(r)
             elif isinstance(c, int):
                 np.random.seed(c)
                 c = fom.C.range.from_numpy(np.random.randn(r, fom.output_dim))
@@ -341,13 +341,13 @@ class OneSidedIRKAReductor(BasicInterface):
                 sigma = np.abs(np.random.randn(r))
             if self.version == 'V':
                 if b is None:
-                    b = fom.B.source.from_numpy(np.ones((r, fom.input_dim)))
+                    b = fom.B.source.ones(r)
                 elif isinstance(b, int):
                     np.random.seed(b)
                     b = fom.B.source.from_numpy(np.random.randn(r, fom.input_dim))
             else:
                 if c is None:
-                    c = fom.C.range.from_numpy(np.ones((r, fom.output_dim)))
+                    c = fom.C.range.ones(r)
                 elif isinstance(c, int):
                     np.random.seed(c)
                     c = fom.C.range.from_numpy(np.random.randn(r, fom.output_dim))

--- a/src/pymor/reductors/interpolation.py
+++ b/src/pymor/reductors/interpolation.py
@@ -85,11 +85,11 @@ class GenericBHIReductor(BasicInterface):
         if b.dim > 1:
             b.scal(1 / b.l2_norm())
         else:
-            b = self.fom.input_space.from_numpy(np.ones((r, 1)))
+            b = self.fom.input_space.ones(r)
         if c.dim > 1:
             c.scal(1 / c.l2_norm())
         else:
-            c = self.fom.output_space.from_numpy(np.ones((r, 1)))
+            c = self.fom.output_space.ones(r)
 
         # compute projection matrices
         self.V = self.fom.state_space.empty(reserve=r)

--- a/src/pymor/reductors/sor_irka.py
+++ b/src/pymor/reductors/sor_irka.py
@@ -140,12 +140,12 @@ class SOR_IRKAReductor(BasicInterface):
                 np.random.seed(sigma)
                 sigma = np.abs(np.random.randn(r))
             if b is None:
-                b = fom.B.source.from_numpy(np.ones((r, fom.input_dim)))
+                b = fom.B.source.ones(r)
             elif isinstance(b, int):
                 np.random.seed(b)
                 b = fom.B.source.from_numpy(np.random.randn(r, fom.input_dim))
             if c is None:
-                c = fom.Cp.range.from_numpy(np.ones((r, fom.output_dim)))
+                c = fom.Cp.range.ones(r)
             elif isinstance(c, int):
                 np.random.seed(c)
                 c = fom.Cp.range.from_numpy(np.random.randn(r, fom.output_dim))

--- a/src/pymor/vectorarrays/interfaces.py
+++ b/src/pymor/vectorarrays/interfaces.py
@@ -78,9 +78,47 @@ class VectorArrayInterface(BasicInterface):
 
         Returns
         -------
-        A |VectorArray| containing `count` vectors with each component zero.
+        A |VectorArray| containing `count` vectors with each DOF set to zero.
         """
         return self.space.zeros(count, reserve=reserve)
+
+    def ones(self, count=1, reserve=0):
+        """Create a |VectorArray| of vectors of the same |VectorSpace| with all DOFs set to one.
+
+        This is a shorthand for `self.space.full(1., count, reserve)`.
+
+        Parameters
+        ----------
+        count
+            The number of vectors.
+        reserve
+            Hint for the backend to which length the array will grow.
+
+        Returns
+        -------
+        A |VectorArray| containing `count` vectors with each DOF set to one.
+        """
+        return self.space.full(1., count, reserve)
+
+    def full(self, value, count=1, reserve=0):
+        """Create a |VectorArray| of vectors with all DOFs set to the same value.
+
+        This is a shorthand for `self.space.full(value, count, reserve)`.
+
+        Parameters
+        ----------
+        value
+            The value each DOF should be set to.
+        count
+            The number of vectors.
+        reserve
+            Hint for the backend to which length the array will grow.
+
+        Returns
+        -------
+        A |VectorArray| containing `count` vectors with each DOF set to `value`.
+        """
+        return self.space.full(value, count, reserve=reserve)
 
     def empty(self, reserve=0):
         """Create an empty |VectorArray| of the same |VectorSpace|.
@@ -598,6 +636,42 @@ class VectorSpaceInterface(ImmutableInterface):
         A |VectorArray| containing `count` vectors with each component zero.
         """
         pass
+
+    def ones(self, count=1, reserve=0):
+        """Create a |VectorArray| of vectors of with all DOFs set to one.
+
+        This is a shorthand for `self.full(1., count, reserve)`.
+
+        Parameters
+        ----------
+        count
+            The number of vectors.
+        reserve
+            Hint for the backend to which length the array will grow.
+
+        Returns
+        -------
+        A |VectorArray| containing `count` vectors with each DOF set to one.
+        """
+        return self.full(1., count, reserve)
+
+    def full(self, value, count=1, reserve=0):
+        """Create a |VectorArray| of vectors with all DOFs set to the same value.
+
+        Parameters
+        ----------
+        value
+            The value each DOF should be set to.
+        count
+            The number of vectors.
+        reserve
+            Hint for the backend to which length the array will grow.
+
+        Returns
+        -------
+        A |VectorArray| containing `count` vectors with each DOF set to `value`.
+        """
+        return self.from_numpy(np.full((count, self.dim), value))
 
     def empty(self, reserve=0):
         """Create an empty |VectorArray|

--- a/src/pymor/vectorarrays/list.py
+++ b/src/pymor/vectorarrays/list.py
@@ -408,7 +408,7 @@ class ListVectorSpace(VectorSpaceInterface):
         return self.full_vector(1.)
 
     def full_vector(self, value):
-        return self.from_numpy(np.full(self.dim, value))
+        return self.vector_from_numpy(np.full(self.dim, value))
 
     @abstractmethod
     def make_vector(self, obj):

--- a/src/pymor/vectorarrays/list.py
+++ b/src/pymor/vectorarrays/list.py
@@ -404,6 +404,12 @@ class ListVectorSpace(VectorSpaceInterface):
     def zero_vector(self):
         pass
 
+    def ones_vector(self):
+        return self.full_vector(1.)
+
+    def full_vector(self, value):
+        return self.from_numpy(np.full(self.dim, value))
+
     @abstractmethod
     def make_vector(self, obj):
         pass
@@ -422,6 +428,14 @@ class ListVectorSpace(VectorSpaceInterface):
     def zeros(self, count=1, reserve=0):
         assert count >= 0 and reserve >= 0
         return ListVectorArray([self.zero_vector() for _ in range(count)], self)
+
+    def ones(self, count=1, reserve=0):
+        assert count >= 0 and reserve >= 0
+        return ListVectorArray([self.ones_vector() for _ in range(count)], self)
+
+    def full(self, value, count=1, reserve=0):
+        assert count >= 0 and reserve >= 0
+        return ListVectorArray([self.full_vector(value) for _ in range(count)], self)
 
     @classinstancemethod
     def make_array(cls, obj, id_=None):
@@ -461,6 +475,12 @@ class NumpyListVectorSpace(ListVectorSpace):
 
     def zero_vector(self):
         return NumpyVector(np.zeros(self.dim))
+
+    def ones_vector(self):
+        return NumpyVector(np.ones(self.dim))
+
+    def full_vector(self, value):
+        return NumpyVector(np.full(self.dim, value))
 
     def make_vector(self, obj):
         obj = np.asarray(obj)

--- a/src/pymor/vectorarrays/numpy.py
+++ b/src/pymor/vectorarrays/numpy.py
@@ -365,6 +365,14 @@ class NumpyVectorSpace(VectorSpaceInterface):
         va._len = count
         return va
 
+    def full(self, value, count=1, reserve=0):
+        assert count >= 0
+        assert reserve >= 0
+        va = NumpyVectorArray(np.empty((0, 0)), self)
+        va._array = np.full((max(count, reserve), self.dim), value)
+        va._len = count
+        return va
+
     @classinstancemethod
     def make_array(cls, obj, id_=None):
         return cls._array_factory(obj, id_=id_)

--- a/src/pymortests/vectorarray.py
+++ b/src/pymortests/vectorarray.py
@@ -180,6 +180,41 @@ def test_zeros(vector_array):
             pass
 
 
+def test_ones(vector_array):
+    with pytest.raises(Exception):
+        vector_array.ones(-1)
+    for c in (0, 1, 2, 30):
+        v = vector_array.ones(count=c)
+        assert v.space == vector_array.space
+        assert len(v) == c
+        if min(v.dim, c) > 0:
+            assert np.allclose(v.sup_norm(), np.ones(c))
+            assert np.allclose(v.l2_norm(), np.full(c, np.sqrt(v.dim)))
+        try:
+            assert v.to_numpy().shape == (c, v.dim)
+            assert np.allclose(v.to_numpy(), np.ones((c, v.dim)))
+        except NotImplementedError:
+            pass
+
+
+def test_full(vector_array):
+    with pytest.raises(Exception):
+        vector_array.ones(-1)
+    for c in (0, 1, 2, 30):
+        for val in (-1e-3,0,7):
+            v = vector_array.full(val, count=c)
+            assert v.space == vector_array.space
+            assert len(v) == c
+            if min(v.dim, c) > 0:
+                assert np.allclose(v.sup_norm(), np.full(c, abs(val)))
+                assert np.allclose(v.l2_norm(), np.full(c, np.sqrt(val**2 * v.dim)))
+            try:
+                assert v.to_numpy().shape == (c, v.dim)
+                assert np.allclose(v.to_numpy(), np.full((c, v.dim), val))
+            except NotImplementedError:
+                pass
+
+
 def test_from_numpy(vector_array):
     try:
         d = vector_array.to_numpy()


### PR DESCRIPTION
As discussed in #544. 

Note that I decided to let `value` be the first argument in `full` since `count` is an optional argument in `zeros`, `ones` and `empty`. Unfortunately, it's the other way around for `numpy.full`. However, I believe it is still better to keep the interface in pyMOR consistent.