### PR TITLE
Fix lincomb of IdentityOperator and NumpyMatrixOperator

### DIFF
--- a/src/pymor/algorithms/lincomb.py
+++ b/src/pymor/algorithms/lincomb.py
@@ -177,7 +177,7 @@ class AssembleLincombRules(RuleTable):
                 coeffs_without_id.append(coeff)
         id_coeff = sum(id_coeffs)
 
-        op = ops_without_id[0]._assemble_lincomb(ops_without_id, self.coefficients, identity_shift=id_coeff,
+        op = ops_without_id[0]._assemble_lincomb(ops_without_id, tuple(coeffs_without_id), identity_shift=id_coeff,
                                                  solver_options=self.solver_options, name=self.name)
 
         if not op:

--- a/src/pymor/algorithms/lincomb.py
+++ b/src/pymor/algorithms/lincomb.py
@@ -177,7 +177,7 @@ class AssembleLincombRules(RuleTable):
                 coeffs_without_id.append(coeff)
         id_coeff = sum(id_coeffs)
 
-        op = ops_without_id[0]._assemble_lincomb(ops_without_id, tuple(coeffs_without_id), identity_shift=id_coeff,
+        op = ops_without_id[0]._assemble_lincomb(ops_without_id, coeffs_without_id, identity_shift=id_coeff,
                                                  solver_options=self.solver_options, name=self.name)
 
         if not op:

--- a/src/pymor/operators/numpy.py
+++ b/src/pymor/operators/numpy.py
@@ -343,7 +343,7 @@ class NumpyMatrixOperator(NumpyMatrixBasedOperator):
 
         common_mat_dtype = reduce(np.promote_types,
                                   (op.matrix.dtype for op in operators if hasattr(op, 'matrix')))
-        common_coef_dtype = reduce(np.promote_types, (type(c) for c in coefficients + (identity_shift,)))
+        common_coef_dtype = reduce(np.promote_types, (type(c) for c in coefficients + [identity_shift]))
         common_dtype = np.promote_types(common_mat_dtype, common_coef_dtype)
 
         if coefficients[0] == 1:

--- a/src/pymortests/operators.py
+++ b/src/pymortests/operators.py
@@ -7,8 +7,10 @@ import pytest
 
 from pymor.algorithms.basic import almost_equal
 from pymor.algorithms.projection import project
+from pymor.algorithms.to_matrix import to_matrix
 from pymor.core.exceptions import InversionError, LinAlgError
 from pymor.operators.constructions import SelectionOperator, InverseOperator, InverseAdjointOperator, IdentityOperator
+from pymor.operators.numpy import NumpyMatrixOperator
 from pymor.parameters.base import ParameterType
 from pymor.parameters.functionals import GenericParameterFunctional
 from pymor.vectorarrays.numpy import NumpyVectorArray, NumpyVectorSpace
@@ -84,6 +86,19 @@ def test_identity_lincomb():
     assert almost_equal(ones * 2, idid.apply_adjoint(ones))
     assert almost_equal(ones * 0.5, idid.apply_inverse(ones))
     assert almost_equal(ones * 0.5, idid.apply_inverse_adjoint(ones))
+
+
+def test_identity_numpy_lincomb():
+    n = 2
+    space = NumpyVectorSpace(n)
+    identity = IdentityOperator(space)
+    numpy_operator = NumpyMatrixOperator(np.ones((n, n)))
+    for alpha in [-1, 0, 1]:
+        for beta in [-1, 0, 1]:
+            idop = alpha * identity + beta * numpy_operator
+            mat1 = alpha * np.eye(n) + beta * np.ones((n, n))
+            mat2 = to_matrix(idop.assemble(), format='dense')
+            assert np.array_equal(mat1, mat2)
 
 
 def test_pickle(operator):


### PR DESCRIPTION
- adds a test to `pymortests.operators`
- fixes the issue in `algorithms.lincomb`