### PR TITLE
Fix dependencies link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Useful Links
 
 * [Latest Changelog](https://pymor.readthedocs.io/en/latest/release_notes.html)
 * [Getting Started](https://pymor.readthedocs.io/en/latest/getting_started.html)
-* [Dependencies](requirements.txt)
+* [Dependencies](https://github.com/pymor/pymor/blob/2019.2.x/requirements.txt)
 
 
 External PDE solvers


### PR DESCRIPTION
The link now points to `requirements.txt` in 2019.2.x branch.