### PR TITLE
sys-mor API changes

### DIFF
--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -672,26 +672,6 @@ class LTIModel(InputStateOutputModel):
         """
         return self._hsv_U_V()[0]
 
-    def hsU(self):
-        """Left Hankel singular vectors.
-
-        Returns
-        -------
-        Uh
-            |NumPy array| of left singluar vectors.
-        """
-        return self._hsv_U_V()[1]
-
-    def hsV(self):
-        """Right Hankel singular vectors.
-
-        Returns
-        -------
-        Vh
-            |NumPy array| of right singluar vectors.
-        """
-        return self._hsv_U_V()[2]
-
     @cached
     def h2_norm(self):
         """Compute the H2-norm of the |LTIModel|."""

--- a/src/pymor/reductors/bt.py
+++ b/src/pymor/reductors/bt.py
@@ -26,23 +26,23 @@ class GenericBTReductor(BasicInterface):
         self.fom = fom
         self.V = None
         self.W = None
-        self.sv = None
-        self.sU = None
-        self.sV = None
+        self._sv = None
+        self._sU = None
+        self._sV = None
 
-    def gramians(self):
+    def _gramians(self):
         """Return low-rank Cholesky factors of Gramians."""
         raise NotImplementedError
 
-    def sv_U_V(self):
+    def _sv_U_V(self):
         """Return singular values and vectors."""
-        if self.sv is None or self.sU is None or self.sV is None:
-            cf, of = self.gramians()
+        if self._sv is None or self._sU is None or self._sV is None:
+            cf, of = self._gramians()
             U, sv, Vh = spla.svd(self.fom.E.apply2(of, cf), lapack_driver='gesvd')
-            self.sv = sv
-            self.sU = U.T
-            self.sV = Vh
-        return self.sv, self.sU, self.sV
+            self._sv = sv
+            self._sU = U.T
+            self._sV = Vh
+        return self._sv, self._sU, self._sV
 
     def error_bounds(self):
         """Returns error bounds for all possible reduced orders."""
@@ -79,8 +79,8 @@ class GenericBTReductor(BasicInterface):
         assert r is None or 0 < r < self.fom.order
         assert projection in ('sr', 'bfsr', 'biorth')
 
-        cf, of = self.gramians()
-        sv, sU, sV = self.sv_U_V()
+        cf, of = self._gramians()
+        sv, sU, sV = self._sv_U_V()
 
         # find reduced order if tol is specified
         if tol is not None:
@@ -124,11 +124,11 @@ class BTReductor(GenericBTReductor):
     fom
         The system which is to be reduced.
     """
-    def gramians(self):
+    def _gramians(self):
         return self.fom.gramian('c_lrcf'), self.fom.gramian('o_lrcf')
 
     def error_bounds(self):
-        sv = self.sv_U_V()[0]
+        sv = self._sv_U_V()[0]
         return 2 * sv[:0:-1].cumsum()[::-1]
 
 
@@ -148,7 +148,7 @@ class LQGBTReductor(GenericBTReductor):
         super().__init__(fom)
         self.solver_options = solver_options
 
-    def gramians(self):
+    def _gramians(self):
         A = self.fom.A
         B = self.fom.B
         C = self.fom.C
@@ -160,7 +160,7 @@ class LQGBTReductor(GenericBTReductor):
         return cf, of
 
     def error_bounds(self):
-        sv = self.sv_U_V()[0]
+        sv = self._sv_U_V()[0]
         return 2 * (sv[:0:-1] / np.sqrt(1 + sv[:0:-1] ** 2)).cumsum()[::-1]
 
 
@@ -183,7 +183,7 @@ class BRBTReductor(GenericBTReductor):
         self.gamma = gamma
         self.solver_options = solver_options
 
-    def gramians(self):
+    def _gramians(self):
         fom = self.fom
         A = fom.A
         B = fom.B
@@ -200,5 +200,5 @@ class BRBTReductor(GenericBTReductor):
         return cf, of
 
     def error_bounds(self):
-        sv = self.sv_U_V()[0]
+        sv = self._sv_U_V()[0]
         return 2 * sv[:0:-1].cumsum()[::-1]

--- a/src/pymor/reductors/bt.py
+++ b/src/pymor/reductors/bt.py
@@ -178,7 +178,7 @@ class BRBTReductor(GenericBTReductor):
     solver_options
         The solver options to use to solve the positive Riccati equations.
     """
-    def __init__(self, fom, gamma, solver_options=None):
+    def __init__(self, fom, gamma=1, solver_options=None):
         super().__init__(fom)
         self.gamma = gamma
         self.solver_options = solver_options
@@ -192,10 +192,10 @@ class BRBTReductor(GenericBTReductor):
         options = self.solver_options
 
         cf = solve_pos_ricc_lrcf(A, E, B.as_range_array(), C.as_source_array(),
-                                 R=self.gamma**2 * np.eye(fom.output_dim),
+                                 R=self.gamma**2 * np.eye(fom.output_dim) if self.gamma != 1 else None,
                                  trans=False, options=options)
         of = solve_pos_ricc_lrcf(A, E, B.as_range_array(), C.as_source_array(),
-                                 R=self.gamma**2 * np.eye(fom.input_dim),
+                                 R=self.gamma**2 * np.eye(fom.input_dim) if self.gamma != 1 else None,
                                  trans=True, options=options)
         return cf, of
 


### PR DESCRIPTION
Some changes to API which should improve things:
- turn some methods in `reductors.bt` private, to show that only `reduce` and `error_bounds` should be used
- remove `hsU` and `hsV` methods from `LTIModel` since `hsv` is far more useful and it could be confused with `hsV`
- give `gamma` in `BRBTReductor` a default value 1, because "bounded real" means "H_inf-norm bounded by 1" in standard terminology