### PR TITLE
SVD for vectorarrays using Gram-Schmidt

### DIFF
--- a/src/pymor/algorithms/hapod.py
+++ b/src/pymor/algorithms/hapod.py
@@ -62,7 +62,7 @@ class DistHAPODTree(Tree):
 def default_pod_method(U, eps, is_root_node, product):
     return pod(U, atol=0., rtol=0.,
                l2_err=eps, product=product,
-               orthonormalize=is_root_node, check=False)
+               orth_tol=None if is_root_node else np.inf)
 
 
 def hapod(tree, snapshots, local_eps, product=None, pod_method=default_pod_method,

--- a/src/pymor/algorithms/pod.py
+++ b/src/pymor/algorithms/pod.py
@@ -14,7 +14,7 @@ from pymor.vectorarrays.interfaces import VectorArrayInterface
 
 @defaults('rtol', 'atol', 'l2_err', 'method', 'orth_tol')
 def pod(A, product=None, modes=None, rtol=4e-8, atol=0., l2_err=0.,
-        method='method_of_snapshots', orth_tol=np.inf):
+        method='method_of_snapshots', orth_tol=1e-10):
     """Proper orthogonal decomposition of `A`.
 
     Viewing the |VectorArray| `A` as a `A.dim` x `len(A)` matrix,

--- a/src/pymor/algorithms/pod.py
+++ b/src/pymor/algorithms/pod.py
@@ -85,6 +85,6 @@ def pod(A, product=None, modes=None, rtol=4e-8, atol=0., l2_err=0.,
         err = np.max(np.abs(POD.inner(POD, product) - np.eye(len(POD))))
         if err >= orth_tol:
             logger.info('Reorthogonalizing POD modes ...')
-            gram_schmidt(POD, product=product, copy=False, check=False)
+            gram_schmidt(POD, product=product, copy=False)
 
     return POD, SVALS

--- a/src/pymor/algorithms/pod.py
+++ b/src/pymor/algorithms/pod.py
@@ -80,7 +80,7 @@ def pod(A, product=None, modes=None, rtol=4e-8, atol=0., l2_err=0.,
     with logger.block('Computing SVD ...'):
         POD, SVALS, _ = svd_va(A, product=product, modes=modes, rtol=rtol, atol=atol, l2_err=l2_err)
 
-    if np.isfinite(orth_tol):
+    if POD.dim > 0 and len(POD) > 0 and np.isfinite(orth_tol):
         logger.info('Checking orthonormality ...')
         err = np.max(np.abs(POD.inner(POD, product) - np.eye(len(POD))))
         if err >= orth_tol:

--- a/src/pymor/algorithms/pod.py
+++ b/src/pymor/algorithms/pod.py
@@ -19,11 +19,12 @@ def pod(A, product=None, modes=None, rtol=4e-8, atol=0., l2_err=0.,
         method='method_of_snapshots', orth_tol=1e-10):
     """Proper orthogonal decomposition of `A`.
 
-    Viewing the |VectorArray| `A` as a `A.dim` x `len(A)` matrix,
-    the return value of this method is the |VectorArray| of left-singular
-    vectors of the singular value decomposition of `A`, where the inner product
-    on R^(`dim(A)`) is given by `product` and the inner product on R^(`len(A)`)
-    is the Euclidean inner product.
+    Viewing the |VectorArray| `A` as a `A.dim` x `len(A)` matrix, the
+    return values of this method are the |VectorArray| of left singular
+    vectors and a |NumPy array| of singular values of the singular value
+    decomposition of `A`, where the inner product on R^(`dim(A)`) is
+    given by `product` and the inner product on R^(`len(A)`) is the
+    Euclidean inner product.
 
     Parameters
     ----------
@@ -32,16 +33,17 @@ def pod(A, product=None, modes=None, rtol=4e-8, atol=0., l2_err=0.,
     product
         Inner product |Operator| w.r.t. which the POD is computed.
     modes
-        If not `None`, only the first `modes` POD modes (singular vectors) are
-        returned.
+        If not `None`, at most the first `modes` POD modes (singular
+        vectors) are returned.
     rtol
-        Singular values smaller than this value multiplied by the largest singular
-        value are ignored.
+        Singular values smaller than this value multiplied by the
+        largest singular value are ignored.
     atol
         Singular values smaller than this value are ignored.
     l2_err
-        Do not return more modes than needed to bound the l2-approximation
-        error by this value. I.e. the number of returned modes is at most ::
+        Do not return more modes than needed to bound the
+        l2-approximation error by this value. I.e. the number of
+        returned modes is at most ::
 
             argmin_N { sum_{n=N+1}^{infty} s_n^2 <= l2_err^2 }
 
@@ -50,15 +52,15 @@ def pod(A, product=None, modes=None, rtol=4e-8, atol=0., l2_err=0.,
         Which SVD method from :mod:`~pymor.algorithms.svd_va` to use
         (`'method_of_snapshots'` or `'qr_svd'`).
     orth_tol
-        POD modes are reorthogonalized if the orthogonality error is above this
-        value.
+        POD modes are reorthogonalized if the orthogonality error is
+        above this value.
 
     Returns
     -------
     POD
         |VectorArray| of POD modes.
     SVALS
-        Sequence of singular values.
+        One-dimensional |NumPy array| of singular values.
     """
 
     if isinstance(product, Number):

--- a/src/pymor/algorithms/pod.py
+++ b/src/pymor/algorithms/pod.py
@@ -14,9 +14,9 @@ from pymor.tools.floatcmp import float_cmp_all
 from pymor.vectorarrays.interfaces import VectorArrayInterface
 
 
-@defaults('rtol', 'atol', 'l2_err', 'symmetrize', 'orthonormalize', 'check', 'check_tol')
+@defaults('rtol', 'atol', 'l2_err', 'orthonormalize', 'check', 'check_tol')
 def pod(A, modes=None, product=None, rtol=4e-8, atol=0., l2_err=0.,
-        symmetrize=False, orthonormalize=True, check=True, check_tol=1e-10):
+        orthonormalize=True, check=True, check_tol=1e-10):
     """Proper orthogonal decomposition of `A`.
 
     Viewing the |VectorArray| `A` as a `A.dim` x `len(A)` matrix,
@@ -46,8 +46,6 @@ def pod(A, modes=None, product=None, rtol=4e-8, atol=0., l2_err=0.,
             argmin_N { sum_{n=N+1}^{infty} s_n^2 <= l2_err^2 }
 
         where `s_n` denotes the n-th singular value.
-    symmetrize
-        If `True`, symmetrize the Gramian again before proceeding.
     orthonormalize
         If `True`, orthonormalize the computed POD modes again using
         the :func:`~pymor.algorithms.gram_schmidt.gram_schmidt` algorithm.
@@ -73,10 +71,6 @@ def pod(A, modes=None, product=None, rtol=4e-8, atol=0., l2_err=0.,
 
     with logger.block(f'Computing Gramian ({len(A)} vectors) ...'):
         B = A.gramian(product)
-
-        if symmetrize:     # according to rbmatlab this is necessary due to rounding
-            B = B + B.T
-            B *= 0.5
 
     with logger.block('Computing eigenvalue decomposition ...'):
         eigvals = None if (modes is None or l2_err > 0.) else (len(B) - modes, len(B) - 1)

--- a/src/pymor/algorithms/pod.py
+++ b/src/pymor/algorithms/pod.py
@@ -2,6 +2,8 @@
 # Copyright 2013-2019 pyMOR developers and contributors. All rights reserved.
 # License: BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
 
+from numbers import Number
+
 import numpy as np
 
 from pymor.algorithms.gram_schmidt import gram_schmidt
@@ -58,6 +60,15 @@ def pod(A, product=None, modes=None, rtol=4e-8, atol=0., l2_err=0.,
     SVALS
         Sequence of singular values.
     """
+
+    if isinstance(product, Number):
+        # old pod signature
+        assert modes is None
+        modes, product = product, None
+        import warnings
+        warnings.warn("pod signature has changed. Provide 'modes' as keyword argument.",
+                      DeprecationWarning, stacklevel=3)
+
     assert isinstance(A, VectorArrayInterface)
     assert product is None or isinstance(product, OperatorInterface)
     assert modes is None or modes <= len(A)

--- a/src/pymor/algorithms/svd_va.py
+++ b/src/pymor/algorithms/svd_va.py
@@ -1,0 +1,212 @@
+# This file is part of the pyMOR project (http://www.pymor.org).
+# Copyright 2013-2019 pyMOR developers and contributors. All rights reserved.
+# License: BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+
+"""Module for SVD method of operators represented by |VectorArrays|."""
+
+import numpy as np
+import scipy.linalg as spla
+
+from pymor.algorithms.gram_schmidt import gram_schmidt
+from pymor.core.defaults import defaults
+from pymor.core.exceptions import AccuracyError
+from pymor.core.logger import getLogger
+from pymor.operators.interfaces import OperatorInterface
+from pymor.vectorarrays.interfaces import VectorArrayInterface
+
+
+@defaults('rtol', 'atol', 'l2_err', 'orthonormalize', 'check', 'check_tol')
+def method_of_snapshots(A, product=None, modes=None, rtol=4e-8, atol=0., l2_err=0.,
+                        orthonormalize=True, check=True, check_tol=1e-10):
+    """Method of snapshots.
+
+    Viewing the |VectorArray| `A` as a `A.dim` x `len(A)` matrix,
+    the return value of this method is the |VectorArray| of left-singular
+    vectors of the singular value decomposition of `A`, where the inner product
+    on R^(`dim(A)`) is given by `product` and the inner product on R^(`len(A)`)
+    is the Euclidean inner product.
+
+    Parameters
+    ----------
+    A
+        The |VectorArray| for which the POD is to be computed.
+    product
+        Inner product |Operator| w.r.t. which the POD is computed.
+    modes
+        If not `None`, only the first `modes` POD modes (singular vectors) are
+        returned.
+    rtol
+        Singular values smaller than this value multiplied by the largest singular
+        value are ignored.
+    atol
+        Singular values smaller than this value are ignored.
+    l2_err
+        Do not return more modes than needed to bound the l2-approximation
+        error by this value. I.e. the number of returned modes is at most ::
+
+            argmin_N { sum_{n=N+1}^{infty} s_n^2 <= l2_err^2 }
+
+        where `s_n` denotes the n-th singular value.
+    orthonormalize
+        If `True`, orthonormalize the computed POD modes again using
+        the :func:`~pymor.algorithms.gram_schmidt.gram_schmidt` algorithm.
+        If `False`, do not orthonormalize.
+    check
+        If `True`, check the computed POD modes for orthonormality.
+    check_tol
+        Tolerance for the orthonormality check.
+
+    Returns
+    -------
+    U
+        |VectorArray| of left singular vectors.
+    s
+        Sequence of singular values.
+    Vh
+        |NumPy array| of right singular vectors.
+    """
+    assert isinstance(A, VectorArrayInterface)
+    assert product is None or isinstance(product, OperatorInterface)
+    assert modes is None or modes <= len(A)
+
+    if A.dim == 0 or len(A) == 0:
+        return A.space.empty(), np.array([]), np.zeros((0, len(A)))
+
+    logger = getLogger('pymor.algorithms.svd_va.method_of_snapshots')
+
+    with logger.block(f'Computing Gramian ({len(A)} vectors) ...'):
+        B = A.gramian(product)
+
+    with logger.block('Computing eigenvalue decomposition ...'):
+        eigvals = (None
+                   if modes is None or l2_err > 0.
+                   else (len(B) - modes, len(B) - 1))
+
+        evals, V = spla.eigh(B, overwrite_a=True, turbo=True, eigvals=eigvals)
+        evals = evals[::-1]
+        V = V.T[::-1, :]
+
+        tol = max(rtol ** 2 * evals[0], atol ** 2)
+        above_tol = np.where(evals >= tol)[0]
+        if len(above_tol) == 0:
+            return A.space.empty(), np.array([]), np.zeros((0, len(A)))
+        last_above_tol = above_tol[-1]
+
+        errs = np.concatenate((np.cumsum(evals[::-1])[::-1], [0.]))
+        below_err = np.where(errs <= l2_err**2)[0]
+        first_below_err = below_err[0]
+
+        selected_modes = min(first_below_err, last_above_tol + 1)
+        if modes is not None:
+            selected_modes = min(selected_modes, modes)
+
+        s = np.sqrt(evals[:selected_modes])
+        V = V[:selected_modes]
+        Vh = V.conj()
+
+    with logger.block(f'Computing left-singular vectors ({len(V)} vectors) ...'):
+        U = A.lincomb(V / s[:, np.newaxis])
+
+    if orthonormalize:
+        with logger.block('Re-orthonormalizing left singular vectors ...'):
+            gram_schmidt(U, product=product, copy=False, check=False)
+        if len(U) < len(s):
+            raise AccuracyError('additional orthonormalization removed basis vectors')
+
+    if check:
+        logger.info('Checking orthonormality ...')
+        err = np.max(np.abs(U.inner(U, product) - np.eye(len(U))))
+        if err >= check_tol:
+            raise AccuracyError(f'result not orthogonal (max err={err})')
+
+    return U, s, Vh
+
+
+@defaults('rtol', 'atol', 'l2_err', 'check', 'check_tol')
+def qr_svd(A, product=None, modes=None, rtol=4e-8, atol=0., l2_err=0., check=True, check_tol=1e-10):
+    """SVD of a |VectorArray| using Gram-Schmidt process.
+
+    If `product` is given, left singular vectors will be orthogonal with
+    respect to it. Otherwise, the Euclidean inner product is used.
+
+    Parameters
+    ----------
+    A
+        The |VectorArray| for which the SVD is to be computed.
+        The vectors are interpreted as columns in a matrix.
+    product
+        Inner product |Operator| w.r.t. which the left singular vectors
+        are computed.
+    modes
+        If not `None`, only the first `modes` POD modes (singular vectors) are
+        returned.
+    rtol
+        Singular values smaller than this value multiplied by the largest singular
+        value are ignored.
+    atol
+        Singular values smaller than this value are ignored.
+    l2_err
+        Do not return more modes than needed to bound the l2-approximation
+        error by this value. I.e. the number of returned modes is at most ::
+
+            argmin_N { sum_{n=N+1}^{infty} s_n^2 <= l2_err^2 }
+
+        where `s_n` denotes the n-th singular value.
+    check
+        If `True`, check the computed POD modes for orthonormality.
+    check_tol
+        Tolerance for the orthonormality check.
+
+    Returns
+    -------
+    U
+        |VectorArray| of left singular vectors.
+    s
+        Sequence of singular values.
+    Vh
+        |NumPy array| of right singular vectors.
+    """
+    assert isinstance(A, VectorArrayInterface)
+    assert product is None or isinstance(product, OperatorInterface)
+    assert modes is None or modes <= len(A)
+
+    if A.dim == 0 or len(A) == 0:
+        return A.space.empty(), np.array([]), np.zeros((0, len(A)))
+
+    logger = getLogger('pymor.algorithms.svd_va.qr_svd')
+
+    with logger.block('Computing QR decomposition ...'):
+        Q, R = gram_schmidt(A, product=product, return_R=True, check=False)
+
+    with logger.block('Computing SVD of R ...'):
+        U2, s, Vh = spla.svd(R, lapack_driver='gesvd')
+
+    with logger.block('Choosing the number of modes ...'):
+        tol = max(rtol * s[0], atol)
+        above_tol = np.where(s >= tol)[0]
+        if len(above_tol) == 0:
+            return A.space.empty(), np.array([]), np.zeros((0, len(A)))
+        last_above_tol = above_tol[-1]
+
+        errs = np.concatenate((np.cumsum(s[::-1] ** 2)[::-1], [0.]))
+        below_err = np.where(errs <= l2_err**2)[0]
+        first_below_err = below_err[0]
+
+        selected_modes = min(first_below_err, last_above_tol + 1)
+        if modes is not None:
+            selected_modes = min(selected_modes, modes)
+
+        U2 = U2[:, :selected_modes]
+        s = s[:selected_modes]
+        Vh = Vh[:selected_modes]
+
+    with logger.block(f'Computing left singular vectors ({selected_modes} modes) ...'):
+        U = Q.lincomb(U2.T)
+
+    if check:
+        logger.info('Checking orthonormality ...')
+        err = np.max(np.abs(U.inner(U, product) - np.eye(len(U))))
+        if err >= check_tol:
+            raise AccuracyError(f'result not orthogonal (max err={err})')
+
+    return U, s, Vh

--- a/src/pymor/algorithms/svd_va.py
+++ b/src/pymor/algorithms/svd_va.py
@@ -9,15 +9,13 @@ import scipy.linalg as spla
 
 from pymor.algorithms.gram_schmidt import gram_schmidt
 from pymor.core.defaults import defaults
-from pymor.core.exceptions import AccuracyError
 from pymor.core.logger import getLogger
 from pymor.operators.interfaces import OperatorInterface
 from pymor.vectorarrays.interfaces import VectorArrayInterface
 
 
-@defaults('rtol', 'atol', 'l2_err', 'orthonormalize', 'check', 'check_tol')
-def method_of_snapshots(A, product=None, modes=None, rtol=4e-8, atol=0., l2_err=0.,
-                        orthonormalize=True, check=True, check_tol=1e-10):
+@defaults('rtol', 'atol', 'l2_err')
+def method_of_snapshots(A, product=None, modes=None, rtol=4e-8, atol=0., l2_err=0.):
     """Method of snapshots.
 
     Viewing the |VectorArray| `A` as a `A.dim` x `len(A)` matrix,
@@ -47,14 +45,6 @@ def method_of_snapshots(A, product=None, modes=None, rtol=4e-8, atol=0., l2_err=
             argmin_N { sum_{n=N+1}^{infty} s_n^2 <= l2_err^2 }
 
         where `s_n` denotes the n-th singular value.
-    orthonormalize
-        If `True`, orthonormalize the computed POD modes again using
-        the :func:`~pymor.algorithms.gram_schmidt.gram_schmidt` algorithm.
-        If `False`, do not orthonormalize.
-    check
-        If `True`, check the computed POD modes for orthonormality.
-    check_tol
-        Tolerance for the orthonormality check.
 
     Returns
     -------
@@ -107,23 +97,11 @@ def method_of_snapshots(A, product=None, modes=None, rtol=4e-8, atol=0., l2_err=
     with logger.block(f'Computing left-singular vectors ({len(V)} vectors) ...'):
         U = A.lincomb(V / s[:, np.newaxis])
 
-    if orthonormalize:
-        with logger.block('Re-orthonormalizing left singular vectors ...'):
-            gram_schmidt(U, product=product, copy=False, check=False)
-        if len(U) < len(s):
-            raise AccuracyError('additional orthonormalization removed basis vectors')
-
-    if check:
-        logger.info('Checking orthonormality ...')
-        err = np.max(np.abs(U.inner(U, product) - np.eye(len(U))))
-        if err >= check_tol:
-            raise AccuracyError(f'result not orthogonal (max err={err})')
-
     return U, s, Vh
 
 
-@defaults('rtol', 'atol', 'l2_err', 'check', 'check_tol')
-def qr_svd(A, product=None, modes=None, rtol=4e-8, atol=0., l2_err=0., check=True, check_tol=1e-10):
+@defaults('rtol', 'atol', 'l2_err')
+def qr_svd(A, product=None, modes=None, rtol=4e-8, atol=0., l2_err=0.):
     """SVD of a |VectorArray| using Gram-Schmidt process.
 
     If `product` is given, left singular vectors will be orthogonal with
@@ -152,10 +130,6 @@ def qr_svd(A, product=None, modes=None, rtol=4e-8, atol=0., l2_err=0., check=Tru
             argmin_N { sum_{n=N+1}^{infty} s_n^2 <= l2_err^2 }
 
         where `s_n` denotes the n-th singular value.
-    check
-        If `True`, check the computed POD modes for orthonormality.
-    check_tol
-        Tolerance for the orthonormality check.
 
     Returns
     -------
@@ -202,11 +176,5 @@ def qr_svd(A, product=None, modes=None, rtol=4e-8, atol=0., l2_err=0., check=Tru
 
     with logger.block(f'Computing left singular vectors ({selected_modes} modes) ...'):
         U = Q.lincomb(U2.T)
-
-    if check:
-        logger.info('Checking orthonormality ...')
-        err = np.max(np.abs(U.inner(U, product) - np.eye(len(U))))
-        if err >= check_tol:
-            raise AccuracyError(f'result not orthogonal (max err={err})')
 
     return U, s, Vh

--- a/src/pymor/algorithms/svd_va.py
+++ b/src/pymor/algorithms/svd_va.py
@@ -16,31 +16,32 @@ from pymor.vectorarrays.interfaces import VectorArrayInterface
 
 @defaults('rtol', 'atol', 'l2_err')
 def method_of_snapshots(A, product=None, modes=None, rtol=4e-8, atol=0., l2_err=0.):
-    """Method of snapshots.
+    """SVD of a |VectorArray| using the method of snapshots.
 
-    Viewing the |VectorArray| `A` as a `A.dim` x `len(A)` matrix,
-    the return value of this method is the |VectorArray| of left-singular
-    vectors of the singular value decomposition of `A`, where the inner product
-    on R^(`dim(A)`) is given by `product` and the inner product on R^(`len(A)`)
-    is the Euclidean inner product.
+    Viewing the |VectorArray| `A` as a `A.dim` x `len(A)` matrix, the
+    return value of this method is the singular value decomposition of
+    `A`, where the inner product on R^(`dim(A)`) is given by `product`
+    and the inner product on R^(`len(A)`) is the Euclidean inner
+    product.
 
     Parameters
     ----------
     A
-        The |VectorArray| for which the POD is to be computed.
+        The |VectorArray| for which the SVD is to be computed.
     product
-        Inner product |Operator| w.r.t. which the POD is computed.
+        Inner product |Operator| w.r.t. which the SVD is computed.
     modes
-        If not `None`, only the first `modes` POD modes (singular vectors) are
-        returned.
+        If not `None`, at most the first `modes` singular values and
+        vectors are returned.
     rtol
-        Singular values smaller than this value multiplied by the largest singular
-        value are ignored.
+        Singular values smaller than this value multiplied by the
+        largest singular value are ignored.
     atol
         Singular values smaller than this value are ignored.
     l2_err
-        Do not return more modes than needed to bound the l2-approximation
-        error by this value. I.e. the number of returned modes is at most ::
+        Do not return more modes than needed to bound the
+        l2-approximation error by this value. I.e. the number of
+        returned modes is at most ::
 
             argmin_N { sum_{n=N+1}^{infty} s_n^2 <= l2_err^2 }
 
@@ -51,7 +52,7 @@ def method_of_snapshots(A, product=None, modes=None, rtol=4e-8, atol=0., l2_err=
     U
         |VectorArray| of left singular vectors.
     s
-        Sequence of singular values.
+        One-dimensional |NumPy array| of singular values.
     Vh
         |NumPy array| of right singular vectors.
     """
@@ -102,30 +103,33 @@ def method_of_snapshots(A, product=None, modes=None, rtol=4e-8, atol=0., l2_err=
 
 @defaults('rtol', 'atol', 'l2_err')
 def qr_svd(A, product=None, modes=None, rtol=4e-8, atol=0., l2_err=0.):
-    """SVD of a |VectorArray| using Gram-Schmidt process.
+    """SVD of a |VectorArray| using Gram-Schmidt orthogonalization.
 
-    If `product` is given, left singular vectors will be orthogonal with
-    respect to it. Otherwise, the Euclidean inner product is used.
+    Viewing the |VectorArray| `A` as a `A.dim` x `len(A)` matrix, the
+    return value of this method is the singular value decomposition of
+    `A`, where the inner product on R^(`dim(A)`) is given by `product`
+    and the inner product on R^(`len(A)`) is the Euclidean inner
+    product.
 
     Parameters
     ----------
     A
         The |VectorArray| for which the SVD is to be computed.
-        The vectors are interpreted as columns in a matrix.
     product
         Inner product |Operator| w.r.t. which the left singular vectors
         are computed.
     modes
-        If not `None`, only the first `modes` POD modes (singular vectors) are
-        returned.
+        If not `None`, at most the first `modes` singular values and
+        vectors are returned.
     rtol
-        Singular values smaller than this value multiplied by the largest singular
-        value are ignored.
+        Singular values smaller than this value multiplied by the
+        largest singular value are ignored.
     atol
         Singular values smaller than this value are ignored.
     l2_err
-        Do not return more modes than needed to bound the l2-approximation
-        error by this value. I.e. the number of returned modes is at most ::
+        Do not return more modes than needed to bound the
+        l2-approximation error by this value. I.e. the number of
+        returned modes is at most ::
 
             argmin_N { sum_{n=N+1}^{infty} s_n^2 <= l2_err^2 }
 
@@ -136,7 +140,7 @@ def qr_svd(A, product=None, modes=None, rtol=4e-8, atol=0., l2_err=0.):
     U
         |VectorArray| of left singular vectors.
     s
-        Sequence of singular values.
+        One-dimensional |NumPy array| of singular values.
     Vh
         |NumPy array| of right singular vectors.
     """

--- a/src/pymor/algorithms/svd_va.py
+++ b/src/pymor/algorithms/svd_va.py
@@ -24,6 +24,11 @@ def method_of_snapshots(A, product=None, modes=None, rtol=4e-8, atol=0., l2_err=
     and the inner product on R^(`len(A)`) is the Euclidean inner
     product.
 
+    .. warning::
+
+        The left singular vectors may not be numerically orthonormal for
+        ill-conditioned `A`.
+
     Parameters
     ----------
     A

--- a/src/pymor/reductors/basic.py
+++ b/src/pymor/reductors/basic.py
@@ -472,7 +472,7 @@ def extend_basis(U, basis, product=None, method='gram_schmidt', pod_modes=1, pod
     elif method == 'pod':
         U_proj_err = U - basis.lincomb(U.inner(basis, product))
 
-        basis.append(pod(U_proj_err, modes=pod_modes, product=product, orthonormalize=False)[0])
+        basis.append(pod(U_proj_err, modes=pod_modes, product=product, orth_tol=np.inf)[0])
 
         if pod_orthonormalize:
             gram_schmidt(basis, offset=basis_length, product=product, copy=False, check=False)

--- a/src/pymordemos/hapod.py
+++ b/src/pymordemos/hapod.py
@@ -66,7 +66,7 @@ def hapod_demo(args):
         U.append(m.solve(mu))
 
     tic = time()
-    pod_modes = pod(U, l2_err=tol * np.sqrt(len(U)), product=m.l2_product, check=False)[0]
+    pod_modes = pod(U, l2_err=tol * np.sqrt(len(U)), product=m.l2_product)[0]
     pod_time = time() - tic
 
     tic = time()

--- a/src/pymordemos/minimal_cpp_demo/demo.py
+++ b/src/pymordemos/minimal_cpp_demo/demo.py
@@ -58,7 +58,7 @@ for mu in fom.parameter_space.sample_uniformly(2):
     snapshots.append(fom.solve(mu))
 
 # apply POD
-reduced_basis = pod(snapshots, 4)[0]
+reduced_basis = pod(snapshots, modes=4)[0]
 
 # reduce the model
 reductor = InstationaryRBReductor(fom, reduced_basis, check_orthonormality=True)

--- a/src/pymortests/algorithms/pod.py
+++ b/src/pymortests/algorithms/pod.py
@@ -1,0 +1,39 @@
+# This file is part of the pyMOR project (http://www.pymor.org).
+# Copyright 2013-2019 pyMOR developers and contributors. All rights reserved.
+# License: BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+
+import numpy as np
+import pytest
+
+from pymor.algorithms.basic import almost_equal
+from pymor.algorithms.pod import pod
+from pymortests.fixtures.operator import operator_with_arrays_and_products
+from pymortests.fixtures.vectorarray import vector_array, vector_array_without_reserve
+
+methods = ['method_of_snapshots', 'qr_svd']
+
+
+@pytest.mark.parametrize('method', methods)
+def test_pod(vector_array, method):
+    A = vector_array
+    print(type(A))
+    print(A.dim, len(A))
+
+    B = A.copy()
+    U, s = pod(A, method=method)
+    assert np.all(almost_equal(A, B))
+    assert len(U) == len(s)
+    assert np.allclose(U.gramian(), np.eye(len(s)))
+
+
+@pytest.mark.parametrize('method', methods)
+def test_pod_with_product(operator_with_arrays_and_products, method):
+    _, _, A, _, p, _ = operator_with_arrays_and_products
+    print(type(A))
+    print(A.dim, len(A))
+
+    B = A.copy()
+    U, s = pod(A, product=p, method=method)
+    assert np.all(almost_equal(A, B))
+    assert len(U) == len(s)
+    assert np.allclose(U.gramian(p), np.eye(len(s)))

--- a/src/pymortests/algorithms/svd_va.py
+++ b/src/pymortests/algorithms/svd_va.py
@@ -1,0 +1,49 @@
+# This file is part of the pyMOR project (http://www.pymor.org).
+# Copyright 2013-2019 pyMOR developers and contributors. All rights reserved.
+# License: BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+
+import numpy as np
+import pytest
+
+from pymor.algorithms.basic import almost_equal
+from pymor.algorithms.svd_va import method_of_snapshots, qr_svd
+from pymortests.fixtures.operator import operator_with_arrays_and_products
+from pymortests.fixtures.vectorarray import vector_array, vector_array_without_reserve
+
+methods = [method_of_snapshots, qr_svd]
+
+
+@pytest.mark.parametrize('method', methods)
+def test_method_of_snapshots(vector_array, method):
+    A = vector_array
+    print(type(A))
+    print(A.dim, len(A))
+
+    B = A.copy()
+    U, s, Vh = method(A)
+    assert np.all(almost_equal(A, B))
+    assert len(U) == len(s) == Vh.shape[0]
+    assert Vh.shape[1] == len(A)
+    assert np.allclose(U.dot(U), np.eye(len(s)))
+    assert np.allclose(Vh @ Vh.T.conj(), np.eye(len(s)))
+    U.scal(s)
+    UsVh = U.lincomb(Vh.T)
+    assert np.all(almost_equal(A, UsVh, rtol=4e-8))
+
+
+@pytest.mark.parametrize('method', methods)
+def test_method_of_snapshots_with_product(operator_with_arrays_and_products, method):
+    _, _, A, _, p, _ = operator_with_arrays_and_products
+    print(type(A))
+    print(A.dim, len(A))
+
+    B = A.copy()
+    U, s, Vh = method(A, product=p)
+    assert np.all(almost_equal(A, B))
+    assert len(U) == len(s) == Vh.shape[0]
+    assert Vh.shape[1] == len(A)
+    assert np.allclose(p.apply2(U, U), np.eye(len(s)))
+    assert np.allclose(Vh @ Vh.T.conj(), np.eye(len(s)))
+    U.scal(s)
+    UsVh = U.lincomb(Vh.T)
+    assert np.all(almost_equal(A, UsVh, rtol=4e-8))

--- a/src/pymortests/algorithms/svd_va.py
+++ b/src/pymortests/algorithms/svd_va.py
@@ -24,7 +24,6 @@ def test_method_of_snapshots(vector_array, method):
     assert np.all(almost_equal(A, B))
     assert len(U) == len(s) == Vh.shape[0]
     assert Vh.shape[1] == len(A)
-    assert np.allclose(U.dot(U), np.eye(len(s)))
     assert np.allclose(Vh @ Vh.T.conj(), np.eye(len(s)))
     U.scal(s)
     UsVh = U.lincomb(Vh.T)
@@ -42,7 +41,6 @@ def test_method_of_snapshots_with_product(operator_with_arrays_and_products, met
     assert np.all(almost_equal(A, B))
     assert len(U) == len(s) == Vh.shape[0]
     assert Vh.shape[1] == len(A)
-    assert np.allclose(p.apply2(U, U), np.eye(len(s)))
     assert np.allclose(Vh @ Vh.T.conj(), np.eye(len(s)))
     U.scal(s)
     UsVh = U.lincomb(Vh.T)


### PR DESCRIPTION
I've added a basic implementation in `algorithms.qr_svd` and a notebook comparing it to `algorithms.pod.pod` which is based on the eigenvalue decomposition of the Gramian matrix.

`pod` is less accurate for small singular values, which is not unexpected, since the eigenvalue decomposition tries to compute the squares of the singular values. I'm not sure why `pod` doesn't try to compute all singular values with `rtol=0`.

I'm also not sure if "Gram-Schmidt + SVD" is the best possible approach. In particular, section 2 of [1] talks about how QR with column pivoting is a good preconditioner for Jacobi SVD. Besides the issue that Jacobi SVD is not yet an option in `scipy.linalg.svd`, I don't see how to compute QR with column pivoting using pyMOR's interfaces.

@pymor/pymor-devs Thoughts?

[1] New Fast and Accurate Jacobi SVD Algorithm. I ([doi](https://doi.org/10.1137/050639193))