### PR TITLE
Not actually a Azure OSX fix

### DIFF
--- a/.ci/azure/pipeline-osx.yml
+++ b/.ci/azure/pipeline-osx.yml
@@ -2,7 +2,7 @@ jobs:
 - job: 'OSX_CI'
   pool:
     vmImage: macOS-10.13
-  timeoutInMinutes: 240
+  timeoutInMinutes: 20
   strategy:
     maxParallel: 8
     matrix:

--- a/.ci/azure/pipeline-osx.yml
+++ b/.ci/azure/pipeline-osx.yml
@@ -25,12 +25,13 @@ jobs:
   - bash: echo "##vso[task.prependpath]$CONDA/bin"
     displayName: Add conda to PATH
 
+  - bash: sudo chown -R $USER $CONDA
+    displayName: Take ownership of conda installation
+
   - bash: |
       set -x -e
       conda config --add channels conda-forge
-      conda config --set always_yes yes --set changeps1 no
-      conda create --yes --name pymorEnv
-      source activate activate pymorEnv
+      conda update --all
       conda install --only-deps pymor
       # these ones are not in the 0.5.1 conda build yet
       conda install pyevtk gmsh=3.0.6 mpi4py
@@ -39,12 +40,11 @@ jobs:
       # install anything which might a new dependency with pip
       pip install -r requirements.txt
       pip install pytest-azurepipelines
+      conda list
     displayName: Configure conda and conda-build
 
   - script: |
       set -ex
-      source activate pymorEnv
-      conda list
       export PYTHONPATH=${PWD}/src:${PYTHONPATH}
       python setup.py build_ext -i
       py.test -r sxX -k "demos"

--- a/.ci/azure/pipeline-win.yml
+++ b/.ci/azure/pipeline-win.yml
@@ -47,7 +47,7 @@ jobs:
         targetFolder: C:\Windows\SysWOW64\mesadrv.dll
         overWrite: true
   - script: |
-        REG IMPORT .ci\replace_opengl_imp.reg
+        REG IMPORT .ci\azure\replace_opengl_imp.reg
         call activate pyMORenv
         python -c "import numpy"
         python -c "import OpenGL.GL as gl; print(gl.glGetString(gl.GL_RENDERER)); print(gl.glGetString(gl.GL_VERSION))"
@@ -55,4 +55,3 @@ jobs:
         python setup.py build_ext -i
         py.test -r sxX -k "thermalblock_adaptive"
     displayName: 'Tests'
-

--- a/dependencies.py
+++ b/dependencies.py
@@ -3,7 +3,7 @@
 # Copyright 2013-2019 pyMOR developers and contributors. All rights reserved.
 # License: BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
 
-_PYTEST = 'pytest>=3.3'
+_PYTEST = 'pytest>=4.4'
 
 def _pymess(rev, major, minor, marker=True):
     url = 'https://www.mpi-magdeburg.mpg.de/mpcsc/software/cmess/{rev}/pymess-{rev}-cp{major}{minor}-cp{major}{minor}m-manylinux1_x86_64.whl'

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -14,5 +14,5 @@ pyamg
 pyevtk>=1.1
 pyopengl
 pytest-cov
-pytest>=3.3
+pytest>=4.4
 slycot>=0.3.3


### PR DESCRIPTION
Basically sometime between 
https://dev.azure.com/pymor/pymor/_build/results?buildId=487
and 
https://dev.azure.com/pymor/pymor/_build/results?buildId=490
the conda setup on OSX just broke. Now updating packages in the env is stalling forever/the python interpreter is missing, depending on if I update conda or not. As a short time workaround I will remove the branch protection requirement for the OSX builds. Other open PRs should still rebase on master after I merge this PR to have OSX fail inside of 20 minutes instead of 2 hours per build. 