### PR TITLE
Ensure that ParameterType.__str__ is always ordered alphabetically

### DIFF
--- a/src/pymor/parameters/base.py
+++ b/src/pymor/parameters/base.py
@@ -89,7 +89,7 @@ class ParameterType(OrderedDict):
         raise NotImplementedError
 
     def __str__(self):
-        return str(dict(self))
+        return '{' + ', '.join(f'{k}: {v}' for k, v in self.items()) + '}'
 
     def __repr__(self):
         return 'ParameterType(' + str(self) + ')'


### PR DESCRIPTION
Fixes #726. @TiKeil, please take a look.