### PR TITLE
Move all backend-agnostic assemble_lincomb logic to algorithms.lincomb

### DIFF
--- a/docs/source/technical_overview.rst
+++ b/docs/source/technical_overview.rst
@@ -92,7 +92,7 @@ operating on objects of the following types:
     representation of the operator as a |VectorArray| of length 1.
 
     Linear combinations of operators can be formed using a |LincombOperator|.
-    When such a linear combination is |assembled|, |assemble_lincomb|
+    When such a linear combination is |assembled|, |_assemble_lincomb|
     is called to ensure that, for instance, linear combinations of operators
     represented by a matrix lead to a new operator holding the linear
     combination of the matrices.
@@ -107,7 +107,7 @@ operating on objects of the following types:
     .. |apply2|            replace:: :meth:`~pymor.operators.interfaces.OperatorInterface.apply2`
     .. |apply_inverse|     replace:: :meth:`~pymor.operators.interfaces.OperatorInterface.apply_inverse`
     .. |assembled|         replace:: :meth:`assembled <pymor.operators.interfaces.OperatorInterface.assemble>`
-    .. |assemble_lincomb| replace:: :meth:`~pymor.operators.interfaces.OperatorInterface.assemble_lincomb`
+    .. |_assemble_lincomb| replace:: :meth:`~pymor.operators.interfaces.OperatorInterface._assemble_lincomb`
     .. |as_vector|         replace:: :meth:`~pymor.operators.interfaces.OperatorInterface.as_vector`
     .. |linear|            replace:: :attr:`~pymor.operators.interfaces.OperatorInterface.linear`
     .. |range|             replace:: :attr:`~pymor.operators.interfaces.OperatorInterface.range`

--- a/src/pymor/algorithms/lincomb.py
+++ b/src/pymor/algorithms/lincomb.py
@@ -1,0 +1,232 @@
+# This file is part of the pyMOR project (http://www.pymor.org).
+# Copyright 2013-2019 pyMOR developers and contributors. All rights reserved.
+# License: BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+
+import numpy as np
+
+from pymor.algorithms.rules import RuleTable, match_generic
+from pymor.core.exceptions import RuleNotMatchingError
+from pymor.operators.block import (BlockOperator, BlockOperatorBase, BlockDiagonalOperator, SecondOrderModelOperator,
+                                   ShiftedSecondOrderModelOperator)
+from pymor.operators.constructions import LincombOperator, ZeroOperator, IdentityOperator, VectorArrayOperator
+
+
+def assemble_lincomb(operators, coefficients, solver_options=None, name=None):
+    return AssembleLincombRules(tuple(coefficients), solver_options, name).apply(tuple(operators))
+
+
+class AssembleLincombRules(RuleTable):
+    def __init__(self, coefficients, solver_options, name):
+        super().__init__(use_caching=False)
+        self.coefficients, self.solver_options, self.name \
+            = coefficients, solver_options, name
+
+    @match_generic(lambda ops: any(isinstance(op, ZeroOperator) for op in ops))
+    def action_ZeroOperator(self, ops):
+        without_zero = [(op, coeff)
+                        for op, coeff in zip(ops, self.coefficients)
+                        if not isinstance(op, ZeroOperator)]
+        if len(without_zero) == 0:
+            return ZeroOperator(ops[0].range, ops[0].source, name=self.name)
+        else:
+            new_ops, new_coeffs = zip(*without_zero)
+            return assemble_lincomb(new_ops, new_coeffs,
+                                    solver_options=self.solver_options, name=self.name)
+
+    @match_generic(lambda ops: any(isinstance(op, IdentityOperator) for op in ops))
+    def action_IdentityOperator(self, ops):
+        id_coeffs, new_ops, new_coeffs = [], [], []
+        for op, coeff in zip(ops, self.coefficients):
+            if isinstance(op, IdentityOperator):
+                id_coeffs.append(coeff)
+            else:
+                new_ops.append(op)
+                new_coeffs.append(coeff)
+
+        id_coeff = sum(id_coeffs)
+        id_op = IdentityOperator(ops[0].source)
+        op_without_id = assemble_lincomb(new_ops, new_coeffs,
+                                         solver_options=self.solver_options, name=self.name)
+
+        if op_without_id:
+            if id_coeff == 0:
+                return op_without_id
+            else:
+                op = assemble_lincomb((op_without_id, id_op),
+                                      (1., id_coeff),
+                                      solver_options=self.solver_options, name=self.name)
+                if op:
+                    return op
+                else:
+                    return LincombOperator((op_without_id, id_op), (1., id_coeff),
+                                           solver_options=self.solver_options, name=self.name)
+        else:
+            if id_coeff == 0:
+                return LincombOperator(new_ops, new_coeffs,
+                                       solver_options=self.solver_options, name=self.name)
+            elif len(id_coeffs) > 1:
+                return LincombOperator(new_ops + [id_op], new_coeffs + [id_coeff],
+                                       solver_options=self.solver_options, name=self.name)
+            else:
+                return None
+
+    @match_generic(lambda ops: all(isinstance(op, VectorArrayOperator)
+                                   and op.adjoint == ops[0].adjoint
+                                   and op.source == ops[0].source
+                                   and op.range == ops[0].range
+                                   for op in ops))
+    def action_VectorArrrayOperator(self, ops):
+        adjoint = ops[0].adjoint
+        assert not self.solver_options
+
+        coeffs = np.conj(self.coefficients) if adjoint else self.coefficients
+
+        if coeffs[0] == 1:
+            array = ops[0]._array.copy()
+        else:
+            array = ops[0]._array * coeffs[0]
+        for op, c in zip(ops[1:], coeffs[1:]):
+            array.axpy(c, op._array)
+
+        return VectorArrayOperator(array, adjoint=adjoint, space_id=ops[0].space_id, name=self.name)
+
+    @match_generic(lambda ops: isinstance(ops[0], BlockDiagonalOperator))
+    def action_BlockDiagonalOpertors(self, ops):
+        operators = _assemble_lincomb_preprocess_operators(ops)
+        coefficients = self.coefficients
+
+        if not all(isinstance(op, BlockOperator) for op in operators):
+            raise RuleNotMatchingError
+
+        # return ShiftedSecondOrderModelOperator if possible
+        if len(operators) == 2 and isinstance(operators[1], SecondOrderModelOperator):
+            return assemble_lincomb(operators[::-1], coefficients[::-1],
+                                    solver_options=self.solver_options, name=self.name)
+
+        # return BlockOperator if not all operators are BlockDiagonalOperators
+        if not all(isinstance(op, BlockDiagonalOperator) for op in operators):
+            raise RuleNotMatchingError
+
+        # return BlockDiagonalOperator
+        num_source_blocks = operators[0].num_source_blocks
+        blocks = np.empty((num_source_blocks,), dtype=object)
+        if len(operators) > 1:
+            for i in range(num_source_blocks):
+                operators_i = [op._blocks[i, i] for op in operators]
+                blocks[i] = assemble_lincomb(operators_i, coefficients,
+                                             solver_options=self.solver_options, name=self.name)
+                if blocks[i] is None:
+                    return None
+            return BlockDiagonalOperator(blocks)
+        else:
+            c = coefficients[0]
+            if c == 1:
+                return operators[0]
+            for i in range(num_source_blocks):
+                blocks[i] = operators[0]._blocks[i, i] * c
+            return BlockDiagonalOperator(blocks)
+
+    @match_generic(lambda ops: isinstance(ops[0], SecondOrderModelOperator))
+    def action_SecondOrderModelOperator(self, ops):
+        operators = _assemble_lincomb_preprocess_operators(ops)
+        coefficients = self.coefficients
+
+        if not all(isinstance(op, BlockOperator) for op in operators):
+            raise RuleNotMatchingError
+
+        # return ShiftedSecondOrderModelOperator if possible
+        if (len(operators) == 2
+                and isinstance(operators[1], BlockDiagonalOperator)
+                and operators[1].num_source_blocks == 2
+                and operators[1].num_range_blocks == 2
+                and isinstance(operators[1]._blocks[0, 0], IdentityOperator)):
+            return ShiftedSecondOrderModelOperator(operators[1]._blocks[1, 1],
+                                                   operators[0].E,
+                                                   operators[0].K,
+                                                   coefficients[1],
+                                                   coefficients[0])
+
+        # return BlockOperator
+        shape = operators[0]._blocks.shape
+        blocks = np.empty(shape, dtype=object)
+        if len(operators) > 1:
+            for (i, j) in np.ndindex(shape):
+                operators_ij = [op._blocks[i, j] for op in operators]
+                blocks[i, j] = assemble_lincomb(operators_ij, coefficients,
+                                                solver_options=self.solver_options, name=self.name)
+                if blocks[i, j] is None:
+                    return None
+            return BlockOperator(blocks)
+        else:
+            c = coefficients[0]
+            if c == 1:
+                return operators[0]
+            for (i, j) in np.ndindex(shape):
+                blocks[i, j] = operators[0]._blocks[i, j] * c
+            return BlockOperator(blocks)
+
+    @match_generic(lambda ops: isinstance(ops[0], ShiftedSecondOrderModelOperator))
+    def action_ShiftedSecondOrderModelOperator(self, ops):
+        operators = _assemble_lincomb_preprocess_operators(ops)
+        coefficients = self.coefficients
+
+        if not all(isinstance(op, BlockOperator) for op in operators):
+            raise RuleNotMatchingError
+
+        shape = operators[0]._blocks.shape
+        blocks = np.empty(shape, dtype=object)
+        if len(operators) > 1:
+            for (i, j) in np.ndindex(shape):
+                operators_ij = [op._blocks[i, j] for op in operators]
+                blocks[i, j] = assemble_lincomb(operators_ij, coefficients,
+                                                solver_options=self.solver_options, name=self.name)
+                if blocks[i, j] is None:
+                    return None
+            return BlockOperator(blocks)
+        else:
+            c = coefficients[0]
+            if c == 1:
+                return operators[0]
+            for (i, j) in np.ndindex(shape):
+                blocks[i, j] = operators[0]._blocks[i, j] * c
+            return BlockOperator(blocks)
+
+    @match_generic(lambda ops: isinstance(ops[0], BlockOperatorBase))
+    def action_BlockOperatorBase(self, ops):
+        operators = self._assemble_lincomb_preprocess_operators(ops)
+        coefficients = self.coefficients
+
+        if not all(isinstance(op, BlockOperatorBase) for op in operators):
+            raise RuleNotMatchingError
+
+        shape = operators[0]._blocks.shape
+        blocks = np.empty(shape, dtype=object)
+        if len(operators) > 1:
+            for (i, j) in np.ndindex(shape):
+                operators_ij = [op._blocks[i, j] for op in operators]
+                blocks[i, j] = assemble_lincomb(operators_ij, coefficients,
+                                                solver_options=self.solver_options, name=self.name)
+                if blocks[i, j] is None:
+                    return None
+            return operators[0].__class__(blocks)
+        else:
+            c = coefficients[0]
+            if c == 1:
+                return operators[0]
+            for (i, j) in np.ndindex(shape):
+                blocks[i, j] = operators[0]._blocks[i, j] * c
+            return operators[0].__class__(blocks)
+
+    @match_generic(lambda ops: True)
+    def action_call_assemble_lincomb_method(self, ops):
+        op = ops[0]._assemble_lincomb(ops, self.coefficients,
+                                      solver_options=self.solver_options, name=self.name)
+        return op
+
+
+def _assemble_lincomb_preprocess_operators(operators):
+    return [
+        BlockDiagonalOperator([IdentityOperator(s) for s in op.source.subspaces])
+        if isinstance(op, IdentityOperator) else op
+        for op in operators if not isinstance(op, ZeroOperator)
+    ]

--- a/src/pymor/algorithms/lincomb.py
+++ b/src/pymor/algorithms/lincomb.py
@@ -52,9 +52,9 @@ class AssembleLincombRules(RuleTable):
             if id_coeff == 0:
                 return op_without_id
             else:
-                op = assemble_lincomb((op_without_id, id_op),
-                                      (1., id_coeff),
-                                      solver_options=self.solver_options, name=self.name)
+                op = op_without_id._assemble_lincomb((op_without_id, id_op),
+                                                     (1., id_coeff),
+                                                     solver_options=self.solver_options, name=self.name)
                 if op:
                     return op
                 else:

--- a/src/pymor/algorithms/lincomb.py
+++ b/src/pymor/algorithms/lincomb.py
@@ -60,8 +60,7 @@ class AssembleLincombRules(RuleTable):
             if id_coeff == 0:
                 return op_without_id
             else:
-                op = op_without_id._assemble_lincomb((op_without_id, id_op),
-                                                     (1., id_coeff),
+                op = op_without_id._assemble_lincomb((op_without_id,), (1.,), shift=id_coeff,
                                                      solver_options=self.solver_options, name=self.name)
                 if op:
                     return op

--- a/src/pymor/algorithms/lincomb.py
+++ b/src/pymor/algorithms/lincomb.py
@@ -177,7 +177,7 @@ class AssembleLincombRules(RuleTable):
                 coeffs_without_id.append(coeff)
         id_coeff = sum(id_coeffs)
 
-        op = ops_without_id[0]._assemble_lincomb(ops_without_id, self.coefficients, shift=id_coeff,
+        op = ops_without_id[0]._assemble_lincomb(ops_without_id, self.coefficients, identity_shift=id_coeff,
                                                  solver_options=self.solver_options, name=self.name)
 
         if not op:

--- a/src/pymor/algorithms/lincomb.py
+++ b/src/pymor/algorithms/lincomb.py
@@ -12,6 +12,39 @@ from pymor.operators.constructions import ZeroOperator, IdentityOperator, Vector
 
 
 def assemble_lincomb(operators, coefficients, solver_options=None, name=None):
+    """Try to assemble a linear combination of the given operators.
+
+    Returns a new |Operator| which represents the sum ::
+
+        c_1*O_1 + ... + c_N*O_N
+
+    where `O_i` are |Operators| and `c_i` scalar coefficients.
+
+    This function is called in the :meth:`assemble` method of |LincombOperator| and
+    is not intended to be used directly. The assembled |Operator| is expected to
+    no longer be a |LincombOperator| nor should it contain any |LincombOperators|.
+    If an assembly of the given linear combination is not possible, `None` is returned.
+
+    To form the linear combination of backend |Operators| (containing actual matrix data),
+    :meth:`~pymor.operators.interfaces.OperatorInterface._assemble_lincomb` will be called
+    on the first |Operator| in the linear combination.
+
+    Parameters
+    ----------
+    operators
+        List of |Operators| `O_i` whose linear combination is formed.
+    coefficients
+        List of the corresponding linear coefficients `c_i`.
+    solver_options
+        |solver_options| for the assembled operator.
+    name
+        Name of the assembled operator.
+
+    Returns
+    -------
+    The assembled |Operator| if assembly is possible, otherwise `None`.
+    """
+
     return AssembleLincombRules(tuple(coefficients), solver_options, name).apply(tuple(operators))
 
 

--- a/src/pymor/algorithms/rules.py
+++ b/src/pymor/algorithms/rules.py
@@ -69,10 +69,7 @@ class rule:
         return ''.join(lines)
 
 
-class match_class(rule):
-    """|rule| that matches when obj is instance of one of the given classes."""
-
-    condition_type = 'CLASS'
+class match_class_base(rule):
 
     def __init__(self, *classes):
         super().__init__()
@@ -81,8 +78,44 @@ class match_class(rule):
         self.classes = classes
         self.condition_description = ', '.join(c.__name__ for c in classes)
 
+
+class match_class(match_class_base):
+    """|rule| that matches when obj is instance of one of the given classes."""
+
+    condition_type = 'CLASS'
+
     def matches(self, obj):
         return isinstance(obj, self.classes)
+
+
+class match_class_all(match_class_base):
+    """|rule| that matches when each item of obj is instance of one of the given classes."""
+
+    condition_type = 'ALLCLASSES'
+
+    def matches(self, obj):
+        return all(isinstance(o, self.classes) for o in obj)
+
+
+class match_class_any(match_class_base):
+    """|rule| that matches when any item of obj is instance of one of the given classes."""
+
+    condition_type = 'ANYCLASS'
+
+    def matches(self, obj):
+        return any(isinstance(o, self.classes) for o in obj)
+
+
+class match_always(rule):
+    """|rule| that always matches."""
+
+    condition_type = 'ALWAYS'
+
+    def __init__(self, action):
+        self(action)
+
+    def matches(self, obj):
+        return True
 
 
 class match_generic(rule):

--- a/src/pymor/algorithms/rules.py
+++ b/src/pymor/algorithms/rules.py
@@ -51,22 +51,8 @@ class rule:
 
     @property
     def source(self):
-        from inspect import getsourcefile, getsourcelines
-        with open(getsourcefile(self.action), 'rt') as f:
-            source = f.readlines()
-        start_line = getsourcelines(self.action)[1] - 1
-        lines = [source[start_line].lstrip()]
-        indent = len(source[start_line]) - len(lines[0])
-        seen_def = False
-        for l in source[start_line + 1:]:
-            if not seen_def and l.lstrip().startswith('def'):
-                seen_def = True
-                lines.append(l[indent:])
-                continue
-            if 0 < len(l) - len(l.lstrip()) <= indent:
-                break
-            lines.append(l[indent:])
-        return ''.join(lines)
+        from inspect import getsourcelines
+        return ''.join(getsourcelines(self.action)[0])
 
 
 class match_class_base(rule):

--- a/src/pymor/bindings/fenics.py
+++ b/src/pymor/bindings/fenics.py
@@ -186,8 +186,10 @@ if config.HAVE_FENICS:
                 _apply_inverse(self.matrix, r.impl, v.impl, options)
             return R
 
-        def _assemble_lincomb(self, operators, coefficients, solver_options=None, name=None):
+        def _assemble_lincomb(self, operators, coefficients, shift=0., solver_options=None, name=None):
             if not all(isinstance(op, FenicsMatrixOperator) for op in operators):
+                return None
+            if shift != 0:
                 return None
             assert not solver_options
 

--- a/src/pymor/bindings/fenics.py
+++ b/src/pymor/bindings/fenics.py
@@ -12,7 +12,6 @@ if config.HAVE_FENICS:
     from pymor.core.defaults import defaults
     from pymor.core.interfaces import BasicInterface
     from pymor.operators.basic import OperatorBase
-    from pymor.operators.constructions import ZeroOperator
     from pymor.vectorarrays.interfaces import _create_random_values
     from pymor.vectorarrays.list import CopyOnWriteVector, ListVectorSpace
 
@@ -187,8 +186,8 @@ if config.HAVE_FENICS:
                 _apply_inverse(self.matrix, r.impl, v.impl, options)
             return R
 
-        def assemble_lincomb(self, operators, coefficients, solver_options=None, name=None):
-            if not all(isinstance(op, (FenicsMatrixOperator, ZeroOperator)) for op in operators):
+        def _assemble_lincomb(self, operators, coefficients, solver_options=None, name=None):
+            if not all(isinstance(op, FenicsMatrixOperator) for op in operators):
                 return None
             assert not solver_options
 
@@ -197,8 +196,6 @@ if config.HAVE_FENICS:
             else:
                 matrix = operators[0].matrix * coefficients[0]
             for op, c in zip(operators[1:], coefficients[1:]):
-                if isinstance(op, ZeroOperator):
-                    continue
                 matrix.axpy(c, op.matrix, False)
                 # in general, we cannot assume the same nonzero pattern for # all matrices. how to improve this?
 

--- a/src/pymor/bindings/fenics.py
+++ b/src/pymor/bindings/fenics.py
@@ -186,10 +186,10 @@ if config.HAVE_FENICS:
                 _apply_inverse(self.matrix, r.impl, v.impl, options)
             return R
 
-        def _assemble_lincomb(self, operators, coefficients, shift=0., solver_options=None, name=None):
+        def _assemble_lincomb(self, operators, coefficients, identity_shift=0., solver_options=None, name=None):
             if not all(isinstance(op, FenicsMatrixOperator) for op in operators):
                 return None
-            if shift != 0:
+            if identity_shift != 0:
                 return None
             assert not solver_options
 

--- a/src/pymor/bindings/ngsolve.py
+++ b/src/pymor/bindings/ngsolve.py
@@ -143,8 +143,10 @@ if config.HAVE_NGSOLVE:
                     r.impl.vec.data = inv * v.impl.vec
             return R
 
-        def _assemble_lincomb(self, operators, coefficients, solver_options=None, name=None):
+        def _assemble_lincomb(self, operators, coefficients, shift=0., solver_options=None, name=None):
             if not all(isinstance(op, NGSolveMatrixOperator) for op in operators):
+                return None
+            if shift != 0:
                 return None
 
             matrix = operators[0].matrix.CreateMatrix()

--- a/src/pymor/bindings/ngsolve.py
+++ b/src/pymor/bindings/ngsolve.py
@@ -11,7 +11,6 @@ if config.HAVE_NGSOLVE:
 
     from pymor.core.interfaces import ImmutableInterface
     from pymor.operators.basic import OperatorBase
-    from pymor.operators.constructions import ZeroOperator
     from pymor.vectorarrays.interfaces import VectorArrayInterface
     from pymor.vectorarrays.numpy import NumpyVectorSpace
     from pymor.vectorarrays.list import CopyOnWriteVector, ListVectorSpace
@@ -144,15 +143,13 @@ if config.HAVE_NGSOLVE:
                     r.impl.vec.data = inv * v.impl.vec
             return R
 
-        def assemble_lincomb(self, operators, coefficients, solver_options=None, name=None):
-            if not all(isinstance(op, (NGSolveMatrixOperator, ZeroOperator)) for op in operators):
+        def _assemble_lincomb(self, operators, coefficients, solver_options=None, name=None):
+            if not all(isinstance(op, NGSolveMatrixOperator) for op in operators):
                 return None
 
             matrix = operators[0].matrix.CreateMatrix()
             matrix.AsVector().data = float(coefficients[0]) * matrix.AsVector()
             for op, c in zip(operators[1:], coefficients[1:]):
-                if isinstance(op, ZeroOperator):
-                    continue
                 matrix.AsVector().data += float(c) * op.matrix.AsVector()
             return NGSolveMatrixOperator(matrix, self.range, self.source, solver_options=solver_options, name=name)
 

--- a/src/pymor/bindings/ngsolve.py
+++ b/src/pymor/bindings/ngsolve.py
@@ -143,10 +143,10 @@ if config.HAVE_NGSOLVE:
                     r.impl.vec.data = inv * v.impl.vec
             return R
 
-        def _assemble_lincomb(self, operators, coefficients, shift=0., solver_options=None, name=None):
+        def _assemble_lincomb(self, operators, coefficients, identity_shift=0., solver_options=None, name=None):
             if not all(isinstance(op, NGSolveMatrixOperator) for op in operators):
                 return None
-            if shift != 0:
+            if identity_shift != 0:
                 return None
 
             matrix = operators[0].matrix.CreateMatrix()

--- a/src/pymor/operators/block.py
+++ b/src/pymor/operators/block.py
@@ -98,38 +98,6 @@ class BlockOperatorBase(OperatorBase):
         else:
             return self.__class__(blocks)
 
-    def _assemble_lincomb_preprocess_operators(self, operators):
-        return [
-            BlockDiagonalOperator([IdentityOperator(s) for s in op.source.subspaces])
-            if isinstance(op, IdentityOperator) else op
-            for op in operators if not isinstance(op, ZeroOperator)
-        ]
-
-    def assemble_lincomb(self, operators, coefficients, solver_options=None, name=None):
-
-        operators = self._assemble_lincomb_preprocess_operators(operators)
-
-        if not all(isinstance(op, BlockOperatorBase) for op in operators):
-            return None
-
-        assert operators[0] is self
-        blocks = np.empty(self._blocks.shape, dtype=object)
-        if len(operators) > 1:
-            for (i, j) in np.ndindex(self._blocks.shape):
-                operators_ij = [op._blocks[i, j] for op in operators]
-                blocks[i, j] = operators_ij[0].assemble_lincomb(operators_ij, coefficients,
-                                                                solver_options=solver_options, name=name)
-                if blocks[i, j] is None:
-                    return None
-            return self.__class__(blocks)
-        else:
-            c = coefficients[0]
-            if c == 1:
-                return self
-            for (i, j) in np.ndindex(self._blocks.shape):
-                blocks[i, j] = self._blocks[i, j] * c
-            return self.__class__(blocks)
-
     def as_range_array(self, mu=None):
 
         def process_row(row, space):
@@ -260,42 +228,6 @@ class BlockDiagonalOperator(BlockOperator):
         else:
             return self.__class__(blocks)
 
-    def assemble_lincomb(self, operators, coefficients, solver_options=None, name=None):
-
-        operators = self._assemble_lincomb_preprocess_operators(operators)
-
-        if not all(isinstance(op, BlockOperator) for op in operators):
-            return None
-
-        assert operators[0] is self
-
-        # return ShiftedSecondOrderModelOperator if possible
-        if len(operators) == 2 and isinstance(operators[1], SecondOrderModelOperator):
-            return operators[1].assemble_lincomb(operators[::-1], coefficients[::-1],
-                                                 solver_options=solver_options, name=name)
-
-        # return BlockOperator if not all operators are BlockDiagonalOperators
-        if not all(isinstance(op, self.__class__) for op in operators):
-            return super().assemble_lincomb(operators, coefficients, solver_options=solver_options, name=name)
-
-        # return BlockDiagonalOperator
-        blocks = np.empty((self.num_source_blocks,), dtype=object)
-        if len(operators) > 1:
-            for i in range(self.num_source_blocks):
-                operators_i = [op._blocks[i, i] for op in operators]
-                blocks[i] = operators_i[0].assemble_lincomb(operators_i, coefficients,
-                                                            solver_options=solver_options, name=name)
-                if blocks[i] is None:
-                    return None
-            return self.__class__(blocks)
-        else:
-            c = coefficients[0]
-            if c == 1:
-                return self
-            for i in range(self.num_source_blocks):
-                blocks[i] = self._blocks[i, i] * c
-            return self.__class__(blocks)
-
 
 class SecondOrderModelOperator(BlockOperator):
     r"""BlockOperator appearing in SecondOrderModel.to_lti().
@@ -378,45 +310,6 @@ class SecondOrderModelOperator(BlockOperator):
             return self
         else:
             return self.__class__(E, K)
-
-    def assemble_lincomb(self, operators, coefficients, solver_options=None, name=None):
-
-        operators = self._assemble_lincomb_preprocess_operators(operators)
-
-        if not all(isinstance(op, BlockOperator) for op in operators):
-            return None
-
-        assert operators[0] is self
-
-        # return ShiftedSecondOrderModelOperator if possible
-        if (len(operators) == 2
-                and isinstance(operators[1], BlockDiagonalOperator)
-                and operators[1].num_source_blocks == 2
-                and operators[1].num_range_blocks == 2
-                and isinstance(operators[1]._blocks[0, 0], IdentityOperator)):
-            return ShiftedSecondOrderModelOperator(operators[1]._blocks[1, 1],
-                                                   self.E,
-                                                   self.K,
-                                                   coefficients[1],
-                                                   coefficients[0])
-
-        # return BlockOperator
-        blocks = np.empty(self._blocks.shape, dtype=object)
-        if len(operators) > 1:
-            for (i, j) in np.ndindex(self._blocks.shape):
-                operators_ij = [op._blocks[i, j] for op in operators]
-                blocks[i, j] = operators_ij[0].assemble_lincomb(operators_ij, coefficients,
-                                                                solver_options=solver_options, name=name)
-                if blocks[i, j] is None:
-                    return None
-            return BlockOperator(blocks)
-        else:
-            c = coefficients[0]
-            if c == 1:
-                return self
-            for (i, j) in np.ndindex(self._blocks.shape):
-                blocks[i, j] = self._blocks[i, j] * c
-            return BlockOperator(blocks)
 
 
 class ShiftedSecondOrderModelOperator(BlockOperator):
@@ -528,28 +421,3 @@ class ShiftedSecondOrderModelOperator(BlockOperator):
             return self
         else:
             return self.__class__(M, E, K, self.a, self.b)
-
-    def assemble_lincomb(self, operators, coefficients, solver_options=None, name=None):
-
-        operators = self._assemble_lincomb_preprocess_operators(operators)
-
-        if not all(isinstance(op, BlockOperator) for op in operators):
-            return None
-
-        assert operators[0] is self
-        blocks = np.empty(self._blocks.shape, dtype=object)
-        if len(operators) > 1:
-            for (i, j) in np.ndindex(self._blocks.shape):
-                operators_ij = [op._blocks[i, j] for op in operators]
-                blocks[i, j] = operators_ij[0].assemble_lincomb(operators_ij, coefficients,
-                                                                solver_options=solver_options, name=name)
-                if blocks[i, j] is None:
-                    return None
-            return BlockOperator(blocks)
-        else:
-            c = coefficients[0]
-            if c == 1:
-                return self
-            for (i, j) in np.ndindex(self._blocks.shape):
-                blocks[i, j] = self._blocks[i, j] * c
-            return BlockOperator(blocks)

--- a/src/pymor/operators/constructions.py
+++ b/src/pymor/operators/constructions.py
@@ -123,7 +123,7 @@ class LincombOperator(OperatorBase):
 
     def assemble(self, mu=None):
         from pymor.algorithms.lincomb import assemble_lincomb
-        operators = [op.assemble(mu) for op in self.operators]
+        operators = tuple(op.assemble(mu) for op in self.operators)
         coefficients = self.evaluate_coefficients(mu)
         op = assemble_lincomb(operators, coefficients, solver_options=self.solver_options,
                               name=self.name + '_assembled')
@@ -133,7 +133,7 @@ class LincombOperator(OperatorBase):
             if self.parametric or operators != self.operators:
                 return LincombOperator(operators, coefficients, solver_options=self.solver_options,
                                        name=self.name + '_assembled')
-            else:
+            else:  # this can only happen when both operators and self.operators are tuples!
                 return self  # avoid infinite recursion
 
     def jacobian(self, U, mu=None):

--- a/src/pymor/operators/interfaces.py
+++ b/src/pymor/operators/interfaces.py
@@ -339,7 +339,7 @@ class OperatorInterface(ImmutableInterface, Parametric):
         """
         pass
 
-    def _assemble_lincomb(self, operators, coefficients, shift=0., solver_options=None, name=None):
+    def _assemble_lincomb(self, operators, coefficients, identity_shift=0., solver_options=None, name=None):
         """Try to assemble a linear combination of the given operators.
 
         Returns a new |Operator| which represents the sum ::
@@ -360,7 +360,7 @@ class OperatorInterface(ImmutableInterface, Parametric):
             List of |Operators| `O_i` whose linear combination is formed.
         coefficients
             List of the corresponding linear coefficients `c_i`.
-        shift
+        identity_shift
             The coefficient `s`.
         solver_options
             |solver_options| for the assembled operator.

--- a/src/pymor/operators/interfaces.py
+++ b/src/pymor/operators/interfaces.py
@@ -339,8 +339,14 @@ class OperatorInterface(ImmutableInterface, Parametric):
         """
         pass
 
-    def _assemble_lincomb(self, operators, coefficients, solver_options=None, name=None):
+    def _assemble_lincomb(self, operators, coefficients, shift=0., solver_options=None, name=None):
         """Try to assemble a linear combination of the given operators.
+
+        Returns a new |Operator| which represents the sum ::
+
+            c_1*O_1 + ... + c_N*O_N + s*I
+
+        where `O_i` are |Operators|, `c_i`, `s` scalar coefficients and `I` the identity.
 
         This method is called in the :meth:`assemble` method of |LincombOperator| on
         the first of its operators. If an assembly of the given linear combination
@@ -351,9 +357,11 @@ class OperatorInterface(ImmutableInterface, Parametric):
         Parameters
         ----------
         operators
-            List of |Operators| whose linear combination is formed.
+            List of |Operators| `O_i` whose linear combination is formed.
         coefficients
-            List of the corresponding linear coefficients.
+            List of the corresponding linear coefficients `c_i`.
+        shift
+            The coefficient `s`.
         solver_options
             |solver_options| for the assembled operator.
         name

--- a/src/pymor/operators/interfaces.py
+++ b/src/pymor/operators/interfaces.py
@@ -339,7 +339,7 @@ class OperatorInterface(ImmutableInterface, Parametric):
         """
         pass
 
-    def assemble_lincomb(self, operators, coefficients, solver_options=None, name=None):
+    def _assemble_lincomb(self, operators, coefficients, solver_options=None, name=None):
         """Try to assemble a linear combination of the given operators.
 
         This method is called in the :meth:`assemble` method of |LincombOperator| on

--- a/src/pymor/operators/mpi.py
+++ b/src/pymor/operators/mpi.py
@@ -159,7 +159,7 @@ class MPIOperator(OperatorBase):
         mu = self.parse_parameter(mu)
         return self.with_(obj_id=mpi.call(mpi.method_call_manage, self.obj_id, 'assemble', mu=mu))
 
-    def assemble_lincomb(self, operators, coefficients, solver_options=None, name=None):
+    def _assemble_lincomb(self, operators, coefficients, solver_options=None, name=None):
         if not all(isinstance(op, MPIOperator) for op in operators):
             return None
         assert solver_options is None
@@ -191,7 +191,7 @@ def _MPIOperator_get_local_spaces(self, source, pickle_local_spaces):
 
 def _MPIOperator_assemble_lincomb(operators, coefficients, name):
     operators = [mpi.get_object(op) for op in operators]
-    return mpi.manage_object(operators[0].assemble_lincomb(operators, coefficients, name=name))
+    return mpi.manage_object(operators[0]._assemble_lincomb(operators, coefficients, name=name))
 
 
 def mpi_wrap_operator(obj_id, mpi_range, mpi_source, with_apply2=False, pickle_local_spaces=True,

--- a/src/pymor/operators/mpi.py
+++ b/src/pymor/operators/mpi.py
@@ -159,12 +159,12 @@ class MPIOperator(OperatorBase):
         mu = self.parse_parameter(mu)
         return self.with_(obj_id=mpi.call(mpi.method_call_manage, self.obj_id, 'assemble', mu=mu))
 
-    def _assemble_lincomb(self, operators, coefficients, solver_options=None, name=None):
+    def _assemble_lincomb(self, operators, coefficients, shift=0., solver_options=None, name=None):
         if not all(isinstance(op, MPIOperator) for op in operators):
             return None
         assert solver_options is None
         operators = [op.obj_id for op in operators]
-        obj_id = mpi.call(_MPIOperator_assemble_lincomb, operators, coefficients, name=name)
+        obj_id = mpi.call(_MPIOperator_assemble_lincomb, operators, coefficients, shift, name=name)
         op = mpi.get_object(obj_id)
         if op is None:
             mpi.call(mpi.remove_object, obj_id)
@@ -189,9 +189,9 @@ def _MPIOperator_get_local_spaces(self, source, pickle_local_spaces):
         return tuple(local_spaces)
 
 
-def _MPIOperator_assemble_lincomb(operators, coefficients, name):
+def _MPIOperator_assemble_lincomb(operators, coefficients, shift, name):
     operators = [mpi.get_object(op) for op in operators]
-    return mpi.manage_object(operators[0]._assemble_lincomb(operators, coefficients, name=name))
+    return mpi.manage_object(operators[0]._assemble_lincomb(operators, coefficients, shift, name=name))
 
 
 def mpi_wrap_operator(obj_id, mpi_range, mpi_source, with_apply2=False, pickle_local_spaces=True,

--- a/src/pymor/operators/mpi.py
+++ b/src/pymor/operators/mpi.py
@@ -159,12 +159,12 @@ class MPIOperator(OperatorBase):
         mu = self.parse_parameter(mu)
         return self.with_(obj_id=mpi.call(mpi.method_call_manage, self.obj_id, 'assemble', mu=mu))
 
-    def _assemble_lincomb(self, operators, coefficients, shift=0., solver_options=None, name=None):
+    def _assemble_lincomb(self, operators, coefficients, identity_shift=0., solver_options=None, name=None):
         if not all(isinstance(op, MPIOperator) for op in operators):
             return None
         assert solver_options is None
         operators = [op.obj_id for op in operators]
-        obj_id = mpi.call(_MPIOperator_assemble_lincomb, operators, coefficients, shift, name=name)
+        obj_id = mpi.call(_MPIOperator_assemble_lincomb, operators, coefficients, identity_shift, name=name)
         op = mpi.get_object(obj_id)
         if op is None:
             mpi.call(mpi.remove_object, obj_id)
@@ -189,9 +189,9 @@ def _MPIOperator_get_local_spaces(self, source, pickle_local_spaces):
         return tuple(local_spaces)
 
 
-def _MPIOperator_assemble_lincomb(operators, coefficients, shift, name):
+def _MPIOperator_assemble_lincomb(operators, coefficients, identity_shift, name):
     operators = [mpi.get_object(op) for op in operators]
-    return mpi.manage_object(operators[0]._assemble_lincomb(operators, coefficients, shift, name=name))
+    return mpi.manage_object(operators[0]._assemble_lincomb(operators, coefficients, identity_shift, name=name))
 
 
 def mpi_wrap_operator(obj_id, mpi_range, mpi_source, with_apply2=False, pickle_local_spaces=True,

--- a/src/pymor/operators/numpy.py
+++ b/src/pymor/operators/numpy.py
@@ -24,7 +24,7 @@ from pymor.core.exceptions import InversionError
 from pymor.core.interfaces import abstractmethod
 from pymor.core.logger import getLogger
 from pymor.operators.basic import OperatorBase
-from pymor.operators.constructions import IdentityOperator, ZeroOperator
+from pymor.operators.constructions import IdentityOperator
 from pymor.vectorarrays.numpy import NumpyVectorSpace
 
 
@@ -334,8 +334,8 @@ class NumpyMatrixOperator(NumpyMatrixBasedOperator):
     def apply_inverse_adjoint(self, U, mu=None, least_squares=False):
         return self.H.apply_inverse(U, mu=mu, least_squares=least_squares)
 
-    def assemble_lincomb(self, operators, coefficients, solver_options=None, name=None):
-        if not all(isinstance(op, (NumpyMatrixOperator, ZeroOperator, IdentityOperator)) for op in operators):
+    def _assemble_lincomb(self, operators, coefficients, solver_options=None, name=None):
+        if not all(isinstance(op, (NumpyMatrixOperator, IdentityOperator)) for op in operators):
             return None
 
         common_mat_dtype = reduce(np.promote_types,
@@ -351,9 +351,7 @@ class NumpyMatrixOperator(NumpyMatrixBasedOperator):
                 matrix = matrix.astype(common_dtype)
 
         for op, c in zip(operators[1:], coefficients[1:]):
-            if type(op) is ZeroOperator:
-                continue
-            elif type(op) is IdentityOperator:
+            if type(op) is IdentityOperator:
                 if c.imag == 0:
                     c = c.real
                 if operators[0].sparse:

--- a/src/pymor/operators/numpy.py
+++ b/src/pymor/operators/numpy.py
@@ -333,13 +333,13 @@ class NumpyMatrixOperator(NumpyMatrixBasedOperator):
     def apply_inverse_adjoint(self, U, mu=None, least_squares=False):
         return self.H.apply_inverse(U, mu=mu, least_squares=least_squares)
 
-    def _assemble_lincomb(self, operators, coefficients, shift=0., solver_options=None, name=None):
+    def _assemble_lincomb(self, operators, coefficients, identity_shift=0., solver_options=None, name=None):
         if not all(isinstance(op, NumpyMatrixOperator) for op in operators):
             return None
 
         common_mat_dtype = reduce(np.promote_types,
                                   (op.matrix.dtype for op in operators if hasattr(op, 'matrix')))
-        common_coef_dtype = reduce(np.promote_types, (type(c) for c in coefficients + (shift,)))
+        common_coef_dtype = reduce(np.promote_types, (type(c) for c in coefficients + (identity_shift,)))
         common_dtype = np.promote_types(common_mat_dtype, common_coef_dtype)
 
         if coefficients[0] == 1:
@@ -366,16 +366,16 @@ class NumpyMatrixOperator(NumpyMatrixBasedOperator):
                 except NotImplementedError:
                     matrix = matrix + (op.matrix * c)
 
-        if shift != 0:
-            if shift.imag == 0:
-                shift = shift.real
+        if identity_shift != 0:
+            if identity_shift.imag == 0:
+                identity_shift = identity_shift.real
             if operators[0].sparse:
                 try:
-                    matrix += (scipy.sparse.eye(matrix.shape[0]) * shift)
+                    matrix += (scipy.sparse.eye(matrix.shape[0]) * identity_shift)
                 except NotImplementedError:
-                    matrix = matrix + (scipy.sparse.eye(matrix.shape[0]) * shift)
+                    matrix = matrix + (scipy.sparse.eye(matrix.shape[0]) * identity_shift)
             else:
-                matrix += (np.eye(matrix.shape[0]) * shift)
+                matrix += (np.eye(matrix.shape[0]) * identity_shift)
 
         return NumpyMatrixOperator(matrix,
                                    source_id=self.source.id,

--- a/src/pymor/playground/operators/numpy.py
+++ b/src/pymor/playground/operators/numpy.py
@@ -84,8 +84,8 @@ class NumpyListVectorArrayMatrixOperator(NumpyMatrixOperator):
         assert not self.sparse
         return self.source.make_array(list(self.matrix.copy()))
 
-    def _assemble_lincomb(self, operators, coefficients, shift=0., solver_options=None, name=None):
-        lincomb = super()._assemble_lincomb(operators, coefficients, shift)
+    def _assemble_lincomb(self, operators, coefficients, identity_shift=0., solver_options=None, name=None):
+        lincomb = super()._assemble_lincomb(operators, coefficients, identity_shift)
         if lincomb is None:
             return None
         else:

--- a/src/pymor/playground/operators/numpy.py
+++ b/src/pymor/playground/operators/numpy.py
@@ -84,8 +84,8 @@ class NumpyListVectorArrayMatrixOperator(NumpyMatrixOperator):
         assert not self.sparse
         return self.source.make_array(list(self.matrix.copy()))
 
-    def assemble_lincomb(self, operators, coefficients, solver_options=None, name=None):
-        lincomb = super().assemble_lincomb(operators, coefficients)
+    def _assemble_lincomb(self, operators, coefficients, solver_options=None, name=None):
+        lincomb = super()._assemble_lincomb(operators, coefficients)
         if lincomb is None:
             return None
         else:

--- a/src/pymor/playground/operators/numpy.py
+++ b/src/pymor/playground/operators/numpy.py
@@ -84,8 +84,8 @@ class NumpyListVectorArrayMatrixOperator(NumpyMatrixOperator):
         assert not self.sparse
         return self.source.make_array(list(self.matrix.copy()))
 
-    def _assemble_lincomb(self, operators, coefficients, solver_options=None, name=None):
-        lincomb = super()._assemble_lincomb(operators, coefficients)
+    def _assemble_lincomb(self, operators, coefficients, shift=0., solver_options=None, name=None):
+        lincomb = super()._assemble_lincomb(operators, coefficients, shift)
         if lincomb is None:
             return None
         else:

--- a/src/pymortests/complex_values.py
+++ b/src/pymortests/complex_values.py
@@ -20,17 +20,17 @@ def test_complex():
     Bop = NumpyMatrixOperator(B)
     Cva = NumpyVectorSpace.from_numpy(C)
 
-    # assemble_lincomb
-    assert not np.iscomplexobj(Aop.assemble_lincomb([Iop, Bop], [1, 1]).matrix)
-    assert not np.iscomplexobj(Aop.assemble_lincomb([Aop, Bop], [1, 1]).matrix)
-    assert np.iscomplexobj(Aop.assemble_lincomb([Aop, Bop], [1 + 0j, 1 + 0j]).matrix)
-    assert np.iscomplexobj(Aop.assemble_lincomb([Aop, Bop], [1j, 1]).matrix)
-    assert np.iscomplexobj(Aop.assemble_lincomb([Bop, Aop], [1, 1j]).matrix)
+    # lincombs
+    assert not np.iscomplexobj((Iop * 1 + Bop * 1).assemble().matrix)
+    assert not np.iscomplexobj((Aop * 1 + Bop * 1).assemble().matrix)
+    assert np.iscomplexobj((Aop * (1+0j) + Bop * (1+0j)).assemble().matrix)
+    assert np.iscomplexobj((Aop * 1j + Bop * 1).assemble().matrix)
+    assert np.iscomplexobj((Bop * 1 + Aop * 1j).assemble().matrix)
 
     # apply_inverse
     assert not np.iscomplexobj(Aop.apply_inverse(Cva).to_numpy())
     assert np.iscomplexobj((Aop * 1j).apply_inverse(Cva).to_numpy())
-    assert np.iscomplexobj(Aop.assemble_lincomb([Aop, Bop], [1, 1j]).apply_inverse(Cva).to_numpy())
+    assert np.iscomplexobj((Aop * 1 + Bop * 1j).assemble().apply_inverse(Cva).to_numpy())
     assert np.iscomplexobj(Aop.apply_inverse(Cva * 1j).to_numpy())
 
     # append

--- a/src/pymortests/operators.py
+++ b/src/pymortests/operators.py
@@ -8,10 +8,10 @@ import pytest
 from pymor.algorithms.basic import almost_equal
 from pymor.algorithms.projection import project
 from pymor.core.exceptions import InversionError, LinAlgError
-from pymor.operators.constructions import SelectionOperator, InverseOperator, InverseAdjointOperator
+from pymor.operators.constructions import SelectionOperator, InverseOperator, InverseAdjointOperator, IdentityOperator
 from pymor.parameters.base import ParameterType
 from pymor.parameters.functionals import GenericParameterFunctional
-from pymor.vectorarrays.numpy import NumpyVectorArray
+from pymor.vectorarrays.numpy import NumpyVectorArray, NumpyVectorSpace
 from pymortests.algorithms.stuff import MonomOperator
 from pymortests.fixtures.operator import (operator, operator_with_arrays, operator_with_arrays_and_products,
                                           picklable_operator)
@@ -73,6 +73,17 @@ def test_lincomb_op():
         projected = project(p, basis, basis)
         pa = projected.apply(vx)
         assert almost_equal(pa, p.apply(vx)).all()
+
+
+def test_identity_lincomb():
+    space = NumpyVectorSpace(10)
+    identity = IdentityOperator(space)
+    ones = space.ones()
+    idid = (identity + identity)
+    assert almost_equal(ones * 2, idid.apply(ones))
+    assert almost_equal(ones * 2, idid.apply_adjoint(ones))
+    assert almost_equal(ones * 0.5, idid.apply_inverse(ones))
+    assert almost_equal(ones * 0.5, idid.apply_inverse_adjoint(ones))
 
 
 def test_pickle(operator):


### PR DESCRIPTION
This moves all `assemble_lincomb` methods for generic `Operators` into `pymor.algorithms.lincomb`. The `RuleTable` also takes care of eliminating `ZeroOperators`. ATM, the backends still need to handle `IdentitiyOperators`. Before merging, this issue should be resolved (e.g. by introducing a `ShiftedOperator` and `apply_inverse_shifted` interface methods or a separate argument to `_assemble_lincomb`).

This addresses #548.

