### PR TITLE
Remove Parameter class and require to explicitly use parse_paramter

### DIFF
--- a/src/pymor/algorithms/adaptivegreedy.py
+++ b/src/pymor/algorithms/adaptivegreedy.py
@@ -12,7 +12,6 @@ from pymor.core.base import BasicObject
 from pymor.core.exceptions import ExtensionError
 from pymor.core.logger import getLogger
 from pymor.parallel.dummy import dummy_pool
-from pymor.parameters.base import Parameter
 from pymor.parameters.spaces import CubicParameterSpace
 from pymor.tools.deprecated import Deprecated
 
@@ -339,7 +338,7 @@ class AdaptiveSampleSet(BasicObject):
 
     def map_vertex_to_mu(self, vertex):
         values = self.ranges[:, 0] + self.dimensions * list(map(float, vertex))
-        mu = Parameter({})
+        mu = {}
         for k, shape in self.parameter_type.items():
             count = np.prod(shape, dtype=int)
             head, values = values[:count], values[count:]

--- a/src/pymor/analyticalproblems/functions.py
+++ b/src/pymor/analyticalproblems/functions.py
@@ -151,19 +151,18 @@ class GenericFunction(Function):
         assert isinstance(shape_range, (Number, tuple))
         if not isinstance(shape_range, tuple):
             shape_range = (shape_range,)
-        if parameter_type is not None:
-            self.build_parameter_type(parameter_type)
+        self.build_parameter_type(parameter_type)
         self.__auto_init(locals())
 
     def __str__(self):
         return f'{self.name}: x -> {self.mapping}'
 
     def evaluate(self, x, mu=None):
+        assert mu >= self.parameter_type
         x = np.array(x, copy=False, ndmin=1)
         assert x.shape[-1] == self.dim_domain
 
         if self.parametric:
-            mu = self.parse_parameter(mu)
             v = self.mapping(x, mu)
         else:
             v = self.mapping(x)
@@ -256,11 +255,11 @@ class LincombFunction(Function):
 
     def evaluate_coefficients(self, mu):
         """Compute the linear coefficients for a given |Parameter| `mu`."""
-        mu = self.parse_parameter(mu)
+        assert mu >= self.parameter_type
         return np.array([c.evaluate(mu) if hasattr(c, 'evaluate') else c for c in self.coefficients])
 
     def evaluate(self, x, mu=None):
-        mu = self.parse_parameter(mu)
+        assert mu >= self.parameter_type
         coeffs = self.evaluate_coefficients(mu)
         return sum(c * f(x, mu) for c, f in zip(coeffs, self.functions))
 
@@ -291,7 +290,7 @@ class ProductFunction(Function):
         self.shape_range = functions[0].shape_range
 
     def evaluate(self, x, mu=None):
-        mu = self.parse_parameter(mu)
+        assert mu >= self.parameter_type
         return np.prod([f(x, mu) for f in self.functions], axis=0)
 
 

--- a/src/pymor/basic.py
+++ b/src/pymor/basic.py
@@ -56,7 +56,6 @@ from pymor.operators.numpy import NumpyGenericOperator, NumpyMatrixOperator
 from pymor.parallel.default import new_parallel_pool
 from pymor.parallel.manager import RemoteObjectManager
 
-from pymor.parameters.base import Parameter
 from pymor.parameters.functionals import (ProjectionParameterFunctional, GenericParameterFunctional,
                                           ExpressionParameterFunctional)
 from pymor.parameters.spaces import CubicParameterSpace

--- a/src/pymor/bindings/fenics.py
+++ b/src/pymor/bindings/fenics.py
@@ -222,7 +222,7 @@ if config.HAVE_FENICS:
             self.build_parameter_type(parameter_type)
 
         def _set_mu(self, mu=None):
-            mu = self.parse_parameter(mu)
+            assert mu >= self.parameter_type
             if self.parameter_setter:
                 self.parameter_setter(mu)
 

--- a/src/pymor/core/cache.py
+++ b/src/pymor/core/cache.py
@@ -80,7 +80,7 @@ from pymor.core.defaults import defaults, defaults_changes
 from pymor.core.exceptions import CacheKeyGenerationError
 from pymor.core.logger import getLogger
 from pymor.core.pickle import dumps
-from pymor.parameters.base import Parameter, ParameterType
+from pymor.parameters.base import ParameterType
 
 
 @atexit.register
@@ -391,12 +391,12 @@ def build_cache_key(obj):
         elif t is np.ndarray:
             if obj.dtype == object:
                 raise CacheKeyGenerationError('Cannot generate cache key for provided arguments')
-            return obj
+            return obj.tolist()
         elif t in (list, tuple):
             return tuple(transform_obj(o) for o in obj)
         elif t in (set, frozenset):
             return tuple(transform_obj(o) for o in sorted(obj))
-        elif t in (dict, Parameter, ParameterType):
+        elif t in (dict, ParameterType):
             return tuple((transform_obj(k), transform_obj(v)) for k, v in sorted(obj.items()))
         elif isinstance(obj, Number):
             # handle numpy number objects

--- a/src/pymor/discretizers/builtin/fv.py
+++ b/src/pymor/discretizers/builtin/fv.py
@@ -264,7 +264,7 @@ class NonlinearAdvectionOperator(Operator):
 
     def apply(self, U, mu=None):
         assert U in self.source
-        mu = self.parse_parameter(mu)
+        assert mu >= self.parameter_type
 
         if not hasattr(self, '_grid_data'):
             self._fetch_grid_data()
@@ -319,7 +319,7 @@ class NonlinearAdvectionOperator(Operator):
 
     def jacobian(self, U, mu=None):
         assert U in self.source and len(U) == 1
-        mu = self.parse_parameter(mu)
+        assert mu >= self.parameter_type
 
         if not hasattr(self, '_grid_data'):
             self._fetch_grid_data()

--- a/src/pymor/models/basic.py
+++ b/src/pymor/models/basic.py
@@ -86,7 +86,7 @@ class StationaryModel(Model):
         )
 
     def _solve(self, mu=None, return_output=False):
-        mu = self.parse_parameter(mu)
+        assert mu >= self.parameter_type
 
         # explicitly checking if logging is disabled saves the str(mu) call
         if not self.logging_disabled:
@@ -203,12 +203,13 @@ class InstationaryModel(Model):
         return self.with_(time_stepper=self.time_stepper.with_(**kwargs))
 
     def _solve(self, mu=None, return_output=False):
-        mu = self.parse_parameter(mu).copy()
+        assert mu >= self.parameter_type
 
         # explicitly checking if logging is disabled saves the expensive str(mu) call
         if not self.logging_disabled:
             self.logger.info(f'Solving {self.name} for {mu} ...')
 
+        mu = mu or {}
         mu['_t'] = 0
         U0 = self.initial_data.as_range_array(mu)
         U = self.time_stepper.solve(operator=self.operator, rhs=self.rhs, initial_data=U0, mass=self.mass,

--- a/src/pymor/models/interface.py
+++ b/src/pymor/models/interface.py
@@ -70,7 +70,7 @@ class Model(CacheableObject, Parametric):
         The solution |VectorArray|. When `return_output` is `True`,
         the output |VectorArray| is returned as second value.
         """
-        mu = self.parse_parameter(mu)
+        assert mu >= self.parameter_type
         return self.cached_method_call(self._solve, mu=mu, return_output=return_output, **kwargs)
 
     def output(self, mu=None, **kwargs):

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -76,7 +76,7 @@ class InputOutputModel(Model):
         if not self.cont_time:
             raise NotImplementedError
 
-        mu = self.parse_parameter(mu)
+        assert mu >= self.parameter_type
         return np.stack([self.eval_tf(1j * wi, mu=mu) for wi in w])
 
     def mag_plot(self, w, mu=None, ax=None, ord=None, Hz=False, dB=False, **mpl_kwargs):
@@ -527,7 +527,7 @@ class LTIModel(InputStateOutputModel):
         -------
         One-dimensional |NumPy array| of system poles.
         """
-        mu = self.parse_parameter(mu)
+        assert mu >= self.parameter_type
         A = self.A.assemble(mu=mu)
         E = self.E.assemble(mu=mu)
 
@@ -567,7 +567,7 @@ class LTIModel(InputStateOutputModel):
             Transfer function evaluated at the complex number `s`, |NumPy array| of shape
             `(self.output_dim, self.input_dim)`.
         """
-        mu = self.parse_parameter(mu)
+        assert mu >= self.parameter_type
         A = self.A
         B = self.B
         C = self.C
@@ -613,7 +613,7 @@ class LTIModel(InputStateOutputModel):
             Derivative of transfer function evaluated at the complex number `s`, |NumPy array| of
             shape `(self.output_dim, self.input_dim)`.
         """
-        mu = self.parse_parameter(mu)
+        assert mu >= self.parameter_type
         A = self.A
         B = self.B
         C = self.C
@@ -671,7 +671,7 @@ class LTIModel(InputStateOutputModel):
 
         assert typ in ('c_lrcf', 'o_lrcf', 'c_dense', 'o_dense')
 
-        mu = self.parse_parameter(mu)
+        assert mu >= self.parameter_type
         A = self.A.assemble(mu)
         B = self.B
         C = self.C
@@ -717,7 +717,7 @@ class LTIModel(InputStateOutputModel):
         Vh
             |NumPy array| of right singular vectors.
         """
-        mu = self.parse_parameter(mu)
+        assert mu >= self.parameter_type
         cf = self.gramian('c_lrcf', mu=mu)
         of = self.gramian('o_lrcf', mu=mu)
         U, hsv, Vh = spla.svd(self.E.apply2(of, cf, mu=mu), lapack_driver='gesvd')
@@ -760,7 +760,7 @@ class LTIModel(InputStateOutputModel):
         """
         if not self.cont_time:
             raise NotImplementedError
-        mu = self.parse_parameter(mu)
+        assert mu >= self.parameter_type
         if self.input_dim <= self.output_dim:
             cf = self.gramian('c_lrcf', mu=mu)
             return np.sqrt(self.C.apply(cf, mu=mu).l2_norm2().sum())
@@ -796,7 +796,7 @@ class LTIModel(InputStateOutputModel):
         if not return_fpeak:
             return self.hinf_norm(mu=mu, return_fpeak=True, ab13dd_equilibrate=ab13dd_equilibrate)[0]
 
-        mu = self.parse_parameter(mu)
+        assert mu >= self.parameter_type
         A, B, C, D, E = (op.assemble(mu=mu) for op in [self.A, self.B, self.C, self.D, self.E])
 
         if self.order >= sparse_min_size():
@@ -873,8 +873,8 @@ class TransferFunction(InputOutputModel):
 
     def __init__(self, input_space, output_space, tf, dtf, cont_time=True, parameter_space=None, name=None):
         super().__init__(input_space, output_space, cont_time=cont_time, name=name)
-        self.parameter_type = parameter_space.parameter_type if parameter_space else None
         self.__auto_init(locals())
+        self.build_parameter_type(parameter_space.parameter_type if parameter_space else None)
 
     def __str__(self):
         return (
@@ -889,17 +889,17 @@ class TransferFunction(InputOutputModel):
         )
 
     def eval_tf(self, s, mu=None):
+        assert mu >= self.parameter_type
         if not self.parametric:
             return self.tf(s)
         else:
-            mu = self.parse_parameter(mu)
             return self.tf(s, mu=mu)
 
     def eval_dtf(self, s, mu=None):
+        assert mu >= self.parameter_type
         if not self.parametric:
             return self.dtf(s)
         else:
-            mu = self.parse_parameter(mu)
             return self.dtf(s, mu=mu)
 
     def __add__(self, other):
@@ -1394,7 +1394,7 @@ class SecondOrderModel(InputStateOutputModel):
             Transfer function evaluated at the complex number `s`, |NumPy array| of shape
             `(self.output_dim, self.input_dim)`.
         """
-        mu = self.parse_parameter(mu)
+        assert mu >= self.parameter_type
         M = self.M
         E = self.E
         K = self.K
@@ -1447,7 +1447,7 @@ class SecondOrderModel(InputStateOutputModel):
             Derivative of transfer function evaluated at the complex number `s`, |NumPy array| of
             shape `(self.output_dim, self.input_dim)`.
         """
-        mu = self.parse_parameter(mu)
+        assert mu >= self.parameter_type
         M = self.M
         E = self.E
         K = self.K
@@ -1979,7 +1979,7 @@ class LinearDelayModel(InputStateOutputModel):
             Transfer function evaluated at the complex number `s`, |NumPy array| of shape
             `(self.output_dim, self.input_dim)`.
         """
-        mu = self.parse_parameter(mu)
+        assert mu >= self.parameter_type
         A = self.A
         Ad = self.Ad
         B = self.B
@@ -2030,7 +2030,7 @@ class LinearDelayModel(InputStateOutputModel):
             Derivative of transfer function evaluated at the complex number `s`, |NumPy array| of
             shape `(self.output_dim, self.input_dim)`.
         """
-        mu = self.parse_parameter(mu)
+        assert mu >= self.parameter_type
         A = self.A
         Ad = self.Ad
         B = self.B

--- a/src/pymor/operators/constructions.py
+++ b/src/pymor/operators/constructions.py
@@ -79,7 +79,7 @@ class LincombOperator(Operator):
         -------
         List of linear coefficients.
         """
-        mu = self.parse_parameter(mu)
+        assert mu >= self.parameter_type
         return [c.evaluate(mu) if hasattr(c, 'evaluate') else c for c in self.coefficients]
 
     def apply(self, U, mu=None):
@@ -295,13 +295,13 @@ class Concatenation(Operator):
                           name=self.name + '_adjoint')
 
     def apply(self, U, mu=None):
-        mu = self.parse_parameter(mu)
+        assert mu >= self.parameter_type
         for op in self.operators[::-1]:
             U = op.apply(U, mu=mu)
         return U
 
     def apply_adjoint(self, V, mu=None):
-        mu = self.parse_parameter(mu)
+        assert mu >= self.parameter_type
         for op in self.operators:
             V = op.apply_adjoint(V, mu=mu)
         return V
@@ -409,7 +409,7 @@ class ProjectedOperator(Operator):
             return ProjectedOperator(self.operator.H, self.source_basis, self.range_basis, solver_options=options)
 
     def apply(self, U, mu=None):
-        mu = self.parse_parameter(mu)
+        assert mu >= self.parameter_type
         if self.source_basis is None:
             if self.range_basis is None:
                 return self.operator.apply(U, mu=mu)
@@ -432,7 +432,7 @@ class ProjectedOperator(Operator):
         if self.linear:
             return self.assemble(mu)
         assert len(U) == 1
-        mu = self.parse_parameter(mu)
+        assert mu >= self.parameter_type
         if self.source_basis is None:
             J = self.operator.jacobian(U, mu=mu)
         else:
@@ -1008,7 +1008,7 @@ class FixedParameterOperator(ProxyOperator):
 
     def __init__(self, operator, mu=None, name=None):
         super().__init__(operator, name)
-        assert operator.parse_parameter(mu) or True
+        assert mu >= operator.parameter_type
         self.mu = mu.copy()
         self.build_parameter_type()
 
@@ -1298,27 +1298,27 @@ class SelectionOperator(Operator):
         return len(self.boundaries)
 
     def assemble(self, mu=None):
-        mu = self.parse_parameter(mu)
+        assert mu >= self.parameter_type
         op = self.operators[self._get_operator_number(mu)]
         return op.assemble(mu)
 
     def apply(self, U, mu=None):
-        mu = self.parse_parameter(mu)
+        assert mu >= self.parameter_type
         operator_number = self._get_operator_number(mu)
         return self.operators[operator_number].apply(U, mu=mu)
 
     def apply_adjoint(self, V, mu=None):
-        mu = self.parse_parameter(mu)
+        assert mu >= self.parameter_type
         op = self.operators[self._get_operator_number(mu)]
         return op.apply_adjoint(V, mu=mu)
 
     def as_range_array(self, mu=None):
-        mu = self.parse_parameter(mu)
+        assert mu >= self.parameter_type
         operator_number = self._get_operator_number(mu)
         return self.operators[operator_number].as_range_array(mu=mu)
 
     def as_source_array(self, mu=None):
-        mu = self.parse_parameter(mu)
+        assert mu >= self.parameter_type
         operator_number = self._get_operator_number(mu)
         return self.operators[operator_number].as_source_array(mu=mu)
 

--- a/src/pymor/operators/ei.py
+++ b/src/pymor/operators/ei.py
@@ -95,7 +95,7 @@ class EmpiricalInterpolatedOperator(Operator):
             return self._operator
 
     def apply(self, U, mu=None):
-        mu = self.parse_parameter(mu)
+        assert mu >= self.parameter_type
         if len(self.interpolation_dofs) == 0:
             return self.range.zeros(len(U))
 
@@ -115,7 +115,7 @@ class EmpiricalInterpolatedOperator(Operator):
         return self.collateral_basis.lincomb(interpolation_coefficients)
 
     def jacobian(self, U, mu=None):
-        mu = self.parse_parameter(mu)
+        assert mu >= self.parameter_type
         options = self.solver_options.get('jacobian') if self.solver_options else None
 
         if len(self.interpolation_dofs) == 0:
@@ -171,7 +171,7 @@ class ProjectedEmpiciralInterpolatedOperator(Operator):
         self.build_parameter_type(restricted_operator)
 
     def apply(self, U, mu=None):
-        mu = self.parse_parameter(mu)
+        assert mu >= self.parameter_type
         U_dofs = self.source_basis_dofs.lincomb(U.to_numpy())
         AU = self.restricted_operator.apply(U_dofs, mu=mu)
         try:
@@ -186,7 +186,7 @@ class ProjectedEmpiciralInterpolatedOperator(Operator):
 
     def jacobian(self, U, mu=None):
         assert len(U) == 1
-        mu = self.parse_parameter(mu)
+        assert mu >= self.parameter_type
         options = self.solver_options.get('jacobian') if self.solver_options else None
 
         if self.interpolation_matrix.shape[0] == 0:

--- a/src/pymor/operators/interface.py
+++ b/src/pymor/operators/interface.py
@@ -110,7 +110,7 @@ class Operator(ImmutableObject, Parametric):
         A |NumPy array| with shape `(len(V), len(U))` containing the 2-form
         evaluations.
         """
-        mu = self.parse_parameter(mu)
+        assert mu >= self.parameter_type
         assert isinstance(V, VectorArray)
         assert isinstance(U, VectorArray)
         AU = self.apply(U, mu=mu)
@@ -136,7 +136,7 @@ class Operator(ImmutableObject, Parametric):
         A |NumPy array| with shape `(len(V),) == (len(U),)` containing
         the 2-form evaluations.
         """
-        mu = self.parse_parameter(mu)
+        assert mu >= self.parameter_type
         assert isinstance(V, VectorArray)
         assert isinstance(U, VectorArray)
         assert len(U) == len(V)

--- a/src/pymor/operators/mpi.py
+++ b/src/pymor/operators/mpi.py
@@ -85,7 +85,7 @@ class MPIOperator(Operator):
 
     def apply(self, U, mu=None):
         assert U in self.source
-        mu = self.parse_parameter(mu)
+        assert mu >= self.parameter_type
         U = U.obj_id if self.mpi_source else U
         if self.mpi_range:
             return self.range.make_array(mpi.call(mpi.method_call_manage, self.obj_id, 'apply', U, mu=mu))
@@ -93,11 +93,11 @@ class MPIOperator(Operator):
             return mpi.call(mpi.method_call, self.obj_id, 'apply', U, mu=mu)
 
     def as_range_array(self, mu=None):
-        mu = self.parse_parameter(mu)
+        assert mu >= self.parameter_type
         return self.range.make_array(mpi.call(mpi.method_call_manage, self.obj_id, 'as_range_array', mu=mu))
 
     def as_source_array(self, mu=None):
-        mu = self.parse_parameter(mu)
+        assert mu >= self.parameter_type
         return self.source.make_array(mpi.call(mpi.method_call_manage, self.obj_id, 'as_source_array', mu=mu))
 
     def apply2(self, V, U, mu=None):
@@ -105,7 +105,7 @@ class MPIOperator(Operator):
             return super().apply2(V, U, mu=mu)
         assert V in self.range
         assert U in self.source
-        mu = self.parse_parameter(mu)
+        assert mu >= self.parameter_type
         U = U.obj_id if self.mpi_source else U
         V = V.obj_id if self.mpi_range else V
         return mpi.call(mpi.method_call, self.obj_id, 'apply2', V, U, mu=mu)
@@ -115,14 +115,14 @@ class MPIOperator(Operator):
             return super().pairwise_apply2(V, U, mu=mu)
         assert V in self.range
         assert U in self.source
-        mu = self.parse_parameter(mu)
+        assert mu >= self.parameter_type
         U = U.obj_id if self.mpi_source else U
         V = V.obj_id if self.mpi_range else V
         return mpi.call(mpi.method_call, self.obj_id, 'pairwise_apply2', V, U, mu=mu)
 
     def apply_adjoint(self, V, mu=None):
         assert V in self.range
-        mu = self.parse_parameter(mu)
+        assert mu >= self.parameter_type
         V = V.obj_id if self.mpi_range else V
         if self.mpi_source:
             return self.source.make_array(
@@ -135,7 +135,7 @@ class MPIOperator(Operator):
         if not self.mpi_source or not self.mpi_range:
             raise NotImplementedError
         assert V in self.range
-        mu = self.parse_parameter(mu)
+        assert mu >= self.parameter_type
         return self.source.make_array(mpi.call(mpi.method_call_manage, self.obj_id, 'apply_inverse',
                                                V.obj_id, mu=mu, least_squares=least_squares))
 
@@ -143,17 +143,17 @@ class MPIOperator(Operator):
         if not self.mpi_source or not self.mpi_range:
             raise NotImplementedError
         assert U in self.source
-        mu = self.parse_parameter(mu)
+        assert mu >= self.parameter_type
         return self.source.make_array(mpi.call(mpi.method_call_manage, self.obj_id, 'apply_inverse_adjoint',
                                                U.obj_id, mu=mu, least_squares=least_squares))
 
     def jacobian(self, U, mu=None):
         assert U in self.source
-        mu = self.parse_parameter(mu)
+        assert mu >= self.parameter_type
         return self.with_(obj_id=mpi.call(mpi.method_call_manage, self.obj_id, 'jacobian', U.obj_id, mu=mu))
 
     def assemble(self, mu=None):
-        mu = self.parse_parameter(mu)
+        assert mu >= self.parameter_type
         return self.with_(obj_id=mpi.call(mpi.method_call_manage, self.obj_id, 'assemble', mu=mu))
 
     def _assemble_lincomb(self, operators, coefficients, identity_shift=0., solver_options=None, name=None):

--- a/src/pymor/operators/numpy.py
+++ b/src/pymor/operators/numpy.py
@@ -66,13 +66,14 @@ class NumpyGenericOperator(Operator):
     def __init__(self, mapping, adjoint_mapping=None, dim_source=1, dim_range=1, linear=False, parameter_type=None,
                  source_id=None, range_id=None, solver_options=None, name=None):
         self.__auto_init(locals())
+        self.build_parameter_type(None)
         self.source = NumpyVectorSpace(dim_source, source_id)
         self.range = NumpyVectorSpace(dim_range, range_id)
 
     def apply(self, U, mu=None):
+        assert mu >= self.parameter_type
         assert U in self.source
         if self.parametric:
-            mu = self.parse_parameter(mu)
             return self.range.make_array(self.mapping(U.to_numpy(), mu=mu))
         else:
             return self.range.make_array(self.mapping(U.to_numpy()))
@@ -81,9 +82,9 @@ class NumpyGenericOperator(Operator):
         if self.adjoint_mapping is None:
             raise ValueError('NumpyGenericOperator: adjoint mapping was not defined.')
         assert V in self.range
+        assert mu >= self.parameter_type
         V = V.to_numpy()
         if self.parametric:
-            mu = self.parse_parameter(mu)
             return self.source.make_array(self.adjoint_mapping(V, mu=mu))
         else:
             return self.source.make_array(self.adjoint_mapping(V))
@@ -114,7 +115,7 @@ class NumpyMatrixBasedOperator(Operator):
         pass
 
     def assemble(self, mu=None):
-        return NumpyMatrixOperator(self._assemble(self.parse_parameter(mu)),
+        return NumpyMatrixOperator(self._assemble(mu),
                                    source_id=self.source.id,
                                    range_id=self.range.id,
                                    solver_options=self.solver_options,

--- a/src/pymor/parameters/base.py
+++ b/src/pymor/parameters/base.py
@@ -186,7 +186,7 @@ class Parametric:
         is not empty.
     """
 
-    parameter_type = None
+    parameter_type = ParameterType({})
 
     @property
     def parameter_space(self):

--- a/src/pymor/parameters/functionals.py
+++ b/src/pymor/parameters/functionals.py
@@ -100,7 +100,7 @@ class ProjectionParameterFunctional(ParameterFunctional):
 
     def evaluate(self, mu=None):
         mu = self.parse_parameter(mu)
-        return mu[self.component_name].item(self.index)
+        return np.asarray(mu[self.component_name]).item(self.index)
 
     def d_mu(self, component, index=()):
         check, index = self._check_and_parse_input(component, index)

--- a/src/pymor/parameters/functionals.py
+++ b/src/pymor/parameters/functionals.py
@@ -99,7 +99,7 @@ class ProjectionParameterFunctional(ParameterFunctional):
         self.build_parameter_type({component_name: component_shape})
 
     def evaluate(self, mu=None):
-        mu = self.parse_parameter(mu)
+        assert mu >= self.parameter_type
         return np.asarray(mu[self.component_name]).item(self.index)
 
     def d_mu(self, component, index=()):
@@ -139,7 +139,7 @@ class GenericParameterFunctional(ParameterFunctional):
         self.build_parameter_type(parameter_type)
 
     def evaluate(self, mu=None):
-        mu = self.parse_parameter(mu)
+        assert mu >= self.parameter_type
         value = self.mapping(mu)
         # ensure that we return a number not an array
         if isinstance(value, np.ndarray):
@@ -270,7 +270,7 @@ class ProductParameterFunctional(ParameterFunctional):
         self.build_parameter_type(*(f for f in factors if isinstance(f, ParameterFunctional)))
 
     def evaluate(self, mu=None):
-        mu = self.parse_parameter(mu)
+        assert mu >= self.parameter_type
         return np.array([f.evaluate(mu) if hasattr(f, 'evaluate') else f for f in self.factors]).prod()
 
     def d_mu(self, component, index=()):
@@ -298,7 +298,7 @@ class ConjugateParameterFunctional(ParameterFunctional):
         self.build_parameter_type(functional)
 
     def evaluate(self, mu=None):
-        mu = self.parse_parameter(mu)
+        assert mu >= self.parameter_type
         return np.conj(self.functional.evaluate(mu))
 
     def d_mu(self, component, index=()):

--- a/src/pymor/parameters/spaces.py
+++ b/src/pymor/parameters/spaces.py
@@ -7,7 +7,7 @@ from itertools import product
 import numpy as np
 
 from pymor.core.base import ImmutableObject, abstractmethod
-from pymor.parameters.base import Parameter, ParameterType
+from pymor.parameters.base import ParameterType
 from pymor.tools.random import get_random_state
 
 
@@ -59,7 +59,7 @@ class CubicParameterSpace(ParameterSpace):
         self.__auto_init(locals())
 
     def parse_parameter(self, mu):
-        return Parameter.from_parameter_type(mu, self.parameter_type)
+        return self.parameter_type.parse_parameter(mu)
 
     def contains(self, mu):
         mu = self.parse_parameter(mu)
@@ -77,8 +77,8 @@ class CubicParameterSpace(ParameterSpace):
         linspaces = tuple(np.linspace(self.ranges[k][0], self.ranges[k][1], num=counts[k]) for k in self.parameter_type)
         iters = tuple(product(ls, repeat=max(1, np.zeros(sps).size))
                       for ls, sps in zip(linspaces, self.parameter_type.values()))
-        return [Parameter(((k, np.array(v).reshape(shp))
-                           for k, v, shp in zip(self.parameter_type, i, self.parameter_type.values())))
+        return [dict(((k, np.array(v).reshape(shp))
+                      for k, v, shp in zip(self.parameter_type, i, self.parameter_type.values())))
                 for i in product(*iters)]
 
     def sample_randomly(self, count=None, random_state=None, seed=None):
@@ -105,8 +105,8 @@ class CubicParameterSpace(ParameterSpace):
         assert not random_state or seed is None
         ranges = self.ranges
         random_state = get_random_state(random_state, seed)
-        get_param = lambda: Parameter(((k, random_state.uniform(ranges[k][0], ranges[k][1], shp))
-                                       for k, shp in self.parameter_type.items()))
+        get_param = lambda: dict(((k, random_state.uniform(ranges[k][0], ranges[k][1], shp))
+                                 for k, shp in self.parameter_type.items()))
         if count is None:
             def param_generator():
                 while True:

--- a/src/pymor/parameters/spaces.py
+++ b/src/pymor/parameters/spaces.py
@@ -62,7 +62,7 @@ class CubicParameterSpace(ParameterSpace):
         return self.parameter_type.parse_parameter(mu)
 
     def contains(self, mu):
-        mu = self.parse_parameter(mu)
+        assert mu >= self.parameter_type
         return all(np.all(self.ranges[k][0] <= mu[k]) and np.all(mu[k] <= self.ranges[k][1])
                    for k in self.parameter_type)
 

--- a/src/pymor/reductors/bt.py
+++ b/src/pymor/reductors/bt.py
@@ -25,8 +25,9 @@ class GenericBTReductor(BasicObject):
     """
     def __init__(self, fom, mu=None):
         assert isinstance(fom, LTIModel)
+        assert mu >= fom.parameter_type
         self.fom = fom
-        self.mu = fom.parse_parameter(mu)
+        self.mu = mu
         self.V = None
         self.W = None
         self._pg_reductor = None

--- a/src/pymor/reductors/h2.py
+++ b/src/pymor/reductors/h2.py
@@ -40,8 +40,9 @@ class GenericIRKAReductor(BasicObject):
         self.errors = []
 
     def __init__(self, fom, mu=None):
+        assert mu >= fom.parameter_type
         self.fom = fom
-        self.mu = fom.parse_parameter(mu)
+        self.mu = mu
         self.V = None
         self.W = None
         self._pg_reductor = None

--- a/src/pymor/reductors/interpolation.py
+++ b/src/pymor/reductors/interpolation.py
@@ -51,8 +51,9 @@ class GenericBHIReductor(BasicObject):
     _PGReductor = ProjectionBasedReductor
 
     def __init__(self, fom, mu=None):
+        assert mu >= fom.parameter_type
         self.fom = fom
-        self.mu = fom.parse_parameter(mu)
+        self.mu = mu
         self.V = None
         self.W = None
         self._pg_reductor = None
@@ -341,8 +342,9 @@ class TFBHIReductor(BasicObject):
         |Parameter|.
     """
     def __init__(self, fom, mu=None):
+        assert mu >= fom.parameter_type
         self.fom = fom
-        self.mu = fom.parse_parameter(mu)
+        self.mu = mu
 
     def reduce(self, sigma, b, c):
         """Realization-independent tangential Hermite interpolation.

--- a/src/pymor/reductors/sobt.py
+++ b/src/pymor/reductors/sobt.py
@@ -27,9 +27,10 @@ class GenericSOBTpvReductor(BasicObject):
         |Parameter|.
     """
     def __init__(self, fom, mu=None):
+        assert mu >= fom.parameter_type
         assert isinstance(fom, SecondOrderModel)
         self.fom = fom
-        self.mu = fom.parse_parameter(mu)
+        self.mu = mu
         self.V = None
         self.W = None
         self._pg_reductor = None
@@ -215,9 +216,10 @@ class SOBTfvReductor(BasicObject):
         |Parameter|.
     """
     def __init__(self, fom, mu=None):
+        assert mu >= fom.parameter_type
         assert isinstance(fom, SecondOrderModel)
         self.fom = fom
-        self.mu = fom.parse_parameter(mu)
+        self.mu = mu
         self.V = None
         self.W = None
         self._pg_reductor = None
@@ -297,9 +299,10 @@ class SOBTReductor(BasicObject):
         |Parameter|.
     """
     def __init__(self, fom, mu=None):
+        assert mu >= fom.parameter_type
         assert isinstance(fom, SecondOrderModel)
         self.fom = fom
-        self.mu = fom.parse_parameter(mu)
+        self.mu = mu
         self.V1 = None
         self.W1 = None
         self.V2 = None

--- a/src/pymordemos/burgers.py
+++ b/src/pymordemos/burgers.py
@@ -73,7 +73,7 @@ def burgers_demo(args):
 
     print(f'The parameter type is {m.parameter_type}')
 
-    mu = args['EXP']
+    mu = m.parse_parameter(args['EXP'])
     print(f'Solving for exponent = {mu} ... ')
     sys.stdout.flush()
     tic = time.time()

--- a/src/pymordemos/fenics_nonlinear.py
+++ b/src/pymordemos/fenics_nonlinear.py
@@ -113,7 +113,7 @@ def fenics_nonlinear_demo(args):
     import numpy as np
 
     # ensure that FFC is not called during runtime measurements
-    rom.solve(1)
+    rom.solve({'c': 1})
 
     errs = []
     speedups = []

--- a/src/pymordemos/thermalblock_simple.py
+++ b/src/pymordemos/thermalblock_simple.py
@@ -192,7 +192,7 @@ def discretize_ngsolve():
     op = LincombOperator([NGSolveMatrixOperator(m, space, space) for m in mats],
                          [ProjectionParameterFunctional('diffusion', (len(coeffs),), (i,)) for i in range(len(coeffs))])
 
-    h1_0_op = op.assemble([1] * len(coeffs)).with_(name='h1_0_semi')
+    h1_0_op = op.assemble({'diffusion': [1] * len(coeffs)}).with_(name='h1_0_semi')
 
     F = space.zeros()
     F._list[0].real_part.impl.vec.data = f.vec

--- a/src/pymortests/fixtures/operator.py
+++ b/src/pymortests/fixtures/operator.py
@@ -106,9 +106,9 @@ def thermalblock_factory(xblocks, yblocks, diameter, seed):
     V = m.operator.range.empty()
     np.random.seed(seed)
     for exp in np.random.random(5):
-        U.append(iop.as_vector(exp))
+        U.append(iop.as_vector({'exp': exp}))
     for exp in np.random.random(6):
-        V.append(iop.as_vector(exp))
+        V.append(iop.as_vector({'exp': exp}))
     return m.operator, m.parameter_space.sample_randomly(1, seed=seed)[0], U, V, m.h1_product, m.l2_product
 
 

--- a/src/pymortests/fixtures/parameter.py
+++ b/src/pymortests/fixtures/parameter.py
@@ -4,8 +4,6 @@
 
 import numpy as np
 
-from pymor.parameters.base import Parameter
-
 
 def parameters_of_type(parameter_type, seed):
     np.random.seed(seed)
@@ -13,4 +11,4 @@ def parameters_of_type(parameter_type, seed):
         if parameter_type is None:
             yield None
         else:
-            yield Parameter({k: np.random.random(v) for k, v in parameter_type.items()})
+            yield {k: np.random.random(v) for k, v in parameter_type.items()}

--- a/src/pymortests/mu_derivatives.py
+++ b/src/pymortests/mu_derivatives.py
@@ -113,7 +113,7 @@ def test_ExpressionParameterFunctional_for_2d_array():
     derivative_to_22_mu_index = epf2d.d_mu('mu', (1,1))
     derivative_to_nu_index = epf2d.d_mu('nu')
 
-    mu = {'mu': (1,2,3,4), 'nu': 0}
+    mu = {'mu': np.array([[1,2],[3,4]]), 'nu': 0}
 
     der_mu_11 = derivative_to_11_mu_index.evaluate(mu)
     der_mu_12 = derivative_to_12_mu_index.evaluate(mu)

--- a/src/pymortests/operators.py
+++ b/src/pymortests/operators.py
@@ -37,7 +37,7 @@ def test_selection_op():
     )
     x = np.linspace(-1., 1., num=3)
     vx = p1.source.make_array(x[:, np.newaxis])
-    assert np.allclose(p1.apply(vx,mu=0).to_numpy(), s1.apply(vx,mu=0).to_numpy())
+    assert np.allclose(p1.apply(vx).to_numpy(), s1.apply(vx, mu={'nrrhs': 0}).to_numpy())
 
     s2 = SelectionOperator(
         operators=[p1,p1,p1,p1],


### PR DESCRIPTION
@pymor/pymor-devs, @TiKeil, in this PR I have played with completely removing the `Parameter` class from pyMOR (first commit).

- To ensure that parameter components of higher dimensions can at least always be indexed with a sequence of indices, I have implemented the following convention: Values must by array-like for dimensions 0 and 1, but have to be NumPy arrays for higher dimensions.
- The check whether a given `mu` fits the `ParameterType` is implemented in `ParameterType.__leq__`. Note that the check is a bit more involved than what currently happens in `parase_parameter` as we have to account for the fact that a value might not be a proper NumPy array.
- Overall, one has to be a bit more careful now when looking at the values of a parameter. For example, see `ProjectionParameterFunctional.evaluate` (note that `item` is used to obtain proper Python floats instead of NumPy number types, in particular for scalar arrays).
- One might think about restricting what a parameter value can be, and only allow a single number or a Python list/1d array of numbers. In that case, the values in `ParameterType` could simply be a number.

In the second commit I have replaced all calls to `parse_parameter` by assertions. In order to make that possible, I have ensured that `parameter_type` is never `None` (but `ParameterType({})` instead).

I am quite happy that these changes didn't break a lot in pyMOR. Please take a look what these changes would mean for you own code. Overall, I think that this is a possible way to go, but I am still unsure if it wouldn't be better to have a dedicated class for a parameter/mu/whatever: it's type has a clear definition and is used all over pyMOR. So this seems like a place where using static types might be advisable from an engineering point of view. The only downside in combination with not using `parse_parameter` everywhere is the added effort in writing `Parameter(...)` or `Mu(...)` in user code.