### PR TITLE
[sys-mor] various reductor improvements

### DIFF
--- a/notebooks/delay.ipynb
+++ b/notebooks/delay.ipynb
@@ -29,7 +29,7 @@
     "\n",
     "from pymor.basic import *\n",
     "from pymor.models.iosys import LinearDelayModel\n",
-    "from pymor.reductors.interpolation import DelayBHIReductor, TFInterpReductor"
+    "from pymor.reductors.interpolation import DelayBHIReductor, TF_BHIReductor"
    ]
   },
   {
@@ -107,7 +107,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "interp = TFInterpReductor(td_lti)"
+    "interp = TF_BHIReductor(td_lti)"
    ]
   },
   {

--- a/notebooks/delay.ipynb
+++ b/notebooks/delay.ipynb
@@ -29,7 +29,7 @@
     "\n",
     "from pymor.basic import *\n",
     "from pymor.models.iosys import LinearDelayModel\n",
-    "from pymor.reductors.interpolation import DelayBHIReductor, TF_BHIReductor"
+    "from pymor.reductors.interpolation import DelayBHIReductor, TFBHIReductor"
    ]
   },
   {
@@ -107,7 +107,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "interp = TF_BHIReductor(td_lti)"
+    "interp = TFBHIReductor(td_lti)"
    ]
   },
   {

--- a/notebooks/heat.ipynb
+++ b/notebooks/heat.ipynb
@@ -764,7 +764,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "tf_irka_reductor = TF_IRKAReductor(tf)\n",
+    "tf_irka_reductor = TFIRKAReductor(tf)\n",
     "rom_tf_irka = tf_irka_reductor.reduce(r)"
    ]
   },

--- a/notebooks/heat.ipynb
+++ b/notebooks/heat.ipynb
@@ -388,7 +388,7 @@
    "outputs": [],
    "source": [
     "fig, ax = plt.subplots()\n",
-    "ax.semilogy(irka_reductor.dist, '.-')\n",
+    "ax.semilogy(irka_reductor.conv_crit, '.-')\n",
     "ax.set_title('Distances between shifts in IRKA iterations')\n",
     "plt.show()"
    ]
@@ -463,7 +463,7 @@
    "outputs": [],
    "source": [
     "fig, ax = plt.subplots()\n",
-    "ax.semilogy(tsia_reductor.dist, '.-')\n",
+    "ax.semilogy(tsia_reductor.conv_crit, '.-')\n",
     "ax.set_title('Distances between shifts in TSIA iterations')\n",
     "plt.show()"
    ]
@@ -534,7 +534,7 @@
    "outputs": [],
    "source": [
     "fig, ax = plt.subplots()\n",
-    "ax.semilogy(one_sided_irka_reductor.dist, '.-')\n",
+    "ax.semilogy(one_sided_irka_reductor.conv_crit, '.-')\n",
     "ax.set_title('Distances between shifts in one-sided IRKA iterations')\n",
     "plt.show()"
    ]

--- a/notebooks/string.ipynb
+++ b/notebooks/string.ipynb
@@ -79,7 +79,7 @@
     "from pymor.reductors.h2 import IRKAReductor\n",
     "from pymor.reductors.sobt import (SOBTpReductor, SOBTvReductor, SOBTpvReductor, SOBTvpReductor,\n",
     "                                  SOBTfvReductor, SOBTReductor)\n",
-    "from pymor.reductors.sor_irka import SOR_IRKAReductor\n",
+    "from pymor.reductors.sor_irka import SORIRKAReductor\n",
     "\n",
     "from pymor.core.logger import set_log_levels\n",
     "set_log_levels({'pymor.algorithms.gram_schmidt.gram_schmidt': 'WARNING'})"
@@ -783,7 +783,7 @@
    "outputs": [],
    "source": [
     "r = 5\n",
-    "sor_irka_reductor = SOR_IRKAReductor(so_sys)\n",
+    "sor_irka_reductor = SORIRKAReductor(so_sys)\n",
     "rom_sor_irka = sor_irka_reductor.reduce(r)"
    ]
   },

--- a/notebooks/string.ipynb
+++ b/notebooks/string.ipynb
@@ -711,7 +711,7 @@
    "outputs": [],
    "source": [
     "fig, ax = plt.subplots()\n",
-    "ax.semilogy(irka_reductor.dist, '.-')\n",
+    "ax.semilogy(irka_reductor.conv_crit, '.-')\n",
     "ax.set_title('IRKA convergence criterion')\n",
     "plt.show()"
    ]
@@ -794,7 +794,7 @@
    "outputs": [],
    "source": [
     "fig, ax = plt.subplots()\n",
-    "ax.semilogy(sor_irka_reductor.dist, '.-')\n",
+    "ax.semilogy(sor_irka_reductor.conv_crit, '.-')\n",
     "ax.set_title('SOR-IRKA convergence criterion')\n",
     "plt.show()"
    ]

--- a/src/pymor/basic.py
+++ b/src/pymor/basic.py
@@ -70,12 +70,12 @@ from pymor.parameters.spaces import CubicParameterSpace
 from pymor.reductors.basic import StationaryRBReductor, InstationaryRBReductor, LTIPGReductor, SOLTIPGReductor
 from pymor.reductors.bt import BTReductor, LQGBTReductor, BRBTReductor
 from pymor.reductors.coercive import CoerciveRBReductor, SimpleCoerciveRBReductor
-from pymor.reductors.h2 import IRKAReductor, TSIAReductor, TF_IRKAReductor
-from pymor.reductors.interpolation import LTI_BHIReductor, SO_BHIReductor, TF_BHIReductor
+from pymor.reductors.h2 import IRKAReductor, TSIAReductor, TFIRKAReductor
+from pymor.reductors.interpolation import LTIBHIReductor, SOBHIReductor, TFBHIReductor
 from pymor.reductors.parabolic import ParabolicRBReductor
 from pymor.reductors.sobt import (SOBTpReductor, SOBTvReductor, SOBTpvReductor, SOBTvpReductor, SOBTfvReductor,
                                   SOBTReductor)
-from pymor.reductors.sor_irka import SOR_IRKAReductor
+from pymor.reductors.sor_irka import SORIRKAReductor
 
 from pymor.tools.random import default_random_state
 

--- a/src/pymor/basic.py
+++ b/src/pymor/basic.py
@@ -71,7 +71,7 @@ from pymor.reductors.basic import StationaryRBReductor, InstationaryRBReductor, 
 from pymor.reductors.bt import BTReductor, LQGBTReductor, BRBTReductor
 from pymor.reductors.coercive import CoerciveRBReductor, SimpleCoerciveRBReductor
 from pymor.reductors.h2 import IRKAReductor, TSIAReductor, TF_IRKAReductor
-from pymor.reductors.interpolation import LTI_BHIReductor, SO_BHIReductor, TFInterpReductor
+from pymor.reductors.interpolation import LTI_BHIReductor, SO_BHIReductor, TF_BHIReductor
 from pymor.reductors.parabolic import ParabolicRBReductor
 from pymor.reductors.sobt import (SOBTpReductor, SOBTvReductor, SOBTpvReductor, SOBTvpReductor, SOBTfvReductor,
                                   SOBTReductor)

--- a/src/pymor/reductors/bt.py
+++ b/src/pymor/reductors/bt.py
@@ -19,7 +19,7 @@ class GenericBTReductor(BasicInterface):
     Parameters
     ----------
     fom
-        The system which is to be reduced.
+        The full-order |LTIModel| to reduce.
     """
     def __init__(self, fom):
         assert isinstance(fom, LTIModel)
@@ -54,26 +54,23 @@ class GenericBTReductor(BasicInterface):
         Parameters
         ----------
         r
-            Order of the reduced model if `tol` is `None`, maximum order
-            if `tol` is specified.
+            Order of the reduced model if `tol` is `None`, maximum order if `tol` is specified.
         tol
             Tolerance for the error bound if `r` is `None`.
         projection
             Projection method used:
 
             - `'sr'`: square root method
-            - `'bfsr'`: balancing-free square root method (default,
-              since it avoids scaling by singular values and
-              orthogonalizes the projection matrices, which might make
-              it more accurate than the square root method)
-            - `'biorth'`: like the balancing-free square root method,
-              except it biorthogonalizes the projection matrices (using
-              :func:`~pymor.algorithms.gram_schmidt.gram_schmidt_biorth`)
+            - `'bfsr'`: balancing-free square root method (default, since it avoids scaling by
+              singular values and orthogonalizes the projection matrices, which might make it more
+              accurate than the square root method)
+            - `'biorth'`: like the balancing-free square root method, except it biorthogonalizes the
+              projection matrices (using :func:`~pymor.algorithms.gram_schmidt.gram_schmidt_biorth`)
 
         Returns
         -------
         rom
-            Reduced system.
+            Reduced-order model.
         """
         assert r is not None or tol is not None
         assert r is None or 0 < r < self.fom.order
@@ -122,7 +119,7 @@ class BTReductor(GenericBTReductor):
     Parameters
     ----------
     fom
-        The system which is to be reduced.
+        The full-order |LTIModel| to reduce.
     """
     def _gramians(self):
         return self.fom.gramian('c_lrcf'), self.fom.gramian('o_lrcf')
@@ -140,7 +137,7 @@ class LQGBTReductor(GenericBTReductor):
     Parameters
     ----------
     fom
-        The system which is to be reduced.
+        The full-order |LTIModel| to reduce.
     solver_options
         The solver options to use to solve the Riccati equations.
     """
@@ -172,7 +169,7 @@ class BRBTReductor(GenericBTReductor):
     Parameters
     ----------
     fom
-        The system which is to be reduced.
+        The full-order |LTIModel| to reduce.
     gamma
         Upper bound for the :math:`\mathcal{H}_\infty`-norm.
     solver_options

--- a/src/pymor/reductors/h2.py
+++ b/src/pymor/reductors/h2.py
@@ -145,7 +145,6 @@ class IRKAReductor(BasicInterface):
             if c is None:
                 c = fom.C.range.ones(r)
             elif isinstance(c, int):
-                np.random.seed(c)
                 c = fom.C.range.random(r, distribution='normal', seed=c)
 
         self.logger.info('Starting IRKA')

--- a/src/pymor/reductors/h2.py
+++ b/src/pymor/reductors/h2.py
@@ -12,7 +12,7 @@ from pymor.core.interfaces import BasicInterface
 from pymor.models.iosys import LTIModel
 from pymor.operators.constructions import IdentityOperator
 from pymor.reductors.basic import LTIPGReductor
-from pymor.reductors.interpolation import LTI_BHIReductor, TFInterpReductor
+from pymor.reductors.interpolation import LTI_BHIReductor, TF_BHIReductor
 
 
 class IRKAReductor(BasicInterface):
@@ -712,7 +712,7 @@ class TF_IRKAReductor(BasicInterface):
         self.sigmas = [np.array(sigma)]
         self.R = [b]
         self.L = [c]
-        interp_reductor = TFInterpReductor(fom)
+        interp_reductor = TF_BHIReductor(fom)
         # main loop
         for it in range(maxit):
             # interpolatory reduced order model

--- a/src/pymor/reductors/h2.py
+++ b/src/pymor/reductors/h2.py
@@ -26,10 +26,17 @@ class IRKAReductor(BasicInterface):
     def __init__(self, fom):
         assert isinstance(fom, LTIModel)
         self.fom = fom
+        self.V = None
+        self.W = None
+        self._pg_reductor = None
+        self.conv_crit = None
+        self.sigmas = None
+        self.R = None
+        self.L = None
+        self.errors = None
 
     def reduce(self, r, sigma=None, b=None, c=None, rom0=None, tol=1e-4, maxit=100, num_prev=1,
-               force_sigma_in_rhp=False, projection='orth', use_arnoldi=False, conv_crit='sigma',
-               compute_errors=False):
+               force_sigma_in_rhp=False, projection='orth', conv_crit='sigma', compute_errors=False):
         r"""Reduce using IRKA.
 
         See [GAB08]_ (Algorithm 4.1) and [ABG10]_ (Algorithm 1).
@@ -88,10 +95,8 @@ class IRKAReductor(BasicInterface):
               respect to the Euclidean inner product
             - `'biorth'`: projection matrices are biorthogolized with
               respect to the E product
-        use_arnoldi
-            Should the Arnoldi process be used for rational
-            interpolation. Available only for SISO systems. Otherwise,
-            it is ignored.
+            - `'arnoldi'`: projection matrices are orthogonalized using
+              the Arnoldi process (available only for SISO systems).
         conv_crit
             Convergence criterion:
 
@@ -116,7 +121,9 @@ class IRKAReductor(BasicInterface):
             raise NotImplementedError
         assert 0 < r < fom.order
         assert isinstance(num_prev, int) and num_prev >= 1
-        assert projection in ('orth', 'biorth')
+        assert projection in ('orth', 'biorth', 'arnoldi')
+        if projection == 'arnoldi':
+            assert fom.input_dim == fom.output_dim == 1
         assert conv_crit in ('sigma', 'h2')
 
         # initial interpolation points and tangential directions
@@ -148,16 +155,16 @@ class IRKAReductor(BasicInterface):
                 c = fom.C.range.random(r, distribution='normal', seed=c)
 
         self.logger.info('Starting IRKA')
-        self.dist = []
+        self.conv_crit = []
         self.sigmas = [np.array(sigma)]
         self.R = [b]
         self.L = [c]
         self.errors = [] if compute_errors else None
-        self.pg_reductor = LTI_BHIReductor(fom)
+        self._pg_reductor = LTI_BHIReductor(fom)
         # main loop
         for it in range(maxit):
             # interpolatory reduced order model
-            rom = self.pg_reductor.reduce(sigma, b, c, projection=projection, use_arnoldi=use_arnoldi)
+            rom = self._pg_reductor.reduce(sigma, b, c, projection=projection)
 
             # new interpolation points and tangential directions
             poles, b, c = _poles_and_tangential_directions(rom)
@@ -169,20 +176,20 @@ class IRKAReductor(BasicInterface):
             # compute convergence criterion
             if conv_crit == 'sigma':
                 dist = _convergence_criterion(self.sigmas[:-num_prev-2:-1], conv_crit)
-                self.dist.append(dist)
+                self.conv_crit.append(dist)
             elif conv_crit == 'h2':
                 if it == 0:
                     rom_list = (num_prev + 1) * [None]
                     rom_list[0] = rom
-                    self.dist.append(np.inf)
+                    self.conv_crit.append(np.inf)
                 else:
                     rom_list[1:] = rom_list[:-1]
                     rom_list[0] = rom
                     dist = _convergence_criterion(rom_list, conv_crit)
-                    self.dist.append(dist)
+                    self.conv_crit.append(dist)
 
             # report convergence
-            self.logger.info(f'Convergence criterion in iteration {it + 1}: {self.dist[-1]:e}')
+            self.logger.info(f'Convergence criterion in iteration {it + 1}: {self.conv_crit[-1]:e}')
             if compute_errors:
                 if np.max(rom.poles().real) < 0:
                     err = fom - rom
@@ -194,19 +201,18 @@ class IRKAReductor(BasicInterface):
                 self.logger.info(f'Relative H2-error in iteration {it + 1}: {rel_H2_err:e}')
 
             # check if convergence criterion is satisfied
-            if self.dist[-1] < tol:
+            if self.conv_crit[-1] < tol:
                 break
 
         # final reduced order model
-        rom = self.pg_reductor.reduce(sigma, b, c, projection=projection, use_arnoldi=use_arnoldi)
-        self.V = self.pg_reductor.V
-        self.W = self.pg_reductor.W
-
+        rom = self._pg_reductor.reduce(sigma, b, c, projection=projection)
+        self.V = self._pg_reductor.V
+        self.W = self._pg_reductor.W
         return rom
 
     def reconstruct(self, u):
         """Reconstruct high-dimensional vector from reduced vector `u`."""
-        return self.pg_reductor.reconstruct(u)
+        return self._pg_reductor.reconstruct(u)
 
 
 class OneSidedIRKAReductor(BasicInterface):
@@ -227,6 +233,13 @@ class OneSidedIRKAReductor(BasicInterface):
         assert version in ('V', 'W')
         self.fom = fom
         self.version = version
+        self.V = None
+        self._pg_reductor = None
+        self.conv_crit = None
+        self.sigmas = None
+        self.R = None
+        self.L = None
+        self.errors = None
 
     def reduce(self, r, sigma=None, b=None, c=None, rd0=None, tol=1e-4, maxit=100, num_prev=1,
                force_sigma_in_rhp=False, projection='orth', conv_crit='sigma',
@@ -340,7 +353,7 @@ class OneSidedIRKAReductor(BasicInterface):
                     c = fom.C.range.random(r, distribution='normal', seed=c)
 
         self.logger.info('Starting one-sided IRKA')
-        self.dist = []
+        self.conv_crit = []
         self.sigmas = [np.array(sigma)]
         if self.version == 'V':
             self.R = [b]
@@ -351,7 +364,7 @@ class OneSidedIRKAReductor(BasicInterface):
         for it in range(maxit):
             # interpolatory reduced order model
             self._projection_matrix(r, sigma, b, c, projection)
-            rom = self.pg_reductor.reduce()
+            rom = self._pg_reductor.reduce()
 
             # new interpolation points and tangential directions
             poles, b, c = _poles_and_tangential_directions(rom)
@@ -365,20 +378,20 @@ class OneSidedIRKAReductor(BasicInterface):
             # compute convergence criterion
             if conv_crit == 'sigma':
                 dist = _convergence_criterion(self.sigmas[:-num_prev-2:-1], conv_crit)
-                self.dist.append(dist)
+                self.conv_crit.append(dist)
             elif conv_crit == 'h2':
                 if it == 0:
                     rom_list = (num_prev + 1) * [None]
                     rom_list[0] = rom
-                    self.dist.append(np.inf)
+                    self.conv_crit.append(np.inf)
                 else:
                     rom_list[1:] = rom_list[:-1]
                     rom_list[0] = rom
                     dist = _convergence_criterion(rom_list, conv_crit)
-                    self.dist.append(dist)
+                    self.conv_crit.append(dist)
 
             # report convergence
-            self.logger.info(f'Convergence criterion in iteration {it + 1}: {self.dist[-1]:e}')
+            self.logger.info(f'Convergence criterion in iteration {it + 1}: {self.conv_crit[-1]:e}')
             if compute_errors:
                 if np.max(rom.poles().real) < 0:
                     err = fom - rom
@@ -390,13 +403,12 @@ class OneSidedIRKAReductor(BasicInterface):
                 self.logger.info(f'Relative H2-error in iteration {it + 1}: {rel_H2_err:e}')
 
             # check if convergence criterion is satisfied
-            if self.dist[-1] < tol:
+            if self.conv_crit[-1] < tol:
                 break
 
         # final reduced order model
         self._projection_matrix(r, sigma, b, c, projection)
-        rom = self.pg_reductor.reduce()
-
+        rom = self._pg_reductor.reduce()
         return rom
 
     def _projection_matrix(self, r, sigma, b, c, projection):
@@ -432,11 +444,11 @@ class OneSidedIRKAReductor(BasicInterface):
         else:
             self.V = gram_schmidt(W, atol=0, rtol=0, product=None if projection == 'orth' else fom.E)
 
-        self.pg_reductor = LTIPGReductor(fom, self.V, self.V, projection == 'Eorth')
+        self._pg_reductor = LTIPGReductor(fom, self.V, self.V, projection == 'Eorth')
 
     def reconstruct(self, u):
         """Reconstruct high-dimensional vector from reduced vector `u`."""
-        return self.pg_reductor.reconstruct(u)
+        return self._pg_reductor.reconstruct(u)
 
 
 class TSIAReductor(BasicInterface):
@@ -450,6 +462,11 @@ class TSIAReductor(BasicInterface):
     def __init__(self, fom):
         assert isinstance(fom, LTIModel)
         self.fom = fom
+        self.V = None
+        self.W = None
+        self._pg_reductor = None
+        self.conv_crit = None
+        self.errors = None
 
     def reduce(self, rom0, tol=1e-4, maxit=100, num_prev=1, projection='orth', conv_crit='sigma',
                compute_errors=False):
@@ -518,21 +535,21 @@ class TSIAReductor(BasicInterface):
 
         data = (num_prev + 1) * [None]
         data[0] = rom0.poles() if conv_crit == 'sigma' else rom0
-        self.dist = []
+        self.conv_crit = []
         self.errors = [] if compute_errors else None
         # main loop
         for it in range(maxit):
             # project the full order model
-            rom = self.pg_reductor.reduce()
+            rom = self._pg_reductor.reduce()
 
             # compute convergence criterion
             data[1:] = data[:-1]
             data[0] = rom.poles() if conv_crit == 'sigma' else rom
             dist = _convergence_criterion(data, conv_crit)
-            self.dist.append(dist)
+            self.conv_crit.append(dist)
 
             # report convergence
-            self.logger.info(f'Convergence criterion in iteration {it + 1}: {self.dist[-1]:e}')
+            self.logger.info(f'Convergence criterion in iteration {it + 1}: {self.conv_crit[-1]:e}')
             if compute_errors:
                 if np.max(rom.poles().real) < 0:
                     err = fom - rom
@@ -547,12 +564,11 @@ class TSIAReductor(BasicInterface):
             self._projection_matrices(rom, projection)
 
             # check convergence criterion
-            if self.dist[-1] < tol:
+            if self.conv_crit[-1] < tol:
                 break
 
         # final reduced order model
-        rom = self.pg_reductor.reduce()
-
+        rom = self._pg_reductor.reduce()
         return rom
 
     def _projection_matrices(self, rom, projection):
@@ -567,11 +583,11 @@ class TSIAReductor(BasicInterface):
         elif projection == 'biorth':
             self.V, self.W = gram_schmidt_biorth(self.V, self.W, product=fom.E)
 
-        self.pg_reductor = LTIPGReductor(fom, self.W, self.V, projection == 'biorth')
+        self._pg_reductor = LTIPGReductor(fom, self.W, self.V, projection == 'biorth')
 
     def reconstruct(self, u):
         """Reconstruct high-dimensional vector from reduced vector `u`."""
-        return self.pg_reductor.reconstruct(u)
+        return self._pg_reductor.reconstruct(u)
 
 
 class TF_IRKAReductor(BasicInterface):
@@ -586,6 +602,10 @@ class TF_IRKAReductor(BasicInterface):
     """
     def __init__(self, fom):
         self.fom = fom
+        self.conv_crit = None
+        self.sigmas = None
+        self.R = None
+        self.L = None
 
     def reduce(self, r, sigma=None, b=None, c=None, rom0=None, tol=1e-4, maxit=100, num_prev=1,
                force_sigma_in_rhp=False, conv_crit='sigma'):
@@ -688,7 +708,7 @@ class TF_IRKAReductor(BasicInterface):
                 c = np.random.randn(fom.output_dim, r)
 
         self.logger.info('Starting TF-IRKA')
-        self.dist = []
+        self.conv_crit = []
         self.sigmas = [np.array(sigma)]
         self.R = [b]
         self.L = [c]
@@ -710,29 +730,32 @@ class TF_IRKAReductor(BasicInterface):
             # compute convergence criterion
             if conv_crit == 'sigma':
                 dist = _convergence_criterion(self.sigmas[:-num_prev-2:-1], conv_crit)
-                self.dist.append(dist)
+                self.conv_crit.append(dist)
             elif conv_crit == 'h2':
                 if it == 0:
                     rom_list = (num_prev + 1) * [None]
                     rom_list[0] = rom
-                    self.dist.append(np.inf)
+                    self.conv_crit.append(np.inf)
                 else:
                     rom_list[1:] = rom_list[:-1]
                     rom_list[0] = rom
                     dist = _convergence_criterion(rom_list, conv_crit)
-                    self.dist.append(dist)
+                    self.conv_crit.append(dist)
 
             # report convergence
-            self.logger.info(f'Convergence criterion in iteration {it + 1}: {self.dist[-1]:e}')
+            self.logger.info(f'Convergence criterion in iteration {it + 1}: {self.conv_crit[-1]:e}')
 
             # check if convergence criterion is satisfied
-            if self.dist[-1] < tol:
+            if self.conv_crit[-1] < tol:
                 break
 
         # final reduced order model
         rom = interp_reductor.reduce(sigma, b, c)
-
         return rom
+
+    def reconstruct(self, u):
+        """Reconstruct high-dimensional vector from reduced vector `u`."""
+        raise TypeError(f'The reconstruct method is not available for {self.__class__.__name__}.')
 
 
 def _poles_and_tangential_directions(rom):

--- a/src/pymor/reductors/h2.py
+++ b/src/pymor/reductors/h2.py
@@ -12,7 +12,7 @@ from pymor.core.interfaces import BasicInterface
 from pymor.models.iosys import LTIModel
 from pymor.operators.constructions import IdentityOperator
 from pymor.reductors.basic import LTIPGReductor
-from pymor.reductors.interpolation import LTI_BHIReductor, TF_BHIReductor
+from pymor.reductors.interpolation import LTIBHIReductor, TFBHIReductor
 
 
 class IRKAReductor(BasicInterface):
@@ -160,7 +160,7 @@ class IRKAReductor(BasicInterface):
         self.R = [b]
         self.L = [c]
         self.errors = [] if compute_errors else None
-        self._pg_reductor = LTI_BHIReductor(fom)
+        self._pg_reductor = LTIBHIReductor(fom)
         # main loop
         for it in range(maxit):
             # interpolatory reduced order model
@@ -590,7 +590,7 @@ class TSIAReductor(BasicInterface):
         return self._pg_reductor.reconstruct(u)
 
 
-class TF_IRKAReductor(BasicInterface):
+class TFIRKAReductor(BasicInterface):
     """Realization-independent IRKA reductor.
 
     See [BG12]_.
@@ -712,7 +712,7 @@ class TF_IRKAReductor(BasicInterface):
         self.sigmas = [np.array(sigma)]
         self.R = [b]
         self.L = [c]
-        interp_reductor = TF_BHIReductor(fom)
+        interp_reductor = TFBHIReductor(fom)
         # main loop
         for it in range(maxit):
             # interpolatory reduced order model

--- a/src/pymor/reductors/h2.py
+++ b/src/pymor/reductors/h2.py
@@ -21,7 +21,7 @@ class IRKAReductor(BasicInterface):
     Parameters
     ----------
     fom
-        |LTIModel|.
+        The full-order |LTIModel| to reduce.
     """
     def __init__(self, fom):
         assert isinstance(fom, LTIModel)
@@ -216,7 +216,7 @@ class OneSidedIRKAReductor(BasicInterface):
     Parameters
     ----------
     fom
-        |LTIModel|.
+        The full-order |LTIModel| to reduce.
     version
         Version of the one-sided IRKA:
 
@@ -446,7 +446,7 @@ class TSIAReductor(BasicInterface):
     Parameters
     ----------
     fom
-        |LTIModel|.
+        The full-order |LTIModel| to reduce.
     """
     def __init__(self, fom):
         assert isinstance(fom, LTIModel)
@@ -583,7 +583,7 @@ class TF_IRKAReductor(BasicInterface):
     Parameters
     ----------
     fom
-        Model with `eval_tf` and `eval_dtf` methods.
+        The full-order |Model| with `eval_tf` and `eval_dtf` methods.
     """
     def __init__(self, fom):
         self.fom = fom

--- a/src/pymor/reductors/interpolation.py
+++ b/src/pymor/reductors/interpolation.py
@@ -263,7 +263,7 @@ class DelayBHIReductor(GenericBHIReductor):
         return Ks.apply_inverse_adjoint(V)
 
 
-class TFInterpReductor(BasicInterface):
+class TF_BHIReductor(BasicInterface):
     """Loewner bitangential Hermite interpolation reductor.
 
     See [BG12]_.

--- a/src/pymor/reductors/interpolation.py
+++ b/src/pymor/reductors/interpolation.py
@@ -17,18 +17,16 @@ class GenericBHIReductor(BasicInterface):
     r"""Generic bitangential Hermite interpolation reductor.
 
     This is a generic reductor for reducing any linear
-    :class:`~pymor.models.iosys.InputStateOutputModel` with
-    the transfer function which can be written in the generalized
-    coprime factorization :math:`\mathcal{C}(s) \mathcal{K}(s)^{-1}
+    :class:`~pymor.models.iosys.InputStateOutputModel` with the transfer function which can be
+    written in the generalized coprime factorization :math:`\mathcal{C}(s) \mathcal{K}(s)^{-1}
     \mathcal{B}(s)` as in [BG09]_.
-    The interpolation here is limited to only up to the first
-    derivative.
+    The interpolation here is limited to only up to the first derivative.
     Hence, interpolation points are assumed to be pairwise distinct.
 
     Parameters
     ----------
     fom
-        Model.
+        The full-order |Model| to reduce.
     """
 
     PGReductor = None
@@ -55,26 +53,22 @@ class GenericBHIReductor(BasicInterface):
         Parameters
         ----------
         sigma
-            Interpolation points (closed under conjugation), list of
-            length `r`.
+            Interpolation points (closed under conjugation), list of length `r`.
         b
-            Right tangential directions, |VectorArray| of length `r`
-            from `self.fom.input_space`.
+            Right tangential directions, |VectorArray| of length `r` from `self.fom.input_space`.
         c
-            Left tangential directions, |VectorArray| of length `r` from
-            `self.fom.output_space`.
+            Left tangential directions, |VectorArray| of length `r` from `self.fom.output_space`.
         projection
             Projection method:
 
-            - `'orth'`: projection matrices are orthogonalized with
-              respect to the Euclidean inner product
-            - `'biorth'`: projection matrices are biorthogolized with
-              respect to the E product
+            - `'orth'`: projection matrices are orthogonalized with respect to the Euclidean inner
+              product
+            - `'biorth'`: projection matrices are biorthogolized with respect to the E product
 
         Returns
         -------
         rom
-            Reduced model.
+            Reduced-order model.
         """
         r = len(sigma)
         assert b in self.fom.input_space and len(b) == r
@@ -134,7 +128,7 @@ class LTI_BHIReductor(GenericBHIReductor):
     Parameters
     ----------
     fom
-        |LTIModel|.
+        The full-order |LTIModel| to reduce.
     """
 
     PGReductor = LTIPGReductor
@@ -164,14 +158,11 @@ class LTI_BHIReductor(GenericBHIReductor):
         Parameters
         ----------
         sigma
-            Interpolation points (closed under conjugation), list of
-            length `r`.
+            Interpolation points (closed under conjugation), list of length `r`.
         b
-            Right tangential directions, |VectorArray| of length `r`
-            from `self.fom.input_space`.
+            Right tangential directions, |VectorArray| of length `r` from `self.fom.input_space`.
         c
-            Left tangential directions, |VectorArray| of length `r` from
-            `self.fom.output_space`.
+            Left tangential directions, |VectorArray| of length `r` from `self.fom.output_space`.
         projection
             Projection method:
 
@@ -187,7 +178,7 @@ class LTI_BHIReductor(GenericBHIReductor):
         Returns
         -------
         rom
-            Reduced model.
+            Reduced-order model.
         """
         if use_arnoldi and self.fom.input_dim == 1 and self.fom.output_dim == 1:
             return self.reduce_arnoldi(sigma, b, c)
@@ -228,12 +219,12 @@ class LTI_BHIReductor(GenericBHIReductor):
 
 
 class SO_BHIReductor(GenericBHIReductor):
-    """Bitangential Hermite interpolation for second-order systems.
+    """Bitangential Hermite interpolation for |SecondOrderModels|.
 
     Parameters
     ----------
     fom
-        :class:`~pymor.models.iosys.SecondOrderModel`.
+        The full-order |SecondOrderModel| to reduce.
     """
 
     PGReductor = SOLTIPGReductor
@@ -261,12 +252,12 @@ class SO_BHIReductor(GenericBHIReductor):
 
 
 class DelayBHIReductor(GenericBHIReductor):
-    """Bitangential Hermite interpolation for delay systems.
+    """Bitangential Hermite interpolation for |LinearDelayModels|.
 
     Parameters
     ----------
     fom
-        :class:`~pymor.models.iosys.LinearDelayModel`.
+        The full-order |LinearDelayModel| to reduce.
     """
 
     PGReductor = DelayLTIPGReductor
@@ -301,7 +292,7 @@ class TFInterpReductor(BasicInterface):
     Parameters
     ----------
     fom
-        Model with `eval_tf` and `eval_dtf` methods.
+        The |Model| with `eval_tf` and `eval_dtf` methods.
     """
     def __init__(self, fom):
         self.fom = fom
@@ -312,19 +303,16 @@ class TFInterpReductor(BasicInterface):
         Parameters
         ----------
         sigma
-            Interpolation points (closed under conjugation), list of
-            length `r`.
+            Interpolation points (closed under conjugation), list of length `r`.
         b
-            Right tangential directions, |NumPy array| of shape
-            `(fom.input_dim, r)`.
+            Right tangential directions, |NumPy array| of shape `(fom.input_dim, r)`.
         c
-            Left tangential directions, |NumPy array| of shape
-            `(fom.output_dim, r)`.
+            Left tangential directions, |NumPy array| of shape `(fom.output_dim, r)`.
 
         Returns
         -------
         lti
-            |LTIModel| interpolating the transfer function of `fom`.
+            The reduced-order |LTIModel| interpolating the transfer function of `fom`.
         """
         fom = self.fom
         r = len(sigma)

--- a/src/pymor/reductors/interpolation.py
+++ b/src/pymor/reductors/interpolation.py
@@ -124,7 +124,7 @@ class GenericBHIReductor(BasicInterface):
         return self._pg_reductor.reconstruct(u)
 
 
-class LTI_BHIReductor(GenericBHIReductor):
+class LTIBHIReductor(GenericBHIReductor):
     """Bitangential Hermite interpolation for |LTIModels|.
 
     Parameters
@@ -197,7 +197,7 @@ class LTI_BHIReductor(GenericBHIReductor):
         return rom
 
 
-class SO_BHIReductor(GenericBHIReductor):
+class SOBHIReductor(GenericBHIReductor):
     """Bitangential Hermite interpolation for |SecondOrderModels|.
 
     Parameters
@@ -263,7 +263,7 @@ class DelayBHIReductor(GenericBHIReductor):
         return Ks.apply_inverse_adjoint(V)
 
 
-class TF_BHIReductor(BasicInterface):
+class TFBHIReductor(BasicInterface):
     """Loewner bitangential Hermite interpolation reductor.
 
     See [BG12]_.

--- a/src/pymor/reductors/sobt.py
+++ b/src/pymor/reductors/sobt.py
@@ -22,7 +22,7 @@ class GenericSOBTpvReductor(BasicInterface):
     Parameters
     ----------
     fom
-        The system which is to be reduced.
+        The full-order |SecondOrderModel| to reduce.
     """
     def __init__(self, fom):
         assert isinstance(fom, SecondOrderModel)
@@ -31,11 +31,11 @@ class GenericSOBTpvReductor(BasicInterface):
         self.W = None
 
     def _gramians(self):
-        """Returns gramians."""
+        """Return Gramians."""
         raise NotImplementedError
 
     def _projection_matrices_and_singular_values(self, r, gramians):
-        """Returns projection matrices and singular values."""
+        """Return projection matrices and singular values."""
         raise NotImplementedError
 
     def reduce(self, r, projection='bfsr'):
@@ -49,17 +49,16 @@ class GenericSOBTpvReductor(BasicInterface):
             Projection method used:
 
             - `'sr'`: square root method
-            - `'bfsr'`: balancing-free square root method (default,
-              since it avoids scaling by singular values and
-              orthogonalizes the projection matrices, which might make
-              it more accurate than the square root method)
-            - `'biorth'`: like the balancing-free square root method,
-              except it biorthogonalizes the projection matrices
+            - `'bfsr'`: balancing-free square root method (default, since it avoids scaling by
+              singular values and orthogonalizes the projection matrices, which might make it more
+              accurate than the square root method)
+            - `'biorth'`: like the balancing-free square root method, except it biorthogonalizes the
+              projection matrices
 
         Returns
         -------
         rom
-            Reduced system.
+            Reduced-order |SecondOrderModel|.
         """
         assert 0 < r < self.fom.order
         assert projection in ('sr', 'bfsr', 'biorth')
@@ -101,7 +100,7 @@ class SOBTpReductor(GenericSOBTpvReductor):
     Parameters
     ----------
     fom
-        The system which is to be reduced.
+        The full-order |SecondOrderModel| to reduce.
     """
     def _gramians(self):
         pcf = self.fom.gramian('pc_lrcf')
@@ -126,7 +125,7 @@ class SOBTvReductor(GenericSOBTpvReductor):
     Parameters
     ----------
     fom
-        The system which is to be reduced.
+        The full-order |SecondOrderModel| to reduce.
     """
     def _gramians(self):
         vcf = self.fom.gramian('vc_lrcf')
@@ -148,7 +147,7 @@ class SOBTpvReductor(GenericSOBTpvReductor):
     Parameters
     ----------
     fom
-        The system which is to be reduced.
+        The full-order |SecondOrderModel| to reduce.
     """
     def _gramians(self):
         pcf = self.fom.gramian('pc_lrcf')
@@ -170,7 +169,7 @@ class SOBTvpReductor(GenericSOBTpvReductor):
     Parameters
     ----------
     fom
-        The system which is to be reduced.
+        The full-order |SecondOrderModel| to reduce.
     """
     def _gramians(self):
         pof = self.fom.gramian('po_lrcf')
@@ -213,17 +212,16 @@ class SOBTfvReductor(BasicInterface):
             Projection method used:
 
             - `'sr'`: square root method
-            - `'bfsr'`: balancing-free square root method (default,
-              since it avoids scaling by singular values and
-              orthogonalizes the projection matrices, which might make
-              it more accurate than the square root method)
-            - `'biorth'`: like the balancing-free square root method,
-              except it biorthogonalizes the projection matrices
+            - `'bfsr'`: balancing-free square root method (default, since it avoids scaling by
+              singular values and orthogonalizes the projection matrices, which might make it more
+              accurate than the square root method)
+            - `'biorth'`: like the balancing-free square root method, except it biorthogonalizes the
+              projection matrices
 
         Returns
         -------
         rom
-            Reduced system.
+            Reduced-order |SecondOrderModel|.
         """
         assert 0 < r < self.fom.order
         assert projection in ('sr', 'bfsr', 'biorth')
@@ -272,7 +270,7 @@ class SOBTReductor(BasicInterface):
     Parameters
     ----------
     fom
-        The system which is to be reduced.
+        The full-order |SecondOrderModel| to reduce.
     """
     def __init__(self, fom):
         assert isinstance(fom, SecondOrderModel)
@@ -293,17 +291,16 @@ class SOBTReductor(BasicInterface):
             Projection method used:
 
             - `'sr'`: square root method
-            - `'bfsr'`: balancing-free square root method (default,
-              since it avoids scaling by singular values and
-              orthogonalizes the projection matrices, which might make
-              it more accurate than the square root method)
-            - `'biorth'`: like the balancing-free square root method,
-              except it biorthogonalizes the projection matrices
+            - `'bfsr'`: balancing-free square root method (default, since it avoids scaling by
+              singular values and orthogonalizes the projection matrices, which might make it more
+              accurate than the square root method)
+            - `'biorth'`: like the balancing-free square root method, except it biorthogonalizes the
+              projection matrices
 
         Returns
         -------
         rom
-            Reduced system.
+            Reduced-order |SecondOrderModel|.
         """
         assert 0 < r < self.fom.order
         assert projection in ('sr', 'bfsr', 'biorth')

--- a/src/pymor/reductors/sor_irka.py
+++ b/src/pymor/reductors/sor_irka.py
@@ -16,7 +16,7 @@ class SOR_IRKAReductor(BasicInterface):
     Parameters
     ----------
     fom
-        SecondOrderModel.
+        The full-order |SecondOrderModel| to reduce.
     """
     def __init__(self, fom):
         assert isinstance(fom, SecondOrderModel)
@@ -104,7 +104,7 @@ class SOR_IRKAReductor(BasicInterface):
         Returns
         -------
         rom
-            Reduced |LTIModel| model.
+            Reduced-order |SecondOrderModel|.
         """
         fom = self.fom
         if not fom.cont_time:

--- a/src/pymor/reductors/sor_irka.py
+++ b/src/pymor/reductors/sor_irka.py
@@ -6,11 +6,11 @@ import numpy as np
 
 from pymor.core.interfaces import BasicInterface
 from pymor.models.iosys import SecondOrderModel
-from pymor.reductors.interpolation import SO_BHIReductor
+from pymor.reductors.interpolation import SOBHIReductor
 from pymor.reductors.h2 import IRKAReductor, _poles_and_tangential_directions, _convergence_criterion
 
 
-class SOR_IRKAReductor(BasicInterface):
+class SORIRKAReductor(BasicInterface):
     """SOR-IRKA reductor.
 
     Parameters
@@ -162,7 +162,7 @@ class SOR_IRKAReductor(BasicInterface):
         self.R = [b]
         self.L = [c]
         self.errors = [] if compute_errors else None
-        self._pg_reductor = SO_BHIReductor(fom)
+        self._pg_reductor = SOBHIReductor(fom)
         # main loop
         for it in range(maxit):
             # interpolatory reduced order model

--- a/src/pymor/reductors/sor_irka.py
+++ b/src/pymor/reductors/sor_irka.py
@@ -21,10 +21,18 @@ class SOR_IRKAReductor(BasicInterface):
     def __init__(self, fom):
         assert isinstance(fom, SecondOrderModel)
         self.fom = fom
+        self.V = None
+        self.W = None
+        self._pg_reductor = None
+        self.conv_crit = None
+        self.sigmas = None
+        self.R = None
+        self.L = None
+        self.errors = None
 
     def reduce(self, r, sigma=None, b=None, c=None, rom0=None, tol=1e-4, maxit=100, num_prev=1,
-               force_sigma_in_rhp=False, projection='orth', use_arnoldi=False, conv_crit='sigma',
-               compute_errors=False, irka_options=None):
+               force_sigma_in_rhp=False, projection='orth', conv_crit='sigma', compute_errors=False,
+               irka_options=None):
         r"""Reduce using SOR-IRKA.
 
         It uses IRKA as the intermediate reductor, to reduce from 2r to
@@ -149,16 +157,16 @@ class SOR_IRKAReductor(BasicInterface):
                 c = fom.Cp.range.random(r, distribution='normal', seed=c)
 
         self.logger.info('Starting SOR-IRKA')
-        self.dist = []
+        self.conv_crit = []
         self.sigmas = [np.array(sigma)]
         self.R = [b]
         self.L = [c]
         self.errors = [] if compute_errors else None
-        self.pg_reductor = SO_BHIReductor(fom)
+        self._pg_reductor = SO_BHIReductor(fom)
         # main loop
         for it in range(maxit):
             # interpolatory reduced order model
-            rom = self.pg_reductor.reduce(sigma, b, c, projection=projection)
+            rom = self._pg_reductor.reduce(sigma, b, c, projection=projection)
 
             # reduction to a system with r poles
             with self.logger.block('Intermediate reduction ...'):
@@ -175,20 +183,20 @@ class SOR_IRKAReductor(BasicInterface):
             # compute convergence criterion
             if conv_crit == 'sigma':
                 dist = _convergence_criterion(self.sigmas[:-num_prev-2:-1], conv_crit)
-                self.dist.append(dist)
+                self.conv_crit.append(dist)
             elif conv_crit == 'h2':
                 if it == 0:
                     rom_list = (num_prev + 1) * [None]
                     rom_list[0] = rom
-                    self.dist.append(np.inf)
+                    self.conv_crit.append(np.inf)
                 else:
                     rom_list[1:] = rom_list[:-1]
                     rom_list[0] = rom
                     dist = _convergence_criterion(rom_list, conv_crit)
-                    self.dist.append(dist)
+                    self.conv_crit.append(dist)
 
             # report convergence
-            self.logger.info(f'Convergence criterion in iteration {it + 1}: {self.dist[-1]:e}')
+            self.logger.info(f'Convergence criterion in iteration {it + 1}: {self.conv_crit[-1]:e}')
             if compute_errors:
                 if np.max(rom.poles().real) < 0:
                     err = fom - rom
@@ -200,16 +208,15 @@ class SOR_IRKAReductor(BasicInterface):
                 self.logger.info(f'Relative H2-error in iteration {it + 1}: {rel_H2_err:e}')
 
             # check if convergence criterion is satisfied
-            if self.dist[-1] < tol:
+            if self.conv_crit[-1] < tol:
                 break
 
         # final reduced order model
-        rom = self.pg_reductor.reduce(sigma, b, c, projection=projection)
-        self.V = self.pg_reductor.V
-        self.W = self.pg_reductor.W
-
+        rom = self._pg_reductor.reduce(sigma, b, c, projection=projection)
+        self.V = self._pg_reductor.V
+        self.W = self._pg_reductor.W
         return rom
 
     def reconstruct(self, u):
         """Reconstruct high-dimensional vector from reduced vector `u`."""
-        return self.pg_reductor.reconstruct(u)
+        return self._pg_reductor.reconstruct(u)

--- a/src/pymordemos/delay.py
+++ b/src/pymordemos/delay.py
@@ -13,7 +13,7 @@ import scipy.linalg as spla
 import matplotlib.pyplot as plt
 
 from pymor.models.iosys import TransferFunction
-from pymor.reductors.interpolation import TFInterpReductor
+from pymor.reductors.interpolation import TF_BHIReductor
 from pymor.reductors.h2 import TF_IRKAReductor
 from pymor.vectorarrays.numpy import NumpyVectorSpace
 
@@ -80,7 +80,7 @@ if __name__ == '__main__':
     sigma_ss = list(sigmas[-1]) + [0]
     b_ss = np.ones((1, r + 1))
     c_ss = np.ones((1, r + 1))
-    interp_reductor = TFInterpReductor(tf)
+    interp_reductor = TF_BHIReductor(tf)
     rom_ss = interp_reductor.reduce(sigma_ss, b_ss, c_ss)
 
     # step response

--- a/src/pymordemos/delay.py
+++ b/src/pymordemos/delay.py
@@ -13,8 +13,8 @@ import scipy.linalg as spla
 import matplotlib.pyplot as plt
 
 from pymor.models.iosys import TransferFunction
-from pymor.reductors.interpolation import TF_BHIReductor
-from pymor.reductors.h2 import TF_IRKAReductor
+from pymor.reductors.interpolation import TFBHIReductor
+from pymor.reductors.h2 import TFIRKAReductor
 from pymor.vectorarrays.numpy import NumpyVectorSpace
 
 if __name__ == '__main__':
@@ -29,7 +29,7 @@ if __name__ == '__main__':
     tf = TransferFunction(NumpyVectorSpace(1), NumpyVectorSpace(1), H, dH)
 
     r = 10
-    tf_irka_reductor = TF_IRKAReductor(tf)
+    tf_irka_reductor = TFIRKAReductor(tf)
     rom = tf_irka_reductor.reduce(r, maxit=1000)
 
     sigmas = tf_irka_reductor.sigmas
@@ -80,7 +80,7 @@ if __name__ == '__main__':
     sigma_ss = list(sigmas[-1]) + [0]
     b_ss = np.ones((1, r + 1))
     c_ss = np.ones((1, r + 1))
-    interp_reductor = TF_BHIReductor(tf)
+    interp_reductor = TFBHIReductor(tf)
     rom_ss = interp_reductor.reduce(sigma_ss, b_ss, c_ss)
 
     # step response

--- a/src/pymordemos/heat.py
+++ b/src/pymordemos/heat.py
@@ -117,7 +117,7 @@ if __name__ == '__main__':
 
     # Shift distances
     fig, ax = plt.subplots()
-    ax.semilogy(irka_reductor.dist, '.-')
+    ax.semilogy(irka_reductor.conv_crit, '.-')
     ax.set_title('Distances between shifts in IRKA iterations')
     plt.show()
 

--- a/src/pymordemos/string_equation.py
+++ b/src/pymordemos/string_equation.py
@@ -298,7 +298,7 @@ if __name__ == '__main__':
     rom_irka = irka_reductor.reduce(r)
 
     fig, ax = plt.subplots()
-    ax.semilogy(irka_reductor.dist, '.-')
+    ax.semilogy(irka_reductor.conv_crit, '.-')
     ax.set_title('IRKA convergence criterion')
     plt.show()
 
@@ -333,7 +333,7 @@ if __name__ == '__main__':
     rom_sor_irka = sor_irka_reductor.reduce(r)
 
     fig, ax = plt.subplots()
-    ax.semilogy(sor_irka_reductor.dist, '.-')
+    ax.semilogy(sor_irka_reductor.conv_crit, '.-')
     ax.set_title('SOR-IRKA convergence criterion')
     plt.show()
 

--- a/src/pymordemos/string_equation.py
+++ b/src/pymordemos/string_equation.py
@@ -15,7 +15,7 @@ from pymor.reductors.bt import BTReductor
 from pymor.reductors.h2 import IRKAReductor
 from pymor.reductors.sobt import (SOBTpReductor, SOBTvReductor, SOBTpvReductor, SOBTvpReductor,
                                   SOBTfvReductor, SOBTReductor)
-from pymor.reductors.sor_irka import SOR_IRKAReductor
+from pymor.reductors.sor_irka import SORIRKAReductor
 
 import logging
 logging.getLogger('pymor.algorithms.gram_schmidt.gram_schmidt').setLevel(logging.ERROR)
@@ -329,7 +329,7 @@ if __name__ == '__main__':
 
     # Second-Order Reduced Iterative Rational Krylov Algorithm (SOR-IRKA)
     r = 5
-    sor_irka_reductor = SOR_IRKAReductor(so_sys)
+    sor_irka_reductor = SORIRKAReductor(so_sys)
     rom_sor_irka = sor_irka_reductor.reduce(r)
 
     fig, ax = plt.subplots()


### PR DESCRIPTION
- removes `reduce_arnoldi` from `LTI_BHIReductor`, merges `use_arnoldi` option with `projection`
- initializes reductor attributes in `__init__`
- makes `pg_redutor` a private attribute
- sets reduced `D` operator in `SOBTReductor`
- renames `TFInterpReductor` to `TF_BHIReductor` to fit with other "BHI" reductors
- docs and other minor improvements