### PR TITLE
Remove 'space' parameter from as_vector

### DIFF
--- a/src/pymor/algorithms/timestepping.py
+++ b/src/pymor/algorithms/timestepping.py
@@ -135,7 +135,7 @@ def implicit_euler(A, F, M, U0, t0, t1, nt, mu=None, num_values=None, solver_opt
         assert F.range == A.range
         F_time_dep = F.parametric and '_t' in F.parameter_type
         if not F_time_dep:
-            dt_F = F.as_vector(mu, space=A.range) * dt
+            dt_F = F.as_vector(mu) * dt
     else:
         assert len(F) == 1
         assert F in A.range
@@ -171,7 +171,7 @@ def implicit_euler(A, F, M, U0, t0, t1, nt, mu=None, num_values=None, solver_opt
         mu['_t'] = t
         rhs = M.apply(U)
         if F_time_dep:
-            dt_F = F.as_vector(mu, space=A.range) * dt
+            dt_F = F.as_vector(mu) * dt
         if F:
             rhs += dt_F
         U = M_dt_A.apply_inverse(rhs, mu=mu)
@@ -192,7 +192,7 @@ def explicit_euler(A, F, U0, t0, t1, nt, mu=None, num_values=None):
         assert F.range == A.range
         F_time_dep = F.parametric and '_t' in F.parameter_type
         if not F_time_dep:
-            F_ass = F.as_vector(mu, space=A.range)
+            F_ass = F.as_vector(mu)
     elif isinstance(F, VectorArrayInterface):
         assert len(F) == 1
         assert F in A.range
@@ -226,7 +226,7 @@ def explicit_euler(A, F, U0, t0, t1, nt, mu=None, num_values=None):
             t += dt
             mu['_t'] = t
             if F_time_dep:
-                F_ass = F.as_vector(mu, space=A.range)
+                F_ass = F.as_vector(mu)
             U.axpy(dt, F_ass - A.apply(U, mu=mu))
             while t - t0 + (min(dt, DT) * 0.5) >= len(R) * DT:
                 R.append(U)

--- a/src/pymor/operators/interfaces.py
+++ b/src/pymor/operators/interfaces.py
@@ -290,7 +290,7 @@ class OperatorInterface(ImmutableInterface, Parametric):
         assert isinstance(self.range, NumpyVectorSpace) and self.linear
         raise NotImplementedError
 
-    def as_vector(self, mu=None, *, space=None):
+    def as_vector(self, mu=None):
         """Return a vector representation of a linear functional or vector operator.
 
         Depending on the operator's :attr:`~OperatorInterface.source` and
@@ -298,18 +298,10 @@ class OperatorInterface(ImmutableInterface, Parametric):
         :meth:`~OperatorInterface.as_range_array` or :meth:`~OperatorInterface.as_source_array`
         respectively. The resulting |VectorArray| is required to have length 1.
 
-        Note that in case both :attr:`~OperatorInterface.source` and
-        :attr:`~OperatorInterface.range` are one-dimensional |NumpyVectorSpaces|
-        but with different :attr:`ids <pymor.vectorarrays.interfaces.VectorSpaceInterface.id>`,
-        it is impossible to determine which space to choose. In this case,
-        the desired space has to be specified via the `space` parameter.
-
         Parameters
         ----------
         mu
             The |Parameter| for which to return the vector representation.
-        space
-            See above.
 
         Returns
         -------
@@ -318,24 +310,9 @@ class OperatorInterface(ImmutableInterface, Parametric):
         """
         if not self.linear:
             raise TypeError('This nonlinear operator does not represent a vector or linear functional.')
-        if space is not None:
-            if self.range == space:
-                V = self.as_range_array(mu)
-                assert len(V) == 1
-                return V
-            elif self.source == space:
-                V = self.as_source_array(mu)
-                assert len(V) == 1
-                return V
-            else:
-                raise TypeError('This operator cannot be represented by a VectorArray in the given space.')
-        elif self.source.is_scalar:
-            if self.range.is_scalar and self.range.id != self.source.id:
-                raise TypeError("Cannot determine space of VectorArray representation (specify 'space' parameter).")
+        if self.source.is_scalar:
             return self.as_range_array(mu)
         elif self.range.is_scalar:
-            if self.source.is_scalar and self.source.id != self.range.id:
-                raise TypeError("Cannot determine space of VectorArray representation (specify 'space' parameter).")
             return self.as_source_array(mu)
         else:
             raise TypeError('This operator does not represent a vector or linear functional.')

--- a/src/pymor/vectorarrays/interfaces.py
+++ b/src/pymor/vectorarrays/interfaces.py
@@ -561,7 +561,8 @@ class VectorSpaceInterface(ImmutableInterface):
         The dimension (number of degrees of freedom) of the
         vectors contained in the space.
     is_scalar
-        Equivalent to `isinstance(space, NumpyVectorSpace) and space.dim == 1`.
+        Equivalent to
+        `isinstance(space, NumpyVectorSpace) and space.dim == 1 and space.id is None`.
     """
 
     id = None

--- a/src/pymor/vectorarrays/numpy.py
+++ b/src/pymor/vectorarrays/numpy.py
@@ -420,7 +420,7 @@ class NumpyVectorSpace(VectorSpaceInterface):
 
     @property
     def is_scalar(self):
-        return self.dim == 1
+        return self.dim == 1 and self.id is None
 
     def __repr__(self):
         return f'NumpyVectorSpace({self.dim})' if self.id is None \


### PR DESCRIPTION
By requiring that `VectorArrays` representing the real/complex numbers should have no space id, the `space` parameter from `OperatorInterface.as_vector` becomes obsolete. This also means that there is one and only one `VectorSpace` representing real/complex numbers, namely `NumpyVectorSpace(1)`.

See #609.