### PR TITLE
Add 'random' method to VectorArrayInterface

### DIFF
--- a/src/pymor/bindings/fenics.py
+++ b/src/pymor/bindings/fenics.py
@@ -13,6 +13,7 @@ if config.HAVE_FENICS:
     from pymor.core.interfaces import BasicInterface
     from pymor.operators.basic import OperatorBase
     from pymor.operators.constructions import ZeroOperator
+    from pymor.vectorarrays.interfaces import _create_random_values
     from pymor.vectorarrays.list import CopyOnWriteVector, ListVectorSpace
 
     class FenicsVector(CopyOnWriteVector):
@@ -138,6 +139,12 @@ if config.HAVE_FENICS:
         def full_vector(self, value):
             impl = df.Function(self.V).vector()
             impl += value
+            return FenicsVector(impl)
+
+        def random_vector(self, distribution, random_state, **kwargs):
+            impl = df.Function(self.V).vector()
+            values = _create_random_values(impl.local_size(), distribution, random_state, **kwargs)
+            impl[:] = values
             return FenicsVector(impl)
 
         def make_vector(self, obj):

--- a/src/pymor/vectorarrays/list.py
+++ b/src/pymor/vectorarrays/list.py
@@ -5,7 +5,8 @@
 import numpy as np
 
 from pymor.core.interfaces import BasicInterface, abstractmethod, abstractclassmethod, classinstancemethod
-from pymor.vectorarrays.interfaces import VectorArrayInterface, VectorSpaceInterface, _INDEXTYPES
+from pymor.tools.random import new_random_state
+from pymor.vectorarrays.interfaces import VectorArrayInterface, VectorSpaceInterface, _INDEXTYPES, _create_random_values
 
 
 class VectorInterface(BasicInterface):
@@ -410,6 +411,10 @@ class ListVectorSpace(VectorSpaceInterface):
     def full_vector(self, value):
         return self.vector_from_numpy(np.full(self.dim, value))
 
+    def random_vector(self, distribution, random_state, **kwargs):
+        values = _create_random_values(self.dim, distribution, random_state, **kwargs)
+        return self.vector_from_numpy(values)
+
     @abstractmethod
     def make_vector(self, obj):
         pass
@@ -436,6 +441,13 @@ class ListVectorSpace(VectorSpaceInterface):
     def full(self, value, count=1, reserve=0):
         assert count >= 0 and reserve >= 0
         return ListVectorArray([self.full_vector(value) for _ in range(count)], self)
+
+    def random(self, count=1, distribution='uniform', random_state=None, seed=None, reserve=0, **kwargs):
+        assert count >= 0 and reserve >= 0
+        assert random_state is None or seed is None
+        random_state = random_state or new_random_state(seed)
+        return ListVectorArray([self.random_vector(distribution=distribution, random_state=random_state, **kwargs)
+                                for _ in range(count)], self)
 
     @classinstancemethod
     def make_array(cls, obj, id_=None):

--- a/src/pymor/vectorarrays/numpy.py
+++ b/src/pymor/vectorarrays/numpy.py
@@ -7,7 +7,8 @@ from scipy.sparse import issparse
 
 from pymor.core import NUMPY_INDEX_QUIRK
 from pymor.core.interfaces import classinstancemethod
-from pymor.vectorarrays.interfaces import VectorArrayInterface, VectorSpaceInterface, _INDEXTYPES
+from pymor.tools.random import new_random_state
+from pymor.vectorarrays.interfaces import VectorArrayInterface, VectorSpaceInterface, _INDEXTYPES, _create_random_values
 
 
 class NumpyVectorArray(VectorArrayInterface):
@@ -371,6 +372,15 @@ class NumpyVectorSpace(VectorSpaceInterface):
         va = NumpyVectorArray(np.empty((0, 0)), self)
         va._array = np.full((max(count, reserve), self.dim), value)
         va._len = count
+        return va
+
+    def random(self, count=1, distribution='uniform', random_state=None, seed=None, reserve=0, **kwargs):
+        assert count >= 0
+        assert reserve >= 0
+        assert random_state is None or seed is None
+        random_state = random_state or new_random_state(seed)
+        va = self.zeros(count, reserve)
+        va._array[:count] = _create_random_values((count, self.dim), distribution, random_state, **kwargs)
         return va
 
     @classinstancemethod

--- a/src/pymortests/vectorarray.py
+++ b/src/pymortests/vectorarray.py
@@ -199,7 +199,7 @@ def test_ones(vector_array):
 
 def test_full(vector_array):
     with pytest.raises(Exception):
-        vector_array.full(-1)
+        vector_array.full(9, -1)
     for c in (0, 1, 2, 30):
         for val in (-1e-3,0,7):
             v = vector_array.full(val, count=c)


### PR DESCRIPTION
As discussed in #544, this adds a `random` method to `VectorArrayInterface`. It has a default implementation for all backends that implement `from_numpy`. The exact signature is

```python
def random(self, count=1, distribution='uniform', random_state=None, seed=None,
           reserve=0, **kwargs):
```

where `kwargs` are additional parameters depending on `distribution`. The names of these parameters are chosen to agree with the parameters of the respective NumPy methods.

`random_state` and `seed` behave as for `CubicParameterSpace.sample_randomly`: either a (mutable) [NumPy RandomState](https://www.numpy.org/devdocs/reference/generated/numpy.random.RandomState.html) can be provided which is then used to sample random numbers, or a `seed` from which a new `RandomState` is initialized. If neither are provided a new random state is created using `pymor.tools.new_random_state` with a `default` seed.

An important consequence: repeated calls to the `random` method will always create the same random numbers when neither `random_state` nor `seed` are provided. This is probably unexpected behavior and I think it should be changed s.t. we have a global default `RandomState` which is initialized once with a fixed seed and which is always used unless the user provides a seed or `RandomState`. This should be handled in a separate PR, however.

I decided to always stick with NumPy `RandomStates`. In case a backend uses its own random generator, the NumPy `RandomState` should be used to create a new seed for the random generator of the backend. This way the interface of `random` stays generic.