### PR TITLE
Add notion of output to ModelInterface

### DIFF
--- a/src/pymor/analyticalproblems/elliptic.py
+++ b/src/pymor/analyticalproblems/elliptic.py
@@ -45,8 +45,8 @@ class StationaryProblem(ImmutableInterface):
         |Function| providing the Neumann boundary values.
     robin_data
         Tuple of two |Functions| providing the Robin parameter and boundary values.
-    functionals
-        `Dict` of additional functionals to assemble. Each value must be a tuple
+    outputs
+        Tuple of additional output functionals to assemble. Each value must be a tuple
         of the form `(functional_type, data)` where `functional_type` is a string
         defining the type of functional to assemble and `data` is a |Function| holding
         the corresponding coefficient function. Currently implemented `functional_types`
@@ -74,14 +74,14 @@ class StationaryProblem(ImmutableInterface):
     dirichlet_data
     neumann_data
     robin_data
-    functionals
+    outputs
     """
 
     def __init__(self, domain,
                  rhs=None, diffusion=None,
                  advection=None, nonlinear_advection=None, nonlinear_advection_derivative=None,
                  reaction=None, nonlinear_reaction=None, nonlinear_reaction_derivative=None,
-                 dirichlet_data=None, neumann_data=None, robin_data=None, functionals=None,
+                 dirichlet_data=None, neumann_data=None, robin_data=None, outputs=None,
                  parameter_space=None, name=None):
 
         assert (rhs is None
@@ -108,9 +108,9 @@ class StationaryProblem(ImmutableInterface):
         assert (robin_data is None
                 or (isinstance(robin_data, tuple) and len(robin_data) == 2
                     and np.all([f.dim_domain == domain.dim and f.shape_range == () for f in robin_data])))
-        assert (functionals is None
+        assert (outputs is None
                 or all(isinstance(v, tuple) and len(v) == 2 and v[0] in ('l2', 'l2_boundary')
-                       and v[1].dim_domain == domain.dim and v[1].shape_range == () for v in functionals.values()))
+                       and v[1].dim_domain == domain.dim and v[1].shape_range == () for v in outputs))
 
         self.domain = domain
         self.rhs = rhs
@@ -124,6 +124,6 @@ class StationaryProblem(ImmutableInterface):
         self.dirichlet_data = dirichlet_data
         self.neumann_data = neumann_data
         self.robin_data = robin_data
-        self.functionals = FrozenDict(functionals) if functionals is not None else None
+        self.outputs = tuple(outputs) if outputs is not None else None
         self.parameter_space = parameter_space
         self.name = name

--- a/src/pymor/discretizers/fv.py
+++ b/src/pymor/discretizers/fv.py
@@ -88,7 +88,7 @@ def discretize_stationary_fv(analytical_problem, diameter=None, domain_discretiz
 
     if analytical_problem.robin_data is not None:
         raise NotImplementedError
-    if p.functionals:
+    if p.outputs:
         raise NotImplementedError
 
     if grid is None:

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -124,6 +124,9 @@ class InputOutputModel(ModelBase):
 
         return out
 
+    def _solve_for_solution(self, mu=None):
+        raise NotImplementedError
+
 
 class InputStateOutputModel(InputOutputModel):
     """Base class for input-output systems with state space."""

--- a/src/pymor/reductors/basic.py
+++ b/src/pymor/reductors/basic.py
@@ -175,19 +175,23 @@ class StationaryRBReductor(ProjectionBasedReductor):
     def project_operators(self):
         fom = self.fom
         RB = self.bases['RB']
-        projected_operators = {'operator': project(fom.operator, RB, RB),
-                               'rhs':      project(fom.rhs, RB, None),
-                               'products': {k: project(v, RB, RB) for k, v in fom.products.items()},
-                               'outputs':  {k: project(v, None, RB) for k, v in fom.outputs.items()}}
+        projected_operators = {
+            'operator':        project(fom.operator, RB, RB),
+            'rhs':             project(fom.rhs, RB, None),
+            'products':        {k: project(v, RB, RB) for k, v in fom.products.items()},
+            'output_operator': project(fom.output_operator, None, RB) if fom.output_operator else None
+        }
         return projected_operators
 
     def project_operators_to_subbasis(self, dims):
         rom = self._last_rom
         dim = dims['RB']
-        projected_operators = {'operator': project_to_subbasis(rom.operator, dim, dim),
-                               'rhs':      project_to_subbasis(rom.rhs, dim, None),
-                               'products': {k: project_to_subbasis(v, dim, dim) for k, v in rom.products.items()},
-                               'outputs':  {k: project_to_subbasis(v, None, dim) for k, v in rom.outputs.items()}}
+        projected_operators = {
+            'operator': project_to_subbasis(rom.operator, dim, dim),
+            'rhs':      project_to_subbasis(rom.rhs, dim, None),
+            'products': {k: project_to_subbasis(v, dim, dim) for k, v in rom.products.items()},
+            'output_operator': project_to_subbasis(rom.output_operator, None, dim) if rom.output_operator else None
+        }
         return projected_operators
 
     def build_rom(self, projected_operators, estimator):
@@ -243,13 +247,14 @@ class InstationaryRBReductor(ProjectionBasedReductor):
             projected_initial_data = project(fom.initial_data, range_basis=RB, source_basis=None,
                                              product=product)
 
-        projected_operators = {'mass':         (None if fom.mass is None or self.product_is_mass else
-                                                project(fom.mass, RB, RB)),
-                               'operator':     project(fom.operator, RB, RB),
-                               'rhs':          project(fom.rhs, RB, None) if fom.rhs is not None else None,
-                               'initial_data': projected_initial_data,
-                               'products':     {k: project(v, RB, RB) for k, v in fom.products.items()},
-                               'outputs':      {k: project(v, None, RB) for k, v in fom.outputs.items()}}
+        projected_operators = {
+            'mass':            None if fom.mass is None or self.product_is_mass else project(fom.mass, RB, RB),
+            'operator':        project(fom.operator, RB, RB),
+            'rhs':             project(fom.rhs, RB, None) if fom.rhs is not None else None,
+            'initial_data':    projected_initial_data,
+            'products':        {k: project(v, RB, RB) for k, v in fom.products.items()},
+            'output_operator': project(fom.output_operator, None, RB) if fom.output_operator else None
+        }
 
         return projected_operators
 
@@ -269,13 +274,15 @@ class InstationaryRBReductor(ProjectionBasedReductor):
         else:
             projected_initial_data = project_to_subbasis(rom.initial_data, dim_range=dim, dim_source=None)
 
-        projected_operators = {'mass':     (None if rom.mass is None or self.product_is_mass else
-                                            project_to_subbasis(rom.mass, dim, dim)),
-                               'operator': project_to_subbasis(rom.operator, dim, dim),
-                               'rhs':      project_to_subbasis(rom.rhs, dim, None) if rom.rhs is not None else None,
-                               'initial_data': projected_initial_data,
-                               'products': {k: project_to_subbasis(v, dim, dim) for k, v in rom.products.items()},
-                               'outputs':  {k: project_to_subbasis(v, None, dim) for k, v in rom.outputs.items()}}
+        projected_operators = {
+            'mass':            (None if rom.mass is None or self.product_is_mass else
+                                project_to_subbasis(rom.mass, dim, dim)),
+            'operator':        project_to_subbasis(rom.operator, dim, dim),
+            'rhs':             project_to_subbasis(rom.rhs, dim, None) if rom.rhs is not None else None,
+            'initial_data':    projected_initial_data,
+            'products':        {k: project_to_subbasis(v, dim, dim) for k, v in rom.products.items()},
+            'output_operator': project_to_subbasis(rom.output_operator, None, dim) if rom.output_operator else None
+        }
         return projected_operators
 
     def build_rom(self, projected_operators, estimator):

--- a/src/pymordemos/heat.py
+++ b/src/pymordemos/heat.py
@@ -40,7 +40,7 @@ if __name__ == '__main__':
             domain=RectDomain([[0., 0.], [1., 1.]], left='robin', right='robin', top='robin', bottom='robin'),
             diffusion=ConstantFunction(1., 2),
             robin_data=(ConstantFunction(1., 2), ExpressionFunction('(x[...,0] < 1e-10) * 1.', 2)),
-            functionals={'output': ('l2_boundary', ExpressionFunction('(x[...,0] > (1 - 1e-10)) * 1.', 2))}
+            outputs=[('l2_boundary', ExpressionFunction('(x[...,0] > (1 - 1e-10)) * 1.', 2))]
         ),
         ConstantFunction(0., 2),
         T=1.


### PR DESCRIPTION
This implements the proposal discussed in #698.

Note that `output` cannot yet be implemented for `LTIModel` as we do not have settled yet on the right notion of `input` in `ModelInterface`. There might be another issue with `SecondOrderSystem`: By definition, `output` gets a `VectorArray` from `solution_space`, which in case of `SecondOrderSystem` does not contain the time derivative of the state, so either `output` would need to compute the time from the state trajectory, `solution_space` would have to be changed, or the definition of `output` would have to be relaxed. Any thoughts, @pmli?