### PR TITLE
Rename bode and Bode plot

### DIFF
--- a/notebooks/delay.ipynb
+++ b/notebooks/delay.ipynb
@@ -91,7 +91,7 @@
     "fig, ax = plt.subplots()\n",
     "w = np.logspace(-1, 2.5, 500)\n",
     "td_lti.mag_plot(w, ax=ax)\n",
-    "ax.set_title('Bode magnitude plot of the FOM')\n",
+    "ax.set_title('Magnitude plot of the FOM')\n",
     "plt.show()"
    ]
   },
@@ -136,7 +136,7 @@
     "fig, ax = plt.subplots()\n",
     "td_lti.mag_plot(w, ax=ax)\n",
     "rom.mag_plot(w, ax=ax)\n",
-    "ax.set_title('Bode magnitude plot of the FOM and ROM')\n",
+    "ax.set_title('Magnitude plot of the FOM and ROM')\n",
     "plt.show()"
    ]
   },
@@ -148,7 +148,7 @@
    "source": [
     "fig, ax = plt.subplots()\n",
     "err_rom.mag_plot(w, ax=ax)\n",
-    "ax.set_title('Bode magnitude plot of the error')\n",
+    "ax.set_title('Magnitude plot of the error')\n",
     "plt.show()"
    ]
   },
@@ -188,7 +188,7 @@
     "td_lti.mag_plot(w, ax=ax)\n",
     "rom.mag_plot(w, ax=ax)\n",
     "td_rom.mag_plot(w, ax=ax)\n",
-    "ax.set_title('Bode magnitude plot of the FOM and ROMs')\n",
+    "ax.set_title('Magnitude plot of the FOM and ROMs')\n",
     "plt.show()"
    ]
   },
@@ -201,7 +201,7 @@
     "fig, ax = plt.subplots()\n",
     "err_rom.mag_plot(w, ax=ax, color='tab:orange')\n",
     "err_td_rom.mag_plot(w, ax=ax, color='tab:green')\n",
-    "ax.set_title('Bode magnitude plot of the errors')\n",
+    "ax.set_title('Magnitude plot of the errors')\n",
     "plt.show()"
    ]
   }

--- a/notebooks/heat.ipynb
+++ b/notebooks/heat.ipynb
@@ -156,7 +156,7 @@
     "w = np.logspace(-2, 3, 100)\n",
     "fig, ax = plt.subplots()\n",
     "lti.mag_plot(w, ax=ax)\n",
-    "ax.set_title('Bode plot of the full model')\n",
+    "ax.set_title('Magnitude plot of the full model')\n",
     "plt.show()"
    ]
   },
@@ -225,7 +225,7 @@
     "fig, ax = plt.subplots()\n",
     "lti.mag_plot(w, ax=ax)\n",
     "rom_bt.mag_plot(w, ax=ax, linestyle='dashed')\n",
-    "ax.set_title('Bode plot of the full and BT reduced model')\n",
+    "ax.set_title('Magnitude plot of the full and BT reduced model')\n",
     "plt.show()"
    ]
   },
@@ -237,7 +237,7 @@
    "source": [
     "fig, ax = plt.subplots()\n",
     "err_bt.mag_plot(w, ax=ax)\n",
-    "ax.set_title('Bode plot of the BT error system')\n",
+    "ax.set_title('Magnitude plot of the BT error system')\n",
     "plt.show()"
    ]
   },
@@ -281,7 +281,7 @@
     "fig, ax = plt.subplots()\n",
     "lti.mag_plot(w, ax=ax)\n",
     "rom_lqgbt.mag_plot(w, ax=ax, linestyle='dashed')\n",
-    "ax.set_title('Bode plot of the full and LQGBT reduced model')\n",
+    "ax.set_title('Magnitude plot of the full and LQGBT reduced model')\n",
     "plt.show()"
    ]
   },
@@ -293,7 +293,7 @@
    "source": [
     "fig, ax = plt.subplots()\n",
     "err_lqgbt.mag_plot(w, ax=ax)\n",
-    "ax.set_title('Bode plot of the LGQBT error system')\n",
+    "ax.set_title('Magnitude plot of the LGQBT error system')\n",
     "plt.show()"
    ]
   },
@@ -337,7 +337,7 @@
     "fig, ax = plt.subplots()\n",
     "lti.mag_plot(w, ax=ax)\n",
     "rom_brbt.mag_plot(w, ax=ax, linestyle='dashed')\n",
-    "ax.set_title('Bode plot of the full and BRBT reduced model')\n",
+    "ax.set_title('Magnitude plot of the full and BRBT reduced model')\n",
     "plt.show()"
    ]
   },
@@ -349,7 +349,7 @@
    "source": [
     "fig, ax = plt.subplots()\n",
     "err_brbt.mag_plot(w, ax=ax)\n",
-    "ax.set_title('Bode plot of the BRBT error system')\n",
+    "ax.set_title('Magnitude plot of the BRBT error system')\n",
     "plt.show()"
    ]
   },
@@ -406,7 +406,7 @@
     "fig, ax = plt.subplots()\n",
     "lti.mag_plot(w, ax=ax)\n",
     "rom_irka.mag_plot(w, ax=ax, linestyle='dashed')\n",
-    "ax.set_title('Bode plot of the full and IRKA reduced model')\n",
+    "ax.set_title('Magnitude plot of the full and IRKA reduced model')\n",
     "plt.show()"
    ]
   },
@@ -418,7 +418,7 @@
    "source": [
     "fig, ax = plt.subplots()\n",
     "err_irka.mag_plot(w, ax=ax)\n",
-    "ax.set_title('Bode plot of the IRKA error system')\n",
+    "ax.set_title('Magnitude plot of the IRKA error system')\n",
     "plt.show()"
    ]
   },
@@ -481,7 +481,7 @@
     "fig, ax = plt.subplots()\n",
     "lti.mag_plot(w, ax=ax)\n",
     "rom_tsia.mag_plot(w, ax=ax, linestyle='dashed')\n",
-    "ax.set_title('Bode plot of the full and TSIA reduced model')\n",
+    "ax.set_title('Magnitude plot of the full and TSIA reduced model')\n",
     "plt.show()"
    ]
   },
@@ -493,7 +493,7 @@
    "source": [
     "fig, ax = plt.subplots()\n",
     "err_tsia.mag_plot(w, ax=ax)\n",
-    "ax.set_title('Bode plot of the TSIA error system')\n",
+    "ax.set_title('Magnitude plot of the TSIA error system')\n",
     "plt.show()"
    ]
   },
@@ -565,7 +565,7 @@
     "fig, ax = plt.subplots()\n",
     "lti.mag_plot(w, ax=ax)\n",
     "rom_one_sided_irka.mag_plot(w, ax=ax, linestyle='dashed')\n",
-    "ax.set_title('Bode plot of the full and one-sided IRKA reduced model')\n",
+    "ax.set_title('Magnitude plot of the full and one-sided IRKA reduced model')\n",
     "plt.show()"
    ]
   },
@@ -577,7 +577,7 @@
    "source": [
     "fig, ax = plt.subplots()\n",
     "err_one_sided_irka.mag_plot(w, ax=ax)\n",
-    "ax.set_title('Bode plot of the one-sided IRKA error system')\n",
+    "ax.set_title('Magnitude plot of the one-sided IRKA error system')\n",
     "plt.show()"
    ]
   },
@@ -700,7 +700,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Here we compare it to the discretized system, by Bode plot, $\\mathcal{H}_2$-norm, and $\\mathcal{H}_2$-distance."
+    "Here we compare it to the discretized system, by magnitude plot, $\\mathcal{H}_2$-norm, and $\\mathcal{H}_2$-distance."
    ]
   },
   {

--- a/notebooks/parametric_delay.ipynb
+++ b/notebooks/parametric_delay.ipynb
@@ -63,7 +63,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Bode plot"
+    "# Magnitude plot"
    ]
   },
   {
@@ -101,7 +101,7 @@
     "\n",
     "fom_w_mu = np.zeros((len(w_list), len(mu_list)))\n",
     "for i, mu in enumerate(mu_list):\n",
-    "    fom_w_mu[:, i] = spla.norm(fom.bode(w_list, mu=mu), axis=(1, 2))"
+    "    fom_w_mu[:, i] = spla.norm(fom.freq_resp(w_list, mu=mu), axis=(1, 2))"
    ]
   },
   {
@@ -167,7 +167,7 @@
     "fig, ax = plt.subplots()\n",
     "for mu, rom in zip(mu_list_short, roms_tf_irka):\n",
     "    rom.mag_plot(w, ax=ax, label=fr'$\\tau = {mu}$')\n",
-    "ax.set_title(\"Bode plot of TF-IRKA's ROMs\")\n",
+    "ax.set_title(\"Magnitude plot of TF-IRKA's ROMs\")\n",
     "ax.legend()\n",
     "plt.show()"
    ]
@@ -181,7 +181,7 @@
     "fig, ax = plt.subplots()\n",
     "for mu, rom in zip(mu_list_short, roms_tf_irka):\n",
     "    (fom - rom).mag_plot(w, ax=ax, mu=mu, label=fr'$\\tau = {mu}$')\n",
-    "ax.set_title(\"Bode plot of error systems\")\n",
+    "ax.set_title(\"Magnitude plot of error systems\")\n",
     "ax.legend()\n",
     "plt.show()"
    ]

--- a/notebooks/parametric_heat.ipynb
+++ b/notebooks/parametric_heat.ipynb
@@ -160,7 +160,7 @@
     "\n",
     "lti_w_mu = np.zeros((len(w_list), len(mu_list)))\n",
     "for i, mu in enumerate(mu_list):\n",
-    "    lti_w_mu[:, i] = spla.norm(lti.bode(w, mu=mu), axis=(1, 2))"
+    "    lti_w_mu[:, i] = spla.norm(lti.freq_resp(w, mu=mu), axis=(1, 2))"
    ]
   },
   {

--- a/notebooks/parametric_string.ipynb
+++ b/notebooks/parametric_string.ipynb
@@ -151,7 +151,7 @@
     "fig, ax = plt.subplots()\n",
     "for mu in mu_list:\n",
     "    so_sys.mag_plot(w, ax=ax, mu=mu, label=fr'$\\mu = {mu}$')\n",
-    "ax.set_title('Bode plot of the full model')\n",
+    "ax.set_title('Magnitude plot of the full model')\n",
     "ax.legend()\n",
     "plt.show()"
    ]
@@ -253,7 +253,7 @@
     "fig, ax = plt.subplots()\n",
     "for mu, rom_sobtp in zip(mu_list, roms_sobtp):\n",
     "    rom_sobtp.mag_plot(w, ax=ax, label=fr'$\\mu = {mu}$')\n",
-    "ax.set_title('Bode plot of SOBTp reduced models')\n",
+    "ax.set_title('Magnitude plot of SOBTp reduced models')\n",
     "ax.legend()\n",
     "plt.show()"
    ]
@@ -267,7 +267,7 @@
     "fig, ax = plt.subplots()\n",
     "for mu, rom_sobtp in zip(mu_list, roms_sobtp):\n",
     "    (so_sys - rom_sobtp).mag_plot(w, ax=ax, mu=mu, label=fr'$\\mu = {mu}$')\n",
-    "ax.set_title('Bode plot of the SOBTp error system')\n",
+    "ax.set_title('Magnitude plot of the SOBTp error system')\n",
     "ax.legend()\n",
     "plt.show()"
    ]
@@ -331,7 +331,7 @@
     "fig, ax = plt.subplots()\n",
     "for mu, rom_sobtv in zip(mu_list, roms_sobtv):\n",
     "    rom_sobtv.mag_plot(w, ax=ax, label=fr'$\\mu = {mu}$')\n",
-    "ax.set_title('Bode plot of SOBTv reduced models')\n",
+    "ax.set_title('Magnitude plot of SOBTv reduced models')\n",
     "ax.legend()\n",
     "plt.show()"
    ]
@@ -345,7 +345,7 @@
     "fig, ax = plt.subplots()\n",
     "for mu, rom_sobtv in zip(mu_list, roms_sobtv):\n",
     "    (so_sys - rom_sobtv).mag_plot(w, ax=ax, mu=mu, label=fr'$\\mu = {mu}$')\n",
-    "ax.set_title('Bode plot of the SOBTv error system')\n",
+    "ax.set_title('Magnitude plot of the SOBTv error system')\n",
     "ax.legend()\n",
     "plt.show()"
    ]
@@ -409,7 +409,7 @@
     "fig, ax = plt.subplots()\n",
     "for mu, rom_sobtpv in zip(mu_list, roms_sobtpv):\n",
     "    rom_sobtpv.mag_plot(w, ax=ax, label=fr'$\\mu = {mu}$')\n",
-    "ax.set_title('Bode plot of SOBTpv reduced models')\n",
+    "ax.set_title('Magnitude plot of SOBTpv reduced models')\n",
     "ax.legend()\n",
     "plt.show()"
    ]
@@ -423,7 +423,7 @@
     "fig, ax = plt.subplots()\n",
     "for mu, rom_sobtpv in zip(mu_list, roms_sobtpv):\n",
     "    (so_sys - rom_sobtpv).mag_plot(w, ax=ax, mu=mu, label=fr'$\\mu = {mu}$')\n",
-    "ax.set_title('Bode plot of the SOBTpv error system')\n",
+    "ax.set_title('Magnitude plot of the SOBTpv error system')\n",
     "ax.legend()\n",
     "plt.show()"
    ]
@@ -487,7 +487,7 @@
     "fig, ax = plt.subplots()\n",
     "for mu, rom_sobtvp in zip(mu_list, roms_sobtvp):\n",
     "    rom_sobtvp.mag_plot(w, ax=ax, label=fr'$\\mu = {mu}$')\n",
-    "ax.set_title('Bode plot of SOBTvp reduced models')\n",
+    "ax.set_title('Magnitude plot of SOBTvp reduced models')\n",
     "ax.legend()\n",
     "plt.show()"
    ]
@@ -501,7 +501,7 @@
     "fig, ax = plt.subplots()\n",
     "for mu, rom_sobtvp in zip(mu_list, roms_sobtvp):\n",
     "    (so_sys - rom_sobtvp).mag_plot(w, ax=ax, mu=mu, label=fr'$\\mu = {mu}$')\n",
-    "ax.set_title('Bode plot of the SOBTvp error system')\n",
+    "ax.set_title('Magnitude plot of the SOBTvp error system')\n",
     "ax.legend()\n",
     "plt.show()"
    ]
@@ -565,7 +565,7 @@
     "fig, ax = plt.subplots()\n",
     "for mu, rom_sobtfv in zip(mu_list, roms_sobtfv):\n",
     "    rom_sobtfv.mag_plot(w, ax=ax, label=fr'$\\mu = {mu}$')\n",
-    "ax.set_title('Bode plot of SOBTfv reduced models')\n",
+    "ax.set_title('Magnitude plot of SOBTfv reduced models')\n",
     "ax.legend()\n",
     "plt.show()"
    ]
@@ -579,7 +579,7 @@
     "fig, ax = plt.subplots()\n",
     "for mu, rom_sobtfv in zip(mu_list, roms_sobtfv):\n",
     "    (so_sys - rom_sobtfv).mag_plot(w, ax=ax, mu=mu, label=fr'$\\mu = {mu}$')\n",
-    "ax.set_title('Bode plot of the SOBTfv error system')\n",
+    "ax.set_title('Magnitude plot of the SOBTfv error system')\n",
     "ax.legend()\n",
     "plt.show()"
    ]
@@ -643,7 +643,7 @@
     "fig, ax = plt.subplots()\n",
     "for mu, rom_sobt in zip(mu_list, roms_sobt):\n",
     "    rom_sobt.mag_plot(w, ax=ax, label=fr'$\\mu = {mu}$')\n",
-    "ax.set_title('Bode plot of SOBT reduced models')\n",
+    "ax.set_title('Magnitude plot of SOBT reduced models')\n",
     "ax.legend()\n",
     "plt.show()"
    ]
@@ -657,7 +657,7 @@
     "fig, ax = plt.subplots()\n",
     "for mu, rom_sobt in zip(mu_list, roms_sobt):\n",
     "    (so_sys - rom_sobt).mag_plot(w, ax=ax, mu=mu, label=fr'$\\mu = {mu}$')\n",
-    "ax.set_title('Bode plot of the SOBT error system')\n",
+    "ax.set_title('Magnitude plot of the SOBT error system')\n",
     "ax.legend()\n",
     "plt.show()"
    ]
@@ -721,7 +721,7 @@
     "fig, ax = plt.subplots()\n",
     "for mu, rom_bt in zip(mu_list, roms_bt):\n",
     "    rom_bt.mag_plot(w, ax=ax, label=fr'$\\mu = {mu}$')\n",
-    "ax.set_title('Bode plot of BT reduced models')\n",
+    "ax.set_title('Magnitude plot of BT reduced models')\n",
     "ax.legend()\n",
     "plt.show()"
    ]
@@ -735,7 +735,7 @@
     "fig, ax = plt.subplots()\n",
     "for mu, rom_bt in zip(mu_list, roms_bt):\n",
     "    (so_sys - rom_bt).mag_plot(w, ax=ax, mu=mu, label=fr'$\\mu = {mu}$')\n",
-    "ax.set_title('Bode plot of the BT error system')\n",
+    "ax.set_title('Magnitude plot of the BT error system')\n",
     "ax.legend()\n",
     "plt.show()"
    ]
@@ -799,7 +799,7 @@
     "fig, ax = plt.subplots()\n",
     "for mu, rom_irka in zip(mu_list, roms_irka):\n",
     "    rom_irka.mag_plot(w, ax=ax, label=fr'$\\mu = {mu}$')\n",
-    "ax.set_title('Bode plot of IRKA reduced models')\n",
+    "ax.set_title('Magnitude plot of IRKA reduced models')\n",
     "ax.legend()\n",
     "plt.show()"
    ]
@@ -813,7 +813,7 @@
     "fig, ax = plt.subplots()\n",
     "for mu, rom_irka in zip(mu_list, roms_irka):\n",
     "    (so_sys - rom_irka).mag_plot(w, ax=ax, mu=mu, label=fr'$\\mu = {mu}$')\n",
-    "ax.set_title('Bode plot of the IRKA error system')\n",
+    "ax.set_title('Magnitude plot of the IRKA error system')\n",
     "ax.legend()\n",
     "plt.show()"
    ]
@@ -877,7 +877,7 @@
     "fig, ax = plt.subplots()\n",
     "for mu, rom_sor_irka in zip(mu_list, roms_sor_irka):\n",
     "    rom_sor_irka.mag_plot(w, ax=ax, label=fr'$\\mu = {mu}$')\n",
-    "ax.set_title('Bode plot of SORIRKA reduced models')\n",
+    "ax.set_title('Magnitude plot of SORIRKA reduced models')\n",
     "ax.legend()\n",
     "plt.show()"
    ]
@@ -891,7 +891,7 @@
     "fig, ax = plt.subplots()\n",
     "for mu, rom_sor_irka in zip(mu_list, roms_sor_irka):\n",
     "    (so_sys - rom_sor_irka).mag_plot(w, ax=ax, mu=mu, label=fr'$\\mu = {mu}$')\n",
-    "ax.set_title('Bode plot of the SORIRKA error system')\n",
+    "ax.set_title('Magnitude plot of the SORIRKA error system')\n",
     "ax.legend()\n",
     "plt.show()"
    ]

--- a/notebooks/parametric_synthetic.ipynb
+++ b/notebooks/parametric_synthetic.ipynb
@@ -104,7 +104,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Bode plot"
+    "# Magnitude plot"
    ]
   },
   {
@@ -142,7 +142,7 @@
     "\n",
     "lti_w_mu = np.zeros((len(w_list), len(mu_list)))\n",
     "for i, mu in enumerate(mu_list):\n",
-    "    lti_w_mu[:, i] = spla.norm(lti.bode(w_list, mu=mu), axis=(1, 2))"
+    "    lti_w_mu[:, i] = spla.norm(lti.freq_resp(w_list, mu=mu), axis=(1, 2))"
    ]
   },
   {

--- a/notebooks/string.ipynb
+++ b/notebooks/string.ipynb
@@ -160,7 +160,7 @@
     "w = np.logspace(-4, 2, 200)\n",
     "fig, ax = plt.subplots()\n",
     "so_sys.mag_plot(w, ax=ax)\n",
-    "ax.set_title('Bode plot of the full model')\n",
+    "ax.set_title('Magnitude plot of the full model')\n",
     "plt.show()"
    ]
   },
@@ -251,7 +251,7 @@
     "fig, ax = plt.subplots()\n",
     "so_sys.mag_plot(w, ax=ax)\n",
     "rom_sobtp.mag_plot(w, ax=ax, linestyle='dashed')\n",
-    "ax.set_title('Bode plot of the full and SOBTp reduced model')\n",
+    "ax.set_title('Magnitude plot of the full and SOBTp reduced model')\n",
     "plt.show()"
    ]
   },
@@ -263,7 +263,7 @@
    "source": [
     "fig, ax = plt.subplots()\n",
     "err_sobtp.mag_plot(w, ax=ax)\n",
-    "ax.set_title('Bode plot of the SOBTp error system')\n",
+    "ax.set_title('Magnitude plot of the SOBTp error system')\n",
     "plt.show()"
    ]
   },
@@ -320,7 +320,7 @@
     "fig, ax = plt.subplots()\n",
     "so_sys.mag_plot(w, ax=ax)\n",
     "rom_sobtv.mag_plot(w, ax=ax, linestyle='dashed')\n",
-    "ax.set_title('Bode plot of the full and SOBTv reduced model')\n",
+    "ax.set_title('Magnitude plot of the full and SOBTv reduced model')\n",
     "plt.show()"
    ]
   },
@@ -332,7 +332,7 @@
    "source": [
     "fig, ax = plt.subplots()\n",
     "err_sobtv.mag_plot(w, ax=ax)\n",
-    "ax.set_title('Bode plot of the SOBTv error system')\n",
+    "ax.set_title('Magnitude plot of the SOBTv error system')\n",
     "plt.show()"
    ]
   },
@@ -389,7 +389,7 @@
     "fig, ax = plt.subplots()\n",
     "so_sys.mag_plot(w, ax=ax)\n",
     "rom_sobtpv.mag_plot(w, ax=ax, linestyle='dashed')\n",
-    "ax.set_title('Bode plot of the full and SOBTpv reduced model')\n",
+    "ax.set_title('Magnitude plot of the full and SOBTpv reduced model')\n",
     "plt.show()"
    ]
   },
@@ -401,7 +401,7 @@
    "source": [
     "fig, ax = plt.subplots()\n",
     "err_sobtpv.mag_plot(w, ax=ax)\n",
-    "ax.set_title('Bode plot of the SOBTpv error system')\n",
+    "ax.set_title('Magnitude plot of the SOBTpv error system')\n",
     "plt.show()"
    ]
   },
@@ -458,7 +458,7 @@
     "fig, ax = plt.subplots()\n",
     "so_sys.mag_plot(w, ax=ax)\n",
     "rom_sobtvp.mag_plot(w, ax=ax, linestyle='dashed')\n",
-    "ax.set_title('Bode plot of the full and SOBTvp reduced model')\n",
+    "ax.set_title('Magnitude plot of the full and SOBTvp reduced model')\n",
     "plt.show()"
    ]
   },
@@ -470,7 +470,7 @@
    "source": [
     "fig, ax = plt.subplots()\n",
     "err_sobtvp.mag_plot(w, ax=ax)\n",
-    "ax.set_title('Bode plot of the SOBTvp error system')\n",
+    "ax.set_title('Magnitude plot of the SOBTvp error system')\n",
     "plt.show()"
    ]
   },
@@ -527,7 +527,7 @@
     "fig, ax = plt.subplots()\n",
     "so_sys.mag_plot(w, ax=ax)\n",
     "rom_sobtfv.mag_plot(w, ax=ax, linestyle='dashed')\n",
-    "ax.set_title('Bode plot of the full and SOBTfv reduced model')\n",
+    "ax.set_title('Magnitude plot of the full and SOBTfv reduced model')\n",
     "plt.show()"
    ]
   },
@@ -539,7 +539,7 @@
    "source": [
     "fig, ax = plt.subplots()\n",
     "err_sobtfv.mag_plot(w, ax=ax)\n",
-    "ax.set_title('Bode plot of the SOBTfv error system')\n",
+    "ax.set_title('Magnitude plot of the SOBTfv error system')\n",
     "plt.show()"
    ]
   },
@@ -596,7 +596,7 @@
     "fig, ax = plt.subplots()\n",
     "so_sys.mag_plot(w, ax=ax)\n",
     "rom_sobt.mag_plot(w, ax=ax, linestyle='dashed')\n",
-    "ax.set_title('Bode plot of the full and SOBT reduced model')\n",
+    "ax.set_title('Magnitude plot of the full and SOBT reduced model')\n",
     "plt.show()"
    ]
   },
@@ -608,7 +608,7 @@
    "source": [
     "fig, ax = plt.subplots()\n",
     "err_sobt.mag_plot(w, ax=ax)\n",
-    "ax.set_title('Bode plot of the SOBT error system')\n",
+    "ax.set_title('Magnitude plot of the SOBT error system')\n",
     "plt.show()"
    ]
   },
@@ -665,7 +665,7 @@
     "fig, ax = plt.subplots()\n",
     "so_sys.mag_plot(w, ax=ax)\n",
     "rom_bt.mag_plot(w, ax=ax, linestyle='dashed')\n",
-    "ax.set_title('Bode plot of the full and BT reduced model')\n",
+    "ax.set_title('Magnitude plot of the full and BT reduced model')\n",
     "plt.show()"
    ]
   },
@@ -677,7 +677,7 @@
    "source": [
     "fig, ax = plt.subplots()\n",
     "err_bt.mag_plot(w, ax=ax)\n",
-    "ax.set_title('Bode plot of the BT error system')\n",
+    "ax.set_title('Magnitude plot of the BT error system')\n",
     "plt.show()"
    ]
   },
@@ -748,7 +748,7 @@
     "fig, ax = plt.subplots()\n",
     "so_sys.mag_plot(w, ax=ax)\n",
     "rom_irka.mag_plot(w, ax=ax, linestyle='dashed')\n",
-    "ax.set_title('Bode plot of the full and IRKA reduced model')\n",
+    "ax.set_title('Magnitude plot of the full and IRKA reduced model')\n",
     "plt.show()"
    ]
   },
@@ -760,7 +760,7 @@
    "source": [
     "fig, ax = plt.subplots()\n",
     "err_irka.mag_plot(w, ax=ax)\n",
-    "ax.set_title('Bode plot of the IRKA error system')\n",
+    "ax.set_title('Magnitude plot of the IRKA error system')\n",
     "plt.show()"
    ]
   },
@@ -831,7 +831,7 @@
     "fig, ax = plt.subplots()\n",
     "so_sys.mag_plot(w, ax=ax)\n",
     "rom_sor_irka.mag_plot(w, ax=ax, linestyle='dashed')\n",
-    "ax.set_title('Bode plot of the full and SOR-IRKA reduced model')\n",
+    "ax.set_title('Magnitude plot of the full and SOR-IRKA reduced model')\n",
     "plt.show()"
    ]
   },
@@ -843,7 +843,7 @@
    "source": [
     "fig, ax = plt.subplots()\n",
     "err_sor_irka.mag_plot(w, ax=ax)\n",
-    "ax.set_title('Bode plot of the SOR-IRKA error system')\n",
+    "ax.set_title('Magnitude plot of the SOR-IRKA error system')\n",
     "plt.show()"
    ]
   }

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -57,7 +57,7 @@ class InputOutputModel(ModelBase):
         raise NotImplementedError
 
     @cached
-    def bode(self, w, mu=None):
+    def freq_resp(self, w, mu=None):
         """Evaluate the transfer function on the imaginary axis.
 
         Parameters
@@ -80,7 +80,7 @@ class InputOutputModel(ModelBase):
         return np.stack([self.eval_tf(1j * wi, mu=mu) for wi in w])
 
     def mag_plot(self, w, mu=None, ax=None, ord=None, Hz=False, dB=False, **mpl_kwargs):
-        """Draw the magnitude Bode plot.
+        """Draw the magnitude plot.
 
         Parameters
         ----------
@@ -110,7 +110,7 @@ class InputOutputModel(ModelBase):
             ax = plt.gca()
 
         freq = w / (2 * np.pi) if Hz else w
-        mag = spla.norm(self.bode(w, mu=mu), ord=ord, axis=(1, 2))
+        mag = spla.norm(self.freq_resp(w, mu=mu), ord=ord, axis=(1, 2))
         if dB:
             out = ax.semilogx(freq, 20 * np.log2(mag), **mpl_kwargs)
         else:

--- a/src/pymordemos/delay.py
+++ b/src/pymordemos/delay.py
@@ -45,12 +45,12 @@ if __name__ == '__main__':
     fig, ax = plt.subplots()
     tf.mag_plot(w, ax=ax)
     rom.mag_plot(w, ax=ax, linestyle='dashed')
-    ax.set_title('Magnitude Bode plots of the full and reduced model')
+    ax.set_title('Magnitude plots of the full and reduced model')
     plt.show()
 
     fig, ax = plt.subplots()
     (tf - rom).mag_plot(w, ax=ax)
-    ax.set_title('Magnitude Bode plots of the error system')
+    ax.set_title('Magnitude plots of the error system')
     plt.show()
 
     # step response

--- a/src/pymordemos/heat.py
+++ b/src/pymordemos/heat.py
@@ -63,11 +63,11 @@ if __name__ == '__main__':
     ax.set_title('System poles')
     plt.show()
 
-    # Bode plot of the full model
+    # Magnitude plot of the full model
     w = np.logspace(-1, 3, 100)
     fig, ax = plt.subplots()
     lti.mag_plot(w, ax=ax)
-    ax.set_title('Bode plot of the full model')
+    ax.set_title('Magnitude plot of the full model')
     plt.show()
 
     # Hankel singular values
@@ -97,17 +97,17 @@ if __name__ == '__main__':
         print('Skipped H_inf-norm calculation due to missing slycot.')
     print(f'BT relative Hankel-error: {err_bt.hankel_norm() / lti.hankel_norm():e}')
 
-    # Bode plot of the full and BT reduced model
+    # Magnitude plot of the full and BT reduced model
     fig, ax = plt.subplots()
     lti.mag_plot(w, ax=ax)
     rom_bt.mag_plot(w, ax=ax, linestyle='dashed')
-    ax.set_title('Bode plot of the full and BT reduced model')
+    ax.set_title('Magnitude plot of the full and BT reduced model')
     plt.show()
 
-    # Bode plot of the BT error system
+    # Magnitude plot of the BT error system
     fig, ax = plt.subplots()
     err_bt.mag_plot(w, ax=ax)
-    ax.set_title('Bode plot of the BT error system')
+    ax.set_title('Magnitude plot of the BT error system')
     plt.show()
 
     # Iterative Rational Krylov Algorithm
@@ -129,15 +129,15 @@ if __name__ == '__main__':
         print('Skipped H_inf-norm calculation due to missing slycot.')
     print(f'IRKA relative Hankel-error: {err_irka.hankel_norm() / lti.hankel_norm():e}')
 
-    # Bode plot of the full and IRKA reduced model
+    # Magnitude plot of the full and IRKA reduced model
     fig, ax = plt.subplots()
     lti.mag_plot(w, ax=ax)
     rom_irka.mag_plot(w, ax=ax, linestyle='dashed')
-    ax.set_title('Bode plot of the full and IRKA reduced model')
+    ax.set_title('Magnitude plot of the full and IRKA reduced model')
     plt.show()
 
-    # Bode plot of the IRKA error system
+    # Magnitude plot of the IRKA error system
     fig, ax = plt.subplots()
     err_irka.mag_plot(w, ax=ax)
-    ax.set_title('Bode plot of the IRKA error system')
+    ax.set_title('Magnitude plot of the IRKA error system')
     plt.show()

--- a/src/pymordemos/string_equation.py
+++ b/src/pymordemos/string_equation.py
@@ -57,7 +57,7 @@ if __name__ == '__main__':
     w = np.logspace(-4, 2, 200)
     fig, ax = plt.subplots()
     so_sys.mag_plot(w, ax=ax)
-    ax.set_title('Bode plot of the full model')
+    ax.set_title('Magnitude plot of the full model')
     plt.show()
 
     psv = so_sys.psv()
@@ -104,12 +104,12 @@ if __name__ == '__main__':
     fig, ax = plt.subplots()
     so_sys.mag_plot(w, ax=ax)
     rom_sobtp.mag_plot(w, ax=ax, linestyle='dashed')
-    ax.set_title('Bode plot of the full and SOBTp reduced model')
+    ax.set_title('Magnitude plot of the full and SOBTp reduced model')
     plt.show()
 
     fig, ax = plt.subplots()
     err_sobtp.mag_plot(w, ax=ax)
-    ax.set_title('Bode plot of the SOBTp error system')
+    ax.set_title('Magnitude plot of the SOBTp error system')
     plt.show()
 
     # Velocity Second-Order Balanced Truncation (SOBTv)
@@ -134,12 +134,12 @@ if __name__ == '__main__':
     fig, ax = plt.subplots()
     so_sys.mag_plot(w, ax=ax)
     rom_sobtv.mag_plot(w, ax=ax, linestyle='dashed')
-    ax.set_title('Bode plot of the full and SOBTv reduced model')
+    ax.set_title('Magnitude plot of the full and SOBTv reduced model')
     plt.show()
 
     fig, ax = plt.subplots()
     err_sobtv.mag_plot(w, ax=ax)
-    ax.set_title('Bode plot of the SOBTv error system')
+    ax.set_title('Magnitude plot of the SOBTv error system')
     plt.show()
 
     # Position-Velocity Second-Order Balanced Truncation (SOBTpv)
@@ -164,12 +164,12 @@ if __name__ == '__main__':
     fig, ax = plt.subplots()
     so_sys.mag_plot(w, ax=ax)
     rom_sobtpv.mag_plot(w, ax=ax, linestyle='dashed')
-    ax.set_title('Bode plot of the full and SOBTpv reduced model')
+    ax.set_title('Magnitude plot of the full and SOBTpv reduced model')
     plt.show()
 
     fig, ax = plt.subplots()
     err_sobtpv.mag_plot(w, ax=ax)
-    ax.set_title('Bode plot of the SOBTpv error system')
+    ax.set_title('Magnitude plot of the SOBTpv error system')
     plt.show()
 
     # Velocity-Position Second-Order Balanced Truncation (SOBTvp)
@@ -194,12 +194,12 @@ if __name__ == '__main__':
     fig, ax = plt.subplots()
     so_sys.mag_plot(w, ax=ax)
     rom_sobtvp.mag_plot(w, ax=ax, linestyle='dashed')
-    ax.set_title('Bode plot of the full and SOBTvp reduced model')
+    ax.set_title('Magnitude plot of the full and SOBTvp reduced model')
     plt.show()
 
     fig, ax = plt.subplots()
     err_sobtvp.mag_plot(w, ax=ax)
-    ax.set_title('Bode plot of the SOBTvp error system')
+    ax.set_title('Magnitude plot of the SOBTvp error system')
     plt.show()
 
     # Free-Velocity Second-Order Balanced Truncation (SOBTfv)
@@ -224,12 +224,12 @@ if __name__ == '__main__':
     fig, ax = plt.subplots()
     so_sys.mag_plot(w, ax=ax)
     rom_sobtfv.mag_plot(w, ax=ax, linestyle='dashed')
-    ax.set_title('Bode plot of the full and SOBTfv reduced model')
+    ax.set_title('Magnitude plot of the full and SOBTfv reduced model')
     plt.show()
 
     fig, ax = plt.subplots()
     err_sobtfv.mag_plot(w, ax=ax)
-    ax.set_title('Bode plot of the SOBTfv error system')
+    ax.set_title('Magnitude plot of the SOBTfv error system')
     plt.show()
 
     # Second-Order Balanced Truncation (SOBT)
@@ -254,12 +254,12 @@ if __name__ == '__main__':
     fig, ax = plt.subplots()
     so_sys.mag_plot(w, ax=ax)
     rom_sobt.mag_plot(w, ax=ax, linestyle='dashed')
-    ax.set_title('Bode plot of the full and SOBT reduced model')
+    ax.set_title('Magnitude plot of the full and SOBT reduced model')
     plt.show()
 
     fig, ax = plt.subplots()
     err_sobt.mag_plot(w, ax=ax)
-    ax.set_title('Bode plot of the SOBT error system')
+    ax.set_title('Magnitude plot of the SOBT error system')
     plt.show()
 
     # Balanced Truncation (BT)
@@ -284,12 +284,12 @@ if __name__ == '__main__':
     fig, ax = plt.subplots()
     so_sys.mag_plot(w, ax=ax)
     rom_bt.mag_plot(w, ax=ax, linestyle='dashed')
-    ax.set_title('Bode plot of the full and BT reduced model')
+    ax.set_title('Magnitude plot of the full and BT reduced model')
     plt.show()
 
     fig, ax = plt.subplots()
     err_bt.mag_plot(w, ax=ax)
-    ax.set_title('Bode plot of the BT error system')
+    ax.set_title('Magnitude plot of the BT error system')
     plt.show()
 
     # Iterative Rational Krylov Algorithm (IRKA)
@@ -319,12 +319,12 @@ if __name__ == '__main__':
     fig, ax = plt.subplots()
     so_sys.mag_plot(w, ax=ax)
     rom_irka.mag_plot(w, ax=ax, linestyle='dashed')
-    ax.set_title('Bode plot of the full and IRKA reduced model')
+    ax.set_title('Magnitude plot of the full and IRKA reduced model')
     plt.show()
 
     fig, ax = plt.subplots()
     err_irka.mag_plot(w, ax=ax)
-    ax.set_title('Bode plot of the IRKA error system')
+    ax.set_title('Magnitude plot of the IRKA error system')
     plt.show()
 
     # Second-Order Reduced Iterative Rational Krylov Algorithm (SOR-IRKA)
@@ -354,10 +354,10 @@ if __name__ == '__main__':
     fig, ax = plt.subplots()
     so_sys.mag_plot(w, ax=ax)
     rom_sor_irka.mag_plot(w, ax=ax, linestyle='dashed')
-    ax.set_title('Bode plot of the full and SOR-IRKA reduced model')
+    ax.set_title('Magnitude plot of the full and SOR-IRKA reduced model')
     plt.show()
 
     fig, ax = plt.subplots()
     err_sor_irka.mag_plot(w, ax=ax)
-    ax.set_title('Bode plot of the SOR-IRKA error system')
+    ax.set_title('Magnitude plot of the SOR-IRKA error system')
     plt.show()


### PR DESCRIPTION
Based on return values of
- Matlab's [`bode`](https://www.mathworks.com/help/control/ref/bode.html),
- Matlab's [`freqresp`](https://www.mathworks.com/help/control/ref/freqresp.html),
- [`scipy.signal.bode`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.bode.html),
- [`scipy.signal.freqresp`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.freqresp.html),

and
- Matlab's frequency response [definition](https://www.mathworks.com/help/control/ref/freqresp.html#btcn_7u)

a better name for [`pymor.models.iosys.InputOutputModel.bode`](https://github.com/pymor/pymor/blob/6fa6e21d49712469b5aa9d7a99dc87b6cfc959fc/src/pymor/models/iosys.py#L60) would be `freqresp` ([python-control's `freqresp`](https://python-control.readthedocs.io/en/0.8.2/generated/control.freqresp.html#control.freqresp) is a bit different and behaves more like `bode` in Matlab and SciPy). Since underscores are common in `pymor.models.iosys` method names, I find `freq_resp` would be even better.

Additionally, this PR replaces "Bode plot" with "magnitude plot". I'm not sure if "magnitude plot" is a name for something or if there is a standard name for the plot of `||H(i omega)||` vs `omega`, but it seems that "Bode plot" and "Bode magnitude plot" refer to a grid of subplots with a column for each input and row for each output.

I would still prefer to have [`pymor.iosys.models.InputOutputModel.mag_plot`](https://github.com/pymor/pymor/blob/6fa6e21d49712469b5aa9d7a99dc87b6cfc959fc/src/pymor/models/iosys.py#L82), since it's commonly used to visualize the MOR error.

@sdrave Thoughts?