### PR TITLE
Fixes and improvements in heat.ipynb

### DIFF
--- a/notebooks/heat.ipynb
+++ b/notebooks/heat.ipynb
@@ -450,10 +450,7 @@
     "Cr = np.ones((1, r))\n",
     "Er = np.eye(r)\n",
     "\n",
-    "rom0 = LTIModel.from_matrices(Ar, Br, Cr, E=Er,\n",
-    "                              input_id=lti.input_space.id,\n",
-    "                              state_id=lti.state_space.id,\n",
-    "                              output_id=lti.output_space.id)\n",
+    "rom0 = LTIModel.from_matrices(Ar, Br, Cr, E=Er)\n",
     "\n",
     "tsia_reductor = TSIAReductor(lti)\n",
     "rom_tsia = tsia_reductor.reduce(rom0, compute_errors=True)"

--- a/notebooks/heat.ipynb
+++ b/notebooks/heat.ipynb
@@ -457,6 +457,56 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots()\n",
+    "ax.semilogy(tsia_reductor.dist, '.-')\n",
+    "ax.set_title('Distances between shifts in TSIA iterations')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "err_tsia = lti - rom_tsia\n",
+    "print(f'TSIA relative H_2-error:    {err_tsia.h2_norm() / lti.h2_norm():e}')\n",
+    "if config.HAVE_SLYCOT:\n",
+    "    print(f'TSIA relative H_inf-error:  {err_tsia.hinf_norm() / lti.hinf_norm():e}')\n",
+    "print(f'TSIA relative Hankel-error: {err_tsia.hankel_norm() / lti.hankel_norm():e}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots()\n",
+    "lti.mag_plot(w, ax=ax)\n",
+    "rom_tsia.mag_plot(w, ax=ax, linestyle='dashed')\n",
+    "ax.set_title('Bode plot of the full and TSIA reduced model')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots()\n",
+    "err_tsia.mag_plot(w, ax=ax)\n",
+    "ax.set_title('Bode plot of the TSIA error system')\n",
+    "plt.show()"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [


### PR DESCRIPTION
This fixes the bug in `heat.ipynb` with setting `input_id` and `output_id` in `rom0` for TSIA, removes setting `state_id` in the same, and shows results of TSIA similar to other reductors.

Related to #609.