### PR TITLE
Fix issue #836

### DIFF
--- a/src/pymor-demo
+++ b/src/pymor-demo
@@ -5,6 +5,7 @@
 
 from __future__ import absolute_import, division, print_function
 
+import importlib
 import pkgutil
 import pprint
 import pymordemos
@@ -25,10 +26,17 @@ if __name__ == '__main__':
 
     modules = []
     shorts = []
+    fails = {}
     for _, module_name, _ in pkgutil.walk_packages(pymordemos.__path__, pymordemos.__name__ + '.'):
         short = module_name[len('pymordemos.'):]
         modules.append(module_name)
         shorts.append(short)
+        try:
+            importlib.import_module(module_name)
+        except (ImportError, ModuleNotFoundError) as e:
+            fails[short] = e
+
+
 
     def usage():
         msg = f'''Usage:
@@ -40,10 +48,20 @@ Arguments:
     DEMO_OPTIONS any arguments for the demo, including -h for detailed help
 '''
         print(msg)
+        if len(fails):
+            print('\nThere are some pyMOR demos for which additional packages need to be installed:')
+            print('\t'+'\n\t'.join(fails))
+            print('\nYou can try to `pip install pymor[full]` to install optional dependencies.\n')
         sys.exit(0)
 
     if len(sys.argv) < 2:
         usage()
-    if sys.argv[1] in shorts:
-        _run(modules[shorts.index(sys.argv[1])])
+    demo = sys.argv[1]
+    if demo in shorts:
+        if demo in fails.keys():
+            print(str(fails[demo]))
+            print(f'\nThe {demo} pyMOR demo needs additional packages to be installed (see above error for details).')
+            print('\nYou can try to `pip install pymor[full]` to install optional dependencies.\n')
+            sys.exit(-1)
+        _run(modules[shorts.index(demo)])
     usage()


### PR DESCRIPTION
With my proposed modification a demo script user would 
experience something like this if they only had installed
the minimal requirements:

```
$ pymor-demo 
Usage:
    /home/rene/.local/share/virtualenvs/issues_tmp-DKykuLNR/bin/pymor-demo DEMO_NAME | -h [DEMO_OPTIONS]

Arguments:
    -h           this message
    DEMO_NAME    select one from these: analyze_pickle,burgers,burgers_ei,delay,elliptic,elliptic2,elliptic_oned,elliptic_unstructured,fenics_nonlinear,hapod,heat,parabolic,parabolic_mor,string_equation,thermalblock,thermalblock_adaptive,thermalblock_gui,thermalblock_simple
    DEMO_OPTIONS any arguments for the demo, including -h for detailed help


There are some pyMOR Demos for which additional packages need to be installed:
	analyze_pickle
	delay
	heat
	string_equation
	thermalblock_gui

You can try to `pip install pymor[full]` to install optional dependencies.
$ pymor-demo delay
No module named 'matplotlib'

The delay pyMOR Demo needs additional packages to be installed (see above error for details).

You can try to `pip install pymor[full]` to install optional dependencies.
```