### PR TITLE
Sphinx warning fixes

### DIFF
--- a/docs/source/substitutions.py
+++ b/docs/source/substitutions.py
@@ -97,19 +97,21 @@ common = '''
 .. |StationaryModels| replace:: :class:`StationaryModels <pymor.models.basic.StationaryModel>`
 .. |InstationaryModel| replace:: :class:`~pymor.models.basic.InstationaryModel`
 
+.. |LTIModel| replace:: :class:`~pymor.models.iosys.LTIModel`
+.. |LTIModels| replace:: :class:`LTIModels <pymor.models.iosys.LTIModel>`
+.. |TransferFunction| replace:: :class:`~pymor.models.iosys.TransferFunction`
+.. |TransferFunctions| replace:: :class:`TransferFunctions <pymor.models.iosys.TransferFunction>`
+.. |SecondOrderModel| replace:: :class:`~pymor.models.iosys.SecondOrderModel`
+.. |SecondOrderModels| replace:: :class:`SecondOrderModels <pymor.models.iosys.SecondOrderModel>`
+.. |LinearDelayModel| replace:: :class:`~pymor.models.iosys.LinearDelayModel`
+.. |LinearDelayModels| replace:: :class:`LinearDelayModels <pymor.models.iosys.LinearDelayModel>`
+
 .. |ParameterType| replace:: :class:`~pymor.parameters.base.ParameterType`
 .. |ParameterTypes| replace:: :class:`ParameterTypes <pymor.parameters.base.ParameterType>`
 .. |Parameter| replace:: :class:`~pymor.parameters.base.Parameter`
 .. |Parameters| replace:: :class:`Parameters <pymor.parameters.base.Parameter>`
 .. |Parametric| replace:: :class:`~pymor.parameters.base.Parametric`
 .. |parametric| replace:: :attr:`~pymor.parameters.base.Parametric.parametric`
-
-.. |LTIModel| replace:: :class:`~pymor.models.iosys.LTIModel`
-.. |LTIModels| replace:: :class:`LTIModels <pymor.models.iosys.LTIModel>`
-.. |SecondOrderModel| replace:: :class:`~pymor.models.iosys.SecondOrderModel`
-.. |SecondOrderModels| replace:: :class:`SecondOrderModels <pymor.models.iosys.SecondOrderModel>`
-.. |TransferFunction| replace:: :class:`~pymor.models.iosys.TransferFunction`
-.. |TransferFunctions| replace:: :class:`TransferFunctions <pymor.models.iosys.TransferFunction>`
 
 .. |NumPy| replace:: :mod:`NumPy <numpy>`
 .. |NumPy array| replace:: :class:`NumPy array <numpy.ndarray>`

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -1093,7 +1093,7 @@ class SecondOrderModel(InputStateOutputModel):
         Returns
         -------
         lti
-            |LTISystem| equivalent to the second order system.
+            |LTIModel| equivalent to the second-order model.
         """
         return LTIModel(A=SecondOrderModelOperator(self.E, self.K),
                         B=BlockColumnOperator([ZeroOperator(self.B.range, self.B.source), self.B]),

--- a/src/pymor/reductors/basic.py
+++ b/src/pymor/reductors/basic.py
@@ -207,7 +207,7 @@ class InstationaryRBReductor(ProjectionBasedReductor):
         Inner product |Operator| w.r.t. which `RB` is orthonormalized. If `None`, the
         the Euclidean inner product is used.
     initial_data_product
-        Inner product |Operator| w.r.t. which the `initial_data` of `fom` is orthogonally projected. 
+        Inner product |Operator| w.r.t. which the `initial_data` of `fom` is orthogonally projected.
         If `None`, the Euclidean inner product is used.
     product_is_mass
         If `True`, no mass matrix for the reduced |Model| is assembled.  Set to `True` if `RB` is
@@ -338,7 +338,7 @@ class LTIPGReductor(ProjectionBasedReductor):
 
 
 class SOLTIPGReductor(ProjectionBasedReductor):
-    """Petrov-Galerkin projection of an |SOLTIModel|.
+    """Petrov-Galerkin projection of an |SecondOrderModel|.
 
     Parameters
     ----------
@@ -395,7 +395,7 @@ class SOLTIPGReductor(ProjectionBasedReductor):
 
 
 class DelayLTIPGReductor(ProjectionBasedReductor):
-    """Petrov-Galerkin projection of an |DelayLTIModel|.
+    """Petrov-Galerkin projection of an |LinearDelayModel|.
 
     Parameters
     ----------

--- a/src/pymor/vectorarrays/interfaces.py
+++ b/src/pymor/vectorarrays/interfaces.py
@@ -133,8 +133,8 @@ class VectorArrayInterface(BasicInterface):
         Note that not all random distributions are necessarily implemented
         by all |VectorSpace| implementations.
 
-        Parameter
-        ---------
+        Parameters
+        ----------
         count
             The number of vectors.
         distribution
@@ -726,8 +726,8 @@ class VectorSpaceInterface(ImmutableInterface):
         Note that not all random distributions are necessarily implemented
         by all |VectorSpace| implementations.
 
-        Parameter
-        ---------
+        Parameters
+        ----------
         count
             The number of vectors.
         distribution


### PR DESCRIPTION
This adds and fixes some substitutions and fixes an issue with the `Parameter` section.

There is still the issue of `release_notes.rst` using system and discretization substitutions.