### PR TITLE
Transfer function h2_norm

### DIFF
--- a/notebooks/heat.ipynb
+++ b/notebooks/heat.ipynb
@@ -730,11 +730,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "tf_h2_int, int_err = spint.quad(lambda w: spla.norm(tf.eval_tf(w * 1j)) ** 2,\n",
-    "                                -np.inf, np.inf)\n",
-    "\n",
-    "tf_h2_norm = np.sqrt(tf_h2_int / 2 / np.pi)\n",
-    "print(f'TF H_2-norm  = {tf_h2_norm:e}')\n",
+    "print(f'TF H_2-norm  = {tf.h2_norm():e}')\n",
     "print(f'LTI H_2-norm = {lti.h2_norm():e}')"
    ]
   },
@@ -744,11 +740,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dist_h2_int, dist_int_err = spint.quad(lambda w: spla.norm(tf_lti_diff.eval_tf(w * 1j)) ** 2,\n",
-    "                                       -np.inf, np.inf, epsabs=1e-16)\n",
-    "\n",
-    "h2_dist = np.sqrt(dist_h2_int / 2 / np.pi)\n",
-    "print(f'TF-LTI relative H_2-distance = {h2_dist / tf_h2_norm:e}')"
+    "print(f'TF-LTI relative H_2-distance = {tf_lti_diff.h2_norm() / tf.h2_norm():e}')"
    ]
   },
   {
@@ -782,11 +774,7 @@
    "outputs": [],
    "source": [
     "err_tf_irka = tf - rom_tf_irka\n",
-    "error_h2, error_int_err = spint.quad(lambda w: spla.norm(err_tf_irka.eval_tf(w * 1j)) ** 2,\n",
-    "                                     -np.inf, np.inf, epsabs=1e-16)\n",
-    "\n",
-    "tf_irka_h2_error = np.sqrt(error_h2 / 2 / np.pi)\n",
-    "print(f'TF-IRKA relative H_2-error = {tf_irka_h2_error / tf_h2_norm:e}')"
+    "print(f'TF-IRKA relative H_2-error = {err_tf_irka.h2_norm() / tf.h2_norm():e}')"
    ]
   },
   {
@@ -796,11 +784,7 @@
    "outputs": [],
    "source": [
     "err_irka_tf = tf - rom_irka\n",
-    "error_irka_h2, error_irka_int_err = spint.quad(lambda w: spla.norm(err_irka_tf.eval_tf(w * 1j)) ** 2,\n",
-    "                                               -np.inf, np.inf, epsabs=1e-16)\n",
-    "\n",
-    "irka_h2_error = np.sqrt(error_irka_h2 / 2 / np.pi)\n",
-    "print(f'IRKA relative H_2-error (from TF) = {irka_h2_error / tf_h2_norm:e}')"
+    "print(f'IRKA relative H_2-error (from TF) = {err_irka_tf.h2_norm() / tf.h2_norm():e}')"
    ]
   }
  ],

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -869,16 +869,52 @@ class TransferFunction(InputOutputModel):
         return self.with_(H=H, dH=dH)
 
     @cached
-    def h2_norm(self):
-        """Compute the H2-norm using quadrature."""
+    def h2_norm(self, return_norm_only=True, **quad_kwargs):
+        """Compute the H2-norm using quadrature.
+
+        This method uses `scipy.integrate.quad` and makes no assumptions on the form of the transfer
+        function.
+
+        By default, the absolute error tolerance in `scipy.integrate.quad` is set to zero (see its
+        optional argument `epsabs`).
+        It can be changed by using the `epsabs` keyword argument.
+
+        Parameters
+        ----------
+        return_norm_only
+            Whether to only return the approximate H2-norm.
+        quad_kwargs
+            Keyword arguments passed to `scipy.integrate.quad`.
+
+        Returns
+        -------
+        norm
+            Computed H2-norm.
+        norm_relerr
+            Relative error estimate (returned if `return_norm_only` is `False`).
+        info
+            Quadrature info (returned if `return_norm_only` is `False` and `full_output` is `True`).
+            See `scipy.integrate.quad` documentation for more details.
+        """
         if not self.cont_time:
             raise NotImplementedError
 
         import scipy.integrate as spint
-        h2_int, _ = spint.quad(lambda w: spla.norm(self.eval_tf(w * 1j))**2,
-                               -np.inf, np.inf,
-                               epsabs=0)
-        return np.sqrt(h2_int / 2 / np.pi)
+        if 'epsabs' not in quad_kwargs:
+            quad_kwargs['epsabs'] = 0
+        quad_out = spint.quad(lambda w: spla.norm(self.eval_tf(w * 1j))**2,
+                              -np.inf, np.inf,
+                              **quad_kwargs)
+        norm = np.sqrt(quad_out[0] / (2 * np.pi))
+        if return_norm_only:
+            return norm
+        else:
+            abserr = quad_out[1]
+            norm_relerr = abserr / (2 * np.pi) / (2 * norm) / norm
+            if len(quad_out) == 2:
+                return norm, norm_relerr
+            else:
+                return norm, norm_relerr, quad_out[2:]
 
 
 class SecondOrderModel(InputStateOutputModel):

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -868,6 +868,18 @@ class TransferFunction(InputOutputModel):
         dH = lambda s: other.eval_dtf(s) @ self.eval_dtf(s)
         return self.with_(H=H, dH=dH)
 
+    @cached
+    def h2_norm(self):
+        """Compute the H2-norm using quadrature."""
+        if not self.cont_time:
+            raise NotImplementedError
+
+        import scipy.integrate as spint
+        h2_int, _ = spint.quad(lambda w: spla.norm(self.eval_tf(w * 1j))**2,
+                               -np.inf, np.inf,
+                               epsabs=0)
+        return np.sqrt(h2_int / 2 / np.pi)
+
 
 class SecondOrderModel(InputStateOutputModel):
     r"""Class for linear second order systems.


### PR DESCRIPTION
Adds `TransferFunction.h2_norm`, using `scipy.integrate.quad`.