### PR TITLE
Add support for nonlinear Operators in FEniCS bindings

### DIFF
--- a/src/pymor/bindings/fenics.py
+++ b/src/pymor/bindings/fenics.py
@@ -253,6 +253,9 @@ if config.HAVE_FENICS:
             return FenicsMatrixOperator(matrix, self.source.V, self.range.V)
 
         def restricted(self, dofs):
+            from pymor.tools.mpi import parallel
+            if parallel:
+                raise NotImplementedError('SubMesh does not work in parallel')
             with self.logger.block(f'Restricting operator to {len(dofs)} dofs ...'):
                 if len(dofs) == 0:
                     return ZeroOperator(NumpyVectorSpace(0), NumpyVectorSpace(0)), np.array([], dtype=np.int)

--- a/src/pymor/bindings/fenics.py
+++ b/src/pymor/bindings/fenics.py
@@ -113,8 +113,8 @@ if config.HAVE_FENICS:
             if not mpi.parallel:
                 return max_ind_on_rank, max_val_on_rank
             else:
-                max_global_ind_on_rank = max_ind_on_rank + self.impl.local_range()[0]
-                comm = self.impl.mpi_comm()
+                max_global_ind_on_rank = max_ind_on_rank + self.real_part.impl.local_range()[0]
+                comm = self.real_part.impl.mpi_comm()
                 comm_size = comm.Get_size()
 
                 max_inds = np.empty(comm_size, dtype='i')
@@ -123,7 +123,7 @@ if config.HAVE_FENICS:
                 max_vals = np.empty(comm_size, dtype=np.float64)
                 comm.Allgather(np.array(max_val_on_rank), max_vals)
 
-                i = np.argmax(max_inds)
+                i = np.argmax(max_vals)
                 return max_inds[i], max_vals[i]
 
     class FenicsVectorSpace(ComplexifiedListVectorSpace):

--- a/src/pymor/bindings/fenics.py
+++ b/src/pymor/bindings/fenics.py
@@ -368,7 +368,7 @@ if config.HAVE_FENICS:
                     raise NotImplementedError
                 restricted_dofs.append(r_dof[0])
             restricted_dofs = np.array(restricted_dofs, dtype=np.int32)
-            assert len(set(restricted_dofs)) == len(restricted_dofs)
+            assert len(set(restricted_dofs)) == len(set(dofs))
             return restricted_dofs
 
     class RestrictedFenicsOperator(OperatorBase):

--- a/src/pymor/bindings/fenics.py
+++ b/src/pymor/bindings/fenics.py
@@ -337,7 +337,7 @@ if config.HAVE_FENICS:
             restricted_source_dofs = np.array(restricted_source_dofs, dtype=np.int32)
             assert len(set(restricted_source_dofs)) == len(source_dofs)
 
-            # source dof mapping
+            # range dof mapping
             self.logger.info('Computing range DOF mapping ...')
             u = df.Function(self.range.V)
             u_vec = u.vector()

--- a/src/pymor/bindings/fenics.py
+++ b/src/pymor/bindings/fenics.py
@@ -355,9 +355,9 @@ if config.HAVE_FENICS:
                 )
                 if self.dirichlet_bc:
                     bc = self.dirichlet_bc
-                    if not bc.user_subdomain():
+                    if not bc.user_sub_domain():
                         raise NotImplementedError
-                    bc_r = df.DirichletBC(V_r_source, bc.value(), bc.user_subdomain(), bc.method())
+                    bc_r = df.DirichletBC(V_r_source, bc.value(), bc.user_sub_domain(), bc.method())
                 else:
                     bc_r = None
 

--- a/src/pymor/bindings/fenics.py
+++ b/src/pymor/bindings/fenics.py
@@ -515,6 +515,7 @@ if config.HAVE_FENICS:
                                 range_min=vmin, range_max=vmax)
                 plt.show(block=block)
 
+    # adapted from dolfin.mesh.ale.init_parent_edge_indices
     def compute_parent_facet_indices(submesh, mesh):
         dim = mesh.topology().dim()
         facet_dim = dim - 1

--- a/src/pymor/bindings/fenics.py
+++ b/src/pymor/bindings/fenics.py
@@ -7,13 +7,16 @@ from pymor.core.config import config
 
 if config.HAVE_FENICS:
     import dolfin as df
+    import ufl
     import numpy as np
 
     from pymor.core.defaults import defaults
     from pymor.core.interfaces import BasicInterface
-    from pymor.operators.basic import LinearComplexifiedListVectorArrayOperatorBase
+    from pymor.operators.basic import LinearComplexifiedListVectorArrayOperatorBase, OperatorBase
     from pymor.vectorarrays.interfaces import _create_random_values
     from pymor.vectorarrays.list import CopyOnWriteVector, ComplexifiedVector, ComplexifiedListVectorSpace
+    from pymor.operators.numpy import NumpyMatrixOperator
+    from pymor.vectorarrays.numpy import NumpyVectorSpace
 
     class FenicsVector(CopyOnWriteVector):
         """Wraps a FEniCS vector to make it usable with ListVectorArray."""
@@ -202,6 +205,290 @@ if config.HAVE_FENICS:
                 # in general, we cannot assume the same nonzero pattern for # all matrices. how to improve this?
 
             return FenicsMatrixOperator(matrix, self.source.V, self.range.V, solver_options=solver_options, name=name)
+
+    class FenicsOperator(OperatorBase):
+        """Wraps a FEniCS form as an |Operator|."""
+
+        linear = False
+
+        @defaults('restriction_method')
+        def __init__(self, form, source_space, range_space, source_function, dirichlet_bc=None,
+                     parameter_setter=None, parameter_type=None, solver_options=None,
+                     restriction_method='submesh', name=None):
+            assert restriction_method in ('assemble_local', 'submesh')
+            assert len(form.arguments()) == 1
+            self.form = form
+            self.source = source_space
+            self.range = range_space
+            self.source_function = source_function
+            self.dirichlet_bc = dirichlet_bc
+            self.parameter_setter = parameter_setter
+            self.build_parameter_type(parameter_type)
+            self.solver_options = solver_options
+            self.restriction_method = restriction_method
+            self.name = name
+
+        def _set_mu(self, mu=None):
+            mu = self.parse_parameter(mu)
+            if self.parameter_setter:
+                self.parameter_setter(mu)
+
+        def apply(self, U, mu=None):
+            assert U in self.source
+            self._set_mu(mu)
+            R = []
+            source_vec = self.source_function.vector()
+            for u in U._list:
+                source_vec[:] = u.impl
+                r = df.assemble(self.form)
+                if self.dirichlet_bc:
+                    self.dirichlet_bc.apply(r, source_vec)
+                R.append(r)
+            return self.range.make_array(R)
+
+        def jacobian(self, U, mu=None):
+            assert U in self.source and len(U) == 1
+            self._set_mu(mu)
+            source_vec = self.source_function.vector()
+            source_vec[:] = U._list[0].impl
+            matrix = df.assemble(df.derivative(self.form, self.source_function))
+            if self.dirichlet_bc:
+                self.dirichlet_bc.apply(matrix)
+            return FenicsMatrixOperator(matrix, self.source.V, self.range.V)
+
+        def restricted(self, dofs):
+            assert self.source.V.mesh().id() == self.range.V.mesh().id()
+
+            # first determine affected cells
+            self.logger.info('Computing affected cells ...')
+            mesh = self.source.V.mesh()
+            range_dofmap = self.range.V.dofmap()
+            affected_cell_indices = set()
+            for c in df.cells(mesh):
+                cell_index = c.index()
+                local_dofs = range_dofmap.cell_dofs(cell_index)
+                for ld in local_dofs:
+                    if ld in dofs:
+                        affected_cell_indices.add(cell_index)
+                        continue
+            affected_cell_indices = list(sorted(affected_cell_indices))
+            affected_cells = [df.Cell(mesh, ci) for ci in affected_cell_indices]
+
+            # increase stencil if needed
+            # TODO
+
+            # determine source dofs
+            self.logger.info('Computing source DOFs ...')
+            source_dofmap = self.source.V.dofmap()
+            source_dofs = set()
+            for cell_index in affected_cell_indices:
+                local_dofs = source_dofmap.cell_dofs(cell_index)
+                source_dofs.update(local_dofs)
+            source_dofs = np.array(sorted(source_dofs), dtype=np.intc)
+
+            if self.restriction_method == 'assemble_local':
+                # range local-to-restricted dof mapping
+                to_restricted = np.zeros(self.range.dim, dtype=np.int32)
+                to_restricted[:] = len(dofs)
+                to_restricted[dofs] = np.arange(len(dofs))
+                range_local_restricted = np.array([to_restricted[range_dofmap.cell_dofs(ci)]
+                                                   for ci in affected_cell_indices])
+
+                # source local-to-restricted dof mapping
+                to_restricted = np.zeros(self.source.dim, dtype=np.int32)
+                to_restricted[:] = len(source_dofs)
+                to_restricted[source_dofs] = np.arange(len(source_dofs))
+                source_local_restricted = np.array([to_restricted[source_dofmap.cell_dofs(ci)]
+                                                   for ci in affected_cell_indices])
+
+                # compute dirichlet DOFs
+                if self.dirichlet_bc:
+                    self.logger.warn('Dirichlet DOF handling will only work for constant, non-paramentric '
+                                     'Dirichlet boundary conditions')
+                    v1 = self.source.zeros()._list[0].impl
+                    v1[:] = 42
+                    v2 = self.source.zeros()._list[0].impl
+                    v2[:] = 0
+                    self.dirichlet_bc.apply(v1)
+                    self.dirichlet_bc.apply(v2)
+                    dir_dofs = [i for i in range(self.source.dim) if (v1[i] != 42) or (v2[i] != 0)]
+                    dir_dofs_r, dir_vals_r = zip(*((i, v1[dof]) for i, dof in enumerate(dofs) if dof in dir_dofs))
+                    dir_dofs_r = np.array(dir_dofs_r, dtype=np.int32)
+                    dir_vals_r = np.array(dir_vals_r)
+                    dir_dofs_r_source = to_restricted[dofs[dir_dofs_r]]
+                else:
+                    dir_dofs_r = None
+                    dir_vals_r = None
+                    dir_dofs_r_source = None
+
+                return (
+                    RestrictedFenicsOperatorAssembleLocal(self, np.array(dofs), source_dofs.copy(), affected_cells,
+                                                          source_local_restricted, range_local_restricted,
+                                                          dir_dofs_r, dir_vals_r, dir_dofs_r_source),
+                    source_dofs
+                )
+
+            elif self.restriction_method == 'submesh':
+                # generate restricted spaces
+                self.logger.info('Building submesh ...')
+                subdomain = df.MeshFunction('size_t', mesh, mesh.geometry().dim())
+                for ci in affected_cell_indices:
+                    subdomain.set_value(ci, 1)
+                submesh = df.SubMesh(mesh, subdomain, 1)
+
+                # build restricted form
+                self.logger.info('Building UFL form on submesh ...')
+                V_r_source = df.FunctionSpace(submesh, self.source.V.ufl_element())
+                V_r_range = df.FunctionSpace(submesh, self.range.V.ufl_element())
+                assert V_r_source.dim() == len(source_dofs)
+
+                if self.source.V != self.range.V:
+                    assert all(arg.ufl_function_space() != self.source.V for arg in self.form.arguments())
+                args = tuple((df.function.argument.Argument(V_r_range, arg.number(), arg.part())
+                              if arg.ufl_function_space() == self.range.V else arg)
+                             for arg in self.form.arguments())
+                if any(isinstance(coeff, df.Function) and coeff != self.source_function for coeff in
+                       self.form.coefficients()):
+                    raise NotImplementedError
+                source_function_r = df.Function(V_r_source)
+                form_r = ufl.replace_integral_domains(
+                    self.form(*args, coefficients={self.source_function: source_function_r}),
+                    submesh.ufl_domain()
+                )
+                if self.dirichlet_bc:
+                    bc = self.dirichlet_bc
+                    if not bc.user_subdomain():
+                        raise NotImplementedError
+                    bc_r = df.DirichletBC(V_r_source, bc.value(), bc.user_subdomain(), bc.method())
+                else:
+                    bc_r = None
+
+                # source dof mapping
+                self.logger.info('Computing source DOF mapping ...')
+                u = df.Function(self.source.V)
+                u_vec = u.vector()
+                restricted_source_dofs = []
+                for source_dof in source_dofs:
+                    u_vec.zero()
+                    u_vec[source_dof] = 1
+                    u_r = df.interpolate(u, V_r_source)
+                    u_r = u_r.vector().get_local()
+                    if not np.all(np.logical_or(np.abs(u_r) < 1e-10, np.abs(u_r - 1.) < 1e-10)):
+                        raise NotImplementedError
+                    r_dof = np.where(np.abs(u_r - 1.) < 1e-10)[0]
+                    if not len(r_dof) == 1:
+                        raise NotImplementedError
+                    restricted_source_dofs.append(r_dof[0])
+                restricted_source_dofs = np.array(restricted_source_dofs, dtype=np.int32)
+                assert len(set(restricted_source_dofs)) == len(source_dofs)
+
+                # source dof mapping
+                self.logger.info('Computing range DOF mapping ...')
+                u = df.Function(self.range.V)
+                u_vec = u.vector()
+                restricted_range_dofs = []
+                for range_dof in dofs:
+                    u_vec.zero()
+                    u_vec[range_dof] = 1
+                    u_r = df.interpolate(u, V_r_range)
+                    u_r = u_r.vector().get_local()
+                    if not np.all(np.logical_or(np.abs(u_r) < 1e-10, np.abs(u_r - 1.) < 1e-10)):
+                        raise NotImplementedError
+                    r_dof = np.where(np.abs(u_r - 1.) < 1e-10)[0]
+                    if not len(r_dof) == 1:
+                        raise NotImplementedError
+                    restricted_range_dofs.append(r_dof[0])
+                restricted_range_dofs = np.array(restricted_range_dofs, dtype=np.int32)
+
+                op_r = FenicsOperator(form_r, FenicsVectorSpace(V_r_source), FenicsVectorSpace(V_r_range),
+                                      source_function_r, dirichlet_bc=bc_r, parameter_setter=self.parameter_setter,
+                                      parameter_type=self.parameter_type)
+
+                return (RestrictedFenicsOperatorSubMesh(op_r, restricted_range_dofs),
+                        source_dofs[np.argsort(restricted_source_dofs)])
+            else:
+                assert False
+
+    class RestrictedFenicsOperatorAssembleLocal(OperatorBase):
+
+        linear = False
+
+        def __init__(self, operator, range_dofs, source_dofs, cells, source_local_restricted, range_local_restricted,
+                     dirichlet_dofs, dirichlet_values, dirichlet_source_dofs):
+            self.source = NumpyVectorSpace(len(source_dofs))
+            self.range = NumpyVectorSpace(len(range_dofs))
+            self.operator = operator
+            self.range_dofs = range_dofs
+            self.source_dofs = source_dofs
+            self.cells = cells
+            self.source_local_restricted = source_local_restricted
+            self.range_local_restricted = range_local_restricted
+            self.dirichlet_dofs = dirichlet_dofs
+            self.dirichlet_values = dirichlet_values
+            self.dirichlet_source_dofs = dirichlet_source_dofs
+            self.build_parameter_type(operator)
+
+        def apply(self, U, mu=None):
+            assert U in self.source
+            operator = self.operator
+            source_vec = operator.source_function.vector()
+            operator._set_mu(mu)
+            R = np.zeros((len(U), self.range.dim + 1))
+            for u, r in zip(U.data, R):
+                source_vec[self.source_dofs] = u
+                for cell, local_restricted in zip(self.cells, self.range_local_restricted):
+                    local_evaluations = df.assemble_local(operator.form, cell)
+                    r[local_restricted] += local_evaluations
+                r[self.dirichlet_dofs] = u[self.dirichlet_source_dofs] - self.dirichlet_values
+            return self.range.make_array(R[:, :-1])
+
+        def jacobian(self, U, mu=None):
+            assert U in self.source and len(U) == 1
+            operator = self.operator
+            source_vec = operator.source_function.vector()
+            operator._set_mu(mu)
+            J = np.zeros((self.range.dim + 1, self.source.dim + 1))
+            source_vec[self.source_dofs] = U.data[0]
+            for cell, range_local_restricted, source_local_restricted in zip(self.cells,
+                                                                             self.range_local_restricted,
+                                                                             self.source_local_restricted):
+                local_matrix = df.assemble_local(df.derivative(operator.form, operator.source_function), cell)
+                J[np.meshgrid(range_local_restricted, source_local_restricted, indexing='ij')] += local_matrix
+            J[self.dirichlet_dofs, :] = 0.
+            J[np.meshgrid(self.dirichlet_dofs, self.dirichlet_source_dofs, indexing='ij')] = 1.
+            return NumpyMatrixOperator(J[:-1, :-1])
+
+        def restricted(self, dofs):
+            raise NotImplementedError
+
+    class RestrictedFenicsOperatorSubMesh(OperatorBase):
+
+        linear = False
+
+        def __init__(self, op, restricted_range_dofs):
+            self.source = NumpyVectorSpace(op.source.dim)
+            self.range = NumpyVectorSpace(len(restricted_range_dofs))
+            self.op = op
+            self.restricted_range_dofs = restricted_range_dofs
+            self.build_parameter_type(op)
+
+        def apply(self, U, mu=None):
+            assert U in self.source
+            UU = self.op.source.zeros(len(U))
+            for uu, u in zip(UU._list, U.data):
+                uu.impl[:] = u
+            VV = self.op.apply(UU, mu=mu)
+            V = self.range.zeros(len(VV))
+            for v, vv in zip(V.data, VV._list):
+                v[:] = vv.impl[self.restricted_range_dofs]
+            return V
+
+        def jacobian(self, U, mu=None):
+            assert U in self.source and len(U) == 1
+            UU = self.op.source.zeros()
+            UU._list[0].impl[:] = U.data[0]
+            JJ = self.op.jacobian(UU, mu=mu)
+            return NumpyMatrixOperator(JJ.matrix.array()[self.restricted_range_dofs, :])
 
     @defaults('solver', 'preconditioner')
     def _solver_options(solver='bicgstab', preconditioner='amg'):

--- a/src/pymor/bindings/fenics.py
+++ b/src/pymor/bindings/fenics.py
@@ -13,9 +13,10 @@ if config.HAVE_FENICS:
     from pymor.core.defaults import defaults
     from pymor.core.interfaces import BasicInterface
     from pymor.operators.basic import LinearComplexifiedListVectorArrayOperatorBase, OperatorBase
+    from pymor.operators.constructions import ZeroOperator
+    from pymor.operators.numpy import NumpyMatrixOperator
     from pymor.vectorarrays.interfaces import _create_random_values
     from pymor.vectorarrays.list import CopyOnWriteVector, ComplexifiedVector, ComplexifiedListVectorSpace
-    from pymor.operators.numpy import NumpyMatrixOperator
     from pymor.vectorarrays.numpy import NumpyVectorSpace
 
     class FenicsVector(CopyOnWriteVector):
@@ -255,6 +256,9 @@ if config.HAVE_FENICS:
             return FenicsMatrixOperator(matrix, self.source.V, self.range.V)
 
         def restricted(self, dofs):
+            if len(dofs) == 0:
+                return ZeroOperator(NumpyVectorSpace(0), NumpyVectorSpace(0)), np.array([], dtype=np.int)
+
             assert self.source.V.mesh().id() == self.range.V.mesh().id()
 
             # first determine affected cells

--- a/src/pymor/core/config.py
+++ b/src/pymor/core/config.py
@@ -17,6 +17,9 @@ def _can_import(module):
 
 def _get_fenics_version():
     import dolfin as df
+    if df.__version__ != '2019.1.0':
+        import warnings
+        warnings.warn(f'FEniCS bindings have been tested for version 2019.1.0 (installed: {df.__version__}).')
     return df.__version__
 
 

--- a/src/pymor/operators/mpi.py
+++ b/src/pymor/operators/mpi.py
@@ -81,6 +81,7 @@ class MPIOperator(OperatorBase):
             self.range = space_type(local_spaces)
         else:
             self.range = op.range
+        self.solver_options = op.solver_options
 
     def apply(self, U, mu=None):
         assert U in self.source

--- a/src/pymordemos/fenics_nonlinear.py
+++ b/src/pymordemos/fenics_nonlinear.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python
+# This file is part of the pyMOR project (http://www.pymor.org).
+# Copyright 2013-2019 pyMOR developers and contributors. All rights reserved.
+# License: BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+
+"""Simple example script for reducing a FEniCS-based nonlinear diffusion problem.
+
+Usage:
+    fenics_nonlinear.py DIM N ORDER
+
+Arguments:
+    DIM               Spatial dimension of the problem.
+    N                 Number of mesh intervals per spatial dimension.
+    ORDER             Finite element order.
+
+Options:
+    -h, --help   Show this message.
+"""
+
+from docopt import docopt
+
+
+def fenics_nonlinear_demo(args):
+    # ### problem definition
+    import dolfin as df
+
+    DIM = int(args['DIM'])
+    N = int(args['N'])
+    ORDER = int(args['ORDER'])
+
+    if DIM == 2:
+        mesh = df.UnitSquareMesh(N, N)
+    elif DIM == 3:
+        mesh = df.UnitCubeMesh(N, N, N)
+    else:
+        raise NotImplementedError
+
+    V = df.FunctionSpace(mesh, "CG", ORDER)
+
+    g = df.Constant(1.0)
+    c = df.Constant(1.)
+
+    class DirichletBoundary(df.SubDomain):
+        def inside(self, x, on_boundary):
+            return abs(x[0] - 1.0) < df.DOLFIN_EPS and on_boundary
+    db = DirichletBoundary()
+    bc = df.DirichletBC(V, g, db)
+
+    u = df.Function(V)
+    v = df.TestFunction(V)
+    f = df.Expression("x[0]*sin(x[1])", degree=2)
+    F = df.inner((1 + c*u**2)*df.grad(u), df.grad(v))*df.dx - f*v*df.dx
+
+    df.solve(F == 0, u, bc,
+             solver_parameters={"newton_solver": {"relative_tolerance": 1e-6}})
+
+    # ### pyMOR wrapping
+    from pymor.bindings.fenics import FenicsVectorSpace, FenicsOperator, FenicsVisualizer
+    from pymor.models.basic import StationaryModel
+    from pymor.operators.constructions import VectorOperator
+    from pymor.parameters.spaces import CubicParameterSpace
+
+    space = FenicsVectorSpace(V)
+    op = FenicsOperator(F, space, space, u, (bc,),
+                        parameter_setter=lambda mu: c.assign(float(mu['c'])),
+                        parameter_type={'c': ()},
+                        solver_options={'inverse': {'type': 'newton', 'rtol': 1e-6}})
+    rhs = VectorOperator(op.range.zeros())
+
+    fom = StationaryModel(op, rhs,
+                          visualizer=FenicsVisualizer(space),
+                          parameter_space=CubicParameterSpace({'c': ()}, 0., 1000.))
+
+    # ### ROM generation (POD/DEIM)
+    from pymor.algorithms.ei import ei_greedy
+    from pymor.algorithms.newton import newton
+    from pymor.algorithms.pod import pod
+    from pymor.operators.ei import EmpiricalInterpolatedOperator
+    from pymor.reductors.basic import StationaryRBReductor
+
+    U = fom.solution_space.empty()
+    residuals = fom.solution_space.empty()
+    for mu in fom.parameter_space.sample_uniformly(10):
+        UU, data = newton(op, rhs.as_vector(), mu=mu, rtol=1e-6, return_residuals=True)
+        U.append(UU)
+        residuals.append(data['residuals'])
+
+    dofs, cb, _ = ei_greedy(residuals, rtol=1e-7)
+    ei_op = EmpiricalInterpolatedOperator(op, collateral_basis=cb, interpolation_dofs=dofs, triangular=True)
+
+    rb, svals = pod(U, rtol=1e-7)
+    fom_ei = fom.with_(operator=ei_op)
+    reductor = StationaryRBReductor(fom_ei, rb)
+    rom = reductor.reduce()
+    # the reductor currently removes all solver_options so we need to add them again
+    rom = rom.with_(operator=rom.operator.with_(solver_options=op.solver_options))
+
+    # ### ROM validation
+    import time
+    import numpy as np
+
+    # ensure that FFC is not called during runtime measurements
+    rom.solve(1)
+
+    errs = []
+    speedups = []
+    for mu in fom.parameter_space.sample_randomly(10):
+        tic = time.time()
+        U = fom.solve(mu)
+        t_fom = time.time() - tic
+
+        tic = time.time()
+        u_red = rom.solve(mu)
+        t_rom = time.time() - tic
+
+        U_red = reductor.reconstruct(u_red)
+        errs.append(((U - U_red).l2_norm() / U.l2_norm())[0])
+        speedups.append(t_fom / t_rom)
+    print(f'Maximum relative ROM error: {max(errs)}')
+    print(f'Median of ROM speedup: {np.median(speedups)}')
+
+
+if __name__ == '__main__':
+    args = docopt(__doc__)
+    fenics_nonlinear_demo(args)

--- a/src/pymortests/demos.py
+++ b/src/pymortests/demos.py
@@ -92,6 +92,11 @@ HAPOD_ARGS = (
     ('hapod', ['--snap=3', '--procs=2', 1e-2, 10, 100]),
 )
 
+FENICS_NONLINEAR_ARGS = (
+    ('fenics_nonlinear', [2, 10, 2]),
+    ('fenics_nonlinear', [3, 5, 1]),
+)
+
 DEMO_ARGS = (
     DISCRETIZATION_ARGS
     + THERMALBLOCK_ARGS
@@ -102,6 +107,7 @@ DEMO_ARGS = (
     + PARABOLIC_MOR_ARGS
     + SYS_MOR_ARGS
     + HAPOD_ARGS
+    + FENICS_NONLINEAR_ARGS
 )
 DEMO_ARGS = [(f'pymordemos.{a}', b) for (a, b) in DEMO_ARGS]
 

--- a/src/pymortests/demos.py
+++ b/src/pymortests/demos.py
@@ -121,7 +121,7 @@ def _skip_if_no_solver(param):
     demo, args = param
     from pymor.core.config import config
     for solver in ['fenics', 'ngsolve']:
-        needs_solver = len([f for f in args if solver in str(f)]) > 0
+        needs_solver = len([f for f in args if solver in str(f)]) > 0 or demo.find(solver) >= 0
         has_solver = getattr(config, 'HAVE_' + solver.upper())
         if needs_solver and not has_solver:
             if not os.environ.get('DOCKER_PYMOR', False):

--- a/src/pymortests/fixtures/operator.py
+++ b/src/pymortests/fixtures/operator.py
@@ -463,7 +463,7 @@ if config.HAVE_FENICS:
         F = df.inner((1 + c*w**2)*df.grad(w), df.grad(v))*df.dx - f*v*df.dx
 
         space = FenicsVectorSpace(V)
-        op = FenicsOperator(F, space, space, w, bc,
+        op = FenicsOperator(F, space, space, w, (bc,),
                             parameter_setter=lambda mu: c.assign(float(mu['c'])),
                             parameter_type={'c': ()},
                             solver_options={'inverse': {'type': 'newton', 'rtol': 1e-6}})

--- a/src/pymortests/fixtures/operator.py
+++ b/src/pymortests/fixtures/operator.py
@@ -467,8 +467,7 @@ if config.HAVE_FENICS:
         op = FenicsOperator(F, space, space, u, bc,
                             parameter_setter=lambda mu: c.assign(float(mu['c'])),
                             parameter_type={'c': ()},
-                            solver_options={'inverse': {'type': 'newton', 'rtol': 1e-6}},
-                            restriction_method='submesh')
+                            solver_options={'inverse': {'type': 'newton', 'rtol': 1e-6}})
 
         prod = FenicsMatrixOperator(df.assemble(v*w*df.dx), V, V)
         return op, op.parse_parameter(42), op.source.random(), op.range.random(), prod, prod

--- a/src/pymortests/fixtures/operator.py
+++ b/src/pymortests/fixtures/operator.py
@@ -448,28 +448,27 @@ if config.HAVE_FENICS:
             def inside(self, x, on_boundary):
                 return abs(x[0] - 1.0) < df.DOLFIN_EPS and on_boundary
 
-
         mesh = df.UnitSquareMesh(10, 10)
         V = df.FunctionSpace(mesh, "CG", 2)
 
-        g = df.Constant(1.0)
+        g = df.Constant(1.)
         c = df.Constant(1.)
         db = DirichletBoundary()
         bc = df.DirichletBC(V, g, db)
 
-        u = df.Function(V)
-        w = df.TrialFunction(V)
+        u = df.TrialFunction(V)
         v = df.TestFunction(V)
+        w = df.Function(V)
         f = df.Expression("x[0]*sin(x[1])", degree=2)
-        F = df.inner((1 + c*u**2)*df.grad(u), df.grad(v))*df.dx - f*v*df.dx
+        F = df.inner((1 + c*w**2)*df.grad(w), df.grad(v))*df.dx - f*v*df.dx
 
         space = FenicsVectorSpace(V)
-        op = FenicsOperator(F, space, space, u, bc,
+        op = FenicsOperator(F, space, space, w, bc,
                             parameter_setter=lambda mu: c.assign(float(mu['c'])),
                             parameter_type={'c': ()},
                             solver_options={'inverse': {'type': 'newton', 'rtol': 1e-6}})
 
-        prod = FenicsMatrixOperator(df.assemble(v*w*df.dx), V, V)
+        prod = FenicsMatrixOperator(df.assemble(u*v*df.dx), V, V)
         return op, op.parse_parameter(42), op.source.random(), op.range.random(), prod, prod
 
     fenics_with_arrays_and_products_generators = [lambda: fenics_nonlinear_operator_factory()]


### PR DESCRIPTION
This adds `FenicsOperator` which can be used to wrap nonlinear UFL forms as pyMOR `Operators`.

Fixes #752.