### PR TITLE
[inplace] add cython implementation of set_unit_rows_cols

### DIFF
--- a/src/pymor/tools/inplace.pyx
+++ b/src/pymor/tools/inplace.pyx
@@ -94,6 +94,44 @@ def set_unit_rows_cols(mat, np.ndarray[np.int32_t] indices):
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
+def clear_rows_cols(mat, np.ndarray[np.int32_t] row_indices, np.ndarray[np.int32_t] col_indices):
+
+    if not isinstance(mat, csr_matrix):
+        raise NotImplementedError('Only csr_matrices are supported!')
+
+    M, N = mat.shape
+    cdef np.int32_t i, index, len_indices, min_index, max_index
+    min_index = 1
+    max_index = -1
+    len_indices = row_indices.shape[0]
+    for i in range(len_indices):
+        index = row_indices[i]
+        min_index = min(min_index, index)
+        max_index = max(max_index, index)
+    if min_index < 0:
+        raise ValueError('row_indices have to be positive')
+    if max_index > M:
+        raise ValueError('row_indices to large')
+    min_index = 1
+    max_index = -1
+    len_indices = col_indices.shape[0]
+    for i in range(len_indices):
+        index = col_indices[i]
+        min_index = min(min_index, index)
+        max_index = max(max_index, index)
+    if min_index < 0:
+        raise ValueError('col_indices have to be positive')
+    if max_index > M:
+        raise ValueError('col_indices to large')
+
+    result = _clear_rows_cols_csr(mat.data, mat.indices, mat.indptr, M, N, row_indices, col_indices)
+
+    if result != 0:
+        raise RuntimeError('unknown problem occurred')
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
 cdef int _set_unit_rows_cols_csr(
         np.ndarray[np.double_t] data, np.ndarray[np.int32_t] indcs, np.ndarray[np.int32_t] indptr,
         np.int32_t M, np.int32_t N,
@@ -138,4 +176,45 @@ cdef int _set_unit_rows_cols_csr(
                         data[j] = 1.
                     else:
                         data[j] = 0.
+    return 0
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+cdef int _clear_rows_cols_csr(
+        np.ndarray[np.double_t] data, np.ndarray[np.int32_t] indices, np.ndarray[np.int32_t] indptr,
+        np.int32_t M, np.int32_t N,
+        np.ndarray[np.int32_t] row_indices,
+        np.ndarray[np.int32_t] col_indices):
+
+    cdef np.int32_t i, j, m, n, index, len_row_indices, len_col_indices
+    cdef bint clear_row, clear_col
+    len_row_indices = row_indices.shape[0]
+    len_col_indices = col_indices.shape[0]
+
+    if len_row_indices == 0 and len_row_indices == 0:
+        return 0
+
+    for m in range(M):
+        clear_row = False
+        for i in range(len_row_indices): # not optimal, order n log(n), increment m and i simultaneously
+            index = row_indices[i]
+            if m == index:
+                clear_row = True
+                break
+        if clear_row:
+            for j in range(indptr[m], indptr[m + 1]):
+                n = indices[j]
+                data[j] = 0.
+        else: # we still need to clear all column entries in this row which are in col_indices
+            for j in range(indptr[m], indptr[m + 1]):
+                n = indices[j]
+                clear_col = False
+                for i in range(len_col_indices): # not optimal, see above
+                    index = row_indices[i]
+                    if n == index:
+                        clear_col = True
+                        break
+                if clear_col:
+                    data[j] = 0.
     return 0

--- a/src/pymor/tools/inplace.pyx
+++ b/src/pymor/tools/inplace.pyx
@@ -70,6 +70,18 @@ def set_unit_rows_cols(mat, np.ndarray[np.int32_t] indices):
     if M != N:
         raise ValueError('matrix has to be square')
 
+    cdef np.int32_t i, index, min_index, max_index
+    min_index = 1
+    max_index = -1
+    for i in range(indices.shape[0]):
+        index = indices[i]
+        min_index = min(min_index, index)
+        max_index = max(max_index, index)
+    if min_index < 0:
+        raise ValueError('indices have to be positive')
+    if max_index > M:
+        raise ValueError('indices to large')
+
     result = _set_unit_rows_cols_csr(mat.data, mat.indices, mat.indptr, M, N, indices)
 
     if result == -1:
@@ -96,7 +108,7 @@ cdef int _set_unit_rows_cols_csr(
 
     for m in range(M):
         clear_row = False
-        for i in range(len_indices):
+        for i in range(len_indices): # not optimal, order n log(n), increment m and i simultaneously
             index = indices[i]
             if m == index:
                 clear_row = True
@@ -116,7 +128,7 @@ cdef int _set_unit_rows_cols_csr(
             for j in range(indptr[m], indptr[m + 1]):
                 n = indcs[j]
                 clear_col = False
-                for i in range(len_indices):
+                for i in range(len_indices): # not optimal, see above
                     index = indices[i]
                     if n == index:
                         clear_col = True


### PR DESCRIPTION
This allows to clear all rows and columns of a CSR matrix and to set the corresponding diagonal entries to 1. Something like this is useful to clear the Dirichlet DoFs of a product matrix in a CG context, for instance.

I needed this at some point since all other pure python implementations the internet and myself could come up with (including conversion to other sparse formats and so on) did not scale. I also could not find something like this in other packages to copy from or import. However, I am not sure if we want to include this in pyMOR.
