### PR TITLE
Fixup reference + math display with nbplots

### DIFF
--- a/.binder/docker-compose.yml
+++ b/.binder/docker-compose.yml
@@ -37,3 +37,5 @@ services:
         - ./..:/src
     restart: "no"
     command: "/src/.ci/gitlab/script.bash"
+
+    command: "/src/.ci/gitlab/test_docs.bash"

--- a/.binder/docker-compose.yml
+++ b/.binder/docker-compose.yml
@@ -38,4 +38,13 @@ services:
     restart: "no"
     command: "/src/.ci/gitlab/script.bash"
 
+  docs:
+    image: pymor/testing:3.7
+    environment:
+      - PYMOR_FORCE_JUPYTER=1
+      - PYMOR_WITH_SPHINX=1
+      - CI_PROJECT_DIR=/src
+    volumes:
+        - ./..:/src
+    restart: "no"
     command: "/src/.ci/gitlab/test_docs.bash"

--- a/.ci/docker/docs/Dockerfile
+++ b/.ci/docker/docs/Dockerfile
@@ -1,3 +1,4 @@
-FROM scratch
+FROM alpine:latest
 
-COPY public/* /public/
+COPY * /public/
+RUN ls -l /public/

--- a/.ci/docker/wipe_docs_container.bash
+++ b/.ci/docker/wipe_docs_container.bash
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+PYMOR_ROOT="$(cd "$(dirname ${BASH_SOURCE[0]})" ; cd ../../ ; pwd -P )"
+IMAGE=zivgitlab.wwu.io/pymor/pymor/docs:latest
+tmpfile=$(mktemp /tmp/dockerfile.XXXXXX)
+echo "FROM scratch" > ${tmpfile}
+# Dockerfile cannot be empty
+echo "COPY . /tmp" >> ${tmpfile}
+docker build -t ${IMAGE} - < ${tmpfile}
+docker push ${IMAGE}
+rm ${tmpfile}

--- a/.ci/gitlab/ci.yml
+++ b/.ci/gitlab/ci.yml
@@ -63,7 +63,8 @@ pages:
     variables:
         IMAGE: ${CI_REGISTRY_IMAGE}/docs:latest
     script:
-        - apk --update add make
+        - apk --update add make python3
+        - pip3 install jinja2 pathlib
         - .ci/gitlab/deploy_docs.bash
 
     # only:

--- a/.ci/gitlab/deploy_docs.bash
+++ b/.ci/gitlab/deploy_docs.bash
@@ -34,3 +34,4 @@ docker build -t ${IMAGE} -f .ci/docker/docs/Dockerfile ${PUBLIC_DIR}
 docker push ${IMAGE}
 # for automatic deploy gitlab uses ${PROJECT_DIR}/public
 mv ${PUBLIC_DIR} ${PYMOR_ROOT}/
+ls ${PYMOR_ROOT}/public/

--- a/.ci/gitlab/docs_makeindex.py
+++ b/.ci/gitlab/docs_makeindex.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+from pathlib import Path
+from jinja2 import Template
+
+
+tpl = '''
+<!doctype html>
+<head>
+<title>pyMOR Documentation</title>
+</head>
+<body>
+<h1>Available versions</h1>
+
+<ul>
+    {%- for subdir in subdirs -%}
+    <li>
+      <a href="{{ subdir }}/index.html">{{ subdir }}</a>
+    </li>
+    {%- endfor %}
+</ul>
+
+</body>
+</html>
+'''
+
+
+def _make_list(root, name='master'):
+    subdirs = []
+    for it in root.iterdir():
+        if it.is_dir() and (it / 'index.html').is_file():
+            subdirs.append(it.name)
+    return sorted(subdirs)
+
+
+def make_index(path):
+    path = path.resolve()
+    with (path / 'list.html').open('wt') as out:
+        out.write(Template(tpl).render(subdirs=_make_list(path)))
+
+
+if __name__ == '__main__':
+    try:
+        path = Path(sys.argv[1])
+    except IndexError:
+        path = Path().cwd()
+    make_index(path)

--- a/.ci/gitlab/template.ci.py
+++ b/.ci/gitlab/template.ci.py
@@ -65,7 +65,8 @@ pages:
     variables:
         IMAGE: ${CI_REGISTRY_IMAGE}/docs:latest
     script:
-        - apk --update add make
+        - apk --update add make python3
+        - pip3 install jinja2 pathlib
         - .ci/gitlab/deploy_docs.bash
 
     # only:

--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,8 @@ test:
 
 image:
 	$(DOCKER_COMPOSE) build
-dockerdocs: image
-	$(DOCKER_COMPOSE) run pytest ./.ci/gitlab/test_docs.bash
+dockerdocs:
+	$(DOCKER_COMPOSE) run docs ./.ci/gitlab/test_docs.bash
 dockerrun: image
 	$(DOCKER_COMPOSE) run jupyter bash
 dockertest: image

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,14 +3,14 @@
 
 # You can set these variables from the command line.
 SPHINXOPTS    =
-SPHINXBUILD   = PYMOR_FORCE_JUPYTER=1 sphinx-build -j auto -v
+SPHINXBUILD   = PYMOR_FORCE_JUPYTER=1 sphinx-build -j auto -v source
 PAPER         =
 BUILDDIR      = _build
 
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4
 PAPEROPT_letter = -D latex_paper_size=letter
-ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) source
+ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) 
 # the i18n builder cannot share the environment and doctrees with the others
 I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 

--- a/docs/public_root/index.html
+++ b/docs/public_root/index.html
@@ -1,5 +1,5 @@
 <head>
   <!-- This should always redirect to the last release -->
   <!-- this file is deployed to the pages root from CI -->
-  <meta http-equiv="refresh" content="0; URL=http://docs-ng.pymor.org/doc-pages/" />
+  <meta http-equiv="refresh" content="0; URL=http://docs-ng.pymor.org/list.html" />
 </head>

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -287,3 +287,5 @@ rst_epilog = substitutions.substitutions
 modindex_common_prefix = ['pymor.']
 
 nbplot_render_output = True
+markdown_http_base = 'https://docs.pymor.org/en/2019.2.x'
+nbplot_cwd = os.path.dirname(os.path.abspath(__file__))

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -87,14 +87,9 @@ extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.viewcode',
               'sphinx.ext.intersphinx',
               'pymordocstring',
-              'nb2plots'
+              'nb2plots',
+              'sphinx.ext.mathjax',
               ]
-try:
-    # was added in sphinx 1.4, some of our target  platforms have only 1.2.x
-    import sphinx.ext.imgmath
-    extensions.append('sphinx.ext.imgmath')
-except ImportError:
-    extensions.append('sphinx.ext.pngmath')
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']


### PR DESCRIPTION
If you take a look at http://docs-ng.pymor.org/mathjax-docs-config/getting_started.html
the downloadable notebook will have markdown links to sphinx domain objects like `|VectorArray|`. Currently the the html root for these links is hardcoded, this still needs to get dynamically set from versioneer info + magic. 