### PR TITLE
Make assumptions on mass Operator in InstationaryModel consistent

### DIFF
--- a/src/pymor/algorithms/timestepping.py
+++ b/src/pymor/algorithms/timestepping.py
@@ -150,8 +150,6 @@ def implicit_euler(A, F, M, U0, t0, t1, nt, mu=None, num_values=None, solver_opt
     assert U0 in A.source
     assert len(U0) == 1
 
-    A_time_dep = A.parametric and '_t' in A.parameter_type
-
     R = A.source.empty(reserve=nt+1)
     R.append(U0)
 
@@ -159,7 +157,7 @@ def implicit_euler(A, F, M, U0, t0, t1, nt, mu=None, num_values=None, solver_opt
               M.solver_options if solver_options == 'mass' else \
               solver_options
     M_dt_A = (M + A * dt).with_(solver_options=options)
-    if not A_time_dep:
+    if not M_dt_A.parametric or '_t' not in M_dt_A.parameter_type:
         M_dt_A = M_dt_A.assemble(mu)
 
     t = t0

--- a/src/pymor/models/basic.py
+++ b/src/pymor/models/basic.py
@@ -158,8 +158,7 @@ class InstationaryModel(ModelBase):
 
     for t in [0,T], where L is a (possibly non-linear) time-dependent
     |Operator|, F is a time-dependent vector-like |Operator|, and u_0 the
-    initial data. The mass |Operator| M is assumed to be linear,
-    time-independent and |Parameter|-independent.
+    initial data. The mass |Operator| M is assumed to be linear.
 
     Parameters
     ----------

--- a/src/pymor/reductors/parabolic.py
+++ b/src/pymor/reductors/parabolic.py
@@ -53,7 +53,10 @@ class ParabolicRBReductor(InstationaryRBReductor):
     """
     def __init__(self, fom, RB=None, product=None, coercivity_estimator=None,
                  check_orthonormality=None, check_tol=None):
-        assert isinstance(fom.time_stepper, ImplicitEulerTimeStepper)
+        if not isinstance(fom.time_stepper, ImplicitEulerTimeStepper):
+            raise NotImplementedError
+        if fom.mass is not None and fom.mass.parametric and '_t' in fom.mass.parameter_type:
+            raise NotImplementedError
         super().__init__(fom, RB, product=product,
                          check_orthonormality=check_orthonormality, check_tol=check_tol)
         self.coercivity_estimator = coercivity_estimator


### PR DESCRIPTION
We allow `mass` to be `parametric` and depend on time.

Fixes #782.