### PR TITLE
[ci] upload test logs and new check results

### DIFF
--- a/.ci/gitlab/ci.yml
+++ b/.ci/gitlab/ci.yml
@@ -11,6 +11,13 @@ stages:
     after_script:
       - .ci/gitlab/after_script.bash
     only: ['branches', 'tags', 'triggers', 'merge-requests']
+    artifacts:
+        name: "$CI_JOB_STAGE-$CI_COMMIT_REF_SLUG"
+        expire_in: 3 months
+        paths:
+            - src/pymortests/testdata/check_results/*/*_changed
+        reports:
+            junit: test_results.xml
 
 3.6_numpy:
     extends: .pytest

--- a/.ci/gitlab/template.ci.py
+++ b/.ci/gitlab/template.ci.py
@@ -13,6 +13,13 @@ stages:
     after_script:
       - .ci/gitlab/after_script.bash
     only: ['branches', 'tags', 'triggers', 'merge-requests']
+    artifacts:
+        name: "$CI_JOB_STAGE-$CI_COMMIT_REF_SLUG"
+        expire_in: 3 months
+        paths:
+            - src/pymortests/testdata/check_results/*/*_changed
+        reports:
+            junit: test_results.xml
 
 3.6_numpy:
     extends: .pytest


### PR DESCRIPTION
These are auto-deleted after 6 months.

This should help with failures like https://zivgitlab.uni-muenster.de/pymor/pymor/-/jobs/82828 since you can just download the `*changed` files in an archive afterwards.