### PR TITLE
Update mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,8 +1,23 @@
-Felix Schindler <felix.schindler@wwu.de> Felix Albrecht <mail@felixalbrecht.de>
-Felix Schindler <felix.schindler@wwu.de> Felix Albrecht <felix.albrecht@uni-muenster.de>
-Felix Schindler <felix.schindler@wwu.de> Felix Albrecht <felix.albrecht@wwu.de>
-Felix Schindler <felix.schindler@wwu.de> Felix Schindler <felix@schindlerfamily.de>
-Rene Milk <rene.milk@uni-muenster.de> renemilk <renemilk@users.noreply.github.com>
-Linus Balicki <linus.balicki@ovgu.de> lbalicki <linuxte@yahoo.de>
-Petar Mlinarić <mlinaric@mpi-magdeburg.mpg.de> Petar Mlinaric <mlinaric@mpi-magdeburg.mpg.de>
-Petar Mlinarić <mlinaric@mpi-magdeburg.mpg.de> Petar Mlinarić <pmli@users.noreply.github.com>
+Christian Himpe <himpe@mpi-magdeburg.mpg.de>
+Dennis Eickhorn <d.eickhorn@uni-muenster.de>
+Dennis Eickhorn <d.eickhorn@uni-muenster.de> <d.eickhorn@mail.de>
+Dennis Eickhorn <d.eickhorn@uni-muenster.de> <d.eickhorn@wwu.de>
+Falk Meyer <falk.meyer@uni-muenster.de>
+Felix Schindler <felix.schindler@wwu.de>
+Felix Schindler <felix.schindler@wwu.de> <felix.albrecht@uni-muenster.de>
+Felix Schindler <felix.schindler@wwu.de> <felix.albrecht@wwu.de>
+Felix Schindler <felix.schindler@wwu.de> <felix@schindlerfamily.de>
+Felix Schindler <felix.schindler@wwu.de> <ftalbrecht@users.noreply.github.com>
+Felix Schindler <felix.schindler@wwu.de> <mail@felixalbrecht.de>
+Linus Balicki <linus.balicki@ovgu.de>
+Linus Balicki <linus.balicki@ovgu.de> <38659258+lbalicki@users.noreply.github.com>
+Linus Balicki <linus.balicki@ovgu.de> <linuxte@yahoo.de>
+Lucas Camphausen <lucascamp@web.de>
+Petar Mlinarić <mlinaric@mpi-magdeburg.mpg.de>
+Petar Mlinarić <mlinaric@mpi-magdeburg.mpg.de> <petar.mlinaric@gmail.com>
+Petar Mlinarić <mlinaric@mpi-magdeburg.mpg.de> <pmli@users.noreply.github.com>
+René Fritze <rene.fritze@uni-muenster.de>
+René Fritze <rene.fritze@uni-muenster.de> <rene.fritze@wwu.de>
+René Fritze <rene.fritze@uni-muenster.de> <rene.milk@uni-muenster.de>
+René Fritze <rene.fritze@uni-muenster.de> <rene.milk@wwu.de>
+René Fritze <rene.fritze@uni-muenster.de> <renemilk@users.noreply.github.com>


### PR DESCRIPTION
This PR makes the result of `git shortlog -nse` as short as possible. Additionally, it uses "Name Surname" format for all contributors.

Documentation on using `.mailmap` is [here](https://git-scm.com/docs/git-check-mailmap#_mapping_authors).

Before:
```
  3066  Stephan Rave <stephanrave@uni-muenster.de>
   626  Petar Mlinarić <mlinaric@mpi-magdeburg.mpg.de>
   353  Rene Milk <rene.milk@uni-muenster.de>
   298  Rene Milk <rene.milk@wwu.de>
   175  René Fritze <rene.fritze@wwu.de>
   139  Felix Schindler <felix.schindler@wwu.de>
    90  René Milk <rene.milk@wwu.de>
    36  Michael Laier <m_laie01@uni-muenster.de>
    29  Andreas Buhr <andreas@andreasbuhr.de>
    27  René Milk <renemilk@users.noreply.github.com>
    12  Linus Balicki <linus.balicki@ovgu.de>
    12  Michael Schaefer <michael.schaefer@uni-muenster.de>
     9  Christian <himpe@mpi-magdeburg.mpg.de>
     5  Felix Schindler <ftalbrecht@users.noreply.github.com>
     5  Petar Mlinarić <petar.mlinaric@gmail.com>
     5  d_eick05 <d.eickhorn@wwu.de>
     4  deneick <d.eickhorn@mail.de>
     4  falk <falk.meyer@uni-muenster.de>
     2  Julia Brunken <julia.brunken@uni-muenster.de>
     1  Linus Balicki <38659258+lbalicki@users.noreply.github.com>
     1  fameyer <falk.meyer@uni-muenster.de>
     1  lucas-ca <lucascamp@web.de>
```

After:
```
  3066  Stephan Rave <stephanrave@uni-muenster.de>
   943  René Fritze <rene.fritze@uni-muenster.de>
   632  Petar Mlinarić <mlinaric@mpi-magdeburg.mpg.de>
   144  Felix Schindler <felix.schindler@wwu.de>
    36  Michael Laier <m_laie01@uni-muenster.de>
    29  Andreas Buhr <andreas@andreasbuhr.de>
    13  Linus Balicki <linus.balicki@ovgu.de>
    12  Michael Schaefer <michael.schaefer@uni-muenster.de>
     9  Christian Himpe <himpe@mpi-magdeburg.mpg.de>
     9  Dennis Eickhorn <d.eickhorn@uni-muenster.de>
     5  Falk Meyer <falk.meyer@uni-muenster.de>
     2  Julia Brunken <julia.brunken@uni-muenster.de>
     1  Lucas Camphausen <lucascamp@web.de>
```