### PR TITLE
Add generic __repr__ method to BasicInterface

### DIFF
--- a/src/pymor/core/interfaces.py
+++ b/src/pymor/core/interfaces.py
@@ -247,6 +247,29 @@ class BasicInterface(metaclass=UberMeta):
             self._uid = UID()
         return self._uid.uid
 
+    def __repr__(self):
+        init_sig = inspect.signature(self.__init__)
+        args = []
+        vals = []
+        for arg, description in init_sig.parameters.items():
+            if arg == 'self':
+                continue
+            vals.append(repr(getattr(self, arg, '??')))
+            if description.default == description.empty:
+                args.append('')
+            else:
+                args.append(f'{arg}=')
+        if any('\n' in val for val in vals):
+            reprs = []
+            for arg, val in zip(args, vals):
+                vs = val.split('\n')
+                reprs.append('\n'.join([f'    {arg}{vs[0]}'] + [' ' * (4+len(arg)) + v for v in vs[1:]]))
+            sep = ",\n"
+            return f'''{type(self).__name__}(
+{sep.join(reprs)}
+)'''
+        return f'{type(self).__name__}({", ".join(reprs)})'
+
 
 abstractmethod = abc.abstractmethod
 abstractproperty = abc.abstractproperty

--- a/src/pymor/core/interfaces.py
+++ b/src/pymor/core/interfaces.py
@@ -75,14 +75,12 @@ import os
 import time
 from types import FunctionType, BuiltinFunctionType
 import uuid
-import textwrap
 
 import numpy as np
 
 from pymor.core import logger
-from pymor.core.defaults import defaults
 from pymor.core.exceptions import ConstError, SIDGenerationError
-from pymor.tools.frozendict import FrozenDict
+from pymor.tools.formatrepr import format_repr, _format_generic
 
 DONT_COPY_DOCSTRINGS = int(os.environ.get('PYMOR_WITH_SPHINX', 0)) == 1
 NoneType = type(None)
@@ -250,98 +248,13 @@ class BasicInterface(metaclass=UberMeta):
             self._uid = UID()
         return self._uid.uid
 
-    @staticmethod
-    def _indent_value(val, indent):
-        if '\n' in val:
-            return textwrap.indent(val, ' ' * indent)[indent:]
-        else:
-            return val
-
-    @staticmethod
-    def _format_list_tuple(val, max_width):
-        brackets = '()' if type(val) is tuple else '[]'
-        reprs = [repr(v) for v in val]
-        if any('\n' in r for r in reprs) or sum(len(r) + 2 for r in reprs) + 2 > max_width:
-            reprs = ',\n '.join(BasicInterface._indent_value(r, 1) for r in reprs)
-            return brackets[0] + reprs + brackets[1]
-        else:
-            return brackets[0] + ', '.join(reprs) + brackets[1]
-
-    @staticmethod
-    def _format_dict(val, max_width):
-        if not val:
-            return '{}'
-        keys, vals = zip(*val.items())
-        reprs = [repr(v) for v in vals]
-        if any('\n' in r for r in reprs) or sum(len(k) + len(r) + 4 for k, r in zip(keys, reprs)) + 2 > max_width:
-            reprs = ',\n '.join(BasicInterface._indent_value(f'{k}: {r}', 1) for k, r in zip(keys, reprs))
-            return '{' + reprs + '}'
-        else:
-            return '{' + ', '.join(f'{k}: {r}' for k, r in zip(keys, reprs)) + '}'
-
-    @staticmethod
-    def _format_array(val, max_width):
-        r = repr(val)
-        if len(r) <= max_width * 3 and '\n' in r:
-            r_one_line = ' '.join(rr.strip() for rr in r.split('\n'))
-            if len(r_one_line) <= max_width:
-                return r_one_line
-            else:
-                return r
-        else:
-            return r
-
-    @staticmethod
-    @defaults('value', sid_ignore=('value'))
-    def repr_max_width(value=120):
-        return value
-
-    def _format_repr(self, max_width, override={}):
-        init_sig = inspect.signature(self.__init__)
-        keys, vals = [], []
-        for arg, description in init_sig.parameters.items():
-            if description.default == description.empty:
-                key = ''
-            else:
-                key = f'{arg}='
-            if arg == 'self':
-                continue
-            if arg in override:
-                vals.append(override[arg])
-            else:
-                val = getattr(self, arg, '??')
-                try:
-                    if val == description.default:
-                        continue
-                except ValueError:  # comparison of numpy arrays
-                    pass
-                if arg == 'name' and val == type(self).__name__:
-                    continue
-                repr_max_width = max_width - len(key) - 4
-                if type(val) in (list, tuple):
-                    vals.append(self._format_list_tuple(val, repr_max_width))
-                elif type(val) in (dict, FrozenDict):
-                    vals.append(self._format_dict(val, repr_max_width))
-                elif isinstance(val, np.ndarray):
-                    vals.append(self._format_array(val, repr_max_width))
-                elif isinstance(val, BasicInterface):
-                    vals.append(val._format_repr(repr_max_width))
-                else:
-                    vals.append(repr(val))
-            keys.append(key)
-
-        if (sum(len(k) + len(v) + 2 for k, v in zip(keys, vals)) + len(type(self).__name__) > max_width
-                or any('\n' in v for v in vals)):
-            args = [f'    {k}{self._indent_value(v, len(k) + 4)}' for k, v in zip(keys, vals)]
-            args = ",\n".join(args)
-            return f'''{type(self).__name__}(
-{args})'''
-        else:
-            args = [f'{k}{v}' for k, v in zip(keys, vals)]
-            return f'{type(self).__name__}({", ".join(args)})'
+    def _format_repr(self, max_width, verbosity, override={}):
+        if verbosity < 3 and self.name == type(self).__name__ and 'name' not in override:
+            override = dict(override, name=None)
+        return _format_generic(self, max_width, verbosity, override=override)
 
     def __repr__(self):
-        return self._format_repr(self.repr_max_width())
+        return format_repr(self)
 
 
 abstractmethod = abc.abstractmethod

--- a/src/pymor/functions/basic.py
+++ b/src/pymor/functions/basic.py
@@ -74,9 +74,6 @@ class ConstantFunction(FunctionBase):
     def __str__(self):
         return f'{self.name}: x -> {self.value}'
 
-    def __repr__(self):
-        return f'ConstantFunction({repr(self.value)}, {self.dim_domain})'
-
     def evaluate(self, x, mu=None):
         x = np.array(x, copy=False, ndmin=1)
         assert x.shape[-1] == self.dim_domain
@@ -181,10 +178,6 @@ class ExpressionFunction(GenericFunction):
         code = compile(expression, '<expression>', 'eval')
         super().__init__(lambda x, mu={}: eval(code, dict(self.functions, **self.values), dict(mu, x=x, mu=mu)),
                          dim_domain, shape_range, parameter_type, name)
-
-    def __repr__(self):
-        return f'ExpressionFunction({self.expression}, {repr(self.parameter_type)}, {self.shape_range}, ' \
-               f'{self.parameter_type}, {self.values})'
 
     def __reduce__(self):
         return (ExpressionFunction,

--- a/src/pymor/grids/oned.py
+++ b/src/pymor/grids/oned.py
@@ -46,9 +46,6 @@ class OnedGrid(AffineGridWithOrthogonalCentersInterface):
         return (f'OnedGrid, domain [{self.domain[0]},{self.domain[1]}], '
                 f'{self.size(0)} elements, {self.size(1)} vertices')
 
-    def __repr__(self):
-        return f'OnedGrid({self.domain}, {self.num_intervals}, {self.identify_left_right})'
-
     def size(self, codim=0):
         assert 0 <= codim <= 1, f'codim has to be between 0 and {self.dim}!'
         return self._sizes[codim]

--- a/src/pymor/grids/rect.py
+++ b/src/pymor/grids/rect.py
@@ -147,9 +147,6 @@ class RectGrid(AffineGridWithOrthogonalCentersInterface):
                 f'x0-intervals: {self.x0_num_intervals}, x1-intervals: {self.x1_num_intervals}\n'
                 f'faces: {self.size(0)}, edges: {self.size(1)}, vertices: {self.size(2)}')
 
-    def __repr__(self):
-        return f'RectGrid({self.num_intervals}, {self.domain}, {self.identify_left_right}, {self.identify_bottom_top})'
-
     def size(self, codim=0):
         assert 0 <= codim <= 2, 'Invalid codimension'
         return self.__sizes[codim]

--- a/src/pymor/grids/tria.py
+++ b/src/pymor/grids/tria.py
@@ -176,12 +176,6 @@ class TriaGrid(AffineGridWithOrthogonalCentersInterface):
                 f'x0-intervals: {self.x0_num_intervals}, x1-intervals: {self.x1_num_intervals}\n'
                 f'elements: {self.size(0)}, edges: {self.size(1)}, vertices: {self.size(2)}')
 
-    def __repr__(self):
-        return 'TriaGrid({}, {}, {}, {})'.format(
-            self.num_intervals, self.domain,
-            self.identify_left_right, self.identify_bottom_top
-        )
-
     def size(self, codim=0):
         assert 0 <= codim <= 2, 'Invalid codimension'
         return self.__sizes[codim]

--- a/src/pymor/operators/numpy.py
+++ b/src/pymor/operators/numpy.py
@@ -392,3 +392,10 @@ class NumpyMatrixOperator(NumpyMatrixBasedOperator):
         if hasattr(self.matrix, 'factorization'):  # remove unplicklable SuperLU factorization
             del self.matrix.factorization
         return self.__dict__
+
+    def _format_repr(self, max_width):
+        if self.sparse:
+            matrix_repr = f'<{self.range.dim}x{self.source.dim} sparse, {self.matrix.nnz} nnz>'
+        else:
+            matrix_repr = f'<{self.range.dim}x{self.source.dim} dense>'
+        return super()._format_repr(max_width, override={'matrix': matrix_repr})

--- a/src/pymor/operators/numpy.py
+++ b/src/pymor/operators/numpy.py
@@ -393,9 +393,9 @@ class NumpyMatrixOperator(NumpyMatrixBasedOperator):
             del self.matrix.factorization
         return self.__dict__
 
-    def _format_repr(self, max_width):
+    def _format_repr(self, max_width, verbosity):
         if self.sparse:
             matrix_repr = f'<{self.range.dim}x{self.source.dim} sparse, {self.matrix.nnz} nnz>'
         else:
             matrix_repr = f'<{self.range.dim}x{self.source.dim} dense>'
-        return super()._format_repr(max_width, override={'matrix': matrix_repr})
+        return super()._format_repr(max_width, verbosity, override={'matrix': matrix_repr})

--- a/src/pymor/parameters/functionals.py
+++ b/src/pymor/parameters/functionals.py
@@ -115,9 +115,6 @@ class ExpressionParameterFunctional(GenericParameterFunctional):
         mapping = lambda mu: eval(code, functions, mu)
         super().__init__(mapping, parameter_type, name)
 
-    def __repr__(self):
-        return f'ExpressionParameterFunctional({self.expression}, {repr(self.parameter_type)})'
-
     def __reduce__(self):
         return (ExpressionParameterFunctional,
                 (self.expression, self.parameter_type, getattr(self, '_name', None)))

--- a/src/pymor/parameters/spaces.py
+++ b/src/pymor/parameters/spaces.py
@@ -106,6 +106,3 @@ class CubicParameterSpace(ParameterSpaceInterface):
                 + '\n'.join(('key: {:' + str(column_widths[0] + 2)
                              + '} shape: {:' + str(column_widths[1] + 2)
                              + '} range: {}').format(c1 + ',', c2 + ',', c3) for (c1, c2, c3) in rows))
-
-    def __repr__(self):
-        return f'CubicParameterSpace({repr(self.parameter_type)}, ranges={repr(self.ranges)})'

--- a/src/pymor/tools/formatrepr.py
+++ b/src/pymor/tools/formatrepr.py
@@ -1,0 +1,122 @@
+# This file is part of the pyMOR project (http://www.pymor.org).
+# Copyright 2013-2019 pyMOR developers and contributors. All rights reserved.
+# License: BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+
+
+import inspect
+import textwrap
+
+import numpy as np
+
+from pymor.core.defaults import defaults
+
+
+def register_format_handler(cls, handler):
+    _format_handlers[cls] = handler
+
+
+def _format_generic(obj, max_width, verbosity, override={}):
+    init_sig = inspect.signature(obj.__init__)
+    keys, vals = [], []
+    for arg, description in init_sig.parameters.items():
+        if verbosity < 2 and description.default == description.empty:
+            key = ''
+        else:
+            key = f'{arg}='
+        if arg == 'self':
+            continue
+        if arg in override:
+            val = override[arg]
+            if val is None:
+                continue
+            vals.append(override[arg])
+        else:
+            val = getattr(obj, arg, '??')
+            try:
+                if verbosity < 3 and val == description.default:
+                    continue
+            except ValueError:  # comparison of numpy arrays
+                pass
+            vals.append(_recurse(val, max_width - len(key) - 4, verbosity))
+        keys.append(key)
+
+    if verbosity > 0 and (sum(len(k) + len(v) + 2 for k, v in zip(keys, vals)) + len(type(obj).__name__) > max_width
+                          or any('\n' in v for v in vals)):
+        args = [f'    {k}{_indent_value(v, len(k) + 4)}' for k, v in zip(keys, vals)]
+        args = ",\n".join(args)
+        return f'''{type(obj).__name__}(
+{args})'''
+    else:
+        args = [f'{k}{v}' for k, v in zip(keys, vals)]
+        return f'{type(obj).__name__}({", ".join(args)})'
+
+
+def _format_list_tuple(val, max_width, verbosity):
+    brackets = '()' if type(val) is tuple else '[]'
+    reprs = [repr(v) for v in val]
+    if verbosity > 0 and (any('\n' in r for r in reprs) or sum(len(r) + 2 for r in reprs) + 2 > max_width):
+        reprs = ',\n '.join(_indent_value(r, 1) for r in reprs)
+        return brackets[0] + reprs + brackets[1]
+    else:
+        return brackets[0] + ', '.join(reprs) + brackets[1]
+
+
+def _format_dict(val, max_width, verbosity):
+    if not val:
+        return '{}'
+    keys, vals = zip(*val.items())
+    reprs = [repr(v) for v in vals]
+    if verbosity > 0 and (any('\n' in r for r in reprs)
+                          or sum(len(k) + len(r) + 4 for k, r in zip(keys, reprs)) + 2 > max_width):
+        reprs = ',\n '.join(_indent_value(f'{k}: {r}', 1) for k, r in zip(keys, reprs))
+        return '{' + reprs + '}'
+    else:
+        return '{' + ', '.join(f'{k}: {r}' for k, r in zip(keys, reprs)) + '}'
+
+
+def _format_array(val, max_width, verbosity):
+    r = repr(val)
+    if len(r) <= max_width * 3 and '\n' in r:
+        r_one_line = ' '.join(rr.strip() for rr in r.split('\n'))
+        if len(r_one_line) <= max_width:
+            return r_one_line
+        else:
+            return r
+    else:
+        return r
+
+
+_format_handlers = {}
+register_format_handler(list, _format_list_tuple)
+register_format_handler(tuple, _format_list_tuple)
+register_format_handler(dict, _format_dict)
+register_format_handler(np.ndarray, _format_array)
+
+
+def _recurse(obj, max_width, verbosity):
+    if hasattr(obj, '_format_repr'):
+        return obj._format_repr(max_width, verbosity)
+
+    handler = None
+    for cls in type(obj).__mro__:
+        try:
+            handler = _format_handlers[cls]
+        except KeyError:
+            pass
+
+    if handler:
+        return handler(obj, max_width, verbosity)
+    else:
+        return repr(obj)
+
+
+@defaults('max_width', 'verbosity', sid_ignore=('max_width', 'all_arg_names'))
+def format_repr(obj, max_width=120, verbosity=1):
+    return _recurse(obj, max_width, verbosity)
+
+
+def _indent_value(val, indent):
+    if '\n' in val:
+        return textwrap.indent(val, ' ' * indent)[indent:]
+    else:
+        return val

--- a/src/pymor/vectorarrays/interfaces.py
+++ b/src/pymor/vectorarrays/interfaces.py
@@ -823,9 +823,6 @@ class VectorSpaceInterface(ImmutableInterface):
     def __hash__(self):
         return hash(self.id)
 
-    def __repr__(self):
-        return f'{self.__class__.__name__}({self.id})'
-
 
 def _create_random_values(shape, distribution, random_state, **kwargs):
     if distribution not in ('uniform', 'normal'):

--- a/src/pymor/vectorarrays/numpy.py
+++ b/src/pymor/vectorarrays/numpy.py
@@ -259,8 +259,8 @@ class NumpyVectorArray(VectorArrayInterface):
     def __str__(self):
         return self._array[:self._len].__str__()
 
-    def __repr__(self):
-        return f'NumpyVectorArray({self._array[:self._len].__str__()}, {self.space})'
+    def _format_repr(self, max_width):
+        return super()._format_repr(max_width, override={'array': str(self._array[:self._len].__str__())})
 
     def __del__(self):
         self._refcount[0] -= 1
@@ -432,10 +432,6 @@ class NumpyVectorSpace(VectorSpaceInterface):
     @property
     def is_scalar(self):
         return self.dim == 1 and self.id is None
-
-    def __repr__(self):
-        return f'NumpyVectorSpace({self.dim})' if self.id is None \
-            else f'NumpyVectorSpace({self.dim}, {self.id})'
 
 
 class NumpyVectorArrayView(NumpyVectorArray):

--- a/src/pymor/vectorarrays/numpy.py
+++ b/src/pymor/vectorarrays/numpy.py
@@ -259,8 +259,8 @@ class NumpyVectorArray(VectorArrayInterface):
     def __str__(self):
         return self._array[:self._len].__str__()
 
-    def _format_repr(self, max_width):
-        return super()._format_repr(max_width, override={'array': str(self._array[:self._len].__str__())})
+    def _format_repr(self, max_width, verbosity):
+        return super()._format_repr(max_width, verbosity, override={'array': str(self._array[:self._len].__str__())})
 
     def __del__(self):
         self._refcount[0] -= 1


### PR DESCRIPTION
In view of #392, #652 and the `__repr__` implementation [here](https://github.com/pymor/pymor/pull/652/files#diff-316acb549dbd98b6e3ec9b278a6f2a06R31), I decided to try to implement a generic `__repr__` for all `BasicInterface` instances.

While the code surely needs refactoring and leave a lot of room for improvements, I quite like the result as a baseline. E.g.

```python
from pymor.basic import *
p = thermal_block_problem()
m, _ = discretize_stationary_cg(p)
print(repr(p))
print()
print(repr(m))
```

yields

```
StationaryProblem(
    RectDomain(domain=array([[0, 0], [1, 1]])),
    rhs=ConstantFunction(dim_domain=2),
    diffusion=LincombFunction(
                  [ExpressionFunction(
                       '(x[..., 0] >= ix * dx) * (x[..., 0] < (ix + 1) * dx) * (x[..., 1] >= iy * dy) * (x[..., 1] < (iy + 1) * dy) * 1.',
                       dim_domain=2,
                       parameter_type=ParameterType({}),
                       values={ix: 0, iy: 0, dx: 0.3333333333333333, dy: 0.3333333333333333},
                       name='diffusion_0_0'),
                   ExpressionFunction(
                       '(x[..., 0] >= ix * dx) * (x[..., 0] < (ix + 1) * dx) * (x[..., 1] >= iy * dy) * (x[..., 1] < (iy + 1) * dy) * 1.',
                       dim_domain=2,
                       parameter_type=ParameterType({}),
                       values={ix: 0, iy: 1, dx: 0.3333333333333333, dy: 0.3333333333333333},
                       name='diffusion_0_1'),
                   ExpressionFunction(
                       '(x[..., 0] >= ix * dx) * (x[..., 0] < (ix + 1) * dx) * (x[..., 1] >= iy * dy) * 1.',
                       dim_domain=2,
                       parameter_type=ParameterType({}),
                       values={ix: 0, iy: 2, dx: 0.3333333333333333, dy: 0.3333333333333333},
                       name='diffusion_0_2'),
                   ExpressionFunction(
                       '(x[..., 0] >= ix * dx) * (x[..., 0] < (ix + 1) * dx) * (x[..., 1] >= iy * dy) * (x[..., 1] < (iy + 1) * dy) * 1.',
                       dim_domain=2,
                       parameter_type=ParameterType({}),
                       values={ix: 1, iy: 0, dx: 0.3333333333333333, dy: 0.3333333333333333},
                       name='diffusion_1_0'),
                   ExpressionFunction(
                       '(x[..., 0] >= ix * dx) * (x[..., 0] < (ix + 1) * dx) * (x[..., 1] >= iy * dy) * (x[..., 1] < (iy + 1) * dy) * 1.',
                       dim_domain=2,
                       parameter_type=ParameterType({}),
                       values={ix: 1, iy: 1, dx: 0.3333333333333333, dy: 0.3333333333333333},
                       name='diffusion_1_1'),
                   ExpressionFunction(
                       '(x[..., 0] >= ix * dx) * (x[..., 0] < (ix + 1) * dx) * (x[..., 1] >= iy * dy) * 1.',
                       dim_domain=2,
                       parameter_type=ParameterType({}),
                       values={ix: 1, iy: 2, dx: 0.3333333333333333, dy: 0.3333333333333333},
                       name='diffusion_1_2'),
                   ExpressionFunction(
                       '(x[..., 0] >= ix * dx) * (x[..., 1] >= iy * dy) * (x[..., 1] < (iy + 1) * dy) * 1.',
                       dim_domain=2,
                       parameter_type=ParameterType({}),
                       values={ix: 2, iy: 0, dx: 0.3333333333333333, dy: 0.3333333333333333},
                       name='diffusion_2_0'),
                   ExpressionFunction(
                       '(x[..., 0] >= ix * dx) * (x[..., 1] >= iy * dy) * (x[..., 1] < (iy + 1) * dy) * 1.',
                       dim_domain=2,
                       parameter_type=ParameterType({}),
                       values={ix: 2, iy: 1, dx: 0.3333333333333333, dy: 0.3333333333333333},
                       name='diffusion_2_1'),
                   ExpressionFunction(
                       '(x[..., 0] >= ix * dx) * (x[..., 1] >= iy * dy) * 1.',
                       dim_domain=2,
                       parameter_type=ParameterType({}),
                       values={ix: 2, iy: 2, dx: 0.3333333333333333, dy: 0.3333333333333333},
                       name='diffusion_2_2')],
                  [ProjectionParameterFunctional('diffusion', (3, 3), coordinates=(2, 0), name='diffusion_0_0'),
                   ProjectionParameterFunctional('diffusion', (3, 3), coordinates=(1, 0), name='diffusion_0_1'),
                   ProjectionParameterFunctional('diffusion', (3, 3), coordinates=(0, 0), name='diffusion_0_2'),
                   ProjectionParameterFunctional('diffusion', (3, 3), coordinates=(2, 1), name='diffusion_1_0'),
                   ProjectionParameterFunctional('diffusion', (3, 3), coordinates=(1, 1), name='diffusion_1_1'),
                   ProjectionParameterFunctional('diffusion', (3, 3), coordinates=(0, 1), name='diffusion_1_2'),
                   ProjectionParameterFunctional('diffusion', (3, 3), coordinates=(2, 2), name='diffusion_2_0'),
                   ProjectionParameterFunctional('diffusion', (3, 3), coordinates=(1, 2), name='diffusion_2_1'),
                   ProjectionParameterFunctional('diffusion', (3, 3), coordinates=(0, 2), name='diffusion_2_2')],
                  name='diffusion'),
    parameter_space=CubicParameterSpace(
                        ParameterType({'diffusion': (3, 3)}),
                        minimum=0.1,
                        maximum=1,
                        ranges={diffusion: (0.1, 1)}),
    name='ThermalBlock((3, 3))')

StationaryModel(
    LincombOperator(
        (NumpyMatrixOperator(<20201x20201 sparse, 140601 nnz>, source_id='STATE', range_id='STATE', name='boundary_part'),
         NumpyMatrixOperator(<20201x20201 sparse, 140601 nnz>, source_id='STATE', range_id='STATE', name='diffusion_0'),
         NumpyMatrixOperator(<20201x20201 sparse, 140601 nnz>, source_id='STATE', range_id='STATE', name='diffusion_1'),
         NumpyMatrixOperator(<20201x20201 sparse, 140601 nnz>, source_id='STATE', range_id='STATE', name='diffusion_2'),
         NumpyMatrixOperator(<20201x20201 sparse, 140601 nnz>, source_id='STATE', range_id='STATE', name='diffusion_3'),
         NumpyMatrixOperator(<20201x20201 sparse, 140601 nnz>, source_id='STATE', range_id='STATE', name='diffusion_4'),
         NumpyMatrixOperator(<20201x20201 sparse, 140601 nnz>, source_id='STATE', range_id='STATE', name='diffusion_5'),
         NumpyMatrixOperator(<20201x20201 sparse, 140601 nnz>, source_id='STATE', range_id='STATE', name='diffusion_6'),
         NumpyMatrixOperator(<20201x20201 sparse, 140601 nnz>, source_id='STATE', range_id='STATE', name='diffusion_7'),
         NumpyMatrixOperator(<20201x20201 sparse, 140601 nnz>, source_id='STATE', range_id='STATE', name='diffusion_8')),
        (1.0,
         ProjectionParameterFunctional('diffusion', (3, 3), coordinates=(2, 0), name='diffusion_0_0'),
         ProjectionParameterFunctional('diffusion', (3, 3), coordinates=(1, 0), name='diffusion_0_1'),
         ProjectionParameterFunctional('diffusion', (3, 3), coordinates=(0, 0), name='diffusion_0_2'),
         ProjectionParameterFunctional('diffusion', (3, 3), coordinates=(2, 1), name='diffusion_1_0'),
         ProjectionParameterFunctional('diffusion', (3, 3), coordinates=(1, 1), name='diffusion_1_1'),
         ProjectionParameterFunctional('diffusion', (3, 3), coordinates=(0, 1), name='diffusion_1_2'),
         ProjectionParameterFunctional('diffusion', (3, 3), coordinates=(2, 2), name='diffusion_2_0'),
         ProjectionParameterFunctional('diffusion', (3, 3), coordinates=(1, 2), name='diffusion_2_1'),
         ProjectionParameterFunctional('diffusion', (3, 3), coordinates=(0, 2), name='diffusion_2_2')),
        name='ellipticOperator'),
    NumpyMatrixOperator(<20201x1 dense>, range_id='STATE', name='L2ProductFunctionalP1'),
    outputs={},
    products={h1: NumpyMatrixOperator(<20201x20201 sparse, 140601 nnz>, source_id='STATE', range_id='STATE'),
              h1_semi: NumpyMatrixOperator(<20201x20201 sparse, 140601 nnz>, source_id='STATE', range_id='STATE', name='h1_semi'),
              l2: NumpyMatrixOperator(<20201x20201 sparse, 140601 nnz>, source_id='STATE', range_id='STATE', name='l2'),
              h1_0: NumpyMatrixOperator(<20201x20201 sparse, 137417 nnz>, source_id='STATE', range_id='STATE'),
              h1_0_semi: NumpyMatrixOperator(<20201x20201 sparse, 140601 nnz>, source_id='STATE', range_id='STATE', name='h1_0_semi'),
              l2_0: NumpyMatrixOperator(<20201x20201 sparse, 140601 nnz>, source_id='STATE', range_id='STATE', name='l2_0')},
    parameter_space=CubicParameterSpace(
                        ParameterType({'diffusion': (3, 3)}),
                        minimum=0.1,
                        maximum=1,
                        ranges={diffusion: (0.1, 1)}),
    visualizer=PatchVisualizer(
                   TriaGrid(num_intervals=(100, 100), domain=array([[0, 0], [1, 1]])),
                   bounding_box=array([[0, 0], [1, 1]])),
    name='ThermalBlock((3, 3))_CG')

```

@pymor/pymor-devs, what do you think?