### PR TITLE
Add partial derivatives w.r.t. parameters

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -18,6 +18,9 @@
     * randomized range approximation algorithms in algorithms.randrangefinder
     * fixed complex norms in vectorarrays.interfaces
 
+* Tim Keil, tim.keil@uni-muenster.de
+    * partial derivatives for parameters d_mu
+
 
 ## pyMOR 0.5
 

--- a/src/pymor/operators/basic.py
+++ b/src/pymor/operators/basic.py
@@ -153,7 +153,7 @@ class OperatorBase(OperatorInterface):
         if self.parametric:
             raise NotImplementedError
         else:
-            return ZeroOperator(self.range, self.source)
+            return ZeroOperator(self.range, self.source, name=self.name + '_d_mu')
 
 class ProjectedOperator(OperatorBase):
     """Generic |Operator| representing the projection of an |Operator| to a subspace.

--- a/src/pymor/operators/basic.py
+++ b/src/pymor/operators/basic.py
@@ -149,9 +149,9 @@ class OperatorBase(OperatorInterface):
     def as_source_array(self, mu=None):
         return self.apply_adjoint(self.range.from_numpy(np.eye(self.range.dim)), mu=mu)
 
-    def mu_derivative(self, component, coordinates=None):
+    def d_mu(self, component, index=()):
         if self.parametric:
-            return NotImplemented
+            raise NotImplementedError
         else:
             return ZeroOperator(self.range, self.source)
 

--- a/src/pymor/operators/basic.py
+++ b/src/pymor/operators/basic.py
@@ -149,6 +149,11 @@ class OperatorBase(OperatorInterface):
     def as_source_array(self, mu=None):
         return self.apply_adjoint(self.range.from_numpy(np.eye(self.range.dim)), mu=mu)
 
+    def mu_derivative(self, component, coordinates=None):
+        if self.parametric:
+            return NotImplemented
+        else:
+            return ZeroOperator(self.range, self.source)
 
 class ProjectedOperator(OperatorBase):
     """Generic |Operator| representing the projection of an |Operator| to a subspace.

--- a/src/pymor/operators/constructions.py
+++ b/src/pymor/operators/constructions.py
@@ -155,17 +155,17 @@ class LincombOperator(OperatorBase):
         else:
             return jac
 
-    def mu_derivative(self, component, coordinates=None):
+    def d_mu(self, component, index=()):
         for op in self.operators:
             if op.parametric:
-                raise NotImplemented
+                raise NotImplementedError
         derivative_coefficients = []
         for coef in self.coefficients:
             try:
-                derivative_coefficients.append(coef.partial_derivative(component, coordinates))
+                derivative_coefficients.append(coef.d_mu(component, index))
             except:
                 derivative_coefficients.append(0.)
-        return LincombOperator(self.operators, derivative_coefficients)
+        return self.with_(coefficients=derivative_coefficients, name=self.name + '_d_mu')
 
     def apply_inverse(self, V, mu=None, least_squares=False):
         if len(self.operators) == 1:

--- a/src/pymor/operators/constructions.py
+++ b/src/pymor/operators/constructions.py
@@ -161,9 +161,9 @@ class LincombOperator(OperatorBase):
                 raise NotImplementedError
         derivative_coefficients = []
         for coef in self.coefficients:
-            try:
+            if isinstance(coef,Parametric):
                 derivative_coefficients.append(coef.d_mu(component, index))
-            except:
+            else:
                 derivative_coefficients.append(0.)
         return self.with_(coefficients=derivative_coefficients, name=self.name + '_d_mu')
 

--- a/src/pymor/operators/constructions.py
+++ b/src/pymor/operators/constructions.py
@@ -155,6 +155,18 @@ class LincombOperator(OperatorBase):
         else:
             return jac
 
+    def mu_derivative(self, component, coordinates=None):
+        for op in self.operators:
+            if op.parametric:
+                raise NotImplemented
+        derivative_coefficients = []
+        for coef in self.coefficients:
+            try:
+                derivative_coefficients.append(coef.partial_derivative(component, coordinates))
+            except:
+                derivative_coefficients.append(0.)
+        return LincombOperator(self.operators, derivative_coefficients)
+
     def apply_inverse(self, V, mu=None, least_squares=False):
         if len(self.operators) == 1:
             if self.coefficients[0] == 0.:

--- a/src/pymor/operators/interfaces.py
+++ b/src/pymor/operators/interfaces.py
@@ -240,6 +240,23 @@ class OperatorInterface(ImmutableInterface, Parametric):
         """
         pass
 
+    @abstractmethod
+    def mu_derivative(self, component, coordinates=None):
+        """Return the operators derivative with respect to a coordinate of a parameter component
+
+        Parameters
+        ----------
+        component
+            Parameter component
+        coordinate
+            coordinate in the parameter component
+
+        Returns
+        -------
+        New |Operator| with partial derivatives of the coefficients
+        """
+        pass
+
     def as_range_array(self, mu=None):
         """Return a |VectorArray| representation of the operator in its range space.
 

--- a/src/pymor/operators/interfaces.py
+++ b/src/pymor/operators/interfaces.py
@@ -241,15 +241,15 @@ class OperatorInterface(ImmutableInterface, Parametric):
         pass
 
     @abstractmethod
-    def mu_derivative(self, component, coordinates=None):
+    def d_mu(self, component, index=()):
         """Return the operators derivative with respect to a coordinate of a parameter component
 
         Parameters
         ----------
         component
             Parameter component
-        coordinate
-            coordinate in the parameter component
+        index
+            index in the parameter component
 
         Returns
         -------

--- a/src/pymor/operators/interfaces.py
+++ b/src/pymor/operators/interfaces.py
@@ -242,7 +242,7 @@ class OperatorInterface(ImmutableInterface, Parametric):
 
     @abstractmethod
     def d_mu(self, component, index=()):
-        """Return the operators derivative with respect to a coordinate of a parameter component
+        """Return the operator's derivative with respect to an index of a parameter component.
 
         Parameters
         ----------
@@ -253,7 +253,7 @@ class OperatorInterface(ImmutableInterface, Parametric):
 
         Returns
         -------
-        New |Operator| with partial derivatives of the coefficients
+        New |Operator| representing the partial derivative.
         """
         pass
 

--- a/src/pymor/parameters/functionals.py
+++ b/src/pymor/parameters/functionals.py
@@ -218,3 +218,26 @@ class ConjugateParameterFunctional(ParameterFunctionalInterface):
 
     def partial_derivative(self, component, coordinates=None):
         return NotImplemented
+
+
+class ConstantParameterFunctional(ParameterFunctionalInterface):
+    """|ParameterFunctional| returning a constant value for each parameter.
+
+
+    Parameters
+    ----------
+    constant_value
+        value of the functional
+    name
+        Name of the functional.
+    """
+
+    def __init__(self, constant_value, name=None):
+        self.constant_value = constant_value
+        self.__auto_init(locals())
+
+    def evaluate(self, mu=None):
+        return self.constant_value
+
+    def d_mu(self, component, index=()):
+        return self.with_(constant_value=0, name=self.name + '_d_mu')

--- a/src/pymor/parameters/functionals.py
+++ b/src/pymor/parameters/functionals.py
@@ -45,7 +45,7 @@ class ProjectionParameterFunctional(ParameterFunctionalInterface):
     def d_mu(self, component, index=()):
         check, index = self._check_and_parse_input(component, index)
         if check:
-            if component == self.component_name and index == self.coordinates:
+            if component == self.component_name and index == self.index:
                 return ConstantParameterFunctional(1, name=self.name + '_d_mu')
         return ConstantParameterFunctional(0, name=self.name + '_d_mu')
 
@@ -67,7 +67,7 @@ class GenericParameterFunctional(ParameterFunctionalInterface):
     name
         The name of the functional.
     derivative_mappings
-        A dict containing all partial derivative of each component and index in the
+        A dict containing all partial derivativess of each component and index in the
         |ParameterType| with the signature `derivative_mappings[component][index](mu)`
     """
 
@@ -120,7 +120,8 @@ class ExpressionParameterFunctional(GenericParameterFunctional):
         The name of the functional.
 
     derivative_expressions
-        A dict of lists of Python expression for the partial derivative of each parameter component
+        A dict containing a Python expression for the partial derivatives of each
+        parameter component.
     """
 
     functions = {k: getattr(np, k) for k in {'sin', 'cos', 'tan', 'arcsin', 'arccos', 'arctan', 'arctan2',

--- a/src/pymor/parameters/interfaces.py
+++ b/src/pymor/parameters/interfaces.py
@@ -37,6 +37,11 @@ class ParameterFunctionalInterface(ImmutableInterface, Parametric):
         """Evaluate the functional for the given |Parameter| `mu`."""
         pass
 
+    @abstractmethod
+    def partial_derivative(self, component, coordinates=None):
+        """returns the derivative of the functional as a new ParameterFunctional."""
+        pass
+
     def __call__(self, mu=None):
         return self.evaluate(mu)
 

--- a/src/pymor/parameters/interfaces.py
+++ b/src/pymor/parameters/interfaces.py
@@ -39,7 +39,19 @@ class ParameterFunctionalInterface(ImmutableInterface, Parametric):
 
     @abstractmethod
     def d_mu(self, component, index=()):
-        """returns the derivative of the functional as a new ParameterFunctional."""
+        """Return the functionals's derivative with respect to an index of a parameter component.
+
+        Parameters
+        ----------
+        component
+            Parameter component
+        index
+            index in the parameter component
+
+        Returns
+        -------
+        New |Parameter| functional representing the partial derivative.
+        """
         pass
 
     def __call__(self, mu=None):
@@ -58,7 +70,7 @@ class ParameterFunctionalInterface(ImmutableInterface, Parametric):
 
     def _check_and_parse_input(self, component, index):
         # check whether component is in parameter_type
-        if not component in self.parameter_type:
+        if component not in self.parameter_type:
             return False, None
         # check whether index has the correct shape
         if isinstance(index, Number):

--- a/src/pymor/parameters/interfaces.py
+++ b/src/pymor/parameters/interfaces.py
@@ -38,7 +38,7 @@ class ParameterFunctionalInterface(ImmutableInterface, Parametric):
         pass
 
     @abstractmethod
-    def partial_derivative(self, component, coordinates=None):
+    def d_mu(self, component, index=()):
         """returns the derivative of the functional as a new ParameterFunctional."""
         pass
 

--- a/src/pymor/parameters/interfaces.py
+++ b/src/pymor/parameters/interfaces.py
@@ -55,3 +55,18 @@ class ParameterFunctionalInterface(ImmutableInterface, Parametric):
 
     def __neg__(self):
         return self * (-1.)
+
+    def _check_and_parse_input(self, component, index):
+        # check whether component is in parameter_type
+        if not component in self.parameter_type:
+            return False, None
+        # check whether index has the correct shape
+        if isinstance(index, Number):
+            index = (index,)
+        index = tuple(index)
+        for idx in index:
+            assert isinstance(idx, Number)
+        shape = self.parameter_type[component]
+        for i,idx in enumerate(index):
+            assert idx < shape[i], 'wrong input `index` given'
+        return True, index

--- a/src/pymortests/mu_derivatives.py
+++ b/src/pymortests/mu_derivatives.py
@@ -99,8 +99,8 @@ def test_d_mu_of_LincombOperator():
 
     operator = LincombOperator(operators, coefficients)
 
-    op_sensitivity_to_first_mu = operator.d_mu('mu', (0,))
-    op_sensitivity_to_second_mu = operator.d_mu('mu', (1,))
+    op_sensitivity_to_first_mu = operator.d_mu('mu', 0)
+    op_sensitivity_to_second_mu = operator.d_mu('mu', 1)
     op_sensitivity_to_nu = operator.d_mu('nu', ())
 
     eval_mu_1 = op_sensitivity_to_first_mu.evaluate_coefficients(mu)

--- a/src/pymortests/mu_derivatives.py
+++ b/src/pymortests/mu_derivatives.py
@@ -1,0 +1,80 @@
+# This file is part of the pyMOR project (http://www.pymor.org).
+# Copyright 2013-2019 pyMOR developers and contributors. All rights reserved.
+# License: BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+
+import numpy as np
+from pymor.parameters.functionals import ProjectionParameterFunctional, ExpressionParameterFunctional
+
+'''
+test for ProjectionParameterFunctional
+'''
+
+pf = ProjectionParameterFunctional('mu', (2,), (0,))
+
+mu = {'mu': (10,2)}
+
+derivative_to_first_coordinate = pf.partial_derivative('mu', 0)
+derivative_to_second_coordinate = pf.partial_derivative('mu', 1)
+
+der_mu_1 = derivative_to_first_coordinate.evaluate(mu)
+der_mu_2 = derivative_to_second_coordinate.evaluate(mu)
+
+assert pf.evaluate(mu) == 10
+assert der_mu_1 == 1
+assert der_mu_2 == 0
+
+
+'''
+test for ExpressionParameterFunctional
+'''
+
+dict_of_partial_derivatives = {'mu': ['100', '2'], 'nu': 'cos(nu)'}
+
+epf = ExpressionParameterFunctional('100 * mu[0] + 2 * mu[1] + sin(nu)',
+                                    {'mu': (2,), 'nu': ()},
+                                    'functional_with_derivative',
+                                    dict_of_partial_derivatives)
+
+mu = {'mu': (10,2), 'nu': 0}
+
+derivative_to_first_mu_coordinate = epf.partial_derivative('mu', 0)
+derivative_to_second_mu_coordinate = epf.partial_derivative('mu', 1)
+derivative_to_nu_coordinate = epf.partial_derivative('nu', ())
+
+der_mu_1 = derivative_to_first_mu_coordinate.evaluate(mu)
+der_mu_2 = derivative_to_second_mu_coordinate.evaluate(mu)
+der_nu = derivative_to_nu_coordinate.evaluate(mu)
+
+assert epf.evaluate(mu) == 1004.
+assert der_mu_1 == 100
+assert der_mu_2 == 2
+assert der_nu == 1
+
+
+'''
+test for mu_derivative of LincombOperator
+'''
+
+from pymor.operators.constructions import LincombOperator, ZeroOperator
+from pymor.basic import NumpyVectorSpace
+
+
+space = NumpyVectorSpace(1)
+zero_op = ZeroOperator(space, space)
+operators = [zero_op, zero_op, zero_op]
+coefficients = [1., pf, epf]
+
+operator = LincombOperator(operators, coefficients)
+
+op_sensitivity_to_first_mu = operator.mu_derivative('mu', (0,))
+op_sensitivity_to_second_mu = operator.mu_derivative('mu', (1,))
+op_sensitivity_to_nu = operator.mu_derivative('nu', ())
+
+eval_mu_1 = op_sensitivity_to_first_mu.evaluate_coefficients(mu)
+eval_mu_2 = op_sensitivity_to_second_mu.evaluate_coefficients(mu)
+eval_nu = op_sensitivity_to_nu.evaluate_coefficients(mu)
+
+assert operator.evaluate_coefficients(mu) == [1., 10, 1004.]
+assert eval_mu_1 == [0., 1., 100.]
+assert eval_mu_2 == [0., 0., 2.]
+assert eval_nu == [0., 0., 1.]

--- a/src/pymortests/mu_derivatives.py
+++ b/src/pymortests/mu_derivatives.py
@@ -2,31 +2,16 @@
 # Copyright 2013-2019 pyMOR developers and contributors. All rights reserved.
 # License: BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
 
-import numpy as np
-from pymor.parameters.functionals import ProjectionParameterFunctional, ExpressionParameterFunctional
+from pymortests.base import runmodule
+import pytest
 
-'''
-test for ProjectionParameterFunctional
-'''
+import numpy as np
+
+from pymor.parameters.functionals import ProjectionParameterFunctional, ExpressionParameterFunctional
+from pymor.operators.constructions import LincombOperator, ZeroOperator
+from pymor.basic import NumpyVectorSpace
 
 pf = ProjectionParameterFunctional('mu', (2,), (0,))
-
-mu = {'mu': (10,2)}
-
-derivative_to_first_coordinate = pf.partial_derivative('mu', 0)
-derivative_to_second_coordinate = pf.partial_derivative('mu', 1)
-
-der_mu_1 = derivative_to_first_coordinate.evaluate(mu)
-der_mu_2 = derivative_to_second_coordinate.evaluate(mu)
-
-assert pf.evaluate(mu) == 10
-assert der_mu_1 == 1
-assert der_mu_2 == 0
-
-
-'''
-test for ExpressionParameterFunctional
-'''
 
 dict_of_partial_derivatives = {'mu': ['100', '2'], 'nu': 'cos(nu)'}
 
@@ -35,46 +20,56 @@ epf = ExpressionParameterFunctional('100 * mu[0] + 2 * mu[1] + sin(nu)',
                                     'functional_with_derivative',
                                     dict_of_partial_derivatives)
 
-mu = {'mu': (10,2), 'nu': 0}
+def test_ProjectionParameterFunctional():
+    mu = {'mu': (10,2)}
 
-derivative_to_first_mu_coordinate = epf.partial_derivative('mu', 0)
-derivative_to_second_mu_coordinate = epf.partial_derivative('mu', 1)
-derivative_to_nu_coordinate = epf.partial_derivative('nu', ())
+    derivative_to_first_coordinate = pf.partial_derivative('mu', 0)
+    derivative_to_second_coordinate = pf.partial_derivative('mu', 1)
 
-der_mu_1 = derivative_to_first_mu_coordinate.evaluate(mu)
-der_mu_2 = derivative_to_second_mu_coordinate.evaluate(mu)
-der_nu = derivative_to_nu_coordinate.evaluate(mu)
+    der_mu_1 = derivative_to_first_coordinate.evaluate(mu)
+    der_mu_2 = derivative_to_second_coordinate.evaluate(mu)
 
-assert epf.evaluate(mu) == 1004.
-assert der_mu_1 == 100
-assert der_mu_2 == 2
-assert der_nu == 1
+    assert pf.evaluate(mu) == 10
+    assert der_mu_1 == 1
+    assert der_mu_2 == 0
 
 
-'''
-test for mu_derivative of LincombOperator
-'''
+def test_ExpressionParameterFunctional():
+    mu = {'mu': (10,2), 'nu': 0}
 
-from pymor.operators.constructions import LincombOperator, ZeroOperator
-from pymor.basic import NumpyVectorSpace
+    derivative_to_first_mu_coordinate = epf.partial_derivative('mu', 0)
+    derivative_to_second_mu_coordinate = epf.partial_derivative('mu', 1)
+    derivative_to_nu_coordinate = epf.partial_derivative('nu', ())
+
+    der_mu_1 = derivative_to_first_mu_coordinate.evaluate(mu)
+    der_mu_2 = derivative_to_second_mu_coordinate.evaluate(mu)
+    der_nu = derivative_to_nu_coordinate.evaluate(mu)
+
+    assert epf.evaluate(mu) == 1004.
+    assert der_mu_1 == 100
+    assert der_mu_2 == 2
+    assert der_nu == 1
 
 
-space = NumpyVectorSpace(1)
-zero_op = ZeroOperator(space, space)
-operators = [zero_op, zero_op, zero_op]
-coefficients = [1., pf, epf]
+def test_mu_derivative_of_LincombOperator():
+    mu = {'mu': (10,2), 'nu': 0}
 
-operator = LincombOperator(operators, coefficients)
+    space = NumpyVectorSpace(1)
+    zero_op = ZeroOperator(space, space)
+    operators = [zero_op, zero_op, zero_op]
+    coefficients = [1., pf, epf]
 
-op_sensitivity_to_first_mu = operator.mu_derivative('mu', (0,))
-op_sensitivity_to_second_mu = operator.mu_derivative('mu', (1,))
-op_sensitivity_to_nu = operator.mu_derivative('nu', ())
+    operator = LincombOperator(operators, coefficients)
 
-eval_mu_1 = op_sensitivity_to_first_mu.evaluate_coefficients(mu)
-eval_mu_2 = op_sensitivity_to_second_mu.evaluate_coefficients(mu)
-eval_nu = op_sensitivity_to_nu.evaluate_coefficients(mu)
+    op_sensitivity_to_first_mu = operator.mu_derivative('mu', (0,))
+    op_sensitivity_to_second_mu = operator.mu_derivative('mu', (1,))
+    op_sensitivity_to_nu = operator.mu_derivative('nu', ())
 
-assert operator.evaluate_coefficients(mu) == [1., 10, 1004.]
-assert eval_mu_1 == [0., 1., 100.]
-assert eval_mu_2 == [0., 0., 2.]
-assert eval_nu == [0., 0., 1.]
+    eval_mu_1 = op_sensitivity_to_first_mu.evaluate_coefficients(mu)
+    eval_mu_2 = op_sensitivity_to_second_mu.evaluate_coefficients(mu)
+    eval_nu = op_sensitivity_to_nu.evaluate_coefficients(mu)
+
+    assert operator.evaluate_coefficients(mu) == [1., 10, 1004.]
+    assert eval_mu_1 == [0., 1., 100.]
+    assert eval_mu_2 == [0., 0., 2.]
+    assert eval_nu == [0., 0., 1.]


### PR DESCRIPTION
This pull request adds a basic version of parameters derivatives to pymor. 

1. Parameters package:

    - `ParameterFunctionalInterface` has now a `partial_derivative` method that returns a new `ParameterFunctional` representing the derivative to a specific component and coordinate of the parameter 

     - For this pull request, it is only possible to differentiate `ProjectionParameterFunctional` and `ExpressionParameterFunctional`. For the latter the user has to provide a `dict` that contains all partial derivatives of the given Parameter. An assertion on the size of this dict might be useful. All shapes of parameters are possible ( scalar, vector and matrix) 

2. Operators package:

     - I added a `mu_derivative` method to the `OperatorInterface` and thus also to `OperatorBase`. This method returns a new Operator representing the old Operator differentiated to a certain component and coordinate of the parameter.   

     - For this pull request, I only implement the `mu_derivative` to `LincombOperator`. This function returns a new `LincombOperator` with the differentiated `ParameterFunctional`. Note that this only makes sense mathematically if the operators of the `LincombOperator` are not parametric. Product rules are not implmented, yet.   

3. The names of the methods and members are just in a first-choice fashion. I am very open for other suggestions  

4. I added a small test to the pymortests where I show the usage of the new functions. I did not use pytest or something else yet. Is that required? 

5. There are multiple things to do that I left for future work for now: 

    a) implement a numeric version of the partial derivative of the parameters 
    b) Use `sympy` to get automatic expressions for the derivative. 
    c) Add `partial derivative` for `ProductParameterFunctional` and `ConjugateParameterFunctional`
    d) Add `mu_derivative` for more `Operators` 

Comments and tips are very welcome