### PR TITLE
Rename parameter coordinates to index

### DIFF
--- a/src/pymor/analyticalproblems/thermalblock.py
+++ b/src/pymor/analyticalproblems/thermalblock.py
@@ -44,7 +44,7 @@ def thermal_block_problem(num_blocks=(3, 3), parameter_range=(0.1, 1)):
     def parameter_functional_factory(ix, iy):
         return ProjectionParameterFunctional(component_name='diffusion',
                                              component_shape=(num_blocks[1], num_blocks[0]),
-                                             coordinates=(num_blocks[1] - iy - 1, ix),
+                                             index=(num_blocks[1] - iy - 1, ix),
                                              name=f'diffusion_{ix}_{iy}')
 
     def diffusion_function_factory(ix, iy):

--- a/src/pymor/parameters/functionals.py
+++ b/src/pymor/parameters/functionals.py
@@ -14,7 +14,7 @@ class ProjectionParameterFunctional(ParameterFunctionalInterface):
 
     For given parameter `mu`, this functional evaluates to ::
 
-        mu[component_name][coordinates]
+        mu[component_name][index]
 
 
     Parameters
@@ -23,24 +23,24 @@ class ProjectionParameterFunctional(ParameterFunctionalInterface):
         The name of the parameter component to return.
     component_shape
         The shape of the parameter component.
-    coordinates
+    index
         See above.
     name
         Name of the functional.
     """
 
-    def __init__(self, component_name, component_shape, coordinates=(), name=None):
+    def __init__(self, component_name, component_shape, index=(), name=None):
         if isinstance(component_shape, Number):
             component_shape = () if component_shape == 0 else (component_shape,)
-        assert len(coordinates) == len(component_shape)
-        assert not component_shape or coordinates < component_shape
+        assert len(index) == len(component_shape)
+        assert not component_shape or index < component_shape
 
         self.__auto_init(locals())
         self.build_parameter_type({component_name: component_shape})
 
     def evaluate(self, mu=None):
         mu = self.parse_parameter(mu)
-        return mu[self.component_name].item(self.coordinates)
+        return mu[self.component_name].item(self.index)
 
 
 class GenericParameterFunctional(ParameterFunctionalInterface):

--- a/src/pymordemos/thermalblock.py
+++ b/src/pymordemos/thermalblock.py
@@ -341,7 +341,7 @@ def _discretize_fenics(xblocks, yblocks, grid_num_intervals, element_order):
     def parameter_functional_factory(x, y):
         return ProjectionParameterFunctional(component_name='diffusion',
                                              component_shape=(yblocks, xblocks),
-                                             coordinates=(yblocks - y - 1, x),
+                                             index=(yblocks - y - 1, x),
                                              name=f'diffusion_{x}_{y}')
     parameter_functionals = tuple(parameter_functional_factory(x, y)
                                   for x in range(xblocks) for y in range(yblocks))

--- a/src/pymordemos/thermalblock_simple.py
+++ b/src/pymordemos/thermalblock_simple.py
@@ -117,7 +117,7 @@ def _discretize_fenics():
     # define parameter functionals (same as in pymor.analyticalproblems.thermalblock)
     parameter_functionals = [ProjectionParameterFunctional(component_name='diffusion',
                                                            component_shape=(YBLOCKS, XBLOCKS),
-                                                           coordinates=(YBLOCKS - y - 1, x))
+                                                           index=(YBLOCKS - y - 1, x))
                              for x in range(XBLOCKS) for y in range(YBLOCKS)]
 
     # wrap operators


### PR DESCRIPTION
In https://github.com/pymor/pymor/pull/748, we discussed that `index` is a better name for a certain index of a parameter component than `coordinates`. Thus, we also change it in `ProjectionParameterFunctional`. 