### PR TITLE
Low-rank updated operators and Sherman-Morrison-Woodbury formula

### DIFF
--- a/src/pymor/algorithms/lincomb.py
+++ b/src/pymor/algorithms/lincomb.py
@@ -55,6 +55,20 @@ class AssembleLincombRules(RuleTable):
         super().__init__(use_caching=False)
         self.__auto_init(locals())
 
+    @match_always
+    def action_zero_coeff(self, ops):
+        if all(coeff != 0 for coeff in self.coefficients):
+            raise RuleNotMatchingError
+        without_zero = [(op, coeff)
+                        for op, coeff in zip(ops, self.coefficients)
+                        if coeff != 0]
+        if len(without_zero) == 0:
+            return ZeroOperator(ops[0].range, ops[0].source, name=self.name)
+        else:
+            new_ops, new_coeffs = zip(*without_zero)
+            return assemble_lincomb(new_ops, new_coeffs,
+                                    solver_options=self.solver_options, name=self.name)
+
     @match_class_any(ZeroOperator)
     def action_ZeroOperator(self, ops):
         without_zero = [(op, coeff)

--- a/src/pymor/algorithms/lincomb.py
+++ b/src/pymor/algorithms/lincomb.py
@@ -218,8 +218,7 @@ class AssembleLincombRules(RuleTable):
                                     solver_options=self.solver_options, name=self.name)
 
     @match_generic(lambda ops: len(ops) >= 2)
-    @match_generic(lambda ops: any(isinstance(op, (LowRankOperator, LowRankUpdatedOperator))
-                                   for op in ops))
+    @match_class_any(LowRankOperator, LowRankUpdatedOperator)
     def action_merge_into_low_rank_updated_operator(self, ops):
         new_ops = []
         new_lr_ops = []

--- a/src/pymor/algorithms/lincomb.py
+++ b/src/pymor/algorithms/lincomb.py
@@ -184,7 +184,7 @@ class AssembleLincombRules(RuleTable):
                 blocks[i, j] = ops[0].blocks[i, j] * c
             return operator_type(blocks)
 
-    @match_generic(lambda ops: len(op for op in ops if isinstance(op, LowRankOperator)) >= 2)
+    @match_generic(lambda ops: sum(1 for op in ops if isinstance(op, LowRankOperator)) >= 2)
     def action_merge_low_rank_operators(self, ops):
         low_rank = []
         not_low_rank = []
@@ -193,14 +193,14 @@ class AssembleLincombRules(RuleTable):
                 low_rank.append((op, coeff))
             else:
                 not_low_rank.append((op, coeff))
-        inverted = [op.inverted for op in low_rank if op.core is not None]
+        inverted = [op.inverted for op, _ in low_rank if op.core is not None]
         if len(inverted) >= 2 and any(inverted) and any([not _ for _ in inverted]):
             raise RuleNotMatchingError
         inverted = inverted[0] if inverted else False
-        left = cat_arrays([op.left for op in low_rank])
-        right = cat_arrays([op.right for op in low_rank])
+        left = cat_arrays([op.left for op, _ in low_rank])
+        right = cat_arrays([op.right for op, _ in low_rank])
         core = []
-        for op, coeff in zip(*low_rank):
+        for op, coeff in low_rank:
             core.append(op.core)
             if core[-1] is None:
                 core[-1] = np.eye(len(op.left))

--- a/src/pymor/operators/constructions.py
+++ b/src/pymor/operators/constructions.py
@@ -465,6 +465,7 @@ class LowRankUpdatedOperator(LincombOperator):
         assert isinstance(lr_operator, LowRankOperator)
         super().__init__([operator, lr_operator], [coeff, lr_coeff],
                          solver_options=solver_options, name=name)
+        self.__auto_init(locals())
 
     def apply_inverse(self, V, mu=None, least_squares=False):
         A, LR = self.operators

--- a/src/pymor/operators/constructions.py
+++ b/src/pymor/operators/constructions.py
@@ -162,7 +162,7 @@ class LincombOperator(OperatorBase):
                 raise NotImplementedError
         derivative_coefficients = []
         for coef in self.coefficients:
-            if isinstance(coef,Parametric):
+            if isinstance(coef, Parametric):
                 derivative_coefficients.append(coef.d_mu(component, index))
             else:
                 derivative_coefficients.append(0.)

--- a/src/pymor/operators/constructions.py
+++ b/src/pymor/operators/constructions.py
@@ -467,9 +467,11 @@ class LowRankUpdatedOperator(LincombOperator):
         self.__auto_init(locals())
 
     def apply_inverse(self, V, mu=None, least_squares=False):
+        if least_squares:
+            return super().apply_inverse(V, mu=mu, least_squares=True)
         A, LR = self.operators
         L, C, R = LR.left, LR.core, LR.right
-        if not self.inverted:
+        if not LR.inverted:
             L = L.lincomb(C.T)
             R = R.lincomb(C.conj())
         alpha, beta = self.evaluate_coefficients(mu)
@@ -483,9 +485,11 @@ class LowRankUpdatedOperator(LincombOperator):
         return U
 
     def apply_inverse_adjoint(self, U, mu=None, least_squares=False):
+        if least_squares:
+            return super().apply_inverse_adjoint(U, mu=mu, least_squares=True)
         A, LR = self.operators
         L, C, R = LR.left, LR.core, LR.right
-        if not self.inverted:
+        if not LR.inverted:
             L = L.lincomb(C.T)
             R = R.lincomb(C.conj())
         alpha, beta = (c.conjugate() for c in self.evaluate_coefficients(mu))

--- a/src/pymortests/low_rank_op.py
+++ b/src/pymortests/low_rank_op.py
@@ -173,3 +173,24 @@ def test_low_rank_updated_assemble():
 
     op = (A + (A + LR).assemble() + LR).assemble()
     assert isinstance(op, LowRankUpdatedOperator)
+
+
+def test_low_rank_updated_assemble_apply():
+    n = 10
+    space = NumpyVectorSpace(n)
+    rng = np.random.RandomState(0)
+    A = NumpyMatrixOperator(rng.randn(n, n))
+
+    r = 2
+    L = space.random(r, distribution='normal', random_state=rng)
+    C = rng.randn(r, r)
+    R = space.random(r, distribution='normal', random_state=rng)
+    LR = LowRankOperator(L, C, R)
+
+    k = 3
+    U = space.random(k, distribution='normal', random_state=rng)
+
+    op = (A + (A + LR).assemble() + LR).assemble()
+    V = op.apply(U)
+    assert np.allclose(V.to_numpy().T,
+                       2 * A.matrix @ U.to_numpy().T + 2 * L.to_numpy().T @ C @ (R.to_numpy() @ U.to_numpy().T))

--- a/src/pymortests/low_rank_op.py
+++ b/src/pymortests/low_rank_op.py
@@ -1,0 +1,58 @@
+# This file is part of the pyMOR project (http://www.pymor.org).
+# Copyright 2013-2019 pyMOR developers and contributors. All rights reserved.
+# License: BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+
+import numpy as np
+
+from pymor.algorithms.lincomb import assemble_lincomb
+from pymor.operators.constructions import LowRankOperator
+from pymor.vectorarrays.numpy import NumpyVectorSpace
+
+
+def test_low_rank_assemble():
+    n = 10
+    space = NumpyVectorSpace(n)
+    rng = np.random.RandomState(0)
+
+    r1 = 2
+    L1 = space.random(r1, distribution='normal', random_state=rng)
+    R1 = space.random(r1, distribution='normal', random_state=rng)
+    C1 = rng.randn(r1, r1)
+
+    r2 = 3
+    L2 = space.random(r2, distribution='normal', random_state=rng)
+    R2 = space.random(r2, distribution='normal', random_state=rng)
+    C2 = rng.randn(r2, r2)
+
+    LR1 = LowRankOperator(L1, R1, C1)
+    LR2 = LowRankOperator(L2, R2, C2)
+    op = assemble_lincomb([LR1, LR2], [1, 1])
+    assert isinstance(op, LowRankOperator)
+    assert len(op.left) == r1 + r2
+    assert not op.inverted
+
+    LR1 = LowRankOperator(L1, R1, C1, inverted=True)
+    LR2 = LowRankOperator(L2, R2, C2, inverted=True)
+    op = assemble_lincomb([LR1, LR2], [1, 1])
+    assert isinstance(op, LowRankOperator)
+    assert len(op.left) == r1 + r2
+    assert op.inverted
+
+    LR1 = LowRankOperator(L1, R1, C1, inverted=True)
+    LR2 = LowRankOperator(L2, R2, C2)
+    op = assemble_lincomb([LR1, LR2], [1, 1])
+    assert op is None
+
+    LR1 = LowRankOperator(L1, R1)
+    LR2 = LowRankOperator(L2, R2, C2)
+    op = assemble_lincomb([LR1, LR2], [1, 1])
+    assert isinstance(op, LowRankOperator)
+    assert len(op.left) == r1 + r2
+    assert not op.inverted
+
+    LR1 = LowRankOperator(L1, R1)
+    LR2 = LowRankOperator(L2, R2, C2, inverted=True)
+    op = assemble_lincomb([LR1, LR2], [1, 1])
+    assert isinstance(op, LowRankOperator)
+    assert len(op.left) == r1 + r2
+    assert op.inverted

--- a/src/pymortests/low_rank_op.py
+++ b/src/pymortests/low_rank_op.py
@@ -17,16 +17,16 @@ def test_low_rank_assemble():
 
     r1 = 2
     L1 = space.random(r1, distribution='normal', random_state=rng)
-    R1 = space.random(r1, distribution='normal', random_state=rng)
     C1 = rng.randn(r1, r1)
+    R1 = space.random(r1, distribution='normal', random_state=rng)
 
     r2 = 3
     L2 = space.random(r2, distribution='normal', random_state=rng)
-    R2 = space.random(r2, distribution='normal', random_state=rng)
     C2 = rng.randn(r2, r2)
+    R2 = space.random(r2, distribution='normal', random_state=rng)
 
-    LR1 = LowRankOperator(L1, R1, C1)
-    LR2 = LowRankOperator(L2, R2, C2)
+    LR1 = LowRankOperator(L1, C1, R1)
+    LR2 = LowRankOperator(L2, C2, R2)
     op = assemble_lincomb([LR1, LR2], [1, 1])
     assert isinstance(op, LowRankOperator)
     assert len(op.left) == r1 + r2
@@ -35,31 +35,17 @@ def test_low_rank_assemble():
     op = (LR1 + (LR1 + LR2) + LR2).assemble()
     assert isinstance(op, LowRankOperator)
 
-    LR1 = LowRankOperator(L1, R1, C1, inverted=True)
-    LR2 = LowRankOperator(L2, R2, C2, inverted=True)
+    LR1 = LowRankOperator(L1, C1, R1, inverted=True)
+    LR2 = LowRankOperator(L2, C2, R2, inverted=True)
     op = assemble_lincomb([LR1, LR2], [1, 1])
     assert isinstance(op, LowRankOperator)
     assert len(op.left) == r1 + r2
     assert op.inverted
 
-    LR1 = LowRankOperator(L1, R1, C1, inverted=True)
-    LR2 = LowRankOperator(L2, R2, C2)
+    LR1 = LowRankOperator(L1, C1, R1, inverted=True)
+    LR2 = LowRankOperator(L2, C2, R2)
     op = assemble_lincomb([LR1, LR2], [1, 1])
     assert op is None
-
-    LR1 = LowRankOperator(L1, R1)
-    LR2 = LowRankOperator(L2, R2, C2)
-    op = assemble_lincomb([LR1, LR2], [1, 1])
-    assert isinstance(op, LowRankOperator)
-    assert len(op.left) == r1 + r2
-    assert not op.inverted
-
-    LR1 = LowRankOperator(L1, R1)
-    LR2 = LowRankOperator(L2, R2, C2, inverted=True)
-    op = assemble_lincomb([LR1, LR2], [1, 1])
-    assert isinstance(op, LowRankOperator)
-    assert len(op.left) == r1 + r2
-    assert op.inverted
 
 
 def test_low_rank_updated_assemble():
@@ -70,9 +56,9 @@ def test_low_rank_updated_assemble():
 
     r = 2
     L = space.random(r, distribution='normal', random_state=rng)
-    R = space.random(r, distribution='normal', random_state=rng)
     C = rng.randn(r, r)
-    LR = LowRankOperator(L, R, C)
+    R = space.random(r, distribution='normal', random_state=rng)
+    LR = LowRankOperator(L, C, R)
 
     op = (A + LR).assemble()
     assert isinstance(op, LowRankUpdatedOperator)

--- a/src/pymortests/low_rank_op.py
+++ b/src/pymortests/low_rank_op.py
@@ -5,7 +5,8 @@
 import numpy as np
 
 from pymor.algorithms.lincomb import assemble_lincomb
-from pymor.operators.constructions import LowRankOperator
+from pymor.operators.constructions import LowRankOperator, LowRankUpdatedOperator
+from pymor.operators.numpy import NumpyMatrixOperator
 from pymor.vectorarrays.numpy import NumpyVectorSpace
 
 
@@ -30,6 +31,9 @@ def test_low_rank_assemble():
     assert isinstance(op, LowRankOperator)
     assert len(op.left) == r1 + r2
     assert not op.inverted
+
+    op = (LR1 + (LR1 + LR2) + LR2).assemble()
+    assert isinstance(op, LowRankOperator)
 
     LR1 = LowRankOperator(L1, R1, C1, inverted=True)
     LR2 = LowRankOperator(L2, R2, C2, inverted=True)
@@ -56,3 +60,25 @@ def test_low_rank_assemble():
     assert isinstance(op, LowRankOperator)
     assert len(op.left) == r1 + r2
     assert op.inverted
+
+
+def test_low_rank_updated_assemble():
+    n = 10
+    space = NumpyVectorSpace(n)
+    rng = np.random.RandomState(0)
+    A = NumpyMatrixOperator(rng.randn(n, n))
+
+    r = 2
+    L = space.random(r, distribution='normal', random_state=rng)
+    R = space.random(r, distribution='normal', random_state=rng)
+    C = rng.randn(r, r)
+    LR = LowRankOperator(L, R, C)
+
+    op = (A + LR).assemble()
+    assert isinstance(op, LowRankUpdatedOperator)
+
+    op = (A + LR + LR).assemble()
+    assert isinstance(op, LowRankUpdatedOperator)
+
+    op = (A + (A + LR).assemble() + LR).assemble()
+    assert isinstance(op, LowRankUpdatedOperator)


### PR DESCRIPTION
So far, this adds `LowRankOperator` and `LowRankUpdatedOperator` to `operators.constructions`. The `LowRankUpdatedOperator` uses [Sherman-Morrison-Woodbury formula](https://en.wikipedia.org/wiki/Woodbury_matrix_identity) in `apply_inverse` and `apply_inverse_adjoint`.

The motivation for L M<sup>-1</sup> R<sup>H</sup> form of the low-rank operator is from Riccati equations appearing in variants of balanced truncation (LQG balanced truncation with nonzero D, balanced stochastic truncation, bounded real balanced truncation with nonzero D, ...). In particular, I'm considering removing the `S` part in [`riccati.solve_ricc_lrcf`](https://github.com/pymor/pymor/blob/e64ad5ca229fe6e72403ad9f25158e5b8908e1bd/src/pymor/algorithms/riccati.py#L20) and instead expect it to be given as a low-rank update in `A`.

What remains is making `LincombOperator` and/or `algorithms.lincomb` aware of these operators, which I'm not sure how to do. One approach might be adding at least three rules to `lincomb`:
- if all operators are `LowRankOperators`, return a single `LowRankOperator`
- if one of the operators is a `LowRankOperator`, return a `LowRankUpdatedOperator`
- if there is a `LowRankUpdatedOperator` and another operator, return a new `LowRankUpdatedOperator`

Another approach might be removing `LowRankUpdatedOperator` and making `LincombOperator` detect `LowRankOperators` and use SMW formula.

@sdrave Thoughts?

Closes #502.