### PR TITLE
Fix OperatorBase.d_mu

### DIFF
--- a/src/pymor/operators/basic.py
+++ b/src/pymor/operators/basic.py
@@ -153,6 +153,7 @@ class OperatorBase(OperatorInterface):
         if self.parametric:
             raise NotImplementedError
         else:
+            from pymor.operators.constructions import ZeroOperator
             return ZeroOperator(self.range, self.source, name=self.name + '_d_mu')
 
 class ProjectedOperator(OperatorBase):

--- a/src/pymor/parameters/functionals.py
+++ b/src/pymor/parameters/functionals.py
@@ -67,7 +67,7 @@ class GenericParameterFunctional(ParameterFunctionalInterface):
     name
         The name of the functional.
     derivative_mappings
-        A dict containing all partial derivativess of each component and index in the
+        A dict containing all partial derivatives of each component and index in the
         |ParameterType| with the signature `derivative_mappings[component][index](mu)`
     """
 


### PR DESCRIPTION
I pushed two small fixes.

One is only a typo.
The other is about ZeroOperator not being available in basic.py. 