### PR TITLE
Complex arithmetic for PDE solvers

### DIFF
--- a/notebooks/complex_op.ipynb
+++ b/notebooks/complex_op.ipynb
@@ -1,0 +1,87 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import scipy.sparse as sps\n",
+    "\n",
+    "from pymor.operators.numpy import NumpyMatrixOperator\n",
+    "from pymor.operators.complex import ComplexOperator\n",
+    "from pymor.vectorarrays.numpy import NumpyVectorSpace"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "n = 5\n",
+    "I = np.eye(n)\n",
+    "Iop = NumpyMatrixOperator(I)\n",
+    "va = Iop.source.from_numpy(np.ones((1, n)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "va"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(Iop + 1j * Iop).apply_inverse(va)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "op = ComplexOperator(Iop, Iop)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "op.apply_inverse(va)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/notebooks/heat_sink.ipynb
+++ b/notebooks/heat_sink.ipynb
@@ -1,0 +1,707 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Problem\n",
+    "\n",
+    "We consider the heat equation over a cross section of a heat sink\n",
+    "$$\n",
+    "\\begin{align*}\n",
+    "  \\partial_t T(\\xi, t) & = c \\Delta T(\\xi, t), & \\xi \\in \\Omega,\\ t > 0, \\\\\n",
+    "  -c \\nabla T(\\xi, t) \\cdot \\vec{n} & = k_1 T(\\xi, t), & \\xi \\in \\Gamma_1,\\ t > 0, \\\\\n",
+    "  -c \\nabla T(\\xi, t) \\cdot \\vec{n} & = k_2 u(t), & \\xi \\in \\Gamma_2,\\ t > 0, \\\\\n",
+    "  T(\\xi, 0) & = 0, & \\xi \\in \\Omega, \\\\\n",
+    "  y(t) & = \\int_{\\Gamma_2} T(\\xi, t) \\,\\mathrm{d}\\xi,\n",
+    "\\end{align*}\n",
+    "$$\n",
+    "where $\\Omega \\subset \\mathbb{R}^2$ is the domain, $\\Gamma_2$ is the bottom boundary, $\\Gamma_1 = \\partial \\Omega \\setminus \\Gamma_2$, $c = 100$, $k_1 = 0.1$, $k_2 = 1000$, $u(t)$ is the input, and $y(t)$ is the output."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Imports and settings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pymor.basic import (set_defaults, InstationaryModel,\n",
+    "                         LTIModel, BTReductor,\n",
+    "                         ExpressionParameterFunctional)\n",
+    "import numpy as np\n",
+    "import dolfin as df\n",
+    "import mshr as ms\n",
+    "from matplotlib import pyplot as plt\n",
+    "\n",
+    "\n",
+    "set_defaults({\n",
+    "    'pymor.algorithms.lyapunov.solve_lyap_lrcf.default_sparse_solver_backend':\n",
+    "    'lradi',\n",
+    "    'pymor.algorithms.lradi.lyap_lrcf_solver_options.projection_shifts_init_seed':\n",
+    "    0\n",
+    "})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# FEniCS discretizer"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "THREE_D = False  # True\n",
+    "WIDTH = 2\n",
+    "HEIGHT = 10\n",
+    "DEPTH = 5\n",
+    "FIN_OFFSET_RATIO = 0.1\n",
+    "FIN_COUNT = 10\n",
+    "FIN_VOL_FRACTION = 0.5\n",
+    "FIN_LENGTH = 6\n",
+    "RESOLUTION = 10\n",
+    "\n",
+    "\n",
+    "def _discretize():\n",
+    "\n",
+    "    fin_height = HEIGHT * (1 - FIN_OFFSET_RATIO) / FIN_COUNT * FIN_VOL_FRACTION\n",
+    "    fin_offset = HEIGHT * FIN_OFFSET_RATIO\n",
+    "    fin_height_with_space = HEIGHT * (1 - FIN_OFFSET_RATIO) / FIN_COUNT\n",
+    "\n",
+    "    if THREE_D:\n",
+    "        domain = ms.Box(df.Point(-WIDTH/2, 0., -DEPTH/2),\n",
+    "                        df.Point(WIDTH/2, HEIGHT, DEPTH/2))\n",
+    "    else:\n",
+    "        domain = ms.Rectangle(df.Point(-WIDTH/2, 0.),\n",
+    "                              df.Point(WIDTH/2, HEIGHT))\n",
+    "\n",
+    "    for f in range(FIN_COUNT):\n",
+    "        ly = fin_offset + (f+1) * fin_height_with_space - fin_height\n",
+    "        if THREE_D:\n",
+    "            domain += ms.Box(df.Point(-FIN_LENGTH, ly, -DEPTH/2),\n",
+    "                             df.Point(FIN_LENGTH, ly+fin_height, DEPTH/2))\n",
+    "        else:\n",
+    "            domain += ms.Rectangle(df.Point(-FIN_LENGTH, ly),\n",
+    "                                   df.Point(FIN_LENGTH, ly+fin_height))\n",
+    "\n",
+    "    mesh = ms.generate_mesh(domain, RESOLUTION)\n",
+    "\n",
+    "    class Boundary(df.SubDomain):\n",
+    "        def inside(self, x, on_boundary):\n",
+    "            return on_boundary\n",
+    "\n",
+    "    class Bottom(df.SubDomain):\n",
+    "        def inside(self, x, on_boundary):\n",
+    "            return on_boundary and df.near(x[1], 0, 1e-14)\n",
+    "\n",
+    "    bottom = Bottom()\n",
+    "    boundary = Boundary()\n",
+    "    boundary_markers = df.MeshFunction('size_t',\n",
+    "                                       mesh,\n",
+    "                                       mesh.geometric_dimension()-1,\n",
+    "                                       value=0)\n",
+    "    boundary.mark(boundary_markers, 1)\n",
+    "    bottom.mark(boundary_markers, 2)\n",
+    "    ds = df.Measure('ds', domain=mesh, subdomain_data=boundary_markers)\n",
+    "\n",
+    "    V = df.FunctionSpace(mesh, 'P', 1)\n",
+    "    u = df.TrialFunction(V)\n",
+    "    v = df.TestFunction(V)\n",
+    "\n",
+    "    MAT = df.assemble(df.Constant(100.)\n",
+    "                      * df.inner(df.grad(u), df.grad(v))\n",
+    "                      * df.dx\n",
+    "                      + df.Constant(0.1) * u * v * ds(1))\n",
+    "    F = df.assemble(df.Constant(1000.) * v * ds(2))\n",
+    "    MASS = df.assemble(u * v * df.dx)\n",
+    "\n",
+    "    from pymor.operators.constructions import VectorOperator\n",
+    "    from pymor.bindings.fenics import (FenicsVectorSpace, FenicsMatrixOperator,\n",
+    "                                       FenicsVisualizer)\n",
+    "    from pymor.models.basic import InstationaryModel\n",
+    "    from pymor.algorithms.timestepping import ImplicitEulerTimeStepper\n",
+    "\n",
+    "    # monkey patch apply_inverse_adjoint, assuming symmetry\n",
+    "    FenicsMatrixOperator.apply_inverse_adjoint = \\\n",
+    "        FenicsMatrixOperator.apply_inverse\n",
+    "\n",
+    "    # define parameter functionals (same as in\n",
+    "    # pymor.analyticalproblems.thermalblock)\n",
+    "    space = FenicsVectorSpace(V)\n",
+    "    op = FenicsMatrixOperator(MAT, V, V)\n",
+    "    rhs = VectorOperator(space.make_array([F]))\n",
+    "    mass = FenicsMatrixOperator(MASS, V, V, name='mass')\n",
+    "\n",
+    "    # build model\n",
+    "    visualizer = FenicsVisualizer(space)\n",
+    "    time_stepper = ImplicitEulerTimeStepper(nt=100)\n",
+    "    d = InstationaryModel(10,  # final time\n",
+    "                                   space.zeros(),\n",
+    "                                   op,\n",
+    "                                   rhs,\n",
+    "                                   mass=mass,\n",
+    "                                   num_values=100,\n",
+    "                                   time_stepper=time_stepper,\n",
+    "                                   visualizer=visualizer)\n",
+    "\n",
+    "    return d\n",
+    "\n",
+    "\n",
+    "def discretize(*args, **kwargs):\n",
+    "    from pymor.tools import mpi\n",
+    "\n",
+    "    if mpi.parallel:\n",
+    "        from pymor.models.mpi import mpi_wrap_model\n",
+    "        return mpi_wrap_model(_discretize, use_with=True,\n",
+    "                              pickle_local_spaces=False)\n",
+    "    else:\n",
+    "        return _discretize()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# InstationaryModel"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fom = discretize()\n",
+    "fom = fom.with_(outputs={'output_functional': fom.rhs.H})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Visualization"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Input function"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "_input = ExpressionParameterFunctional('sin(pi*_t/3)**2', {'_t': ()})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Trajectory"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "traj_fom = fom.with_(rhs=fom.rhs * _input).solve()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Storing for visualization in ParaView"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fom.visualize(traj_fom, filename='fig/fom.pvd')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Snapshot at final time"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "U = traj_fom[-1]\n",
+    "function = df.Function(U.space.V)\n",
+    "function.vector()[:] = U._list[0].impl\n",
+    "plt.figure()\n",
+    "p = df.plot(function, cmap='inferno')\n",
+    "plt.colorbar(p)\n",
+    "plt.axis('off')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# LTIModel"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lti = fom.to_lti().with_(solver_options={'lyap_lrcf': 'lradi'})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Order, number of inputs, and number of outputs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(lti)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Bode plot"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "w = np.logspace(-2, 5, 20)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots()\n",
+    "lti.mag_plot(w, ax=ax)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## $\\mathcal{H}_\\infty$-norm\n",
+    "This is valid because the system is state-space symmetric ($E^T = E$, $A = A^T$, $C = B^T$)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hinf_norm = lti.eval_tf(0)[0, 0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Balanced truncation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Instatiating a reductor object"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "reductor_bt = BTReductor(lti)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## $\\mathcal{H}_\\infty$-error bounds"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "error_bounds = reductor_bt.error_bounds()[:20]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "hsv = lti.hsv()[:21]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots()\n",
+    "ax.semilogy(range(1, len(error_bounds) + 1), error_bounds / hinf_norm, '.-')\n",
+    "ax.semilogy(range(1, len(hsv)), hsv[1:] / hinf_norm, '.-')\n",
+    "ax.set_xticks([1, 5, 10, 15, 20])\n",
+    "ax.grid()\n",
+    "ax.set_xlabel('Reduced order')\n",
+    "ax.set_ylabel(r'Relative $\\mathcal{H}_\\infty$-error')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Reduction"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "r = 10\n",
+    "rom_bt = reductor_bt.reduce(r)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots()\n",
+    "lti.mag_plot(w, ax=ax)\n",
+    "rom_bt.mag_plot(w, ax=ax)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Error system"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "err_bt = lti - rom_bt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots()\n",
+    "err_bt.mag_plot(w, ax=ax)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Relative $\\mathcal{H}_\\infty$-error bounds"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "hsv[r - 1] / hinf_norm, error_bounds[r - 1] / hinf_norm"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Relative $\\mathcal{H}_2$-error"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "err_bt.h2_norm() / lti.h2_norm()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## ROM visualization"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Form the ROM as a InstationaryModel to use the `solve` method"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rd = InstationaryModel(\n",
+    "    10,\n",
+    "    rom_bt.solution_space.zeros(),\n",
+    "    -rom_bt.A,\n",
+    "    rom_bt.B,\n",
+    "    mass=rom_bt.E,\n",
+    "    num_values=100,\n",
+    "    time_stepper=fom.time_stepper,\n",
+    "    visualizer=fom.visualizer,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Trajectory of the ROM and its reconstruction in the high-order space"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "traj_rom = rd.with_(rhs=rd.rhs * _input).solve()\n",
+    "traj_rom_rc = reductor_bt.V.lincomb(traj_rom.to_numpy())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Reconstructed snapshot at final time"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "U = traj_rom_rc[-1]\n",
+    "function = df.Function(U.space.V)\n",
+    "function.vector()[:] = U._list[0].impl\n",
+    "plt.figure()\n",
+    "p = df.plot(function, cmap='inferno')\n",
+    "plt.colorbar(p)\n",
+    "plt.axis('off')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## State error visualization"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Trajectory of the error system"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "traj_err = traj_fom - traj_rom_rc"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Error at final time"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "U = traj_err[-1]\n",
+    "function = df.Function(U.space.V)\n",
+    "function.vector()[:] = U._list[0].impl\n",
+    "vmax = U.sup_norm()[0]\n",
+    "plt.figure()\n",
+    "p = df.plot(function, cmap='coolwarm', vmin=-vmax, vmax=vmax)\n",
+    "plt.colorbar(p)\n",
+    "plt.axis('off')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Output for the FOM, ROM and error"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Output (average temperature at the bottom boundary) for the FOM and ROM"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "time_points = np.linspace(0, 10, 100)\n",
+    "\n",
+    "C_norm = lti.C.array.l1_norm()[0]\n",
+    "output_fom = lti.C.apply(traj_fom).to_numpy()[:, 0] / C_norm\n",
+    "output_rom = rom_bt.C.apply(traj_rom).to_numpy()[:, 0] / C_norm"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Comparison of the FOM and ROM, and error"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, (ax0, ax1) = plt.subplots(2, 1, sharex=True)\n",
+    "ax0.plot(time_points, output_fom, label='FOM')\n",
+    "ax0.plot(time_points, output_rom, '--', label='ROM')\n",
+    "ax0.set_ylabel('temperature')\n",
+    "ax0.grid()\n",
+    "ax0.legend()\n",
+    "\n",
+    "ax1.plot(time_points, output_fom - output_rom, 'tab:green', label='Error')\n",
+    "ax1.set_xlabel('time')\n",
+    "ax1.ticklabel_format(style='sci', axis='y', scilimits=(-3, -3), useMathText=True)\n",
+    "ax1.grid()\n",
+    "ax1.legend()\n",
+    "plt.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/src/pymor/operators/complex.py
+++ b/src/pymor/operators/complex.py
@@ -1,0 +1,69 @@
+# This file is part of the pyMOR project (http://www.pymor.org).
+# Copyright 2013-2019 pyMOR developers and contributors. All rights reserved.
+# License: BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+
+"""Module for complex operators."""
+
+from pymor.operators.basic import OperatorBase
+from pymor.operators.block import BlockOperator
+from pymor.vectorarrays.block import BlockVectorSpace
+
+
+class ComplexOperator(OperatorBase):
+    def __init__(self, real, imag, solver_options=None, name=None):
+        assert real.source == imag.source
+        assert real.range == imag.range
+        self.__auto_init(locals())
+        self.source = real.source
+        self.range = real.range
+
+    @property
+    def H(self):
+        options = (
+            {'inverse': self.solver_options.get('inverse_adjoint'),
+             'inverse_adjoint': self.solver_options.get('inverse')}
+            if self.solver_options else None
+        )
+        return ComplexOperator(self.real, -self.imag,
+                               solver_options=options,
+                               name=self.name + '_adjoint')
+
+    def apply(self, U, mu=None):
+        assert U in self.source
+        real = self.real.apply(U.real, mu=mu) - self.imag.apply(U.imag, mu=mu)
+        imag = self.real.apply(U.imag, mu=mu) + self.imag.apply(U.real, mu=mu)
+        return real + imag * 1j
+
+    def apply_adjoint(self, V, mu=None):
+        assert V in self.range
+        real = (self.real.apply_adjoint(V.real, mu=mu)
+                + self.imag.apply_adjoint(V.imag, mu=mu))
+        imag = (self.real.apply_adjoint(V.imag, mu=mu)
+                - self.imag.apply_adjoint(V.real, mu=mu))
+        return real + imag * 1j
+
+    def apply_inverse(self, V, mu=None, least_squares=False):
+        op = BlockOperator([[self.real, -self.imag], [self.imag, self.real]])
+        rhs = BlockVectorSpace([self.range, self.range]).make_array([V.real, V.imag])
+        U = op.apply_inverse(rhs)
+        return U.block(0) + U.block(1) * 1j
+
+    def apply_inverse_adjoint(self, U, mu=None, least_squares=False):
+        op = BlockOperator([[self.real, -self.imag], [self.imag, self.real]])
+        rhs = BlockVectorSpace([self.source, self.source]).make_array([U.real, U.imag])
+        V = op.apply_inverse_adjoint(rhs)
+        return V.block(0) + V.block(1) * 1j
+
+    def as_range_array(self, mu=None):
+        real = self.real.as_range_array(mu=mu)
+        imag = self.imag.as_range_array(mu=mu)
+        return real + imag * 1j
+
+    def as_source_array(self, mu=None):
+        real = self.real.as_source_array(mu=mu)
+        imag = self.imag.as_source_array(mu=mu)
+        return real + imag * 1j
+
+    def assemble(self, mu=None):
+        return ComplexOperator(self.real.assemble(mu=mu),
+                               self.imag.assemble(mu=mu))


### PR DESCRIPTION
The goal here is to enable complex arithmetic for PDE solvers which only support real arithmetic.

There was a discussion about finding a generic solution, focusing on solving shifted linear systems involving the `s E - A` operator, with complex scalar `s` and real operators `A` and `E`. The two proposals were adding a `ShiftedOperator` and `apply_shifted_inverse`.

Since the result of solving a complex system is (generally) a complex vector, we additionally need support for such vectors. Additionally:
- `A` or `E` need not be "simple" (they can be, e.g., `LincombOperators` or `BlockDiagonalOperators`),
- for second-order systems, we need to solve with `s^2 M + s E + K` (e.g., in `SecondOrderModel.eval_tf`),
- for time-delay systems, also a more complicated linear combination appears,
- forming `s E - A` can be beneficial when also the adjoint system needs to be solved (for `NumpyMatrixOperators`, the sparse LU can be cached),
- complex arithmetic appears not only when solving shifted linear systems (e.g., in `SecondOrderModel.eval_dtf` there is `(2 s M + E).apply(...)`).

For these reasons, I would propose here "complexifying" vectors and operators directly, by adding an attribute containing the imaginary part (which can be `None` to avoid forming unnecessary zero vectors/matrices). So far, I focused on FEniCS bindings and added `FenicsVector._imag` and `FenicsMatrixOperator.imag`. I've added a FEniCS example in `notebooks/heat_sink.ipynb` for experimenting.

@pymor/pymor-devs Thoughts?