### PR TITLE
Complex arithmetic for PDE solvers 2

### DIFF
--- a/src/pymor/algorithms/genericsolvers.py
+++ b/src/pymor/algorithms/genericsolvers.py
@@ -339,7 +339,10 @@ def lgmres(A, b, x0=None, tol=1e-5, maxiter=1000, M=None, callback=None,
             e1 = np.zeros((j+1,))
             e1[0] = inner_res_0
             for q in range(j):
-                hess[:(q+2), q] = hs[q]
+                hsq = np.array(hs[q])
+                common_dtype = np.promote_types(hess.dtype, hsq.dtype)
+                hess = hess.astype(common_dtype, copy=False)
+                hess[:(q+2), q] = hsq
 
             y, resids, rank, s = lstsq(hess, e1)
             inner_res = np.linalg.norm(np.dot(hess, y) - e1)

--- a/src/pymor/algorithms/gram_schmidt.py
+++ b/src/pymor/algorithms/gram_schmidt.py
@@ -85,7 +85,7 @@ def gram_schmidt(A, product=None, return_R=False, atol=1e-13, rtol=1e-13, offset
                     p = A[j].pairwise_inner(A[i], product)[0]
                     A[i].axpy(-p, A[j])
                     common_dtype = np.promote_types(R.dtype, type(p))
-                    R = R.astype(common_dtype)
+                    R = R.astype(common_dtype, copy=False)
                     R[j, i] += p
 
                 # calculate new norm

--- a/src/pymor/bindings/fenics.py
+++ b/src/pymor/bindings/fenics.py
@@ -15,7 +15,7 @@ if config.HAVE_FENICS:
     from pymor.vectorarrays.interfaces import _create_random_values
     from pymor.vectorarrays.list import CopyOnWriteVector, ComplexifiedVector, ComplexifiedListVectorSpace
 
-    class RealFenicsVector(CopyOnWriteVector):
+    class FenicsVector(CopyOnWriteVector):
         """Wraps a FEniCS vector to make it usable with ListVectorArray."""
 
         def __init__(self, impl):
@@ -72,7 +72,7 @@ if config.HAVE_FENICS:
             raise NotImplementedError  # is implemented for complexified vector
 
         def __add__(self, other):
-            return RealFenicsVector(self.impl + other.impl)
+            return FenicsVector(self.impl + other.impl)
 
         def __iadd__(self, other):
             self._copy_data_if_needed()
@@ -82,7 +82,7 @@ if config.HAVE_FENICS:
         __radd__ = __add__
 
         def __sub__(self, other):
-            return RealFenicsVector(self.impl - other.impl)
+            return FenicsVector(self.impl - other.impl)
 
         def __isub__(self, other):
             self._copy_data_if_needed()
@@ -90,10 +90,10 @@ if config.HAVE_FENICS:
             return self
 
         def __mul__(self, other):
-            return RealFenicsVector(self.impl * other)
+            return FenicsVector(self.impl * other)
 
         def __neg__(self):
-            return RealFenicsVector(-self.impl)
+            return FenicsVector(-self.impl)
 
     class ComplexifiedFenicsVector(ComplexifiedVector):
 
@@ -142,21 +142,21 @@ if config.HAVE_FENICS:
 
         def real_zero_vector(self):
             impl = df.Function(self.V).vector()
-            return RealFenicsVector(impl)
+            return FenicsVector(impl)
 
         def real_full_vector(self, value):
             impl = df.Function(self.V).vector()
             impl += value
-            return RealFenicsVector(impl)
+            return FenicsVector(impl)
 
         def real_random_vector(self, distribution, random_state, **kwargs):
             impl = df.Function(self.V).vector()
             values = _create_random_values(impl.local_size(), distribution, random_state, **kwargs)
             impl[:] = values
-            return RealFenicsVector(impl)
+            return FenicsVector(impl)
 
         def real_make_vector(self, obj):
-            return RealFenicsVector(obj)
+            return FenicsVector(obj)
 
     class FenicsMatrixOperator(LinearComplexifiedListVectorArrayOperatorBase):
         """Wraps a FEniCS matrix as an |Operator|."""

--- a/src/pymor/bindings/ngsolve.py
+++ b/src/pymor/bindings/ngsolve.py
@@ -28,7 +28,7 @@ if config.HAVE_NGSOLVE:
         def dofs(self, dof_indices):
             return self.to_numpy()[dof_indices]
 
-    class RealNGSolveVector(NGSolveVectorCommon, CopyOnWriteVector):
+    class NGSolveVector(NGSolveVectorCommon, CopyOnWriteVector):
         """Wraps a NGSolve BaseVector to make it usable with ListVectorArray."""
 
         def __init__(self, impl):
@@ -64,12 +64,12 @@ if config.HAVE_NGSOLVE:
         def l2_norm2(self):
             return self.impl.vec.Norm() ** 2
 
-    class NGSolveVector(NGSolveVectorCommon, ComplexifiedVector):
+    class ComplexifiedNGSolveVector(NGSolveVectorCommon, ComplexifiedVector):
         pass
 
     class NGSolveVectorSpace(ComplexifiedListVectorSpace):
 
-        complexified_vector_type = NGSolveVector
+        complexified_vector_type = ComplexifiedNGSolveVector
 
         def __init__(self, V, id='STATE'):
             self.__auto_init(locals())
@@ -98,10 +98,10 @@ if config.HAVE_NGSOLVE:
 
         def real_zero_vector(self):
             impl = ngs.GridFunction(self.V)
-            return RealNGSolveVector(impl)
+            return NGSolveVector(impl)
 
         def real_make_vector(self, obj):
-            return RealNGSolveVector(obj)
+            return NGSolveVector(obj)
 
         def real_vector_from_numpy(self, data, ensure_copy=False):
             v = self.zero_vector()

--- a/src/pymor/bindings/ngsolve.py
+++ b/src/pymor/bindings/ngsolve.py
@@ -10,12 +10,25 @@ if config.HAVE_NGSOLVE:
     import numpy as np
 
     from pymor.core.interfaces import ImmutableInterface
-    from pymor.operators.basic import OperatorBase
+    from pymor.operators.basic import LinearComplexifiedListVectorArrayOperatorBase
     from pymor.vectorarrays.interfaces import VectorArrayInterface
     from pymor.vectorarrays.numpy import NumpyVectorSpace
-    from pymor.vectorarrays.list import CopyOnWriteVector, ListVectorSpace
+    from pymor.vectorarrays.list import CopyOnWriteVector, ComplexifiedVector, ComplexifiedListVectorSpace
 
-    class NGSolveVector(CopyOnWriteVector):
+    class NGSolveVectorCommon:
+        def l1_norm(self):
+            return np.linalg.norm(self.to_numpy(), ord=1)
+
+        def amax(self):
+            A = np.abs(self.to_numpy())
+            max_ind = np.argmax(A)
+            max_val = A[max_ind]
+            return max_ind, max_val
+
+        def dofs(self, dof_indices):
+            return self.to_numpy()[dof_indices]
+
+    class RealNGSolveVector(NGSolveVectorCommon, CopyOnWriteVector):
         """Wraps a NGSolve BaseVector to make it usable with ListVectorArray."""
 
         def __init__(self, impl):
@@ -45,25 +58,18 @@ if config.HAVE_NGSOLVE:
         def dot(self, other):
             return self.impl.vec.InnerProduct(other.impl.vec)
 
-        def l1_norm(self):
-            return np.linalg.norm(self.to_numpy(), ord=1)
-
         def l2_norm(self):
             return self.impl.vec.Norm()
 
         def l2_norm2(self):
             return self.impl.vec.Norm() ** 2
 
-        def dofs(self, dof_indices):
-            return self.to_numpy()[dof_indices]
+    class NGSolveVector(NGSolveVectorCommon, ComplexifiedVector):
+        pass
 
-        def amax(self):
-            A = np.abs(self.to_numpy())
-            max_ind = np.argmax(A)
-            max_val = A[max_ind]
-            return max_ind, max_val
+    class NGSolveVectorSpace(ComplexifiedListVectorSpace):
 
-    class NGSolveVectorSpace(ListVectorSpace):
+        complexified_vector_type = NGSolveVector
 
         def __init__(self, V, id='STATE'):
             self.__auto_init(locals())
@@ -90,53 +96,49 @@ if config.HAVE_NGSOLVE:
         def space_from_vector_obj(cls, vec, id):
             return cls(vec.space, id)
 
-        def zero_vector(self):
+        def real_zero_vector(self):
             impl = ngs.GridFunction(self.V)
-            return NGSolveVector(impl)
+            return RealNGSolveVector(impl)
 
-        def make_vector(self, obj):
-            return NGSolveVector(obj)
+        def real_make_vector(self, obj):
+            return RealNGSolveVector(obj)
 
-        def vector_from_numpy(self, data, ensure_copy=False):
+        def real_vector_from_numpy(self, data, ensure_copy=False):
             v = self.zero_vector()
             v.to_numpy()[:] = data
             return v
 
-    class NGSolveMatrixOperator(OperatorBase):
+    class NGSolveMatrixOperator(LinearComplexifiedListVectorArrayOperatorBase):
         """Wraps a NGSolve matrix as an |Operator|."""
-
-        linear = True
 
         def __init__(self, matrix, range, source, solver_options=None, name=None):
             self.__auto_init(locals())
 
-        def apply(self, U, mu=None):
-            assert U in self.source
-            R = self.range.zeros(len(U))
-            for u, r in zip(U._list, R._list):
-                self.matrix.Mult(u.impl.vec, r.impl.vec)
-            return R
-
-        def apply_adjoint(self, V, mu=None):
-            assert V in self.range
-            U = self.source.zeros(len(V))
-            mat = self.matrix.Transpose()  # untested in complex case
-            for v, u in zip(V._list, U._list):
-                mat.Mult(v.impl.vec, u.impl.vec)
-            return U
-
         @defaults('default_solver')
-        def apply_inverse(self, V, mu=None, least_squares=False, default_solver=''):
-            assert V in self.range
-            if least_squares:
-                raise NotImplementedError
-            solver = self.solver_options.get('inverse', default_solver) if self.solver_options else default_solver
-            R = self.source.zeros(len(V))
-            with ngs.TaskManager():
+        def _prepare_apply(self, U, mu, kind, least_squares=False, default_solver=''):
+            if kind == 'apply_inverse':
+                if least_squares:
+                    raise NotImplementedError
+                solver = self.solver_options.get('inverse', default_solver) if self.solver_options else default_solver
                 inv = self.matrix.Inverse(self.source.V.FreeDofs(), inverse=solver)
-                for r, v in zip(R._list, V._list):
-                    r.impl.vec.data = inv * v.impl.vec
-            return R
+                return inv
+
+        def _real_apply_one_vector(self, u, mu=None, prepare_data=None):
+            r = self.range.real_zero_vector()
+            self.matrix.Mult(u.impl.vec, r.impl.vec)
+            return r
+
+        def _real_apply_adjoint_one_vector(self, v, mu=None, prepare_data=None):
+            u = self.source.real_zero_vector()
+            mat = self.matrix.Transpose()
+            mat.Mult(v.impl.vec, u.impl.vec)
+            return u
+
+        def _real_apply_inverse_one_vector(self, v, mu=None, least_squares=False, prepare_data=None):
+            inv = prepare_data
+            r = self.source.real_zero_vector()
+            r.impl.vec.data = inv * v.impl.vec
+            return r
 
         def _assemble_lincomb(self, operators, coefficients, identity_shift=0., solver_options=None, name=None):
             if not all(isinstance(op, NGSolveMatrixOperator) for op in operators):
@@ -168,6 +170,8 @@ if config.HAVE_NGSOLVE:
             assert all(u in self.space for u in U)
             if any(len(u) != 1 for u in U):
                 raise NotImplementedError
+            if any(u._list[0].imag_part is not None for u in U):
+                raise NotImplementedError
 
             if legend is None:
                 legend = [f'VectorArray{i}' for i in range(len(U))]
@@ -180,4 +184,4 @@ if config.HAVE_NGSOLVE:
                 raise NotImplementedError
 
             for u, name in zip(U, legend):
-                ngs.Draw(u._list[0].impl, self.mesh, name=name)
+                ngs.Draw(u._list[0].real_part.impl, self.mesh, name=name)

--- a/src/pymor/operators/basic.py
+++ b/src/pymor/operators/basic.py
@@ -8,6 +8,7 @@ import numpy as np
 
 from pymor.algorithms import genericsolvers
 from pymor.core.exceptions import InversionError, LinAlgError
+from pymor.core.interfaces import abstractmethod
 from pymor.operators.interfaces import OperatorInterface
 from pymor.parameters.interfaces import ParameterFunctionalInterface
 from pymor.vectorarrays.interfaces import VectorArrayInterface
@@ -148,6 +149,114 @@ class OperatorBase(OperatorInterface):
 
     def as_source_array(self, mu=None):
         return self.apply_adjoint(self.range.from_numpy(np.eye(self.range.dim)), mu=mu)
+
+
+class ListVectorArrayOperatorBase(OperatorBase):
+
+    def _prepare_apply(self, U, mu, kind, least_squares=False):
+        pass
+
+    @abstractmethod
+    def _apply_one_vector(self, u, mu=None, prepare_data=None):
+        pass
+
+    def _apply_inverse_one_vector(self, v, mu=None, least_squares=False, prepare_data=None):
+        raise NotImplementedError
+
+    def _apply_adjoint_one_vector(self, v, mu=None, prepare_data=None):
+        raise NotImplementedError
+
+    def _apply_inverse_adjoint_one_vector(self, u, mu=None, least_squares=False, prepare_data=None):
+        raise NotImplementedError
+
+    def apply(self, U, mu=None):
+        assert U in self.source
+        data = self._prepare_apply(U, mu, 'apply')
+        V = [self._apply_one_vector(u, mu=mu, prepare_data=data) for u in U._list]
+        return self.range.make_array(V)
+
+    def apply_inverse(self, V, mu=None, least_squares=False):
+        assert V in self.range
+        try:
+            data = self._prepare_apply(V, mu, 'apply_inverse', least_squares=least_squares)
+            U = [self._apply_inverse_one_vector(v, mu=mu, least_squares=least_squares, prepare_data=data)
+                 for v in V._list]
+        except NotImplementedError:
+            return super().apply_inverse(V, mu=mu, least_squares=least_squares)
+        return self.source.make_array(U)
+
+    def apply_adjoint(self, V, mu=None):
+        assert V in self.range
+        try:
+            data = self._prepare_apply(V, mu, 'apply_adjoint')
+            U = [self._apply_adjoint_one_vector(v, mu=mu, prepare_data=data) for v in V._list]
+        except NotImplementedError:
+            return super().apply_adjoint(V, mu=mu)
+        return self.source.make_array(U)
+
+    def apply_inverse_adjoint(self, U, mu=None, least_squares=False):
+        assert U in self.source
+        try:
+            data = self._prepare_apply(U, mu, 'apply_inverse_adjoint', least_squares=least_squares)
+            V = [self._apply_inverse_adjoint_one_vector(u, mu=mu, least_squares=least_squares, prepare_data=data)
+                 for u in U._list]
+        except NotImplementedError:
+            return super().apply_inverse_adjoint(U, mu=mu, least_squares=least_squares)
+        return self.range.make_array(V)
+
+
+class LinearComplexifiedListVectorArrayOperatorBase(ListVectorArrayOperatorBase):
+
+    linear = True
+
+    @abstractmethod
+    def _real_apply_one_vector(self, u, mu=None, prepare_data=None):
+        pass
+
+    def _real_apply_inverse_one_vector(self, v, mu=None, least_squares=False, prepare_data=None):
+        raise NotImplementedError
+
+    def _real_apply_adjoint_one_vector(self, v, mu=None, prepare_data=None):
+        raise NotImplementedError
+
+    def _real_apply_inverse_adjoint_one_vector(self, u, mu=None, least_squares=False, prepare_data=None):
+        raise NotImplementedError
+
+    def _apply_one_vector(self, u, mu=None, prepare_data=None):
+        real_part = self._real_apply_one_vector(u.real_part, mu=mu, prepare_data=prepare_data)
+        if u.imag_part is not None:
+            imag_part = self._real_apply_one_vector(u.imag_part, mu=mu, prepare_data=prepare_data)
+        else:
+            imag_part = None
+        return self.range.complexified_vector_type(real_part, imag_part)
+
+    def _apply_inverse_one_vector(self, v, mu=None, least_squares=False, prepare_data=None):
+        real_part = self._real_apply_inverse_one_vector(v.real_part, mu=mu, least_squares=least_squares,
+                                                        prepare_data=prepare_data)
+        if v.imag_part is not None:
+            imag_part = self._real_apply_inverse_one_vector(v.imag_part, mu=mu, least_squares=least_squares,
+                                                            prepare_data=prepare_data)
+        else:
+            imag_part = None
+        return self.source.complexified_vector_type(real_part, imag_part)
+
+    def _apply_adjoint_one_vector(self, v, mu=None, prepare_data=None):
+        real_part = self._real_apply_adjoint_one_vector(v.real_part, mu=mu, prepare_data=prepare_data)
+        if v.imag_part is not None:
+            imag_part = self._real_apply_adjoint_one_vector(v.imag_part, mu=mu, prepare_data=prepare_data)
+        else:
+            imag_part = None
+        return self.source.complexified_vector_type(real_part, imag_part)
+
+    def _apply_inverse_adjoint_one_vector(self, u, mu=None, least_squares=False, prepare_data=None):
+        real_part = self._real_apply_inverse_adjoint_one_vector(u.real_part, mu=mu, least_squares=least_squares,
+                                                                prepare_data=prepare_data)
+        if u.imag_part is not None:
+            imag_part = self._real_apply_inverse_adjoint_one_vector(u.imag_part, mu=mu, least_squares=least_squares,
+                                                                    prepare_data=prepare_data)
+        else:
+            imag_part = None
+        return self.range.complexified_vector_type(real_part, imag_part)
 
 
 class ProjectedOperator(OperatorBase):

--- a/src/pymor/vectorarrays/list.py
+++ b/src/pymor/vectorarrays/list.py
@@ -535,7 +535,7 @@ class ListVectorArray(VectorArrayInterface):
 
     @property
     def real(self):
-        return self.__class__([v.real for v in self._list], self.space)
+        return ListVectorArray([v.real for v in self._list], self.space)
 
     @property
     def imag(self):
@@ -543,7 +543,7 @@ class ListVectorArray(VectorArrayInterface):
         # of a real vector, so we have to check for that.
         # returning None is allowed as ComplexifiedVector does not know
         # how to create a new zero vector.
-        return self.__class__([v.imag or self.space.zero_vector() for v in self._list], self.space)
+        return ListVectorArray([v.imag or self.space.zero_vector() for v in self._list], self.space)
 
     def conj(self):
         return self.__class__([v.conj() for v in self._list], self.space)

--- a/src/pymor/vectorarrays/list.py
+++ b/src/pymor/vectorarrays/list.py
@@ -613,7 +613,7 @@ class ListVectorSpace(VectorSpaceInterface):
 
     @make_array.instancemethod
     def make_array(self, obj):
-        return ListVectorArray([self.make_vector(v) for v in obj], self)
+        return ListVectorArray([v if isinstance(v, VectorInterface) else self.make_vector(v) for v in obj], self)
 
     @classinstancemethod
     def from_numpy(cls, data, id=None, ensure_copy=False):

--- a/src/pymor/vectorarrays/list.py
+++ b/src/pymor/vectorarrays/list.py
@@ -296,22 +296,34 @@ class NumpyVector(CopyOnWriteVector):
         self._array = self._array.copy()
 
     def _scal(self, alpha):
-        self._array *= alpha
+        try:
+            self._array *= alpha
+        except TypeError:  # e.g. when scaling real array by complex alpha
+            self._array = self._array * alpha
 
     def _axpy(self, alpha, x):
         assert self.dim == x.dim
         if alpha == 0:
             return
         if alpha == 1:
-            self._array += x._array
+            try:
+                self._array += x._array
+            except TypeError:
+                self._array = self._array + x._array
         elif alpha == -1:
-            self._array -= x._array
+            try:
+                self._array -= x._array
+            except TypeError:
+                self._array = self._array - x._array
         else:
-            self._array += x._array * alpha
+            try:
+                self._array += x._array * alpha
+            except TypeError:
+                self._array = self._array + x._array * alpha
 
     def dot(self, other):
         assert self.dim == other.dim
-        return np.sum(self._array * other._array)
+        return np.sum(self._array.conj() * other._array)
 
     def l1_norm(self):
         return np.sum(np.abs(self._array))
@@ -329,7 +341,7 @@ class NumpyVector(CopyOnWriteVector):
         A = np.abs(self._array)
         max_ind = np.argmax(A)
         max_val = A[max_ind]
-        return max_ind, max_val
+        return max_ind, np.abs(max_val)
 
     @property
     def real(self):

--- a/src/pymor/vectorarrays/list.py
+++ b/src/pymor/vectorarrays/list.py
@@ -93,6 +93,17 @@ class VectorInterface(BasicInterface):
         result.scal(-1)
         return result
 
+    @property
+    def real(self):
+        return self.copy()
+
+    @property
+    def imag(self):
+        return None
+
+    def conj(self):
+        return self.copy()
+
 
 class CopyOnWriteVector(VectorInterface):
 
@@ -207,6 +218,17 @@ class NumpyVector(CopyOnWriteVector):
         max_ind = np.argmax(A)
         max_val = A[max_ind]
         return max_ind, max_val
+
+    @property
+    def real(self):
+        return self.__class__(self._array.real.copy())
+
+    @property
+    def imag(self):
+        return self.__class__(self._array.imag.copy())
+
+    def conj(self):
+        return self.__class__(self._array.conj())
 
 
 class ListVectorArray(VectorArrayInterface):
@@ -393,6 +415,21 @@ class ListVectorArray(VectorArrayInterface):
             MI[k], MV[k] = v.amax()
 
         return MI, MV
+
+    @property
+    def real(self):
+        return self.__class__([v.real for v in self._list], self.space)
+
+    @property
+    def imag(self):
+        # note that VectorInterface.imag is allowed to return None in case
+        # of a real vector, so we have to check for that.
+        # returning None is allowed as ComplexifiedVector does not know
+        # how to create a new zero vector.
+        return self.__class__([v.imag or self.space.zero_vector() for v in self._list], self.space)
+
+    def conj(self):
+        return self.__class__([v.conj() for v in self._list], self.space)
 
     def __str__(self):
         return f'ListVectorArray of {len(self._list)} of space {self.space}'

--- a/src/pymordemos/thermalblock_simple.py
+++ b/src/pymordemos/thermalblock_simple.py
@@ -201,7 +201,7 @@ def discretize_ngsolve():
     h1_0_op = op.assemble([1] * len(coeffs)).with_(name='h1_0_semi')
 
     F = space.zeros()
-    F._list[0].impl.vec.data = f.vec
+    F._list[0].real_part.impl.vec.data = f.vec
     F = VectorOperator(F)
 
     return StationaryModel(op, F, visualizer=NGSolveVisualizer(mesh, V),

--- a/src/pymortests/algorithms/basic.py
+++ b/src/pymortests/algorithms/basic.py
@@ -29,7 +29,13 @@ def test_almost_equal(compatible_vector_array_pair):
     for ind1, ind2 in valid_inds_of_same_length(v1, v2):
         for rtol, atol in ((1e-5, 1e-8), (1e-10, 1e-12), (0., 1e-8), (1e-5, 1e-8)):
             for n, o in [('sup', np.inf), ('l1', 1), ('l2', 2)]:
-                r = almost_equal(v1[ind1], v2[ind2], norm=n)
+                try:
+                    r = almost_equal(v1[ind1], v2[ind2], norm=n)
+                except NotImplementedError as e:
+                    if n == 'l1':
+                        pytest.xfail('l1_norm not implemented')
+                    else:
+                        raise e
                 assert isinstance(r, np.ndarray)
                 assert r.shape == (v1.len_ind(ind1),)
                 if dv1 is not None:
@@ -67,7 +73,13 @@ def test_almost_equal_self(vector_array):
     for ind in valid_inds(v):
         for rtol, atol in ((1e-5, 1e-8), (1e-10, 1e-12), (0., 1e-8), (1e-5, 1e-8), (1e-12, 0.)):
             for n in ['sup', 'l1', 'l2']:
-                r = almost_equal(v[ind], v[ind], norm=n)
+                try:
+                    r = almost_equal(v[ind], v[ind], norm=n)
+                except NotImplementedError as e:
+                    if n == 'l1':
+                        pytest.xfail('l1_norm not implemented')
+                    else:
+                        raise e
                 assert isinstance(r, np.ndarray)
                 assert r.shape == (v.len_ind(ind),)
                 assert np.all(r)

--- a/src/pymortests/algorithms/gram_schmidt.py
+++ b/src/pymortests/algorithms/gram_schmidt.py
@@ -17,7 +17,7 @@ def test_gram_schmidt(vector_array):
     onb = gram_schmidt(U, copy=True)
     assert np.all(almost_equal(U, V))
     assert np.allclose(onb.dot(onb), np.eye(len(onb)))
-    assert np.all(almost_equal(U, onb.lincomb(U.dot(onb)), rtol=1e-13))
+    assert np.all(almost_equal(U, onb.lincomb(onb.dot(U).T), rtol=1e-13))
 
     onb2 = gram_schmidt(U, copy=False)
     assert np.all(almost_equal(onb, onb2))
@@ -31,7 +31,7 @@ def test_gram_schmidt_with_R(vector_array):
     onb, R = gram_schmidt(U, return_R=True, copy=True)
     assert np.all(almost_equal(U, V))
     assert np.allclose(onb.dot(onb), np.eye(len(onb)))
-    assert np.all(almost_equal(U, onb.lincomb(U.dot(onb)), rtol=1e-13))
+    assert np.all(almost_equal(U, onb.lincomb(onb.dot(U).T), rtol=1e-13))
     assert np.all(almost_equal(V, onb.lincomb(R.T)))
 
     onb2, R2 = gram_schmidt(U, return_R=True, copy=False)
@@ -47,7 +47,7 @@ def test_gram_schmidt_with_product(operator_with_arrays_and_products):
     onb = gram_schmidt(U, product=p, copy=True)
     assert np.all(almost_equal(U, V))
     assert np.allclose(p.apply2(onb, onb), np.eye(len(onb)))
-    assert np.all(almost_equal(U, onb.lincomb(p.apply2(U, onb)), rtol=1e-13))
+    assert np.all(almost_equal(U, onb.lincomb(p.apply2(onb, U).T), rtol=1e-13))
 
     onb2 = gram_schmidt(U, product=p, copy=False)
     assert np.all(almost_equal(onb, onb2))
@@ -61,7 +61,7 @@ def test_gram_schmidt_with_product_and_R(operator_with_arrays_and_products):
     onb, R = gram_schmidt(U, product=p, return_R=True, copy=True)
     assert np.all(almost_equal(U, V))
     assert np.allclose(p.apply2(onb, onb), np.eye(len(onb)))
-    assert np.all(almost_equal(U, onb.lincomb(p.apply2(U, onb)), rtol=1e-13))
+    assert np.all(almost_equal(U, onb.lincomb(p.apply2(onb, U).T), rtol=1e-13))
     assert np.all(almost_equal(U, onb.lincomb(R.T)))
 
     onb2, R2 = gram_schmidt(U, product=p, return_R=True, copy=False)
@@ -88,8 +88,8 @@ def test_gram_schmidt_biorth(vector_array):
     assert np.all(almost_equal(U2, V2))
     assert np.allclose(A2.dot(A1), np.eye(len(A1)))
     c = np.linalg.cond(A1.to_numpy()) * np.linalg.cond(A2.to_numpy())
-    assert np.all(almost_equal(U1, A1.lincomb(U1.dot(A2)), rtol=c * 1e-14))
-    assert np.all(almost_equal(U2, A2.lincomb(U2.dot(A1)), rtol=c * 1e-14))
+    assert np.all(almost_equal(U1, A1.lincomb(A2.dot(U1).T), rtol=c * 1e-14))
+    assert np.all(almost_equal(U2, A2.lincomb(A1.dot(U2).T), rtol=c * 1e-14))
 
     B1, B2 = gram_schmidt_biorth(U1, U2, copy=False)
     assert np.all(almost_equal(A1, B1))
@@ -116,8 +116,8 @@ def test_gram_schmidt_biorth_with_product(operator_with_arrays_and_products):
     assert np.all(almost_equal(U2, V2))
     assert np.allclose(p.apply2(A2, A1), np.eye(len(A1)))
     c = np.linalg.cond(A1.to_numpy()) * np.linalg.cond(p.apply(A2).to_numpy())
-    assert np.all(almost_equal(U1, A1.lincomb(p.apply2(U1, A2)), rtol=c * 1e-14))
-    assert np.all(almost_equal(U2, A2.lincomb(p.apply2(U2, A1)), rtol=c * 1e-14))
+    assert np.all(almost_equal(U1, A1.lincomb(p.apply2(A2, U1).T), rtol=c * 1e-14))
+    assert np.all(almost_equal(U2, A2.lincomb(p.apply2(A1, U2).T), rtol=c * 1e-14))
 
     B1, B2 = gram_schmidt_biorth(U1, U2, product=p, copy=False)
     assert np.all(almost_equal(A1, B1))

--- a/src/pymortests/fixtures/vectorarray.py
+++ b/src/pymortests/fixtures/vectorarray.py
@@ -23,12 +23,18 @@ def random_integers(count, seed):
 
 def numpy_vector_array_factory(length, dim, seed):
     np.random.seed(seed)
-    return NumpyVectorSpace.from_numpy(np.random.random((length, dim)))
+    if np.random.randint(2):
+        return NumpyVectorSpace.from_numpy(np.random.random((length, dim)))
+    else:
+        return NumpyVectorSpace.from_numpy(np.random.random((length, dim)) + np.random.random((length, dim)) * 1j)
 
 
 def numpy_list_vector_array_factory(length, dim, seed):
     np.random.seed(seed)
-    return NumpyListVectorSpace.from_numpy(np.random.random((length, dim)))
+    if np.random.randint(2):
+        return NumpyListVectorSpace.from_numpy(np.random.random((length, dim)))
+    else:
+        return NumpyListVectorSpace.from_numpy(np.random.random((length, dim)) + np.random.random((length, dim)) * 1j)
 
 
 def block_vector_array_factory(length, dims, seed):
@@ -44,12 +50,18 @@ if config.HAVE_FENICS:
                      for ni in [1, 10, 32, 100]]
 
     def fenics_vector_array_factory(length, space, seed):
-        V = fenics_spaces[space]
-        U = FenicsVectorSpace(V).zeros(length)
-        dim = U.dim
+        V = FenicsVectorSpace(fenics_spaces[space])
+        U = V.zeros(length)
+        dim = V.dim
         np.random.seed(seed)
         for v, a in zip(U._list, np.random.random((length, dim))):
-            v.impl[:] = a
+            v.real_part.impl[:] = a
+        if np.random.randint(2):
+            UU = V.zeros(length)
+            for v, a in zip(UU._list, np.random.random((length, dim))):
+                v.real_part.impl[:] = a
+            for u, uu in zip(U._list, UU._list):
+                u.imag_part = uu.real_part
         return U
 
     fenics_vector_array_factory_arguments = \
@@ -98,6 +110,12 @@ if config.HAVE_NGSOLVE:
         np.random.seed(seed)
         for v, a in zip(U._list, np.random.random((length, dim))):
             v.to_numpy()[:] = a
+        if np.random.randint(2):
+            UU = NGSOLVE_spaces[dim].zeros(length)
+            for v, a in zip(UU._list, np.random.random((length, dim))):
+                v.real_part.to_numpy()[:] = a
+            for u, uu in zip(U._list, UU._list):
+                u.imag_part = uu.real_part
         return U
 
 

--- a/src/pymortests/vectorarray.py
+++ b/src/pymortests/vectorarray.py
@@ -863,9 +863,9 @@ def test_amax(vector_array):
         return
     for ind in valid_inds(v):
         max_inds, max_vals = v[ind].amax()
-        assert np.allclose(np.abs(max_vals), v[ind].sup_norm())
+        assert np.allclose(max_vals, v[ind].sup_norm())
         for i, max_ind, max_val in zip(ind_to_list(v, ind), max_inds, max_vals):
-            assert np.allclose(max_val, v[[i]].dofs([max_ind]))
+            assert np.allclose(max_val, np.abs(v[[i]].dofs([max_ind])))
 
 
 # def test_amax_zero_dim(zero_dimensional_vector_space):

--- a/src/pymortests/vectorarray.py
+++ b/src/pymortests/vectorarray.py
@@ -486,7 +486,6 @@ def test_axpy(compatible_vector_array_pair):
             assert np.all(almost_equal(c1[ind1_complement], v1[ind1_complement]))
             assert np.all(almost_equal(c2, v2))
             assert np.all(c1[ind1].sup_norm() <= v1[ind1].sup_norm() + abs(a) * v2[ind2].sup_norm() * (1. + 1e-10))
-            assert np.all(c1[ind1].l1_norm() <= (v1[ind1].l1_norm() + abs(a) * v2[ind2].l1_norm()) * (1. + 1e-10))
             assert np.all(c1[ind1].l2_norm() <= (v1[ind1].l2_norm() + abs(a) * v2[ind2].l2_norm()) * (1. + 1e-10))
             try:
                 x = v1.to_numpy(True)
@@ -531,7 +530,6 @@ def test_axpy_one_x(compatible_vector_array_pair):
             assert np.all(almost_equal(c1[ind1_complement], v1[ind1_complement]))
             assert np.all(almost_equal(c2, v2))
             assert np.all(c1[ind1].sup_norm() <= v1[ind1].sup_norm() + abs(a) * v2[ind2].sup_norm() * (1. + 1e-10))
-            assert np.all(c1[ind1].l1_norm() <= (v1[ind1].l1_norm() + abs(a) * v2[ind2].l1_norm()) * (1. + 1e-10))
             assert np.all(c1[ind1].l2_norm() <= (v1[ind1].l2_norm() + abs(a) * v2[ind2].l2_norm()) * (1. + 1e-10))
             try:
                 x = v1.to_numpy(True)
@@ -574,7 +572,6 @@ def test_axpy_self(vector_array):
             assert len(c) == len(v)
             assert np.all(almost_equal(c[ind1_complement], v[ind1_complement]))
             assert np.all(c[ind1].sup_norm() <= v[ind1].sup_norm() + abs(a) * v[ind2].sup_norm() * (1. + 1e-10))
-            assert np.all(c[ind1].l1_norm() <= (v[ind1].l1_norm() + abs(a) * v[ind2].l1_norm()) * (1. + 1e-10))
             try:
                 x = v.to_numpy(True)
                 if isinstance(ind1, Number):
@@ -722,7 +719,10 @@ def test_l1_norm(vector_array):
     v = vector_array
     for ind in valid_inds(v):
         c = v.copy()
-        norm = c[ind].l1_norm()
+        try:
+            norm = c[ind].l1_norm()
+        except NotImplementedError:
+            pytest.xfail('l1_norm not implemented')
         assert isinstance(norm, np.ndarray)
         assert norm.shape == (v.len_ind(ind),)
         assert np.all(norm >= 0)


### PR DESCRIPTION
This PR adds generic support for complex-valued VectorArrays for PDE solvers with `ListVectorArray`-based bindings. The construction is generic and does not require any complex number support within the PDE solver. The approach is similar to #747, but provides base classes for `Vectors` and `Operators` that can be used for arbitrary solver bindings.

Unlike #747, complex linear combinations are completely handled by `LincombOperator`. Should the need arise, an `assemble_lincomb` rule could be added, which separately assembles real and imaginary parts.

Moreover, this PR adds complex data to the `VectorArray` fixtures and fixes various complex number issues, both in the tests and the implementations.

I have tried to fix `lgmres`, but more testing / checking the code is required. The `heat_sink` notebook seems to work, although the error system magnitude plot looks different. (At first sight, both plots look strange, and maybe the lgmres tolerances are not chosen correctly.) `lgmres` seems to run significantly faster compared to #747.