### PR TITLE
Remove VectorSpace id handling from projection methods

### DIFF
--- a/.ci/azure/pipeline-osx.yml
+++ b/.ci/azure/pipeline-osx.yml
@@ -33,7 +33,7 @@ jobs:
       source activate activate pymorEnv
       conda install --only-deps pymor
       # these ones are not in the 0.5.1 conda build yet
-      conda install pyevtk gmsh mpi4py
+      conda install pyevtk gmsh=3.0.6 mpi4py
       # these are buildtime, not a runtime,  deps for our conda package
       conda install cython pytest-cov pytest
       # install anything which might a new dependency with pip

--- a/src/pymor/algorithms/projection.py
+++ b/src/pymor/algorithms/projection.py
@@ -111,7 +111,7 @@ class ProjectRules(RuleTable):
                     raise RuleNotMatchingError('apply_adjoint not implemented')
                 if isinstance(op.source, NumpyVectorSpace):
                     from pymor.operators.numpy import NumpyMatrixOperator
-                    return NumpyMatrixOperator(V.to_numpy(), name=op.name)
+                    return NumpyMatrixOperator(V.to_numpy(), source_id=op.source.id, name=op.name)
                 else:
                     from pymor.operators.constructions import VectorArrayOperator
                     return VectorArrayOperator(V, adjoint=True, name=op.name)
@@ -120,7 +120,7 @@ class ProjectRules(RuleTable):
                 V = op.apply(source_basis)
                 if isinstance(op.range, NumpyVectorSpace):
                     from pymor.operators.numpy import NumpyMatrixOperator
-                    return NumpyMatrixOperator(V.to_numpy().T, name=op.name)
+                    return NumpyMatrixOperator(V.to_numpy().T, range_id=op.range.id, name=op.name)
                 else:
                     from pymor.operators.constructions import VectorArrayOperator
                     return VectorArrayOperator(V, adjoint=False, name=op.name)

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -236,9 +236,8 @@ class LTIModel(InputStateOutputModel):
 
     @classmethod
     def from_matrices(cls, A, B, C, D=None, E=None, cont_time=True,
-                      input_id='INPUT', state_id='STATE', output_id='OUTPUT',
-                      solver_options=None, estimator=None, visualizer=None,
-                      cache_region='memory', name=None):
+                      state_id='STATE', solver_options=None, estimator=None,
+                      visualizer=None, cache_region='memory', name=None):
         """Create |LTIModel| from matrices.
 
         Parameters
@@ -257,12 +256,8 @@ class LTIModel(InputStateOutputModel):
             assumed to be identity).
         cont_time
             `True` if the system is continuous-time, otherwise `False`.
-        input_id
-            Id of the input space.
         state_id
             Id of the state space.
-        output_id
-            Id of the output space.
         solver_options
             The solver options to use to solve the Lyapunov equations.
         estimator
@@ -295,10 +290,10 @@ class LTIModel(InputStateOutputModel):
         assert E is None or isinstance(E, (np.ndarray, sps.spmatrix))
 
         A = NumpyMatrixOperator(A, source_id=state_id, range_id=state_id)
-        B = NumpyMatrixOperator(B, source_id=input_id, range_id=state_id)
-        C = NumpyMatrixOperator(C, source_id=state_id, range_id=output_id)
+        B = NumpyMatrixOperator(B, range_id=state_id)
+        C = NumpyMatrixOperator(C, source_id=state_id)
         if D is not None:
-            D = NumpyMatrixOperator(D, source_id=input_id, range_id=output_id)
+            D = NumpyMatrixOperator(D)
         if E is not None:
             E = NumpyMatrixOperator(E, source_id=state_id, range_id=state_id)
 
@@ -308,8 +303,7 @@ class LTIModel(InputStateOutputModel):
 
     @classmethod
     def from_files(cls, A_file, B_file, C_file, D_file=None, E_file=None, cont_time=True,
-                   input_id='INPUT', state_id='STATE', output_id='OUTPUT',
-                   solver_options=None, estimator=None, visualizer=None,
+                   state_id='STATE', solver_options=None, estimator=None, visualizer=None,
                    cache_region='memory', name=None):
         """Create |LTIModel| from matrices stored in separate files.
 
@@ -329,12 +323,8 @@ class LTIModel(InputStateOutputModel):
             E.
         cont_time
             `True` if the system is continuous-time, otherwise `False`.
-        input_id
-            Id of the input space.
         state_id
             Id of the state space.
-        output_id
-            Id of the output space.
         solver_options
             The solver options to use to solve the Lyapunov equations.
         estimator
@@ -369,15 +359,14 @@ class LTIModel(InputStateOutputModel):
         E = load_matrix(E_file) if E_file is not None else None
 
         return cls.from_matrices(A, B, C, D, E, cont_time=cont_time,
-                                 input_id=input_id, state_id=state_id, output_id=output_id,
-                                 solver_options=solver_options, estimator=estimator, visualizer=visualizer,
+                                 state_id=state_id, solver_options=solver_options,
+                                 estimator=estimator, visualizer=visualizer,
                                  cache_region=cache_region, name=name)
 
     @classmethod
     def from_mat_file(cls, file_name, cont_time=True,
-                      input_id='INPUT', state_id='STATE', output_id='OUTPUT',
-                      solver_options=None, estimator=None, visualizer=None,
-                      cache_region='memory', name=None):
+                      state_id='STATE', solver_options=None, estimator=None,
+                      visualizer=None, cache_region='memory', name=None):
         """Create |LTIModel| from matrices stored in a .mat file.
 
         Parameters
@@ -387,12 +376,8 @@ class LTIModel(InputStateOutputModel):
             be included) containing A, B, C, and optionally D and E.
         cont_time
             `True` if the system is continuous-time, otherwise `False`.
-        input_id
-            Id of the input space.
         state_id
             Id of the state space.
-        output_id
-            Id of the output space.
         solver_options
             The solver options to use to solve the Lyapunov equations.
         estimator
@@ -430,15 +415,14 @@ class LTIModel(InputStateOutputModel):
         E = mat_dict['E'] if 'E' in mat_dict else None
 
         return cls.from_matrices(A, B, C, D, E, cont_time=cont_time,
-                                 input_id=input_id, state_id=state_id, output_id=output_id,
-                                 solver_options=solver_options, estimator=estimator, visualizer=visualizer,
+                                 state_id=state_id, solver_options=solver_options,
+                                 estimator=estimator, visualizer=visualizer,
                                  cache_region=cache_region, name=name)
 
     @classmethod
     def from_abcde_files(cls, files_basename, cont_time=True,
-                         input_id='INPUT', state_id='STATE', output_id='OUTPUT',
-                         solver_options=None, estimator=None, visualizer=None,
-                         cache_region='memory', name=None):
+                         state_id='STATE', solver_options=None, estimator=None,
+                         visualizer=None, cache_region='memory', name=None):
         """Create |LTIModel| from matrices stored in a .[ABCDE] files.
 
         Parameters
@@ -448,12 +432,8 @@ class LTIModel(InputStateOutputModel):
             and E.
         cont_time
             `True` if the system is continuous-time, otherwise `False`.
-        input_id
-            Id of the input space.
         state_id
             Id of the state space.
-        output_id
-            Id of the output space.
         solver_options
             The solver options to use to solve the Lyapunov equations.
         estimator
@@ -489,8 +469,8 @@ class LTIModel(InputStateOutputModel):
         E = load_matrix(files_basename + '.E') if os.path.isfile(files_basename + '.E') else None
 
         return cls.from_matrices(A, B, C, D, E, cont_time=cont_time,
-                                 input_id=input_id, state_id=state_id, output_id=output_id,
-                                 solver_options=solver_options, estimator=estimator, visualizer=visualizer,
+                                 state_id=state_id, solver_options=solver_options,
+                                 estimator=estimator, visualizer=visualizer,
                                  cache_region=cache_region, name=name)
 
     def __add__(self, other):
@@ -819,10 +799,10 @@ class TransferFunction(InputOutputModel):
     Parameters
     ----------
     input_space
-        The input |VectorSpace|. Typically `NumpyVectorSpace(m, 'INPUT')` where
+        The input |VectorSpace|. Typically `NumpyVectorSpace(m)` where
         m is the number of inputs.
     output_space
-        The output |VectorSpace|. Typically `NumpyVectorSpace(p, 'OUTPUT')` where
+        The output |VectorSpace|. Typically `NumpyVectorSpace(p)` where
         p is the number of outputs.
     H
         The transfer function defined at least on the open right complex
@@ -1040,9 +1020,8 @@ class SecondOrderModel(InputStateOutputModel):
 
     @classmethod
     def from_matrices(cls, M, E, K, B, Cp, Cv=None, D=None, cont_time=True,
-                      input_id='INPUT', state_id='STATE', output_id='OUTPUT',
-                      solver_options=None, estimator=None, visualizer=None,
-                      cache_region='memory', name=None):
+                      state_id='STATE', solver_options=None, estimator=None,
+                      visualizer=None, cache_region='memory', name=None):
         """Create a second order system from matrices.
 
         Parameters
@@ -1101,12 +1080,12 @@ class SecondOrderModel(InputStateOutputModel):
         M = NumpyMatrixOperator(M, source_id=state_id, range_id=state_id)
         E = NumpyMatrixOperator(E, source_id=state_id, range_id=state_id)
         K = NumpyMatrixOperator(K, source_id=state_id, range_id=state_id)
-        B = NumpyMatrixOperator(B, source_id=input_id, range_id=state_id)
-        Cp = NumpyMatrixOperator(Cp, source_id=state_id, range_id=output_id)
+        B = NumpyMatrixOperator(B, range_id=state_id)
+        Cp = NumpyMatrixOperator(Cp, source_id=state_id)
         if Cv is not None:
-            Cv = NumpyMatrixOperator(Cv, source_id=state_id, range_id=output_id)
+            Cv = NumpyMatrixOperator(Cv, source_id=state_id)
         if D is not None:
-            D = NumpyMatrixOperator(D, source_id=input_id, range_id=output_id)
+            D = NumpyMatrixOperator(D)
 
         return cls(M, E, K, B, Cp, Cv, D, cont_time=cont_time,
                    solver_options=solver_options, estimator=estimator, visualizer=visualizer,

--- a/src/pymor/operators/basic.py
+++ b/src/pymor/operators/basic.py
@@ -189,10 +189,8 @@ class ProjectedOperator(OperatorBase):
                     and operator.range == product.source
                     and product.range == product.source))
         self.build_parameter_type(operator)
-        self.source = (NumpyVectorSpace(len(source_basis), operator.source.id)
-                       if source_basis is not None else operator.source)
-        self.range = (NumpyVectorSpace(len(range_basis), operator.range.id)
-                      if range_basis is not None else operator.range)
+        self.source = NumpyVectorSpace(len(source_basis)) if source_basis is not None else operator.source
+        self.range = NumpyVectorSpace(len(range_basis)) if range_basis is not None else operator.range
         self.solver_options = solver_options
         self.name = operator.name
         self.operator = operator

--- a/src/pymor/reductors/basic.py
+++ b/src/pymor/reductors/basic.py
@@ -235,7 +235,7 @@ class InstationaryRBReductor(ProjectionBasedReductor):
         if self.initial_data_product != product:
             # TODO there should be functionality for this somewhere else
             projection_matrix = RB.gramian(self.initial_data_product)
-            projection_op = NumpyMatrixOperator(projection_matrix, source_id=RB.space.id, range_id=RB.space.id)
+            projection_op = NumpyMatrixOperator(projection_matrix)
             inverse_projection_op = InverseOperator(projection_op, 'inverse_projection_op')
             pid = project(fom.initial_data, range_basis=RB, source_basis=None, product=self.initial_data_product)
             projected_initial_data = Concatenation([inverse_projection_op, pid])

--- a/src/pymor/reductors/interpolation.py
+++ b/src/pymor/reductors/interpolation.py
@@ -381,5 +381,4 @@ class TFInterpReductor(BasicInterface):
         Br = (T.dot(Br)).real
         Cr = (Cr.dot(T.conj().T)).real
 
-        return LTIModel.from_matrices(Ar, Br, Cr, D=None, E=Er, cont_time=fom.cont_time,
-                                      input_id=fom.input_space.id, output_id=fom.output_space.id)
+        return LTIModel.from_matrices(Ar, Br, Cr, D=None, E=Er, cont_time=fom.cont_time)

--- a/src/pymor/reductors/sobt.py
+++ b/src/pymor/reductors/sobt.py
@@ -336,7 +336,7 @@ class SOBTReductor(BasicInterface):
             self.V2.scal(alpha2)
             self.W2.scal(alpha2)
             W1TV1invW1TV2 = self.W1.inner(self.V2)
-            projected_ops = {'M': IdentityOperator(NumpyVectorSpace(r, self.fom.state_space.id))}
+            projected_ops = {'M': IdentityOperator(NumpyVectorSpace(r))}
         elif projection == 'bfsr':
             self.V1 = gram_schmidt(self.V1, atol=0, rtol=0)
             self.W1 = gram_schmidt(self.W1, atol=0, rtol=0)
@@ -348,7 +348,7 @@ class SOBTReductor(BasicInterface):
             self.V1, self.W1 = gram_schmidt_biorth(self.V1, self.W1)
             self.V2, self.W2 = gram_schmidt_biorth(self.V2, self.W2, product=self.fom.M)
             W1TV1invW1TV2 = self.W1.inner(self.V2)
-            projected_ops = {'M': IdentityOperator(NumpyVectorSpace(r, self.fom.state_space.id))}
+            projected_ops = {'M': IdentityOperator(NumpyVectorSpace(r))}
 
         projected_ops.update({'E': project(self.fom.E,
                                            range_basis=self.W2,

--- a/src/pymordemos/delay.py
+++ b/src/pymordemos/delay.py
@@ -26,7 +26,7 @@ if __name__ == '__main__':
     def dH(s):
         return np.array([[-(tau * s + tau + 1) * np.exp(-s) / (tau * s + 1) ** 2]])
 
-    tf = TransferFunction(NumpyVectorSpace(1, 'INPUT'), NumpyVectorSpace(1, 'OUTPUT'), H, dH)
+    tf = TransferFunction(NumpyVectorSpace(1), NumpyVectorSpace(1), H, dH)
 
     r = 10
     tf_irka_reductor = TF_IRKAReductor(tf)


### PR DESCRIPTION
As discussed in #609. Also, since some sys-mor reductors used `from_matrices` and now ids are removed when projecting, I decided to also remove the `input_id` and `output_id` parameters from the iosys factory methods (which defaulted to `'INPUT'` and `'OUTPUT'`) as they felt somewhat less useful than `state_id`. (ATM, all models coming from pyMOR's discretizations have `'STATE'` as state space id.)