### PR TITLE
[WIP] generic Dirichlet shift

### DIFF
--- a/src/pymor/algorithms/error.py
+++ b/src/pymor/algorithms/error.py
@@ -86,8 +86,7 @@ def reduction_error_analysis(rom, fom, reductor,
         :basis_sizes:            The reduced basis dimensions which have been considered.
 
         :norms:                  |Array| of the norms of the high-dimensional solutions
-                                 w.r.t. all given test |Parameters|, reduced basis
-                                 dimensions and norms in `error_norms`.
+                                 w.r.t. all given test |Parameters| and norms in `error_norms`.
                                  (Only present when `error_norms` has been specified.)
 
         :max_norms:              Maxima of `norms` over the given test |Parameters|.

--- a/src/pymor/algorithms/simplify.py
+++ b/src/pymor/algorithms/simplify.py
@@ -1,0 +1,221 @@
+# This file is part of the pyMOR project (http://www.pymor.org).
+# Copyright 2013-2019 pyMOR developers and contributors. All rights reserved.
+# License: BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+
+import numpy as np
+from numbers import Number
+
+from pymor.algorithms.lincomb import assemble_lincomb
+from pymor.algorithms.rules import RuleTable, match_class, match_generic, match_class_all, match_class_any
+from pymor.core.exceptions import RuleNotMatchingError, NoMatchingRuleError
+from pymor.models.basic import StationaryModel
+from pymor.operators.constructions import IdentityOperator, Concatenation, ConstantOperator, LincombOperator
+from pymor.operators.interfaces import OperatorInterface
+from pymor.operators.numpy import NumpyMatrixOperator
+from pymor.vectorarrays.numpy import NumpyVectorArray
+
+
+def simplify(obj, assemble=True):
+    """Simplification of various constructs, e.g. concatenation of |Operator|s.
+
+    How the simplification is realized will depend on the given object,
+    the exact algorithm is specified in :class:`SimplifyRules`.
+
+    Parameters
+    ----------
+    obj
+        The object to be simplified (only |Operator|s supported at the moment).
+
+    Returns
+    -------
+    The simplified object, if applicable, else the original object.
+    """
+
+    try:
+        return SimplifyRules(assemble).apply(obj)
+    except NoMatchingRuleError:
+        obj.logger.warning(f'could not be simplified')
+        return obj
+
+
+class SimplifyConcatenationOfTwoNonLincombOps(RuleTable):
+
+    def __init__(self, assemble=True):
+        super().__init__(use_caching=True)
+        self.__auto_init(locals())
+
+    @match_class_any(IdentityOperator)
+    def action_IdentityOperator(self, tpl):
+        if len(tpl) != 2:
+            raise RuleNotMatchingError
+        second, first = tpl
+        if isinstance(second, IdentityOperator):
+            return first
+        else:
+            return second
+
+    @match_generic(lambda tpl: isinstance(tpl[0], ConstantOperator), 'ConstantOperator last')
+    def action_ConstantOperator_last(self, tpl):
+        if len(tpl) != 2:
+            raise RuleNotMatchingError
+        return tpl[0]
+
+    @match_generic(lambda tpl: not tpl[0].parametric and isinstance(tpl[1], ConstantOperator) and not tpl[1].parametric,
+                   'ConstantOperator first')
+    def action_nonparametric_ConstantOperator_first(self, tpl):
+        if len(tpl) != 2:
+            raise RuleNotMatchingError
+        second, first = tpl
+        return ConstantOperator(self.apply((second, first.value)), source=first.source)
+
+    @match_generic(lambda tpl: isinstance(tpl[0], NumpyMatrixOperator) and isinstance(tpl[1], NumpyVectorArray),
+                   'NumpyMatrixOperator applied to NumpyVectorArray')
+    def action_NumpyMatrixOperator_applied_to_NumpyVectorArray(self, tpl):
+        if len(tpl) != 2:
+            raise RuleNotMatchingError
+        second, first = tpl
+        return second.apply(first)
+
+    @match_class_all(NumpyMatrixOperator)
+    def action_NumpyMatrixOperator(self, tpl):
+        if len(tpl) != 2:
+            raise RuleNotMatchingError
+        second, first = tpl
+        if second.source != first.range:
+            raise RuleNotMatchingError(f'second.source = {second.source} != {first.range} = first.range')
+        if second.solver_options and not first.solver_options:
+            solver_options = second.solver_options
+        elif not second.solver_options and first.solver_options:
+            solver_options = first.solver_options
+        elif second.solver_options and first.solver_options and (second.solver_options == first.solver_options):
+            solver_options = first.solver_options
+        else:
+            solver_options = None
+        return NumpyMatrixOperator(second.matrix@first.matrix, source_id=first.source_id, range_id=second.range_id,
+                solver_options=solver_options, name=f'product of {second.name} and {first.name}')
+
+
+class SimplifyRules(RuleTable):
+    """|RuleTable| for the :func:`simplify` algorithm."""
+
+    def __init__(self, assemble=True):
+        super().__init__(use_caching=True)
+        self._simplify_concat = SimplifyConcatenationOfTwoNonLincombOps(assemble)
+        self.__auto_init(locals())
+
+    @match_class(StationaryModel)
+    def action_StationaryModel(self, model):
+        return model.with_(
+                operator=self.apply(model.operator),
+                rhs=self.apply(model.rhs),
+                output_functional=self.apply(model.output_functional),
+                products={name: self.apply(prod) for name, prod in model.products.items()})
+
+    @match_class(NumpyMatrixOperator)
+    def action_NumpyMatrixOperator(self, op):
+        return op
+
+    @match_class(Concatenation)
+    def action_Concatenation(self, cop):
+        if len(cop.operators) == 1:
+            return self.apply(cop.operators[0])
+        last, rest = cop.operators[0], cop.operators[1:]
+        if len(rest) > 1:
+            rest = self.apply(Concatenation(rest)).operators
+            if len(rest) > 1:
+                raise RuleNotMatchingError('Could not simplify remaining parts of a Concatenation.')
+        first = rest[0]
+        last = self.apply(last)
+        first = self.apply(first)
+        if isinstance(last, LincombOperator):
+            ops = [self.apply(Concatenation((op, first))) for op in last.operators]
+            coeffs = last.coefficients
+            return self.apply(LincombOperator(ops, coeffs, name=cop.name))
+        elif last.linear and isinstance(first, LincombOperator):
+            ops = [self.apply(Concatenation((last, op))) for op in first.operators]
+            coeffs = first.coefficients
+            return self.apply(LincombOperator(ops, coeffs, name=cop.name))
+        else:
+            return self._simplify_concat.apply((last, first))
+
+    @match_class(ConstantOperator)
+    def action_ConstantOperator(self, op):
+        return op
+
+    @match_class(IdentityOperator)
+    def action_IdentityOperator(self, op):
+        return op
+
+    @match_class(LincombOperator)
+    def action_LincombOperator(self, lop):
+        lop = self.replace_children(lop)
+
+        def flatten(op, coeff):
+            if not isinstance(op, LincombOperator):
+                return [op,], [coeff,]
+            ops, coeffs = [], []
+            for oo, cc in zip(op.operators, op.coefficients):
+                oo, cc = flatten(oo, cc)
+                ops.extend(oo)
+                coeffs.extend([c if coeff == 1 else coeff*c for c in cc])
+            return ops, coeffs
+
+        lops, lcoeffs = flatten(lop, 1.)
+
+        # sort ops by coefficient
+        nonparametric_part = ([], [])
+        parametric_part = {}
+        for op, coeff in zip(lops, lcoeffs):
+            if isinstance(coeff, Number):
+                nonparametric_part[0].append(coeff)
+                nonparametric_part[1].append(op)
+            elif not coeff.parametric:
+                nonparametric_part[0].append(coeff.evaluate())
+                nonparametric_part[1].append(op)
+            else:
+                if coeff.parameter_type in parametric_part:
+                    parametric_part[coeff.parameter_type][0].append(coeff)
+                    parametric_part[coeff.parameter_type][1].append(op)
+                else:
+                    parametric_part[coeff.parameter_type] = ([coeff,], [op,])
+
+        # nonparametric_part
+        if len(nonparametric_part[0]) > 0:
+            if self.assemble:
+                op = assemble_lincomb(nonparametric_part[1], nonparametric_part[0])
+                if op and len(parametric_part) == 0:
+                    return op
+                elif op:
+                    ops = [op,]
+                    coeffs = [1.,]
+                else:
+                    ops = nonparametric_part[1]
+                    coeffs = nonparametric_part[0]
+            else: 
+                ops = nonparametric_part[1]
+                coeffs = nonparametric_part[0]
+        else:
+            ops, coeffs = [], []
+        
+        # parametric part
+        for _, (ccs, oos) in parametric_part.items():
+            op = assemble_lincomb(oos, np.ones(len(oos)))
+            if not op:
+                a = b
+                raise RuleNotMatchingError('Could not assemble parametric contributions of LincombOperator.')
+            coeff = ccs[0]
+            for i in range(1, len(ccs)):
+                coeff += ccs[i]
+            ops.append(op)
+            coeffs.append(coeff)
+
+        return LincombOperator(ops, coeffs, solver_options=lop.solver_options, name=lop.name)
+
+    @match_generic(lambda op: isinstance(op, OperatorInterface) and op.linear and not op.parametric,
+                   'linear and nonparametric operator')
+    def action_linear_nonparametric_operator(self, op):
+        if self.assemble:
+            return op.assemble()
+        else:
+            return op
+

--- a/src/pymor/basic.py
+++ b/src/pymor/basic.py
@@ -20,6 +20,7 @@ from pymor.algorithms.newton import newton
 from pymor.algorithms.pod import pod
 from pymor.algorithms.preassemble import preassemble
 from pymor.algorithms.projection import project, project_to_subbasis
+from pymor.algorithms.simplify import simplify
 
 from pymor.analyticalproblems.burgers import burgers_problem, burgers_problem_2d
 from pymor.analyticalproblems.elliptic import StationaryProblem

--- a/src/pymor/operators/cg.py
+++ b/src/pymor/operators/cg.py
@@ -973,3 +973,30 @@ class InterpolationOperator(NumpyMatrixBasedOperator):
 
     def _assemble(self, mu=None):
         return self.function.evaluate(self.grid.centers(self.grid.dim), mu=mu).reshape((-1, 1))
+
+
+class BoundaryInterpolationOperator(InterpolationOperator):
+    """|InterpolationOperator| restricted to a part of the boundary..
+
+    Parameters
+    ----------
+    grid
+        The |Grid| on which to interpolate.
+    function
+        The |Function| to interpolate.
+    boundary_info
+        The |BoundaryInfo| defining the physical boundary (has to match grid).
+    boundary_type
+        The type of the physical boundary.
+    """
+
+    def __init__(self, grid, function, boundary_info, boundary_type='dirichlet'):
+        super().__init__(grid, function)
+        self.__auto_init(locals())
+        self.boundary_mask = boundary_info.boundaries(boundary_type, grid.dim)
+
+    def _assemble(self, mu=None):
+        result = np.zeros(self.range.dim)
+        interpolation = super()._assemble(mu=mu)
+        result[self.boundary_mask] = interpolation[self.boundary_mask].ravel()
+        return result.reshape((-1, 1))

--- a/src/pymor/operators/cg.py
+++ b/src/pymor/operators/cg.py
@@ -484,7 +484,7 @@ class DiffusionOperatorP1(NumpyMatrixBasedOperator):
         self.logger.info('Calulate gradients of shape functions transformed by reference map ...')
         SF_GRADS = np.einsum('eij,pj->epi', g.jacobian_inverse_transposed(0), SF_GRAD)
 
-        self.logger.info('Calculate all local scalar products beween gradients ...')
+        self.logger.info('Calculate all local scalar products between gradients ...')
         if self.diffusion_function is not None and self.diffusion_function.shape_range == ():
             D = self.diffusion_function(self.grid.centers(0), mu=mu)
             SF_INTS = np.einsum('epi,eqi,e,e->epq', SF_GRADS, SF_GRADS, g.volumes(0), D).ravel()
@@ -597,7 +597,7 @@ class DiffusionOperatorQ1(NumpyMatrixBasedOperator):
         self.logger.info('Calulate gradients of shape functions transformed by reference map ...')
         SF_GRADS = np.einsum('eij,pjc->epic', g.jacobian_inverse_transposed(0), SF_GRAD)
 
-        self.logger.info('Calculate all local scalar products beween gradients ...')
+        self.logger.info('Calculate all local scalar products between gradients ...')
         if self.diffusion_function is not None and self.diffusion_function.shape_range == ():
             D = self.diffusion_function(self.grid.centers(0), mu=mu)
             SF_INTS = np.einsum('epic,eqic,c,e,e->epq', SF_GRADS, SF_GRADS, w, g.integration_elements(0), D).ravel()
@@ -717,7 +717,7 @@ class AdvectionOperatorP1(NumpyMatrixBasedOperator):
         SFQ = np.array(tuple(f(q) for f in SF))
         # SFQ(function, quadraturepoint)
 
-        self.logger.info('Calculate all local scalar products beween gradients ...')
+        self.logger.info('Calculate all local scalar products between gradients ...')
         D = self.advection_function(self.grid.centers(0), mu=mu)
         SF_INTS = - np.einsum('pc,eqi,c,e,ec->eqp', SFQ, SF_GRADS, w, g.integration_elements(0), D).ravel()
         del D
@@ -829,7 +829,7 @@ class AdvectionOperatorQ1(NumpyMatrixBasedOperator):
         SFQ = np.array(tuple(f(q) for f in SF))
         # SFQ(function, quadraturepoint)
 
-        self.logger.info('Calculate all local scalar products beween gradients ...')
+        self.logger.info('Calculate all local scalar products between gradients ...')
 
         D = self.advection_function(self.grid.centers(0), mu=mu)
         SF_INTS = - np.einsum('pc,eqic,c,e,ei->eqp', SFQ, SF_GRADS, w, g.integration_elements(0), D).ravel()
@@ -887,10 +887,10 @@ class RobinBoundaryOperator(NumpyMatrixBasedOperator):
     grid
         The |Grid| over which to assemble the operator.
     boundary_info
-        |BoundaryInfo| for the treatment of Dirichlet boundary conditions.
+        |BoundaryInfo| defining the Robin boundary.
     robin_data
-        Tuple providing two |Functions| that represent the Robin parameter and boundary
-        value function. If `None`, the resulting operator is zero.
+        Tuple `(c, g)` providing two |Functions| that represent the Robin parameter `c` and boundary
+        value function `g`. If `None`, the resulting operator is zero.
     solver_options
         The |solver_options| for the operator.
     name


### PR DESCRIPTION
I would like to use this pr to discuss possible algorithmic requirements to automatically handle the Dirichlet shift that is required for MOR of problems with non-homogeneous Dirichlet data (see below for a MWE). Questions to consider (among others) are:

* do we want to support some generic processing at all?
* if yes, should this happen in the discretizer already or is this a postprocessing of the fom (I currently favor the former)
* if yes, do we provide a shifted visualize?