### PR TITLE
Use VectorArrayInterface.random where possible

### DIFF
--- a/src/pymor/algorithms/lradi.py
+++ b/src/pymor/algorithms/lradi.py
@@ -11,6 +11,7 @@ from pymor.algorithms.lyapunov import _solve_lyap_lrcf_check_args
 from pymor.core.defaults import defaults
 from pymor.core.logger import getLogger
 from pymor.operators.constructions import IdentityOperator
+from pymor.tools.random import get_random_state
 
 
 @defaults('lradi_tol', 'lradi_maxiter', 'lradi_shifts', 'projection_shifts_z_columns', 'projection_shifts_init_maxiter',
@@ -65,9 +66,6 @@ def solve_lyap_lrcf(A, E, B, trans=False, options=None):
 
     This function uses the low-rank ADI iteration as described in
     Algorithm 4.3 in [PK16]_.
-    We assume in :func:`projection_shifts_init` for
-    `A.source.from_numpy` to be implemented if projecting (A, E) with B
-    does not give stable eigenvalues.
 
     Parameters
     ----------
@@ -174,15 +172,14 @@ def projection_shifts_init(A, E, B, shift_options):
     shifts
         A |NumPy array| containing a set of stable shift parameters.
     """
+    random_state = get_random_state(seed=shift_options['init_seed'])
     for i in range(shift_options['init_maxiter']):
         Q = gram_schmidt(B, atol=0, rtol=0)
         shifts = spla.eigvals(A.apply2(Q, Q), E.apply2(Q, Q))
         shifts = shifts[shifts.real < 0]
         if shifts.size == 0:
             # use random subspace instead of span{B} (with same dimensions)
-            if shift_options['init_seed'] is not None:
-                np.random.seed(shift_options['init_seed'] + i)
-            B = B.space.from_numpy(np.random.randn(len(B), B.space.dim))
+            B = B.random(len(B), distribution='normal', random_state=random_state)
         else:
             return shifts
     raise RuntimeError('Could not generate initial shifts for low-rank ADI iteration.')

--- a/src/pymor/reductors/h2.py
+++ b/src/pymor/reductors/h2.py
@@ -141,13 +141,12 @@ class IRKAReductor(BasicInterface):
             if b is None:
                 b = fom.B.source.ones(r)
             elif isinstance(b, int):
-                np.random.seed(b)
-                b = fom.B.source.from_numpy(np.random.randn(r, fom.input_dim))
+                b = fom.B.source.random(r, distribution='normal', seed=b)
             if c is None:
                 c = fom.C.range.ones(r)
             elif isinstance(c, int):
                 np.random.seed(c)
-                c = fom.C.range.from_numpy(np.random.randn(r, fom.output_dim))
+                c = fom.C.range.random(r, distribution='normal', seed=c)
 
         # being logging
         self.logger.info('Starting IRKA')
@@ -343,14 +342,12 @@ class OneSidedIRKAReductor(BasicInterface):
                 if b is None:
                     b = fom.B.source.ones(r)
                 elif isinstance(b, int):
-                    np.random.seed(b)
-                    b = fom.B.source.from_numpy(np.random.randn(r, fom.input_dim))
+                    b = fom.B.source.random(r, distribution='normal', seed=b)
             else:
                 if c is None:
                     c = fom.C.range.ones(r)
                 elif isinstance(c, int):
-                    np.random.seed(c)
-                    c = fom.C.range.from_numpy(np.random.randn(r, fom.output_dim))
+                    c = fom.C.range.random(r, distribution='normal', seed=c)
 
         # begin logging
         self.logger.info('Starting one-sided IRKA')

--- a/src/pymor/reductors/sor_irka.py
+++ b/src/pymor/reductors/sor_irka.py
@@ -142,13 +142,11 @@ class SOR_IRKAReductor(BasicInterface):
             if b is None:
                 b = fom.B.source.ones(r)
             elif isinstance(b, int):
-                np.random.seed(b)
-                b = fom.B.source.from_numpy(np.random.randn(r, fom.input_dim))
+                b = fom.B.source.random(r, distribution='normal', seed=b)
             if c is None:
                 c = fom.Cp.range.ones(r)
             elif isinstance(c, int):
-                np.random.seed(c)
-                c = fom.Cp.range.from_numpy(np.random.randn(r, fom.output_dim))
+                c = fom.Cp.range.random(r, distribution='normal', seed=c)
 
         # begin logging
         self.logger.info('Starting SOR-IRKA')


### PR DESCRIPTION
@pmli, I am wondering: Now that the interface supports it, would it maybe be better to always initialize with random values? Should the user always have to specify a seed? Also, is there mathematical reason why the normal distribution is chosen over a uniform distribution?

This is the remaining step to implement #544.