### PR TITLE
Remove 'order' arguments from CG operators

### DIFF
--- a/src/pymor/discretizers/cg.py
+++ b/src/pymor/discretizers/cg.py
@@ -140,7 +140,7 @@ def discretize_stationary_cg(analytical_problem, diameter=None, domain_discretiz
 
     # robin boundaries
     if p.robin_data is not None:
-        Li += [RobinBoundaryOperator(grid, boundary_info, robin_data=p.robin_data, order=2, name='robin')]
+        Li += [RobinBoundaryOperator(grid, boundary_info, robin_data=p.robin_data, name='robin')]
         coefficients.append(1.)
 
     L = LincombOperator(operators=Li, coefficients=coefficients, name='ellipticOperator')


### PR DESCRIPTION
This PR simplifies the implementation in `operators.cg` by removing the optional integration `order` arguments from all `Operators`. All data functions are now evaluated at the entity centers, corresponding to the mid-point integration rule. For the implemented first-order schemes this should be sufficient (assuming regularity of the coefficient functions).

For discontinuous diffusion tensors, it is now in particular clear, that these are approximated by entity-wise constant functions (given by evaluation at the entity centers).