### PR TITLE
Ensure that with_ works for all immutable objects

### DIFF
--- a/src/pymor/algorithms/lincomb.py
+++ b/src/pymor/algorithms/lincomb.py
@@ -97,11 +97,11 @@ class AssembleLincombRules(RuleTable):
         coeffs = np.conj(self.coefficients) if adjoint else self.coefficients
 
         if coeffs[0] == 1:
-            array = ops[0]._array.copy()
+            array = ops[0].array.copy()
         else:
-            array = ops[0]._array * coeffs[0]
+            array = ops[0].array * coeffs[0]
         for op, c in zip(ops[1:], coeffs[1:]):
-            array.axpy(c, op._array)
+            array.axpy(c, op.array)
 
         return VectorArrayOperator(array, adjoint=adjoint, space_id=ops[0].space_id, name=self.name)
 

--- a/src/pymor/algorithms/lincomb.py
+++ b/src/pymor/algorithms/lincomb.py
@@ -113,10 +113,10 @@ class AssembleLincombRules(RuleTable):
             ops, coeffs = ops[::-1], self.coefficients[::-1]
         else:
             ops, coeffs = ops, self. coefficients
-        if not isinstance(ops[1]._blocks[0, 0], IdentityOperator):
+        if not isinstance(ops[1].blocks[0, 0], IdentityOperator):
             raise RuleNotMatchingError
 
-        return ShiftedSecondOrderModelOperator(ops[1]._blocks[1, 1],
+        return ShiftedSecondOrderModelOperator(ops[1].blocks[1, 1],
                                                ops[0].E,
                                                ops[0].K,
                                                coeffs[1],
@@ -129,7 +129,7 @@ class AssembleLincombRules(RuleTable):
         blocks = np.empty((num_source_blocks,), dtype=object)
         if len(ops) > 1:
             for i in range(num_source_blocks):
-                operators_i = [op._blocks[i, i] for op in ops]
+                operators_i = [op.blocks[i, i] for op in ops]
                 blocks[i] = assemble_lincomb(operators_i, coefficients,
                                              solver_options=self.solver_options, name=self.name)
                 if blocks[i] is None:
@@ -140,19 +140,19 @@ class AssembleLincombRules(RuleTable):
             if c == 1:
                 return ops[0]
             for i in range(num_source_blocks):
-                blocks[i] = ops[0]._blocks[i, i] * c
+                blocks[i] = ops[0].blocks[i, i] * c
             return BlockDiagonalOperator(blocks)
 
     @match_class_all(BlockOperatorBase)
     def action_BlockOperatorBase(self, ops):
         coefficients = self.coefficients
-        shape = ops[0]._blocks.shape
+        shape = ops[0].blocks.shape
         blocks = np.empty(shape, dtype=object)
         operator_type = ((BlockOperator if ops[0].blocked_source else BlockColumnOperator) if ops[0].blocked_range
                          else BlockRowOperator)
         if len(ops) > 1:
             for (i, j) in np.ndindex(shape):
-                operators_ij = [op._blocks[i, j] for op in ops]
+                operators_ij = [op.blocks[i, j] for op in ops]
                 blocks[i, j] = assemble_lincomb(operators_ij, coefficients,
                                                 solver_options=self.solver_options, name=self.name)
                 if blocks[i, j] is None:
@@ -163,7 +163,7 @@ class AssembleLincombRules(RuleTable):
             if c == 1:
                 return ops[0]
             for (i, j) in np.ndindex(shape):
-                blocks[i, j] = ops[0]._blocks[i, j] * c
+                blocks[i, j] = ops[0].blocks[i, j] * c
             return operator_type(blocks)
 
     @match_always

--- a/src/pymor/algorithms/projection.py
+++ b/src/pymor/algorithms/projection.py
@@ -90,9 +90,9 @@ class ProjectRules(RuleTable):
     def action_ConstantOperator(self, op):
         range_basis, source_basis, product = self.range_basis, self.source_basis, self.product
         if range_basis is not None:
-            projected_value = NumpyVectorSpace.make_array(range_basis.inner(op._value, product).T)
+            projected_value = NumpyVectorSpace.make_array(range_basis.inner(op.value, product).T)
         else:
-            projected_value = op._value
+            projected_value = op.value
         if source_basis is None:
             return ConstantOperator(projected_value, op.source, name=op.name)
         else:
@@ -260,7 +260,7 @@ class ProjectToSubbasisRules(RuleTable):
     def action_ConstantOperator(self, op):
         dim_range, dim_source = self.dim_range, self.dim_source
         source = op.source if dim_source is None else NumpyVectorSpace(dim_source)
-        value = op._value if dim_range is None else NumpyVectorSpace(op._value.to_numpy()[:, :dim_range])
+        value = op.value if dim_range is None else NumpyVectorSpace(op.value.to_numpy()[:, :dim_range])
         return ConstantOperator(value, source, name=op.name)
 
     @match_class(IdentityOperator)

--- a/src/pymor/algorithms/to_matrix.py
+++ b/src/pymor/algorithms/to_matrix.py
@@ -64,7 +64,7 @@ class ToMatrixRules(RuleTable):
     @match_class(BlockOperatorBase)
     def action_BlockOperator(self, op):
         format = self.format
-        op_blocks = op._blocks
+        op_blocks = op.blocks
         mat_blocks = [[] for i in range(op.num_range_blocks)]
         is_dense = True
         for i in range(op.num_range_blocks):

--- a/src/pymor/algorithms/to_matrix.py
+++ b/src/pymor/algorithms/to_matrix.py
@@ -142,7 +142,7 @@ class ToMatrixRules(RuleTable):
     @match_class(VectorArrayOperator)
     def action_VectorArrayOperator(self, op):
         format = self.format
-        res = op._array.conj().to_numpy() if op.adjoint else op._array.to_numpy().T
+        res = op.array.conj().to_numpy() if op.adjoint else op.array.to_numpy().T
         if format is not None and format != 'dense':
             res = getattr(sps, format + '_matrix')(res)
         return res

--- a/src/pymor/basic.py
+++ b/src/pymor/basic.py
@@ -47,7 +47,7 @@ from pymor.discretizers.fv import discretize_stationary_fv, discretize_instation
 from pymor.functions.basic import ConstantFunction, GenericFunction, ExpressionFunction, LincombFunction
 from pymor.functions.bitmap import BitmapFunction
 
-from pymor.grids.boundaryinfos import EmptyBoundaryInfo, BoundaryInfoFromIndicators, AllDirichletBoundaryInfo
+from pymor.grids.boundaryinfos import EmptyBoundaryInfo, GenericBoundaryInfo, AllDirichletBoundaryInfo
 from pymor.grids.oned import OnedGrid
 from pymor.grids.rect import RectGrid
 from pymor.grids.tria import TriaGrid

--- a/src/pymor/bindings/fenics.py
+++ b/src/pymor/bindings/fenics.py
@@ -116,9 +116,9 @@ if config.HAVE_FENICS:
 
     class FenicsVectorSpace(ListVectorSpace):
 
-        def __init__(self, V, id_='STATE'):
+        def __init__(self, V, id='STATE'):
             self.V = V
-            self.id = id_
+            self.id = id
 
         @property
         def dim(self):

--- a/src/pymor/bindings/fenics.py
+++ b/src/pymor/bindings/fenics.py
@@ -156,6 +156,8 @@ if config.HAVE_FENICS:
 
         def __init__(self, matrix, source_space, range_space, solver_options=None, name=None):
             assert matrix.rank() == 2
+            self.source_space = source_space
+            self.range_space = range_space
             self.source = FenicsVectorSpace(source_space)
             self.range = FenicsVectorSpace(range_space)
             self.matrix = matrix

--- a/src/pymor/bindings/ngsolve.py
+++ b/src/pymor/bindings/ngsolve.py
@@ -65,9 +65,9 @@ if config.HAVE_NGSOLVE:
 
     class NGSolveVectorSpace(ListVectorSpace):
 
-        def __init__(self, V, id_='STATE'):
+        def __init__(self, V, id='STATE'):
             self.V = V
-            self.id = id_
+            self.id = id
 
         def __eq__(self, other):
             return type(other) is NGSolveVectorSpace and self.V == other.V and self.id == other.id
@@ -88,8 +88,8 @@ if config.HAVE_NGSOLVE:
             return self.V.ndofglobal * self.value_dim
 
         @classmethod
-        def space_from_vector_obj(cls, vec, id_):
-            return cls(vec.space, id_)
+        def space_from_vector_obj(cls, vec, id):
+            return cls(vec.space, id)
 
         def zero_vector(self):
             impl = ngs.GridFunction(self.V)

--- a/src/pymor/core/interfaces.py
+++ b/src/pymor/core/interfaces.py
@@ -309,7 +309,7 @@ class ImmutableMeta(UberMeta):
         assert all(hasattr(instance, arg) for arg in instance._init_arguments), \
             (f'__init__ arguments {[arg for arg in instance._init_arguments if not hasattr(instance,arg)]} '
              f'of class {self.__name__} not available as instance attributes\n'
-             f'(all __init__ args need to be attributes for _with to work).')
+             f'(all __init__ args need to be attributes for with_ to work).')
         instance._locked = True
         return instance
 

--- a/src/pymor/core/interfaces.py
+++ b/src/pymor/core/interfaces.py
@@ -308,7 +308,7 @@ class ImmutableMeta(UberMeta):
         instance = super().__call__(*args, **kwargs)
         assert all(hasattr(instance, arg) for arg in instance._init_arguments), \
             (f'__init__ arguments {[arg for arg in instance._init_arguments if not hasattr(instance,arg)]} '
-             f'not available as instance attributes\n'
+             f'of class {self.__name__} not available as instance attributes\n'
              f'(all __init__ args need to be attributes for _with to work).')
         instance._locked = True
         return instance

--- a/src/pymor/core/interfaces.py
+++ b/src/pymor/core/interfaces.py
@@ -306,6 +306,10 @@ class ImmutableMeta(UberMeta):
 
     def _call(self, *args, **kwargs):
         instance = super().__call__(*args, **kwargs)
+        assert all(hasattr(instance, arg) for arg in instance._init_arguments), \
+            (f'__init__ arguments {[arg for arg in instance._init_arguments if not hasattr(instance,arg)]} '
+             f'not available as instance attributes\n'
+             f'(all __init__ args need to be attributes for _with to work).')
         instance._locked = True
         return instance
 

--- a/src/pymor/domaindiscretizers/default.py
+++ b/src/pymor/domaindiscretizers/default.py
@@ -170,9 +170,9 @@ def discretize_domain_default(domain_description, diameter=1 / 100, grid_type=No
         else:
             return discretize_TorusDomain()
     elif isinstance(domain_description, PolygonalDomain):
-        from pymor.grids.gmsh import GmshGrid
+        from pymor.grids.unstructured import UnstructuredTriangleGrid
         from pymor.domaindiscretizers.gmsh import discretize_gmsh
-        assert grid_type is None or grid_type is GmshGrid
+        assert grid_type is None or grid_type is UnstructuredTriangleGrid
         return discretize_gmsh(domain_description, clscale=diameter)
     else:
         grid_type = grid_type or OnedGrid

--- a/src/pymor/domaindiscretizers/default.py
+++ b/src/pymor/domaindiscretizers/default.py
@@ -7,7 +7,7 @@ import numpy as np
 
 from pymor.domaindescriptions.basic import RectDomain, CylindricalDomain, TorusDomain, LineDomain, CircleDomain
 from pymor.domaindescriptions.polygonal import PolygonalDomain
-from pymor.grids.boundaryinfos import BoundaryInfoFromIndicators, EmptyBoundaryInfo
+from pymor.grids.boundaryinfos import GenericBoundaryInfo, EmptyBoundaryInfo
 from pymor.grids.oned import OnedGrid
 from pymor.grids.rect import RectGrid
 from pymor.grids.tria import TriaGrid
@@ -83,7 +83,7 @@ def discretize_domain_default(domain_description, diameter=1 / 100, grid_type=No
 
         indicators = {bt: indicator_factory(domain_description, bt)
                       for bt in domain_description.boundary_types}
-        bi = BoundaryInfoFromIndicators(grid, indicators)
+        bi = GenericBoundaryInfo.from_indicators(grid, indicators)
 
         return grid, bi
 
@@ -109,7 +109,7 @@ def discretize_domain_default(domain_description, diameter=1 / 100, grid_type=No
 
         indicators = {bt: indicator_factory(domain_description, bt)
                       for bt in domain_description.boundary_types}
-        bi = BoundaryInfoFromIndicators(grid, indicators)
+        bi = GenericBoundaryInfo.from_indicators(grid, indicators)
 
         return grid, bi
 
@@ -142,7 +142,7 @@ def discretize_domain_default(domain_description, diameter=1 / 100, grid_type=No
 
         indicators = {bt: indicator_factory(domain_description, bt)
                       for bt in domain_description.boundary_types}
-        bi = BoundaryInfoFromIndicators(grid, indicators)
+        bi = GenericBoundaryInfo.from_indicators(grid, indicators)
 
         return grid, bi
 

--- a/src/pymor/functions/basic.py
+++ b/src/pymor/functions/basic.py
@@ -120,12 +120,12 @@ class GenericFunction(FunctionBase):
         self.dim_domain = dim_domain
         self.shape_range = shape_range if isinstance(shape_range, tuple) else (shape_range,)
         self.name = name
-        self._mapping = mapping
+        self.mapping = mapping
         if parameter_type is not None:
             self.build_parameter_type(parameter_type)
 
     def __str__(self):
-        return f'{self.name}: x -> {self._mapping}'
+        return f'{self.name}: x -> {self.mapping}'
 
     def evaluate(self, x, mu=None):
         x = np.array(x, copy=False, ndmin=1)
@@ -133,9 +133,9 @@ class GenericFunction(FunctionBase):
 
         if self.parametric:
             mu = self.parse_parameter(mu)
-            v = self._mapping(x, mu)
+            v = self.mapping(x, mu)
         else:
-            v = self._mapping(x)
+            v = self.mapping(x)
 
         if v.shape != x.shape[:-1] + self.shape_range:
             assert v.shape[:len(x.shape) - 1] == x.shape[:-1]

--- a/src/pymor/functions/basic.py
+++ b/src/pymor/functions/basic.py
@@ -66,24 +66,24 @@ class ConstantFunction(FunctionBase):
         assert dim_domain > 0
         assert isinstance(value, (Number, np.ndarray))
         value = np.array(value)
-        self._value = value
+        self.value = value
         self.dim_domain = dim_domain
         self.shape_range = value.shape
         self.name = name
 
     def __str__(self):
-        return f'{self.name}: x -> {self._value}'
+        return f'{self.name}: x -> {self.value}'
 
     def __repr__(self):
-        return f'ConstantFunction({repr(self._value)}, {self.dim_domain})'
+        return f'ConstantFunction({repr(self.value)}, {self.dim_domain})'
 
     def evaluate(self, x, mu=None):
         x = np.array(x, copy=False, ndmin=1)
         assert x.shape[-1] == self.dim_domain
         if x.ndim == 1:
-            return np.array(self._value)
+            return np.array(self.value)
         else:
-            return np.tile(self._value, x.shape[:-1] + (1,) * len(self.shape_range))
+            return np.tile(self.value, x.shape[:-1] + (1,) * len(self.shape_range))
 
 
 class GenericFunction(FunctionBase):

--- a/src/pymor/functions/bitmap.py
+++ b/src/pymor/functions/bitmap.py
@@ -34,6 +34,7 @@ class BitmapFunction(FunctionBase):
         if not img.mode == "L":
             self.logger.warning("Image " + filename + " not in grayscale mode. Convertig to grayscale.")
             img = img.convert('L')
+        self.filename = filename
         self.bitmap = np.array(img).T[:, ::-1]
         self.bounding_box = bounding_box
         self.lower_left = np.array(bounding_box[0])

--- a/src/pymor/grids/boundaryinfos.py
+++ b/src/pymor/grids/boundaryinfos.py
@@ -34,7 +34,9 @@ class BoundaryInfoFromIndicators(BoundaryInfoInterface):
 
     def __init__(self, grid, indicators, assert_unique_type=None, assert_some_type=None):
         self.grid = grid
-        assert_unique_type = assert_unique_type if assert_unique_type else [1]
+        self.indicators = indicators
+        self.assert_unique_type = assert_unique_type = assert_unique_type if assert_unique_type else [1]
+        self.assert_some_type = assert_some_type
         assert_some_type = assert_some_type if assert_some_type else []
         self.boundary_types = frozenset(indicators.keys())
         self._masks = {boundary_type: [np.zeros(grid.size(codim), dtype='bool') for codim in range(1, grid.dim + 1)]

--- a/src/pymor/grids/interfaces.py
+++ b/src/pymor/grids/interfaces.py
@@ -6,6 +6,7 @@ import numpy as np
 
 from pymor.core.interfaces import abstractmethod
 from pymor.core.cache import CacheableInterface, cached
+from pymor.domaindescriptions.interfaces import KNOWN_BOUNDARY_TYPES
 from pymor.grids.defaultimpl import (ConformalTopologicalGridDefaultImplementations,
                                      ReferenceElementDefaultImplementations,
                                      AffineGridDefaultImplementations,)
@@ -336,6 +337,10 @@ class BoundaryInfoInterface(CacheableInterface):
         return np.equal(sum(self.mask(bt, codim=codim).astype(np.int) for bt in self.boundary_types), 0)
 
     def check_boundary_types(self, assert_unique_type=(1,), assert_some_type=()):
+        for bt in self.boundary_types:
+            if bt not in KNOWN_BOUNDARY_TYPES:
+                self.logger.warning(f'Unknown boundary type: {bt}')
+
         if assert_unique_type:
             for codim in assert_unique_type:
                 assert np.all(self.unique_boundary_type_mask(codim))

--- a/src/pymor/grids/oned.py
+++ b/src/pymor/grids/oned.py
@@ -26,24 +26,24 @@ class OnedGrid(AffineGridWithOrthogonalCentersInterface):
     def __init__(self, domain=(0, 1), num_intervals=4, identify_left_right=False):
         assert domain[0] < domain[1]
         self.reference_element = line
-        self._domain = np.array(domain)
-        self._num_intervals = num_intervals
-        self._identify_left_right = identify_left_right
+        self.domain = np.array(domain)
+        self.num_intervals = num_intervals
+        self.identify_left_right = identify_left_right
         self._sizes = [num_intervals, num_intervals] if identify_left_right else [num_intervals, num_intervals + 1]
-        self._width = np.abs(self._domain[1] - self._domain[0]) / self._num_intervals
-        self.__subentities = np.vstack((np.arange(self._num_intervals, dtype=np.int32),
-                                        np.arange(self._num_intervals, dtype=np.int32) + 1))
+        self._width = np.abs(self.domain[1] - self.domain[0]) / self.num_intervals
+        self.__subentities = np.vstack((np.arange(self.num_intervals, dtype=np.int32),
+                                        np.arange(self.num_intervals, dtype=np.int32) + 1))
         if identify_left_right:
             self.__subentities[-1, -1] = 0
-        self.__A = np.ones(self._num_intervals, dtype=np.int32)[:, np.newaxis, np.newaxis] * self._width
-        self.__B = (self._domain[0] + self._width * (np.arange(self._num_intervals, dtype=np.int32)))[:, np.newaxis]
+        self.__A = np.ones(self.num_intervals, dtype=np.int32)[:, np.newaxis, np.newaxis] * self._width
+        self.__B = (self.domain[0] + self._width * (np.arange(self.num_intervals, dtype=np.int32)))[:, np.newaxis]
 
     def __reduce__(self):
         return (OnedGrid,
-                (self._domain, self._num_intervals, self._identify_left_right))
+                (self.domain, self.num_intervals, self.identify_left_right))
 
     def __str__(self):
-        return (f'OnedGrid, domain [{self._domain[0]},{self._domain[1]}], '
+        return (f'OnedGrid, domain [{self.domain[0]},{self.domain[1]}], '
                 f'{self.size(0)} elements, {self.size(1)} vertices')
 
     def __repr__(self):
@@ -71,7 +71,7 @@ class OnedGrid(AffineGridWithOrthogonalCentersInterface):
             return super().embeddings(codim)
 
     def bounding_box(self):
-        return np.array(self._domain).reshape((2, 1))
+        return np.array(self.domain).reshape((2, 1))
 
     def orthogonal_centers(self):
         return self.centers(0)

--- a/src/pymor/grids/subgrid.py
+++ b/src/pymor/grids/subgrid.py
@@ -6,6 +6,7 @@ import weakref
 
 import numpy as np
 
+from pymor.grids.boundaryinfos import GenericBoundaryInfo
 from pymor.grids.interfaces import AffineGridInterface
 
 
@@ -17,9 +18,9 @@ class SubGrid(AffineGridInterface):
 
     Parameters
     ----------
-    grid
+    parent_grid
         |Grid| of which a subgrid is to be created.
-    entities
+    parent_entities
         |NumPy array| of global indices of the codim-0 entities which
         are to be contained in the subgrid.
 
@@ -107,3 +108,48 @@ class SubGrid(AffineGridInterface):
         d = self.__dict__.copy()
         del d['_SubGrid__parent_grid']
         return d
+
+
+def make_sub_grid_boundary_info(sub_grid, parent_grid, parent_grid_boundary_info, new_boundary_type=None):
+    """Derives a |BoundaryInfo| for a :class:`~pymor.grids.subgrid.SubGrid`.
+
+    Parameters
+    ----------
+    sub_grid
+        The :class:`~pymor.grids.subgrid.SubGrid` for which a |BoundaryInfo| is created.
+    parent_grid
+        The parent |Grid|.
+    parent_grid_boundary_info
+        The |BoundaryInfo| of the parent |Grid| from which to derive the |BoundaryInfo|
+    new_boundary_type
+        The boundary type which is assigned to the new boundaries of `subgrid`. If
+        `None`, no boundary type is assigned.
+
+    Returns
+    -------
+    |BoundaryInfo| associated with sub_grid.
+    """
+    boundary_types = parent_grid_boundary_info.boundary_types
+
+    masks = {}
+    for codim in range(1, sub_grid.dim + 1):
+        parent_indices = sub_grid.parent_indices(codim)[sub_grid.boundaries(codim)]
+        new_boundaries = np.where(np.logical_not(parent_grid.boundary_mask(codim)[parent_indices]))
+        new_boundaries_sg_indices = sub_grid.boundaries(codim)[new_boundaries]
+        for t in boundary_types:
+            m = parent_grid_boundary_info.mask(t, codim)[sub_grid.parent_indices(codim)]
+            if t == new_boundary_type:
+                m[new_boundaries_sg_indices] = True
+            if codim == 1:
+                masks[t] = [m]
+            else:
+                masks[t].append(m)
+        if new_boundary_type is not None and new_boundary_type not in boundary_types:
+            m = np.zeros(sub_grid.size(codim), dtype=np.bool)
+            m[new_boundaries_sg_indices] = True
+            if codim == 1:
+                masks[new_boundary_type] = [m]
+            else:
+                masks[new_boundary_type].append(m)
+
+    return GenericBoundaryInfo(sub_grid, masks)

--- a/src/pymor/gui/matplotlib.py
+++ b/src/pymor/gui/matplotlib.py
@@ -86,8 +86,8 @@ if config.HAVE_QT and config.HAVE_MATPLOTLIB:
             self.codim = codim
             lines = ()
             centers = grid.centers(1)
-            if grid._identify_left_right:
-                centers = np.concatenate((centers, [[grid._domain[1]]]), axis=0)
+            if grid.identify_left_right:
+                centers = np.concatenate((centers, [[grid.domain[1]]]), axis=0)
                 self.periodic = True
             else:
                 self.periodic = False

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -803,8 +803,8 @@ class TransferFunction(InputOutputModel):
     def __init__(self, input_space, output_space, H, dH, cont_time=True, cache_region='memory', name=None):
         assert cont_time in (True, False)
 
-        self.tf = H
-        self.dtf = dH
+        self.tf = self.H = H
+        self.dtf = self.dH = dH
         super().__init__(input_space, output_space, cont_time=cont_time, cache_region=cache_region, name=name)
 
     def eval_tf(self, s):

--- a/src/pymor/operators/cg.py
+++ b/src/pymor/operators/cg.py
@@ -13,8 +13,8 @@ from pymor.operators.numpy import NumpyMatrixBasedOperator
 from pymor.vectorarrays.numpy import NumpyVectorSpace
 
 
-def CGVectorSpace(grid, id_='STATE'):
-    return NumpyVectorSpace(grid.size(grid.dim), id_)
+def CGVectorSpace(grid, id='STATE'):
+    return NumpyVectorSpace(grid.size(grid.dim), id)
 
 
 class L2ProductFunctionalP1(NumpyMatrixBasedOperator):

--- a/src/pymor/operators/constructions.py
+++ b/src/pymor/operators/constructions.py
@@ -442,11 +442,11 @@ class ConstantOperator(OperatorBase):
         self.source = source
         self.range = value.space
         self.name = name
-        self._value = value.copy()
+        self.value = value.copy()
 
     def apply(self, U, mu=None):
         assert U in self.source
-        return self._value[[0] * len(U)].copy()
+        return self.value[[0] * len(U)].copy()
 
     def jacobian(self, U, mu=None):
         assert U in self.source
@@ -455,7 +455,7 @@ class ConstantOperator(OperatorBase):
 
     def restricted(self, dofs):
         assert all(0 <= c < self.range.dim for c in dofs)
-        restricted_value = NumpyVectorSpace.make_array(self._value.dofs(dofs))
+        restricted_value = NumpyVectorSpace.make_array(self.value.dofs(dofs))
         return ConstantOperator(restricted_value, NumpyVectorSpace(len(dofs))), dofs
 
     def apply_inverse(self, V, mu=None, least_squares=False):

--- a/src/pymor/operators/constructions.py
+++ b/src/pymor/operators/constructions.py
@@ -624,6 +624,7 @@ class VectorOperator(VectorArrayOperator):
         assert isinstance(vector, VectorArrayInterface)
         assert len(vector) == 1
         super().__init__(vector, adjoint=False, name=name)
+        self.vector = self.array  # do not init with vector arg, as vector gets copied in VectorArrayOperator.__init__
 
 
 class VectorFunctional(VectorArrayOperator):

--- a/src/pymor/operators/constructions.py
+++ b/src/pymor/operators/constructions.py
@@ -541,7 +541,7 @@ class VectorArrayOperator(OperatorBase):
     linear = True
 
     def __init__(self, array, adjoint=False, space_id=None, name=None):
-        self._array = array.copy()
+        self.array = array.copy()
         if adjoint:
             self.source = array.space
             self.range = NumpyVectorSpace(len(array), space_id)
@@ -554,42 +554,42 @@ class VectorArrayOperator(OperatorBase):
 
     @property
     def H(self):
-        return VectorArrayOperator(self._array, not self.adjoint, self.space_id, self.name + '_adjoint')
+        return VectorArrayOperator(self.array, not self.adjoint, self.space_id, self.name + '_adjoint')
 
     def apply(self, U, mu=None):
         assert U in self.source
         if not self.adjoint:
-            return self._array.lincomb(U.to_numpy())
+            return self.array.lincomb(U.to_numpy())
         else:
-            return self.range.make_array(self._array.dot(U).T)
+            return self.range.make_array(self.array.dot(U).T)
 
     def apply_adjoint(self, V, mu=None):
         assert V in self.range
         if not self.adjoint:
-            return self.source.make_array(self._array.dot(V).T)
+            return self.source.make_array(self.array.dot(V).T)
         else:
-            return self._array.lincomb(V.to_numpy())
+            return self.array.lincomb(V.to_numpy())
 
     def apply_inverse_adjoint(self, U, mu=None, least_squares=False):
-        adjoint_op = VectorArrayOperator(self._array, adjoint=not self.adjoint)
+        adjoint_op = VectorArrayOperator(self.array, adjoint=not self.adjoint)
         return adjoint_op.apply_inverse(U, mu=mu, least_squares=least_squares)
 
     def as_range_array(self, mu=None):
         if not self.adjoint:
-            return self._array.copy()
+            return self.array.copy()
         else:
             return super().as_range_array(mu)
 
     def as_source_array(self, mu=None):
         if self.adjoint:
-            return self._array.copy()
+            return self.array.copy()
         else:
             return super().as_source_array(mu)
 
     def restricted(self, dofs):
         assert all(0 <= c < self.range.dim for c in dofs)
         if not self.adjoint:
-            restricted_value = NumpyVectorSpace.make_array(self._array.dofs(dofs))
+            restricted_value = NumpyVectorSpace.make_array(self.array.dofs(dofs))
             return VectorArrayOperator(restricted_value, False), np.arange(self.source.dim, dtype=np.int32)
         else:
             raise NotImplementedError

--- a/src/pymor/operators/constructions.py
+++ b/src/pymor/operators/constructions.py
@@ -389,6 +389,7 @@ class IdentityOperator(OperatorBase):
 
     def __init__(self, space, name=None):
         self.source = self.range = space
+        self.space = space
         self.name = name
 
     @property

--- a/src/pymor/operators/constructions.py
+++ b/src/pymor/operators/constructions.py
@@ -667,6 +667,8 @@ class VectorFunctional(VectorArrayOperator):
             super().__init__(vector, adjoint=True, name=name)
         else:
             super().__init__(product.apply(vector), adjoint=True, name=name)
+        self.vector = self.array  # do not init with vector arg, as vector gets copied in VectorArrayOperator.__init__
+        self.product = product
 
 
 class ProxyOperator(OperatorBase):

--- a/src/pymor/operators/ei.py
+++ b/src/pymor/operators/ei.py
@@ -148,6 +148,11 @@ class EmpiricalInterpolatedOperator(OperatorBase):
             return Concatenation([J, ComponentProjection(self.source_dofs, self.source)],
                                  solver_options=options, name=self.name + '_jacobian')
 
+    def __getstate__(self):
+        d = self.__dict__.copy()
+        del d['_operator']
+        return d
+
 
 class ProjectedEmpiciralInterpolatedOperator(OperatorBase):
     """A projected |EmpiricalInterpolatedOperator|."""

--- a/src/pymor/operators/ei.py
+++ b/src/pymor/operators/ei.py
@@ -2,6 +2,8 @@
 # Copyright 2013-2019 pyMOR developers and contributors. All rights reserved.
 # License: BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
 
+import weakref
+
 import numpy as np
 from scipy.linalg import solve, solve_triangular
 
@@ -71,6 +73,7 @@ class EmpiricalInterpolatedOperator(OperatorBase):
         self.solver_options = solver_options
         self.name = name or f'{operator.name}_interpolated'
 
+        self._operator = weakref.ref(operator)
         interpolation_dofs = np.array(interpolation_dofs, dtype=np.int32)
         self.interpolation_dofs = interpolation_dofs
         self.triangular = triangular
@@ -84,6 +87,10 @@ class EmpiricalInterpolatedOperator(OperatorBase):
             interpolation_matrix = collateral_basis.dofs(interpolation_dofs).T
             self.interpolation_matrix = interpolation_matrix
             self.collateral_basis = collateral_basis.copy()
+
+    @property
+    def operator(self):
+        return self._operator()
 
     def apply(self, U, mu=None):
         mu = self.parse_parameter(mu)

--- a/src/pymor/operators/fv.py
+++ b/src/pymor/operators/fv.py
@@ -11,8 +11,7 @@ from pymor.core.defaults import defaults
 from pymor.core.interfaces import ImmutableInterface, abstractmethod
 from pymor.functions.interfaces import FunctionInterface
 from pymor.grids.interfaces import AffineGridWithOrthogonalCentersInterface
-from pymor.grids.boundaryinfos import SubGridBoundaryInfo
-from pymor.grids.subgrid import SubGrid
+from pymor.grids.subgrid import SubGrid, make_sub_grid_boundary_info
 from pymor.operators.basic import OperatorBase
 from pymor.operators.constructions import ComponentProjection
 from pymor.operators.numpy import NumpyMatrixBasedOperator, NumpyMatrixOperator
@@ -252,7 +251,7 @@ class NonlinearAdvectionOperator(OperatorBase):
                                    np.array([-1], dtype=np.int32),
                                    assume_unique=True)
         sub_grid = SubGrid(self.grid, source_dofs)
-        sub_boundary_info = SubGridBoundaryInfo(sub_grid, self.grid, self.boundary_info)
+        sub_boundary_info = make_sub_grid_boundary_info(sub_grid, self.grid, self.boundary_info)
         op = self.with_(grid=sub_grid, boundary_info=sub_boundary_info, space_id=None,
                         name=f'{self.name}_restricted')
         sub_grid_indices = sub_grid.indices_from_parent_indices(dofs, codim=0)

--- a/src/pymor/operators/fv.py
+++ b/src/pymor/operators/fv.py
@@ -251,7 +251,7 @@ class NonlinearAdvectionOperator(OperatorBase):
         source_dofs = np.setdiff1d(np.union1d(self.grid.neighbours(0, 0)[dofs].ravel(), dofs),
                                    np.array([-1], dtype=np.int32),
                                    assume_unique=True)
-        sub_grid = SubGrid(self.grid, entities=source_dofs)
+        sub_grid = SubGrid(self.grid, source_dofs)
         sub_boundary_info = SubGridBoundaryInfo(sub_grid, self.grid, self.boundary_info)
         op = self.with_(grid=sub_grid, boundary_info=sub_boundary_info, space_id=None,
                         name=f'{self.name}_restricted')

--- a/src/pymor/operators/fv.py
+++ b/src/pymor/operators/fv.py
@@ -22,8 +22,8 @@ from pymor.tools.quadratures import GaussQuadratures
 from pymor.vectorarrays.numpy import NumpyVectorSpace
 
 
-def FVVectorSpace(grid, id_='STATE'):
-    return NumpyVectorSpace(grid.size(0), id_)
+def FVVectorSpace(grid, id='STATE'):
+    return NumpyVectorSpace(grid.size(0), id)
 
 
 class NumericalConvectiveFluxInterface(ImmutableInterface, Parametric):

--- a/src/pymor/operators/mpi.py
+++ b/src/pymor/operators/mpi.py
@@ -240,8 +240,8 @@ def _mpi_wrap_operator_LincombOperator_manage_operators(obj_id):
 
 def _mpi_wrap_operator_VectorArrayOperator_manage_array(obj_id, pickle_local_spaces):
     op = mpi.get_object(obj_id)
-    array_obj_id = mpi.manage_object(op._array)
-    local_space = op._array.space
+    array_obj_id = mpi.manage_object(op.array)
+    local_space = op.array.space
     if not pickle_local_spaces:
         local_space = _register_local_space(local_space)
     local_spaces = mpi.comm.gather(local_space, root=0)

--- a/src/pymor/operators/numpy.py
+++ b/src/pymor/operators/numpy.py
@@ -71,6 +71,8 @@ class NumpyGenericOperator(OperatorBase):
         self.name = name
         self.mapping = mapping
         self.adjoint_mapping = adjoint_mapping
+        self.dim_source = dim_source
+        self.dim_range = dim_range
         self.linear = linear
         if parameter_type is not None:
             self.build_parameter_type(parameter_type)

--- a/src/pymor/operators/numpy.py
+++ b/src/pymor/operators/numpy.py
@@ -69,8 +69,8 @@ class NumpyGenericOperator(OperatorBase):
         self.range = NumpyVectorSpace(dim_range, range_id)
         self.solver_options = solver_options
         self.name = name
-        self._mapping = mapping
-        self._adjoint_mapping = adjoint_mapping
+        self.mapping = mapping
+        self.adjoint_mapping = adjoint_mapping
         self.linear = linear
         if parameter_type is not None:
             self.build_parameter_type(parameter_type)
@@ -81,20 +81,20 @@ class NumpyGenericOperator(OperatorBase):
         assert U in self.source
         if self.parametric:
             mu = self.parse_parameter(mu)
-            return self.range.make_array(self._mapping(U.to_numpy(), mu=mu))
+            return self.range.make_array(self.mapping(U.to_numpy(), mu=mu))
         else:
-            return self.range.make_array(self._mapping(U.to_numpy()))
+            return self.range.make_array(self.mapping(U.to_numpy()))
 
     def apply_adjoint(self, V, mu=None):
-        if self._adjoint_mapping is None:
+        if self.adjoint_mapping is None:
             raise ValueError('NumpyGenericOperator: adjoint mapping was not defined.')
         assert V in self.range
         V = V.to_numpy()
         if self.parametric:
             mu = self.parse_parameter(mu)
-            return self.source.make_array(self._adjoint_mapping(V, mu=mu))
+            return self.source.make_array(self.adjoint_mapping(V, mu=mu))
         else:
-            return self.source.make_array(self._adjoint_mapping(V))
+            return self.source.make_array(self.adjoint_mapping(V))
 
 
 class NumpyMatrixBasedOperator(OperatorBase):

--- a/src/pymor/parameters/functionals.py
+++ b/src/pymor/parameters/functionals.py
@@ -35,6 +35,7 @@ class ProjectionParameterFunctional(ParameterFunctionalInterface):
             component_shape = () if component_shape == 0 else (component_shape,)
         self.build_parameter_type({component_name: component_shape})
         self.component_name = component_name
+        self.component_shape = component_shape
         self.coordinates = coordinates
         assert len(coordinates) == len(component_shape)
         assert not component_shape or coordinates < component_shape

--- a/src/pymor/parameters/functionals.py
+++ b/src/pymor/parameters/functionals.py
@@ -65,12 +65,12 @@ class GenericParameterFunctional(ParameterFunctionalInterface):
 
     def __init__(self, mapping, parameter_type, name=None):
         self.name = name
-        self._mapping = mapping
+        self.mapping = mapping
         self.build_parameter_type(parameter_type)
 
     def evaluate(self, mu=None):
         mu = self.parse_parameter(mu)
-        value = self._mapping(mu)
+        value = self.mapping(mu)
         # ensure that we return a number not an array
         if isinstance(value, np.ndarray):
             return value.item()

--- a/src/pymor/parameters/spaces.py
+++ b/src/pymor/parameters/spaces.py
@@ -38,6 +38,8 @@ class CubicParameterSpace(ParameterSpaceInterface):
         assert minimum is None or minimum < maximum
         parameter_type = ParameterType(parameter_type)
         self.parameter_type = parameter_type
+        self.minimum = minimum
+        self.maximum = maximum
         self.ranges = {k: (minimum, maximum) for k in parameter_type} if ranges is None else ranges
 
     def parse_parameter(self, mu):

--- a/src/pymor/vectorarrays/list.py
+++ b/src/pymor/vectorarrays/list.py
@@ -425,11 +425,11 @@ class ListVectorSpace(VectorSpaceInterface):
         raise NotImplementedError
 
     @classmethod
-    def space_from_vector_obj(cls, vec, id_):
+    def space_from_vector_obj(cls, vec, id):
         raise NotImplementedError
 
     @classmethod
-    def space_from_dim(cls, dim, id_):
+    def space_from_dim(cls, dim, id):
         raise NotImplementedError
 
     def zeros(self, count=1, reserve=0):
@@ -452,18 +452,18 @@ class ListVectorSpace(VectorSpaceInterface):
                                 for _ in range(count)], self)
 
     @classinstancemethod
-    def make_array(cls, obj, id_=None):
+    def make_array(cls, obj, id=None):
         if len(obj) == 0:
             raise NotImplementedError
-        return cls.space_from_vector_obj(obj[0], id_=id_).make_array(obj)
+        return cls.space_from_vector_obj(obj[0], id=id).make_array(obj)
 
     @make_array.instancemethod
     def make_array(self, obj):
         return ListVectorArray([self.make_vector(v) for v in obj], self)
 
     @classinstancemethod
-    def from_numpy(cls, data, id_=None, ensure_copy=False):
-        return cls.space_from_dim(data.shape[1], id_=id_).from_numpy(data, ensure_copy=ensure_copy)
+    def from_numpy(cls, data, id=None, ensure_copy=False):
+        return cls.space_from_dim(data.shape[1], id=id).from_numpy(data, ensure_copy=ensure_copy)
 
     @from_numpy.instancemethod
     def from_numpy(self, data, ensure_copy=False):
@@ -472,20 +472,20 @@ class ListVectorSpace(VectorSpaceInterface):
 
 class NumpyListVectorSpace(ListVectorSpace):
 
-    def __init__(self, dim, id_=None):
+    def __init__(self, dim, id=None):
         self.dim = dim
-        self.id = id_
+        self.id = id
 
     def __eq__(self, other):
         return type(other) is NumpyListVectorSpace and self.dim == other.dim and self.id == other.id
 
     @classmethod
-    def space_from_vector_obj(cls, vec, id_):
-        return cls(len(vec), id_)
+    def space_from_vector_obj(cls, vec, id):
+        return cls(len(vec), id)
 
     @classmethod
-    def space_from_dim(cls, dim, id_):
-        return cls(dim, id_)
+    def space_from_dim(cls, dim, id):
+        return cls(dim, id)
 
     def zero_vector(self):
         return NumpyVector(np.zeros(self.dim))

--- a/src/pymor/vectorarrays/numpy.py
+++ b/src/pymor/vectorarrays/numpy.py
@@ -341,9 +341,9 @@ class NumpyVectorSpace(VectorSpaceInterface):
         See :attr:`~pymor.vectorarrays.interfaces.VectorSpaceInterface.id`.
     """
 
-    def __init__(self, dim, id_=None):
+    def __init__(self, dim, id=None):
         self.dim = dim
-        self.id = id_
+        self.id = id
 
     def __eq__(self, other):
         return type(other) is type(self) and self.dim == other.dim and self.id == other.id
@@ -377,23 +377,23 @@ class NumpyVectorSpace(VectorSpaceInterface):
         return va
 
     @classinstancemethod
-    def make_array(cls, obj, id_=None):
-        return cls._array_factory(obj, id_=id_)
+    def make_array(cls, obj, id=None):
+        return cls._array_factory(obj, id=id)
 
     @make_array.instancemethod
     def make_array(self, obj):
         return self._array_factory(obj, space=self)
 
     @classinstancemethod
-    def from_numpy(cls, data, id_=None, ensure_copy=False):
-        return cls._array_factory(data.copy() if ensure_copy else data, id_=id_)
+    def from_numpy(cls, data, id=None, ensure_copy=False):
+        return cls._array_factory(data.copy() if ensure_copy else data, id=id)
 
     @from_numpy.instancemethod
     def from_numpy(self, data, ensure_copy=False):
         return self._array_factory(data.copy() if ensure_copy else data, space=self)
 
     @classinstancemethod
-    def from_file(cls, path, key=None, single_vector=False, transpose=False, id_=None):
+    def from_file(cls, path, key=None, single_vector=False, transpose=False, id=None):
         assert not (single_vector and transpose)
         from pymor.tools.io import load_matrix
         array = load_matrix(path, key=key)
@@ -406,14 +406,14 @@ class NumpyVectorSpace(VectorSpaceInterface):
             array = array.reshape((1, -1))
         if transpose:
             array = array.T
-        return cls.make_array(array, id_=id_)
+        return cls.make_array(array, id=id)
 
     @from_file.instancemethod
     def from_file(self, path, key=None, single_vector=False, transpose=False):
-        return type(self).from_file(path, key=key, single_vector=single_vector, transpose=transpose, id_=self.id)
+        return type(self).from_file(path, key=key, single_vector=single_vector, transpose=transpose, id=self.id)
 
     @classmethod
-    def _array_factory(cls, array, space=None, id_=None):
+    def _array_factory(cls, array, space=None, id=None):
         if type(array) is np.ndarray:
             pass
         elif issparse(array):
@@ -424,7 +424,7 @@ class NumpyVectorSpace(VectorSpaceInterface):
             assert array.ndim == 1
             array = np.reshape(array, (1, -1))
         if space is None:
-            return NumpyVectorArray(array, cls(array.shape[1], id_))
+            return NumpyVectorArray(array, cls(array.shape[1], id))
         else:
             assert array.shape[1] == space.dim
             return NumpyVectorArray(array, space)

--- a/src/pymortests/fixtures/grid.py
+++ b/src/pymortests/fixtures/grid.py
@@ -53,8 +53,9 @@ oned_grid_generators = [lambda kwargs=kwargs: OnedGrid(**kwargs) for kwargs in
                          dict(domain=np.array((2, 3)), num_intervals=10, identify_left_right=True),
                          dict(domain=np.array((1, 2)), num_intervals=10000)]]
 
-unstructured_grid_generators = [lambda: UnstructuredTriangleGrid(np.array([[0, 0], [-1, -1], [1, -1], [1, 1], [-1, 1]]),
-                                                                 np.array([[0, 1, 2], [0, 3, 4], [0, 4, 1]]))]
+unstructured_grid_generators = \
+    [lambda: UnstructuredTriangleGrid.from_vertices(np.array([[0, 0], [-1, -1], [1, -1], [1, 1], [-1, 1]]),
+                                                    np.array([[0, 1, 2], [0, 3, 4], [0, 4, 1]]))]
 
 
 def subgrid_factory(grid_generator, neq, seed):


### PR DESCRIPTION
This rather large PR adds some code to `ImmutableMeta.__call__` which checks if all `__init__` arguments of an immutable class are available as attributes of the generated object. This is necessary for `with_` to work correctly.

All other commits in this PR fix various classes for which this condition is not satisfied. In some cases some attributes are renamed (from _foo to foo) and many missing attributes are added. Some refactoring happened along the way:

- `UnstructuredTriangleGrid` now has a factory method `from_vertices` which will be usually used to instantiate the grid.
- `GmshGrid` has been removed. Instead an `UnstructuredTriangleGrid` is instantiated directly.
- `BoundaryInfoFromIndicators` is now `GenericBoundaryInfo` with a `from_indicators` factory method.
- `GmshBoundaryInfo` has been removed. Instead, `GenericBoundaryInfo` is used.
- `SubgridBoundaryInfo` has been removed. Instead, `GenericBoundaryInfo` is used.

One main motivation for #549 was to ensure that `with_` always works. Since dataclasses do not really seem to work for us, this PR can be seen as a step towards a similar goal. (Another PR will follow to get rid of some of the boilerplate code in `__init__`.)