### PR TITLE
Add __auto_init method and use it where applicable

### DIFF
--- a/src/pymor/algorithms/image.py
+++ b/src/pymor/algorithms/image.py
@@ -223,8 +223,7 @@ class CollectOperatorRangeRules(RuleTable):
 
     def __init__(self, source, image, extends):
         super().__init__(use_caching=True)
-        self.source, self.image, self.extends = \
-            source, image, extends
+        self.__auto_init(locals())
 
     @match_generic(lambda op: op.linear and not op.parametric)
     def action_apply_operator(self, op):

--- a/src/pymor/algorithms/lincomb.py
+++ b/src/pymor/algorithms/lincomb.py
@@ -53,8 +53,7 @@ def assemble_lincomb(operators, coefficients, solver_options=None, name=None):
 class AssembleLincombRules(RuleTable):
     def __init__(self, coefficients, solver_options, name):
         super().__init__(use_caching=False)
-        self.coefficients, self.solver_options, self.name \
-            = coefficients, solver_options, name
+        self.__auto_init(locals())
 
     @match_class_any(ZeroOperator)
     def action_ZeroOperator(self, ops):

--- a/src/pymor/algorithms/projection.py
+++ b/src/pymor/algorithms/projection.py
@@ -71,8 +71,7 @@ class ProjectRules(RuleTable):
 
     def __init__(self, range_basis, source_basis, product):
         super().__init__(use_caching=True)
-        self.range_basis, self.source_basis, self.product = \
-            range_basis, source_basis, product
+        self.__auto_init(locals())
 
     @match_class(ZeroOperator)
     def action_ZeroOperator(self, op):
@@ -244,7 +243,7 @@ class ProjectToSubbasisRules(RuleTable):
 
     def __init__(self, dim_range, dim_source):
         super().__init__(use_caching=True)
-        self.dim_range, self.dim_source = dim_range, dim_source
+        self.__auto_init(locals())
 
     @match_class(LincombOperator)
     def action_recurse(self, op):

--- a/src/pymor/algorithms/timestepping.py
+++ b/src/pymor/algorithms/timestepping.py
@@ -89,8 +89,7 @@ class ImplicitEulerTimeStepper(TimeStepperInterface):
     """
 
     def __init__(self, nt, solver_options='operator'):
-        self.nt = nt
-        self.solver_options = solver_options
+        self.__auto_init(locals())
 
     def solve(self, initial_time, end_time, initial_data, operator, rhs=None, mass=None, mu=None, num_values=None):
         return implicit_euler(operator, rhs, mass, initial_data, initial_time, end_time, self.nt, mu, num_values,
@@ -111,7 +110,7 @@ class ExplicitEulerTimeStepper(TimeStepperInterface):
     """
 
     def __init__(self, nt):
-        self.nt = nt
+        self.__auto_init(locals())
 
     def solve(self, initial_time, end_time, initial_data, operator, rhs=None, mass=None, mu=None, num_values=None):
         if mass is not None:

--- a/src/pymor/algorithms/to_matrix.py
+++ b/src/pymor/algorithms/to_matrix.py
@@ -43,7 +43,7 @@ class ToMatrixRules(RuleTable):
 
     def __init__(self, format, mu):
         super().__init__()
-        self.format, self.mu = format, mu
+        self.__auto_init(locals())
 
     @match_class(NumpyMatrixOperator)
     def action_NumpyMatrixOperator(self, op):

--- a/src/pymor/analyticalproblems/elliptic.py
+++ b/src/pymor/analyticalproblems/elliptic.py
@@ -112,18 +112,6 @@ class StationaryProblem(ImmutableInterface):
                 or all(isinstance(v, tuple) and len(v) == 2 and v[0] in ('l2', 'l2_boundary')
                        and v[1].dim_domain == domain.dim and v[1].shape_range == () for v in functionals.values()))
 
-        self.domain = domain
-        self.rhs = rhs
-        self.diffusion = diffusion
-        self.advection = advection
-        self.nonlinear_advection = nonlinear_advection
-        self.nonlinear_advection_derivative = nonlinear_advection_derivative
-        self.reaction = reaction
-        self.nonlinear_reaction = nonlinear_reaction
-        self.nonlinear_reaction_derivative = nonlinear_reaction_derivative
-        self.dirichlet_data = dirichlet_data
-        self.neumann_data = neumann_data
-        self.robin_data = robin_data
-        self.functionals = FrozenDict(functionals) if functionals is not None else None
-        self.parameter_space = parameter_space
-        self.name = name
+        functionals = FrozenDict(functionals) if functionals is not None else None
+
+        self.__auto_init(locals())

--- a/src/pymor/analyticalproblems/instationary.py
+++ b/src/pymor/analyticalproblems/instationary.py
@@ -38,12 +38,8 @@ class InstationaryProblem(ImmutableInterface):
     """
 
     def __init__(self, stationary_part, initial_data, T=1., parameter_space=None, name=None):
-
-        self.stationary_part = stationary_part
-        self.initial_data = initial_data
-        self.T = T
-        self.parameter_space = parameter_space or stationary_part.parameter_space
-        self.name = name or ('instationary_' + stationary_part.name)
+        name = name or ('instationary_' + stationary_part.name)
+        self.__auto_init(locals())
 
     def with_stationary_part(self, **kwargs):
         return self.with_(stationary_part=self.stationary_part.with_(**kwargs))

--- a/src/pymor/bindings/fenics.py
+++ b/src/pymor/bindings/fenics.py
@@ -117,8 +117,7 @@ if config.HAVE_FENICS:
     class FenicsVectorSpace(ListVectorSpace):
 
         def __init__(self, V, id='STATE'):
-            self.V = V
-            self.id = id
+            self.__auto_init(locals())
 
         @property
         def dim(self):
@@ -156,13 +155,9 @@ if config.HAVE_FENICS:
 
         def __init__(self, matrix, source_space, range_space, solver_options=None, name=None):
             assert matrix.rank() == 2
-            self.source_space = source_space
-            self.range_space = range_space
+            self.__auto_init(locals())
             self.source = FenicsVectorSpace(source_space)
             self.range = FenicsVectorSpace(range_space)
-            self.matrix = matrix
-            self.solver_options = solver_options
-            self.name = name
 
         def apply(self, U, mu=None):
             assert U in self.source

--- a/src/pymor/bindings/ngsolve.py
+++ b/src/pymor/bindings/ngsolve.py
@@ -66,8 +66,7 @@ if config.HAVE_NGSOLVE:
     class NGSolveVectorSpace(ListVectorSpace):
 
         def __init__(self, V, id='STATE'):
-            self.V = V
-            self.id = id
+            self.__auto_init(locals())
 
         def __eq__(self, other):
             return type(other) is NGSolveVectorSpace and self.V == other.V and self.id == other.id
@@ -109,11 +108,7 @@ if config.HAVE_NGSOLVE:
         linear = True
 
         def __init__(self, matrix, range, source, solver_options=None, name=None):
-            self.range = range
-            self.source = source
-            self.matrix = matrix
-            self.solver_options = solver_options
-            self.name = name
+            self.__auto_init(locals())
 
         def apply(self, U, mu=None):
             assert U in self.source
@@ -163,8 +158,7 @@ if config.HAVE_NGSOLVE:
         """Visualize an NGSolve grid function."""
 
         def __init__(self, mesh, fespace):
-            self.mesh = mesh
-            self.fespace = fespace
+            self.__auto_init(locals())
             self.space = NGSolveVectorSpace(fespace)
 
         def visualize(self, U, m, legend=None, separate_colorbars=True, block=True):

--- a/src/pymor/core/interfaces.py
+++ b/src/pymor/core/interfaces.py
@@ -146,6 +146,25 @@ class UberMeta(abc.ABCMeta):
                                 base_doc = doc
                             item.__doc__ = base_doc
 
+        def __auto_init(self, locals_):
+            """Automatically assign __init__ arguments.
+
+            This method is used in __init__ to automatically assign __init__ arguments to equally
+            named object attributes. The values are provided by the `locals_` dict. Usually,
+            `__auto_init` is called as::
+
+                self.__auto_init(locals())
+
+            where `locals()` returns a dictionary of all local variables in the current scope.
+            Only attributes which have not already been set by the user are initialized by
+            `__auto_init`.
+            """
+            for arg in c._init_arguments:
+                if arg not in self.__dict__:
+                    setattr(self, arg, locals_[arg])
+
+        classdict[f'_{classname}__auto_init'] = __auto_init
+
         c = abc.ABCMeta.__new__(cls, classname, bases, classdict)
 
         # getargspec is deprecated and does not work with keyword only args

--- a/src/pymor/domaindescriptions/basic.py
+++ b/src/pymor/domaindescriptions/basic.py
@@ -44,12 +44,9 @@ class RectDomain(DomainDescriptionInterface):
         for bt in (left, right, top, bottom):
             if bt is not None and bt not in KNOWN_BOUNDARY_TYPES:
                 self.logger.warning(f'Unknown boundary type: {bt}')
+        domain = np.array(domain)
+        self.__auto_init(locals())
         self.boundary_types = frozenset({left, right, top, bottom})
-        self.left = left
-        self.right = right
-        self.top = top
-        self.bottom = bottom
-        self.domain = np.array(domain)
 
     @property
     def lower_left(self):
@@ -106,10 +103,9 @@ class CylindricalDomain(DomainDescriptionInterface):
         for bt in (top, bottom):
             if bt is not None and bt not in KNOWN_BOUNDARY_TYPES:
                 self.logger.warning(f'Unknown boundary type: {bt}')
+        domain = np.array(domain)
+        self.__auto_init(locals())
         self.boundary_types = frozenset({top, bottom})
-        self.top = top
-        self.bottom = bottom
-        self.domain = np.array(domain)
 
     @property
     def lower_left(self):
@@ -212,10 +208,9 @@ class LineDomain(DomainDescriptionInterface):
         for bt in (left, right):
             if bt is not None and bt not in KNOWN_BOUNDARY_TYPES:
                 self.logger.warning(f'Unknown boundary type: {bt}')
+        domain = np.array(domain)
+        self.__auto_init(locals())
         self.boundary_types = frozenset({left, right})
-        self.left = left
-        self.right = right
-        self.domain = np.array(domain)
 
     @property
     def width(self):

--- a/src/pymor/domaindescriptions/polygonal.py
+++ b/src/pymor/domaindescriptions/polygonal.py
@@ -34,11 +34,9 @@ class PolygonalDomain(DomainDescriptionInterface):
 
     def __init__(self, points, boundary_types, holes=None):
         holes = holes or []
-        self.points = points
-        self.holes = holes
 
         if isinstance(boundary_types, dict):
-            self.boundary_types = boundary_types
+            pass
         # if the boundary types are not given as a dict, try to evaluate at the edge centers to get a dict.
         else:
             points = [points]
@@ -52,11 +50,13 @@ class PolygonalDomain(DomainDescriptionInterface):
                        for p0, p1 in zip(ps, ps_d)]
             # evaluate the boundary at the edge centers and save the boundary types together with the
             # corresponding edge id.
-            self.boundary_types = dict(zip([boundary_types(centers)], [list(range(1, len(centers)+1))]))
+            boundary_types = dict(zip([boundary_types(centers)], [list(range(1, len(centers)+1))]))
 
-        for bt in self.boundary_types.keys():
+        for bt in boundary_types.keys():
             if bt is not None and bt not in KNOWN_BOUNDARY_TYPES:
                 self.logger.warning(f'Unknown boundary type: {bt}')
+
+        self.__auto_init(locals())
 
 
 class CircularSectorDomain(PolygonalDomain):
@@ -86,29 +86,25 @@ class CircularSectorDomain(PolygonalDomain):
     """
 
     def __init__(self, angle, radius, arc='dirichlet', radii='dirichlet', num_points=100):
-        self.angle = angle
-        self.radius = radius
-        self.arc = arc
-        self.radii = radii
-        self.num_points = num_points
-        assert (0 < self.angle) and (self.angle < 2*np.pi)
-        assert self.radius > 0
-        assert self.num_points > 0
+        assert (0 < angle) and (angle < 2*np.pi)
+        assert radius > 0
+        assert num_points > 0
 
         points = [[0., 0.]]
-        points.extend([[self.radius*np.cos(t), self.radius*np.sin(t)] for t in
-                       np.linspace(start=0, stop=angle, num=self.num_points, endpoint=True)])
+        points.extend([[radius*np.cos(t), radius*np.sin(t)] for t in
+                       np.linspace(start=0, stop=angle, num=num_points, endpoint=True)])
 
-        if self.arc == self.radii:
-            boundary_types = {self.arc: list(range(1, len(points)+1))}
+        if arc == radii:
+            boundary_types = {arc: list(range(1, len(points)+1))}
         else:
-            boundary_types = {self.arc: list(range(2, len(points)))}
-            boundary_types.update({self.radii: [1, len(points)]})
+            boundary_types = {arc: list(range(2, len(points)))}
+            boundary_types.update({radii: [1, len(points)]})
 
         if None in boundary_types:
             del boundary_types[None]
 
         super().__init__(points, boundary_types)
+        self.__auto_init(locals())
 
 
 class DiscDomain(PolygonalDomain):
@@ -131,14 +127,12 @@ class DiscDomain(PolygonalDomain):
     """
 
     def __init__(self, radius, boundary='dirichlet', num_points=100):
-        self.radius = radius
-        self.boundary = boundary
-        self.num_points = num_points
-        assert self.radius > 0
-        assert self.num_points > 0
+        assert radius > 0
+        assert num_points > 0
 
-        points = [[self.radius*np.cos(t), self.radius*np.sin(t)] for t in
+        points = [[radius*np.cos(t), radius*np.sin(t)] for t in
                   np.linspace(start=0, stop=2*np.pi, num=num_points, endpoint=False)]
-        boundary_types = {} if self.boundary is None else {boundary: list(range(1, len(points)+1))}
+        boundary_types = {} if boundary is None else {boundary: list(range(1, len(points)+1))}
 
         super().__init__(points, boundary_types)
+        self.__auto_init(locals())

--- a/src/pymor/functions/bitmap.py
+++ b/src/pymor/functions/bitmap.py
@@ -34,12 +34,10 @@ class BitmapFunction(FunctionBase):
         if not img.mode == "L":
             self.logger.warning("Image " + filename + " not in grayscale mode. Convertig to grayscale.")
             img = img.convert('L')
-        self.filename = filename
+        self.__auto_init(locals())
         self.bitmap = np.array(img).T[:, ::-1]
-        self.bounding_box = bounding_box
         self.lower_left = np.array(bounding_box[0])
         self.size = np.array(bounding_box[1] - self.lower_left)
-        self.range = range
 
     def evaluate(self, x, mu=None):
         indices = np.maximum(np.floor((x - self.lower_left) * np.array(self.bitmap.shape) / self.size).astype(int), 0)

--- a/src/pymor/grids/boundaryinfos.py
+++ b/src/pymor/grids/boundaryinfos.py
@@ -11,7 +11,7 @@ class EmptyBoundaryInfo(BoundaryInfoInterface):
     """|BoundaryInfo| with no boundary types attached to any boundary."""
 
     def __init__(self, grid):
-        self.grid = grid
+        self.__auto_init(locals())
         self.boundary_types = frozenset()
 
     def mask(self, boundary_type, codim):
@@ -21,11 +21,8 @@ class EmptyBoundaryInfo(BoundaryInfoInterface):
 class GenericBoundaryInfo(BoundaryInfoInterface):
     """Generic |BoundaryInfo| storing entity masks per boundary type."""
 
-    def __init__(self, grid, masks, assert_unique_type=None, assert_some_type=None):
-        self.assert_unique_type = assert_unique_type if assert_unique_type else [1]
-        self.assert_some_type = assert_some_type if assert_some_type else []
-        self.grid = grid
-        self.masks = masks
+    def __init__(self, grid, masks, assert_unique_type=(1,), assert_some_type=()):
+        self.__auto_init(locals())
         self.boundary_types = frozenset(masks)
         self.check_boundary_types(assert_unique_type=self.assert_unique_type, assert_some_type=self.assert_some_type)
 
@@ -58,7 +55,7 @@ class AllDirichletBoundaryInfo(BoundaryInfoInterface):
     """|BoundaryInfo| where the boundary type 'dirichlet' is attached to each boundary entity."""
 
     def __init__(self, grid):
-        self.grid = grid
+        self.__auto_init(locals())
         self.boundary_types = frozenset({'dirichlet'})
 
     def mask(self, boundary_type, codim):

--- a/src/pymor/grids/oned.py
+++ b/src/pymor/grids/oned.py
@@ -25,10 +25,8 @@ class OnedGrid(AffineGridWithOrthogonalCentersInterface):
 
     def __init__(self, domain=(0, 1), num_intervals=4, identify_left_right=False):
         assert domain[0] < domain[1]
-        self.reference_element = line
-        self.domain = np.array(domain)
-        self.num_intervals = num_intervals
-        self.identify_left_right = identify_left_right
+        domain = np.array(domain)
+        self.__auto_init(locals())
         self._sizes = [num_intervals, num_intervals] if identify_left_right else [num_intervals, num_intervals + 1]
         self._width = np.abs(self.domain[1] - self.domain[0]) / self.num_intervals
         self.__subentities = np.vstack((np.arange(self.num_intervals, dtype=np.int32),

--- a/src/pymor/grids/rect.py
+++ b/src/pymor/grids/rect.py
@@ -51,10 +51,8 @@ class RectGrid(AffineGridWithOrthogonalCentersInterface):
             assert num_intervals[0] > 1
         if identify_bottom_top:
             assert num_intervals[1] > 1
-        self.num_intervals = num_intervals
-        self.domain = np.array(domain)
-        self.identify_left_right = identify_left_right
-        self.identify_bottom_top = identify_bottom_top
+        domain = np.array(domain)
+        self.__auto_init(locals())
 
         self.x0_num_intervals = num_intervals[0]
         self.x1_num_intervals = num_intervals[1]

--- a/src/pymor/grids/tria.py
+++ b/src/pymor/grids/tria.py
@@ -56,10 +56,8 @@ class TriaGrid(AffineGridWithOrthogonalCentersInterface):
             assert num_intervals[0] > 1
         if identify_bottom_top:
             assert num_intervals[1] > 1
-        self.num_intervals = num_intervals
-        self.domain = np.array(domain)
-        self.identify_left_right = identify_left_right
-        self.identify_bottom_top = identify_bottom_top
+        domain = np.array(domain)
+        self.__auto_init(locals())
 
         self.x0_num_intervals = x0_num_intervals = num_intervals[0]
         self.x1_num_intervals = x1_num_intervals = num_intervals[1]

--- a/src/pymor/grids/unstructured.py
+++ b/src/pymor/grids/unstructured.py
@@ -20,9 +20,7 @@ class UnstructuredTriangleGrid(AffineGridInterface):
     reference_element = triangle
 
     def __init__(self, sizes, subentity_data, embedding_data):
-        self.sizes = sizes
-        self.subentity_data = subentity_data
-        self.embedding_data = embedding_data
+        self.__auto_init(locals())
         vertices = self.centers(2)
         self.domain = np.array([[np.min(vertices[:, 0]), np.min(vertices[:, 1])],
                                 [np.max(vertices[:, 0]), np.max(vertices[:, 1])]])

--- a/src/pymor/gui/visualizers.py
+++ b/src/pymor/gui/visualizers.py
@@ -35,11 +35,8 @@ class PatchVisualizer(BasicInterface):
         assert grid.reference_element in (triangle, square)
         assert grid.dim == 2
         assert codim in (0, 2)
-        self.grid = grid
-        self.bounding_box = bounding_box
-        self.codim = codim
-        self.backend = backend or 'jupyter' if is_jupyter() else None
-        self.block = block
+        backend or 'jupyter' if is_jupyter() else None
+        self.__auto_init(locals())
 
     def visualize(self, U, m, title=None, legend=None, separate_colorbars=False,
                   rescale_colorbars=False, block=None, filename=None, columns=2):
@@ -117,9 +114,7 @@ class OnedVisualizer(BasicInterface):
     def __init__(self, grid, codim=1, block=False):
         assert isinstance(grid, OnedGrid)
         assert codim in (0, 1)
-        self.grid = grid
-        self.codim = codim
-        self.block = block
+        self.__auto_init(locals())
 
     def visualize(self, U, m, title=None, legend=None, block=None):
         """Visualize the provided data.

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -33,9 +33,7 @@ class InputOutputModel(ModelBase):
                  estimator=None, visualizer=None, cache_region='memory', name=None):
         assert cont_time in (True, False)
         super().__init__(estimator=estimator, visualizer=visualizer, cache_region=cache_region, name=name)
-        self.input_space = input_space
-        self.output_space = output_space
-        self.cont_time = cont_time
+        self.__auto_init(locals())
 
     @property
     def input_dim(self):
@@ -132,7 +130,7 @@ class InputStateOutputModel(InputOutputModel):
                  estimator=None, visualizer=None, cache_region='memory', name=None):
         super().__init__(input_space, output_space, cont_time=cont_time,
                          estimator=estimator, visualizer=visualizer, cache_region=cache_region, name=name)
-        self.solution_space = solution_space
+        self.__auto_init(locals())
 
     @property
     def order(self):
@@ -234,15 +232,8 @@ class LTIModel(InputStateOutputModel):
         super().__init__(B.source, A.source, C.range, cont_time=cont_time,
                          estimator=estimator, visualizer=visualizer,
                          cache_region=cache_region, name=name)
-
-        self.A = A
-        self.B = B
-        self.C = C
-        self.D = D
-        self.E = E
-        self.solver_options = solver_options
         self.build_parameter_type(A, B, C, D, E)
-        self.parameter_space = parameter_space
+        self.__auto_init(locals())
 
     def __str__(self):
         return (
@@ -898,10 +889,8 @@ class TransferFunction(InputOutputModel):
     def __init__(self, input_space, output_space, tf, dtf, cont_time=True, parameter_space=None,
                  cache_region='memory', name=None):
         super().__init__(input_space, output_space, cont_time=cont_time, cache_region=cache_region, name=name)
-        self.tf = tf
-        self.dtf = dtf
         self.parameter_type = parameter_space.parameter_type if parameter_space else None
-        self.parameter_space = parameter_space
+        self.__auto_init(locals())
 
     def __str__(self):
         return (
@@ -1147,16 +1136,8 @@ class SecondOrderModel(InputStateOutputModel):
         super().__init__(B.source, M.source, Cp.range, cont_time=cont_time,
                          estimator=estimator, visualizer=visualizer,
                          cache_region=cache_region, name=name)
-        self.M = M
-        self.E = E
-        self.K = K
-        self.B = B
-        self.Cp = Cp
-        self.Cv = Cv
-        self.D = D
-        self.solver_options = solver_options
         self.build_parameter_type(M, E, K, B, Cp, Cv, D)
-        self.parameter_space = parameter_space
+        self.__auto_init(locals())
 
     def __str__(self):
         return (
@@ -1823,17 +1804,10 @@ class LinearDelayModel(InputStateOutputModel):
                          estimator=estimator, visualizer=visualizer,
                          cache_region=cache_region, name=name)
 
-        self.A = A
-        self.Ad = Ad
-        self.B = B
-        self.C = C
-        self.D = D
-        self.E = E
-        self.tau = tau
+        self.build_parameter_type(A, *Ad, B, C, D, E)
+        self.__auto_init(locals())
         self.q = len(Ad)
         self.solution_space = A.source
-        self.build_parameter_type(A, *Ad, B, C, D, E)
-        self.parameter_space = parameter_space
 
     def __str__(self):
         return (
@@ -2214,12 +2188,7 @@ class LinearStochasticModel(InputStateOutputModel):
                          estimator=estimator, visualizer=visualizer,
                          cache_region=cache_region, name=name)
 
-        self.A = A
-        self.As = As
-        self.B = B
-        self.C = C
-        self.D = D
-        self.E = E
+        self.__auto_init(locals())
         self.q = len(As)
 
     def __str__(self):
@@ -2342,12 +2311,7 @@ class BilinearModel(InputStateOutputModel):
                          estimator=estimator, visualizer=visualizer,
                          cache_region=cache_region, name=name)
 
-        self.A = A
-        self.N = N
-        self.B = B
-        self.C = C
-        self.D = D
-        self.E = E
+        self.__auto_init(locals())
         self.linear = False
 
     def __str__(self):

--- a/src/pymor/operators/basic.py
+++ b/src/pymor/operators/basic.py
@@ -188,16 +188,15 @@ class ProjectedOperator(OperatorBase):
                     and range_basis is not None
                     and operator.range == product.source
                     and product.range == product.source))
+        if source_basis is not None:
+            source_basis = source_basis.copy()
+        if range_basis is not None:
+            range_basis = range_basis.copy()
+        self.__auto_init(locals())
         self.build_parameter_type(operator)
         self.source = NumpyVectorSpace(len(source_basis)) if source_basis is not None else operator.source
         self.range = NumpyVectorSpace(len(range_basis)) if range_basis is not None else operator.range
-        self.solver_options = solver_options
-        self.name = operator.name
-        self.operator = operator
-        self.source_basis = source_basis.copy() if source_basis is not None else None
-        self.range_basis = range_basis.copy() if range_basis is not None else None
         self.linear = operator.linear
-        self.product = product
 
     @property
     def H(self):

--- a/src/pymor/operators/block.py
+++ b/src/pymor/operators/block.py
@@ -18,7 +18,7 @@ class BlockOperatorBase(OperatorBase):
             yield self.blocks[i, j]
 
     def __init__(self, blocks):
-        blocks = np.array(blocks)
+        self.blocks = blocks = np.array(blocks)
         assert 1 <= blocks.ndim <= 2
         if self.blocked_source and self.blocked_range:
             assert blocks.ndim == 2
@@ -28,7 +28,6 @@ class BlockOperatorBase(OperatorBase):
         else:
             if blocks.ndim == 1:
                 blocks.shape = (len(blocks), 1)
-        self.blocks = blocks
         assert all(isinstance(op, OperatorInterface) or op is None for op in self._operators())
 
         # check if every row/column contains at least one operator
@@ -276,8 +275,7 @@ class SecondOrderModelOperator(BlockOperator):
     def __init__(self, E, K):
         super().__init__([[None, IdentityOperator(E.source)],
                           [K * (-1), E * (-1)]])
-        self.E = E
-        self.K = K
+        self.__auto_init(locals())
 
     def apply(self, U, mu=None):
         assert U in self.source
@@ -367,11 +365,7 @@ class ShiftedSecondOrderModelOperator(BlockOperator):
     def __init__(self, M, E, K, a, b):
         super().__init__([[IdentityOperator(M.source) * a, IdentityOperator(M.source) * b],
                           [((-b) * K).assemble(), (a * M - b * E).assemble()]])
-        self.M = M
-        self.E = E
-        self.K = K
-        self.a = a
-        self.b = b
+        self.__auto_init(locals())
 
     def apply(self, U, mu=None):
         assert U in self.source

--- a/src/pymor/operators/cg.py
+++ b/src/pymor/operators/cg.py
@@ -42,12 +42,8 @@ class L2ProductFunctionalP1(NumpyMatrixBasedOperator):
         assert grid.reference_element(0) in {line, triangle}
         assert function.shape_range == ()
         assert not dirichlet_clear_dofs or boundary_info
+        self.__auto_init(locals())
         self.range = CGVectorSpace(grid)
-        self.grid = grid
-        self.function = function
-        self.dirichlet_clear_dofs = dirichlet_clear_dofs
-        self.boundary_info = boundary_info
-        self.name = name
         self.build_parameter_type(function)
 
     def _assemble(self, mu=None):
@@ -113,13 +109,8 @@ class BoundaryL2ProductFunctional(NumpyMatrixBasedOperator):
         assert grid.reference_element(0) in {line, triangle, square}
         assert function.shape_range == ()
         assert not (boundary_type or dirichlet_clear_dofs) or boundary_info
+        self.__auto_init(locals())
         self.range = CGVectorSpace(grid)
-        self.grid = grid
-        self.function = function
-        self.boundary_type = boundary_type
-        self.dirichlet_clear_dofs = dirichlet_clear_dofs
-        self.boundary_info = boundary_info
-        self.name = name
         self.build_parameter_type(function)
 
     def _assemble(self, mu=None):
@@ -167,11 +158,8 @@ class BoundaryDirichletFunctional(NumpyMatrixBasedOperator):
 
     def __init__(self, grid, dirichlet_data, boundary_info, name=None):
         assert grid.reference_element(0) in {line, triangle, square}
+        self.__auto_init(locals())
         self.range = CGVectorSpace(grid)
-        self.grid = grid
-        self.dirichlet_data = dirichlet_data
-        self.boundary_info = boundary_info
-        self.name = name
         self.build_parameter_type(dirichlet_data)
 
     def _assemble(self, mu=None):
@@ -210,12 +198,8 @@ class L2ProductFunctionalQ1(NumpyMatrixBasedOperator):
         assert grid.reference_element(0) in {square}
         assert function.shape_range == ()
         assert not dirichlet_clear_dofs or boundary_info
+        self.__auto_init(locals())
         self.range = CGVectorSpace(grid)
-        self.grid = grid
-        self.function = function
-        self.dirichlet_clear_dofs = dirichlet_clear_dofs
-        self.boundary_info = boundary_info
-        self.name = name
         self.build_parameter_type(function)
 
     def _assemble(self, mu=None):
@@ -285,15 +269,8 @@ class L2ProductP1(NumpyMatrixBasedOperator):
     def __init__(self, grid, boundary_info, dirichlet_clear_rows=True, dirichlet_clear_columns=False,
                  dirichlet_clear_diag=False, coefficient_function=None, solver_options=None, name=None):
         assert grid.reference_element in (line, triangle)
+        self.__auto_init(locals())
         self.source = self.range = CGVectorSpace(grid)
-        self.grid = grid
-        self.boundary_info = boundary_info
-        self.dirichlet_clear_rows = dirichlet_clear_rows
-        self.dirichlet_clear_columns = dirichlet_clear_columns
-        self.dirichlet_clear_diag = dirichlet_clear_diag
-        self.coefficient_function = coefficient_function
-        self.solver_options = solver_options
-        self.name = name
         self.build_parameter_type(coefficient_function)
 
     def _assemble(self, mu=None):
@@ -383,15 +360,8 @@ class L2ProductQ1(NumpyMatrixBasedOperator):
     def __init__(self, grid, boundary_info, dirichlet_clear_rows=True, dirichlet_clear_columns=False,
                  dirichlet_clear_diag=False, coefficient_function=None, solver_options=None, name=None):
         assert grid.reference_element in {square}
+        self.__auto_init(locals())
         self.source = self.range = CGVectorSpace(grid)
-        self.grid = grid
-        self.boundary_info = boundary_info
-        self.dirichlet_clear_rows = dirichlet_clear_rows
-        self.dirichlet_clear_columns = dirichlet_clear_columns
-        self.dirichlet_clear_diag = dirichlet_clear_diag
-        self.coefficient_function = coefficient_function
-        self.solver_options = solver_options
-        self.name = name
         self.build_parameter_type(coefficient_function)
 
     def _assemble(self, mu=None):
@@ -491,15 +461,8 @@ class DiffusionOperatorP1(NumpyMatrixBasedOperator):
                 and diffusion_function.dim_domain == grid.dim
                 and diffusion_function.shape_range == ()
                 or diffusion_function.shape_range == (grid.dim,) * 2)
+        self.__auto_init(locals())
         self.source = self.range = CGVectorSpace(grid)
-        self.grid = grid
-        self.boundary_info = boundary_info
-        self.diffusion_constant = diffusion_constant
-        self.diffusion_function = diffusion_function
-        self.dirichlet_clear_columns = dirichlet_clear_columns
-        self.dirichlet_clear_diag = dirichlet_clear_diag
-        self.solver_options = solver_options
-        self.name = name
         if diffusion_function is not None:
             self.build_parameter_type(diffusion_function)
 
@@ -612,15 +575,8 @@ class DiffusionOperatorQ1(NumpyMatrixBasedOperator):
                 and diffusion_function.dim_domain == grid.dim
                 and diffusion_function.shape_range == ()
                 or diffusion_function.shape_range == (grid.dim,) * 2)
+        self.__auto_init(locals())
         self.source = self.range = CGVectorSpace(grid)
-        self.grid = grid
-        self.boundary_info = boundary_info
-        self.diffusion_constant = diffusion_constant
-        self.diffusion_function = diffusion_function
-        self.dirichlet_clear_columns = dirichlet_clear_columns
-        self.dirichlet_clear_diag = dirichlet_clear_diag
-        self.solver_options = solver_options
-        self.name = name
         if diffusion_function is not None:
             self.build_parameter_type(diffusion_function)
 
@@ -731,15 +687,8 @@ class AdvectionOperatorP1(NumpyMatrixBasedOperator):
             or (isinstance(advection_function, FunctionInterface)
                 and advection_function.dim_domain == grid.dim
                 and advection_function.shape_range == (grid.dim,))
+        self.__auto_init(locals())
         self.source = self.range = CGVectorSpace(grid)
-        self.grid = grid
-        self.boundary_info = boundary_info
-        self.advection_constant = advection_constant
-        self.advection_function = advection_function
-        self.dirichlet_clear_columns = dirichlet_clear_columns
-        self.dirichlet_clear_diag = dirichlet_clear_diag
-        self.solver_options = solver_options
-        self.name = name
         if advection_function is not None:
             self.build_parameter_type(advection_function)
 
@@ -849,15 +798,8 @@ class AdvectionOperatorQ1(NumpyMatrixBasedOperator):
             or (isinstance(advection_function, FunctionInterface)
                 and advection_function.dim_domain == grid.dim
                 and advection_function.shape_range == (grid.dim,))
+        self.__auto_init(locals())
         self.source = self.range = CGVectorSpace(grid)
-        self.grid = grid
-        self.boundary_info = boundary_info
-        self.advection_constant = advection_constant
-        self.advection_function = advection_function
-        self.dirichlet_clear_columns = dirichlet_clear_columns
-        self.dirichlet_clear_diag = dirichlet_clear_diag
-        self.solver_options = solver_options
-        self.name = name
         if advection_function is not None:
             self.build_parameter_type(advection_function)
 
@@ -964,12 +906,8 @@ class RobinBoundaryOperator(NumpyMatrixBasedOperator):
                                           and (f.shape_range == ()
                                                or f.shape_range == (grid.dim,))
                                           for f in robin_data])
+        self.__auto_init(locals())
         self.source = self.range = CGVectorSpace(grid)
-        self.grid = grid
-        self.boundary_info = boundary_info
-        self.robin_data = robin_data
-        self.solver_options = solver_options
-        self.name = name
         if self.robin_data is not None:
             self.build_parameter_type(self.robin_data[0])
 
@@ -1029,8 +967,7 @@ class InterpolationOperator(NumpyMatrixBasedOperator):
     def __init__(self, grid, function):
         assert function.dim_domain == grid.dim
         assert function.shape_range == ()
-        self.grid = grid
-        self.function = function
+        self.__auto_init(locals())
         self.range = CGVectorSpace(grid)
         self.build_parameter_type(function)
 

--- a/src/pymor/operators/ei.py
+++ b/src/pymor/operators/ei.py
@@ -159,17 +159,14 @@ class ProjectedEmpiciralInterpolatedOperator(OperatorBase):
 
     def __init__(self, restricted_operator, interpolation_matrix, source_basis_dofs,
                  projected_collateral_basis, triangular, solver_options=None, name=None):
+
+        name = name or f'{restricted_operator.name}_projected'
+
+        self.__auto_init(locals())
         self.source = NumpyVectorSpace(len(source_basis_dofs))
         self.range = projected_collateral_basis.space
         self.linear = restricted_operator.linear
         self.build_parameter_type(restricted_operator)
-        self.restricted_operator = restricted_operator
-        self.interpolation_matrix = interpolation_matrix
-        self.source_basis_dofs = source_basis_dofs
-        self.projected_collateral_basis = projected_collateral_basis
-        self.triangular = triangular
-        self.solver_options = solver_options
-        self.name = name or f'{restricted_operator.name}_projected'
 
     def apply(self, U, mu=None):
         mu = self.parse_parameter(mu)

--- a/src/pymor/operators/fv.py
+++ b/src/pymor/operators/fv.py
@@ -78,8 +78,7 @@ class LaxFriedrichsFlux(NumericalConvectiveFluxInterface):
     """
 
     def __init__(self, flux, lxf_lambda=1.0):
-        self.flux = flux
-        self.lxf_lambda = lxf_lambda
+        self.__auto_init(locals())
         self.build_parameter_type(flux)
 
     def evaluate_stage1(self, U, mu=None):
@@ -107,8 +106,7 @@ class SimplifiedEngquistOsherFlux(NumericalConvectiveFluxInterface):
     """
 
     def __init__(self, flux, flux_derivative):
-        self.flux = flux
-        self.flux_derivative = flux_derivative
+        self.__auto_init(locals())
         self.build_parameter_type(flux, flux_derivative)
 
     def evaluate_stage1(self, U, mu=None):
@@ -156,10 +154,7 @@ class EngquistOsherFlux(NumericalConvectiveFluxInterface):
     """
 
     def __init__(self, flux, flux_derivative, gausspoints=5, intervals=1):
-        self.flux = flux
-        self.flux_derivative = flux_derivative
-        self.gausspoints = gausspoints
-        self.intervals = intervals
+        self.__auto_init(locals())
         self.build_parameter_type(flux, flux_derivative)
         points, weights = GaussQuadratures.quadrature(npoints=self.gausspoints)
         points = points / intervals
@@ -221,20 +216,14 @@ class NonlinearAdvectionOperator(OperatorBase):
                  space_id='STATE', name=None):
         assert dirichlet_data is None or isinstance(dirichlet_data, FunctionInterface)
 
-        self.grid = grid
-        self.boundary_info = boundary_info
-        self.numerical_flux = numerical_flux
-        self.dirichlet_data = dirichlet_data
-        self.solver_options = solver_options
-        self.space_id = space_id
-        self.name = name
+        self.__auto_init(locals())
         if (isinstance(dirichlet_data, FunctionInterface) and boundary_info.has_dirichlet
                 and not dirichlet_data.parametric):
             self._dirichlet_values = self.dirichlet_data(grid.centers(1)[boundary_info.dirichlet_boundaries(1)])
             self._dirichlet_values = self._dirichlet_values.ravel()
             self._dirichlet_values_flux_shaped = self._dirichlet_values.reshape((-1, 1))
-        self.build_parameter_type(numerical_flux, dirichlet_data)
         self.source = self.range = FVVectorSpace(grid, space_id)
+        self.build_parameter_type(numerical_flux, dirichlet_data)
 
     def with_numerical_flux(self, **kwargs):
         return self.with_(numerical_flux=self.numerical_flux.with_(**kwargs))
@@ -479,14 +468,9 @@ class LinearAdvectionLaxFriedrichs(NumpyMatrixBasedOperator):
     """
 
     def __init__(self, grid, boundary_info, velocity_field, lxf_lambda=1.0, solver_options=None, name=None):
-        self.grid = grid
-        self.boundary_info = boundary_info
-        self.velocity_field = velocity_field
-        self.lxf_lambda = lxf_lambda
-        self.solver_options = solver_options
-        self.name = name
-        self.build_parameter_type(velocity_field)
+        self.__auto_init(locals())
         self.source = self.range = FVVectorSpace(grid)
+        self.build_parameter_type(velocity_field)
 
     def _assemble(self, mu=None):
         g = self.grid
@@ -545,10 +529,8 @@ class L2Product(NumpyMatrixBasedOperator):
     sparse = True
 
     def __init__(self, grid, solver_options=None, name=None):
+        self.__auto_init(locals())
         self.source = self.range = FVVectorSpace(grid)
-        self.grid = grid
-        self.solver_options = solver_options
-        self.name = name
 
     def _assemble(self, mu=None):
 
@@ -580,11 +562,8 @@ class ReactionOperator(NumpyMatrixBasedOperator):
 
     def __init__(self, grid, reaction_coefficient, solver_options=None, name=None):
         assert reaction_coefficient.dim_domain == grid.dim and reaction_coefficient.shape_range == ()
+        self.__auto_init(locals())
         self.source = self.range = FVVectorSpace(grid)
-        self.grid = grid
-        self.reaction_coefficient = reaction_coefficient
-        self.solver_options = solver_options
-        self.name = name
         self.build_parameter_type(reaction_coefficient)
 
     def _assemble(self, mu=None):
@@ -600,13 +579,9 @@ class NonlinearReactionOperator(OperatorBase):
     linear = False
 
     def __init__(self, grid, reaction_function, reaction_function_derivative=None, space_id='STATE', name=None):
-        self.grid = grid
-        self.reaction_function = reaction_function
-        self.reaction_function_derivative = reaction_function_derivative
-        self.build_parameter_type(reaction_function, reaction_function_derivative)
-        self.space_id = space_id
-        self.name = name
+        self.__auto_init(locals())
         self.source = self.range = FVVectorSpace(grid, space_id)
+        self.build_parameter_type(reaction_function, reaction_function_derivative)
 
     def apply(self, U, ind=None, mu=None):
         assert U in self.source
@@ -666,16 +641,8 @@ class L2ProductFunctional(NumpyMatrixBasedOperator):
     def __init__(self, grid, function=None, boundary_info=None, dirichlet_data=None, diffusion_function=None,
                  diffusion_constant=None, neumann_data=None, order=1, name=None):
         assert function is None or function.shape_range == ()
+        self.__auto_init(locals())
         self.range = FVVectorSpace(grid)
-        self.grid = grid
-        self.boundary_info = boundary_info
-        self.function = function
-        self.dirichlet_data = dirichlet_data
-        self.diffusion_function = diffusion_function
-        self.diffusion_constant = diffusion_constant
-        self.neumann_data = neumann_data
-        self.order = order
-        self.name = name
         self.build_parameter_type(function, dirichlet_data, diffusion_function, neumann_data)
 
     def _assemble(self, mu=None):
@@ -761,12 +728,7 @@ class DiffusionOperator(NumpyMatrixBasedOperator):
                 or (isinstance(diffusion_function, FunctionInterface)
                     and diffusion_function.dim_domain == grid.dim
                     and diffusion_function.shape_range == ()))
-        self.grid = grid
-        self.boundary_info = boundary_info
-        self.diffusion_function = diffusion_function
-        self.diffusion_constant = diffusion_constant
-        self.solver_options = solver_options
-        self.name = name
+        self.__auto_init(locals())
         self.source = self.range = FVVectorSpace(grid)
         if diffusion_function is not None:
             self.build_parameter_type(diffusion_function)

--- a/src/pymor/operators/mpi.py
+++ b/src/pymor/operators/mpi.py
@@ -61,13 +61,9 @@ class MPIOperator(OperatorBase):
     def __init__(self, obj_id, mpi_range, mpi_source, with_apply2=False, pickle_local_spaces=True,
                  space_type=MPIVectorSpace):
         assert mpi_source or mpi_range
-        self.obj_id = obj_id
-        self.mpi_source = mpi_source
-        self.mpi_range = mpi_range
+
+        self.__auto_init(locals())
         self.op = op = mpi.get_object(obj_id)
-        self.with_apply2 = with_apply2
-        self.pickle_local_spaces = pickle_local_spaces
-        self.space_type = space_type
         self.linear = op.linear
         self.name = op.name
         self.build_parameter_type(op)

--- a/src/pymor/operators/numpy.py
+++ b/src/pymor/operators/numpy.py
@@ -65,19 +65,9 @@ class NumpyGenericOperator(OperatorBase):
 
     def __init__(self, mapping, adjoint_mapping=None, dim_source=1, dim_range=1, linear=False, parameter_type=None,
                  source_id=None, range_id=None, solver_options=None, name=None):
+        self.__auto_init(locals())
         self.source = NumpyVectorSpace(dim_source, source_id)
         self.range = NumpyVectorSpace(dim_range, range_id)
-        self.solver_options = solver_options
-        self.name = name
-        self.mapping = mapping
-        self.adjoint_mapping = adjoint_mapping
-        self.dim_source = dim_source
-        self.dim_range = dim_range
-        self.linear = linear
-        if parameter_type is not None:
-            self.build_parameter_type(parameter_type)
-        self.source_id = source_id  # needed for with_
-        self.range_id = range_id
 
     def apply(self, U, mu=None):
         assert U in self.source
@@ -195,13 +185,10 @@ class NumpyMatrixOperator(NumpyMatrixBasedOperator):
             matrix.setflags(write=False)  # make numpy arrays read-only
         except AttributeError:
             pass
+
+        self.__auto_init(locals())
         self.source = NumpyVectorSpace(matrix.shape[1], source_id)
         self.range = NumpyVectorSpace(matrix.shape[0], range_id)
-        self.solver_options = solver_options
-        self.name = name
-        self.matrix = matrix
-        self.source_id = source_id
-        self.range_id = range_id
         self.sparse = issparse(matrix)
 
     @classmethod

--- a/src/pymor/parallel/ipython.py
+++ b/src/pymor/parallel/ipython.py
@@ -48,12 +48,7 @@ class new_ipcluster_pool(BasicInterface):
     """
 
     def __init__(self, profile=None, cluster_id=None, num_engines=None, ipython_dir=None, min_wait=1, timeout=60):
-        self.profile = profile
-        self.cluster_id = cluster_id
-        self.num_engines = num_engines
-        self.ipython_dir = ipython_dir
-        self.min_wait = min_wait
-        self.timeout = timeout
+        self.__auto_init(locals())
 
     def __enter__(self):
         args = []

--- a/src/pymor/parameters/functionals.py
+++ b/src/pymor/parameters/functionals.py
@@ -30,15 +30,13 @@ class ProjectionParameterFunctional(ParameterFunctionalInterface):
     """
 
     def __init__(self, component_name, component_shape, coordinates=(), name=None):
-        self.name = name
         if isinstance(component_shape, Number):
             component_shape = () if component_shape == 0 else (component_shape,)
-        self.build_parameter_type({component_name: component_shape})
-        self.component_name = component_name
-        self.component_shape = component_shape
-        self.coordinates = coordinates
         assert len(coordinates) == len(component_shape)
         assert not component_shape or coordinates < component_shape
+
+        self.__auto_init(locals())
+        self.build_parameter_type({component_name: component_shape})
 
     def evaluate(self, mu=None):
         mu = self.parse_parameter(mu)
@@ -64,8 +62,7 @@ class GenericParameterFunctional(ParameterFunctionalInterface):
     """
 
     def __init__(self, mapping, parameter_type, name=None):
-        self.name = name
-        self.mapping = mapping
+        self.__auto_init(locals())
         self.build_parameter_type(parameter_type)
 
     def evaluate(self, mu=None):
@@ -134,8 +131,7 @@ class ProductParameterFunctional(ParameterFunctionalInterface):
     def __init__(self, factors, name=None):
         assert len(factors) > 0
         assert all(isinstance(f, (ParameterFunctionalInterface, Number)) for f in factors)
-        self.name = name
-        self.factors = tuple(factors)
+        self.__auto_init(locals())
         self.build_parameter_type(*(f for f in factors if isinstance(f, ParameterFunctionalInterface)))
 
     def evaluate(self, mu=None):

--- a/src/pymor/parameters/spaces.py
+++ b/src/pymor/parameters/spaces.py
@@ -36,11 +36,10 @@ class CubicParameterSpace(ParameterSpaceInterface):
         assert ranges is not None or (minimum is not None and maximum is not None),\
             'Must specify minimum, maximum or ranges'
         assert minimum is None or minimum < maximum
+        if ranges is None:
+            ranges = {k: (minimum, maximum) for k in parameter_type}
         parameter_type = ParameterType(parameter_type)
-        self.parameter_type = parameter_type
-        self.minimum = minimum
-        self.maximum = maximum
-        self.ranges = {k: (minimum, maximum) for k in parameter_type} if ranges is None else ranges
+        self.__auto_init(locals())
 
     def parse_parameter(self, mu):
         return Parameter.from_parameter_type(mu, self.parameter_type)

--- a/src/pymor/reductors/basic.py
+++ b/src/pymor/reductors/basic.py
@@ -44,11 +44,9 @@ class ProjectionBasedReductor(BasicInterface):
     @defaults('check_orthonormality', 'check_tol')
     def __init__(self, fom, bases, products={}, check_orthonormality=True, check_tol=1e-3):
         assert products.keys() <= bases.keys()
-        self.fom = fom
-        self.bases = dict(bases)
-        self.products = dict(products)
-        self.check_orthonormality = check_orthonormality
-        self.check_tol = check_tol
+        bases = dict(bases)
+        products = dict(products)
+        self.__auto_init(locals())
         self._last_rom = None
 
         if check_orthonormality:

--- a/src/pymor/reductors/coercive.py
+++ b/src/pymor/reductors/coercive.py
@@ -63,9 +63,7 @@ class CoerciveRBEstimator(ImmutableInterface):
     """
 
     def __init__(self, residual, residual_range_dims, coercivity_estimator):
-        self.residual = residual
-        self.residual_range_dims = residual_range_dims
-        self.coercivity_estimator = coercivity_estimator
+        self.__auto_init(locals())
 
     def estimate(self, U, mu, m):
         est = self.residual.apply(U, mu=mu).l2_norm()
@@ -212,8 +210,7 @@ class SimpleCoerciveRBEstimator(ImmutableInterface):
     """
 
     def __init__(self, estimator_matrix, coercivity_estimator):
-        self.estimator_matrix = estimator_matrix
-        self.coercivity_estimator = coercivity_estimator
+        self.__auto_init(locals())
         self.norm = induced_norm(estimator_matrix)
 
     def estimate(self, U, mu, m):

--- a/src/pymor/reductors/parabolic.py
+++ b/src/pymor/reductors/parabolic.py
@@ -96,11 +96,7 @@ class ParabolicRBEstimator(ImmutableInterface):
 
     def __init__(self, residual, residual_range_dims, initial_residual, initial_residual_range_dims,
                  coercivity_estimator):
-        self.residual = residual
-        self.residual_range_dims = residual_range_dims
-        self.initial_residual = initial_residual
-        self.initial_residual_range_dims = initial_residual_range_dims
-        self.coercivity_estimator = coercivity_estimator
+        self.__auto_init(locals())
 
     def estimate(self, U, mu, m, return_error_sequence=False):
         dt = m.T / m.time_stepper.nt

--- a/src/pymor/reductors/residual.py
+++ b/src/pymor/reductors/residual.py
@@ -65,8 +65,7 @@ class ResidualReductor(BasicInterface):
             or (rhs.source.is_scalar and rhs.range == operator.range and rhs.linear)
         assert product is None or product.source == product.range == operator.range
 
-        self.RB, self.operator, self.rhs, self.product, self.riesz_representatives = \
-            RB, operator, rhs, product, riesz_representatives
+        self.__auto_init(locals())
         self.residual_range = operator.range.empty()
         self.residual_range_dims = []
 
@@ -114,13 +113,11 @@ class ResidualOperator(OperatorBase):
     """Instantiated by :class:`ResidualReductor`."""
 
     def __init__(self, operator, rhs, name=None):
+        self.__auto_init(locals())
         self.source = operator.source
         self.range = operator.range
         self.linear = operator.linear
-        self.operator = operator
-        self.rhs = rhs
         self.rhs_vector = rhs.as_range_array() if rhs and not rhs.parametric else None
-        self.name = name
 
     def apply(self, U, mu=None):
         V = self.operator.apply(U, mu=mu)
@@ -146,7 +143,7 @@ class NonProjectedResidualOperator(ResidualOperator):
 
     def __init__(self, operator, rhs, riesz_representatives, product):
         super().__init__(operator, rhs)
-        self.riesz_representatives, self.product = riesz_representatives, product
+        self.__auto_init(locals())
 
     def apply(self, U, mu=None):
         R = super().apply(U, mu=mu)
@@ -220,12 +217,7 @@ class ImplicitEulerResidualReductor(BasicInterface):
             or rhs.source.is_scalar and rhs.range == operator.range and rhs.linear
         assert product is None or product.source == product.range == operator.range
 
-        self.RB = RB
-        self.operator = operator
-        self.mass = mass
-        self.dt = dt
-        self.rhs = rhs
-        self.product = product
+        self.__auto_init(locals())
         self.residual_range = operator.range.empty()
         self.residual_range_dims = []
 
@@ -271,15 +263,11 @@ class ImplicitEulerResidualOperator(OperatorBase):
     """Instantiated by :class:`ImplicitEulerResidualReductor`."""
 
     def __init__(self, operator, mass, rhs, dt, name=None):
+        self.__auto_init(locals())
         self.source = operator.source
         self.range = operator.range
         self.linear = operator.linear
-        self.operator = operator
-        self.mass = mass
-        self.rhs = rhs
         self.rhs_vector = rhs.as_range_array() if rhs and not rhs.parametric else None
-        self.dt = dt
-        self.name = name
 
     def apply(self, U, U_old, mu=None):
         V = self.operator.apply(U, mu=mu)


### PR DESCRIPTION
This PR superseeds #687 and #711.

With this PR, `BasicInterface` and derived classes get `__auto_init(self, locals_)` methods which initialize object attributes corresponding to `__init__` arguments with values provided by the `locals_` dict. Typically, `locals_` will be given by `locals()`.

Compared to #711, I decided to get rid of the additional `cls` parameter by creating a private `__auto_init` for each class. - There is not too much magic involved, and I do not see a reason for letting `cls` be anything different from `__class__`.

Overall I really think that apart from reducing boiler plate code, `__auto_init` really improves readability since it is much easier to see if anything interesting happens in `__init__`.