### PR TITLE
Gram_schmidt algorithm discards complex values in the R matrix. 

### DIFF
--- a/src/pymor/algorithms/gram_schmidt.py
+++ b/src/pymor/algorithms/gram_schmidt.py
@@ -84,6 +84,8 @@ def gram_schmidt(A, product=None, return_R=False, atol=1e-13, rtol=1e-13, offset
                         continue
                     p = A[j].pairwise_inner(A[i], product)[0]
                     A[i].axpy(-p, A[j])
+                    common_dtype = np.promote_types(R.dtype, type(p))
+                    R = R.astype(common_dtype)
                     R[j, i] += p
 
                 # calculate new norm


### PR DESCRIPTION
Example:
```
from pymor.basic import *
v = NumpyVectorSpace(3).random(3, seed=0)+1j*NumpyVectorSpace(3).random(3, seed=1)
print(gram_schmidt(v,return_R=True)[1])
```

Output:
```
array([[1.36703713, 0.89474946, 1.30606313],
       [0.        , 0.43790411, 0.42856623],
       [0.        , 0.        , 0.49438602]])
```

Output should be:
```
array([[1.36703713+0.j    , 0.89474946-0.15063988j,   1.30606313-0.17295746j],
       [0.        +0.j    , 0.43790411+0.j        ,    0.42856623+0.25122766j],
       [0.        +0.j    , 0.        +0.j        ,        0.49438602+0.j        ]])
```

In line 87 in `R[j, i] += p` the complex valued `p` is casted to float. 
I suggest to replace line 62: `R = np.eye(len(A))`
by `R = np.eye(len(A), dtype=A.data.dtype)`.
