### PR TITLE
CI updates

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -51,6 +51,7 @@ python_class = Test
 pep8maxlinelength = 120
 pep8ignore = E221,E226,E241,E242
 addopts=-p no:warnings
+junit_family=xunit2
 
 [metadata]
 # this is mandatory to lave license end up in .whl

--- a/src/pymor/core/config.py
+++ b/src/pymor/core/config.py
@@ -4,6 +4,7 @@
 
 from importlib import import_module
 import sys
+import platform
 
 
 def _can_import(module):
@@ -25,6 +26,10 @@ def _get_fenics_version():
 
 def is_windows_platform():
     return sys.platform == 'win32' or sys.platform == 'cygwin'
+
+
+def is_macos_platform():
+    return 'Darwin' in platform.system()
 
 
 def _get_matplotib_version():

--- a/src/pymortests/demos.py
+++ b/src/pymortests/demos.py
@@ -13,7 +13,7 @@ import shutil
 from pymortests.base import runmodule, check_results
 from pymor.core.exceptions import QtMissing, GmshMissing, MeshioMissing
 from pymor.discretizers.builtin.gui.qt import stop_gui_processes
-from pymor.core.config import is_windows_platform
+from pymor.core.config import is_windows_platform, is_macos_platform
 from pymor.tools.mpi import parallel
 
 
@@ -236,7 +236,9 @@ def test_analyze_pickle4():
     finally:
         shutil.rmtree(d)
 
+
 @pytest.mark.skipif(is_windows_platform(), reason='hangs indefinitely')
+@pytest.mark.skipif(is_macos_platform(), reason='spurious JSON Decode errors in Ipython launch')
 def test_thermalblock_ipython(demo_args):
     if demo_args[0] != 'pymordemos.thermalblock':
         return


### PR DESCRIPTION
- switch junit output format ahead of time, avoiding a warning
 - skip buggy Ipython test on macosx