### PR TITLE
[github] add a workflow for Labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,39 @@
+algorithms:
+  - src/pymortests/algorithms/*
+  - src/pymor/algorithms/*
+
+buildsystem:
+  - .ci/*
+  - .github/*
+  - .binder/*
+  - Makefile
+  - azure-pipelines.yml
+  - requirements*
+  - pyproject.toml
+  - MANIFEST.in
+  - dependencies.py
+  - setup.*
+  - versioneer.py
+
+bindings:
+  - src/pymor/bindings/*
+
+builtin-models:
+  - src/pymor/discretizers/*
+  - src/pymor/playground/discretizers/*
+  - src/pymortests/model.py
+  - src/pymortests/fixtures/model.py
+  - src/pymor/models/*
+
+docs:
+  - docs/*
+  - notebooks/*
+
+testing:
+  - src/pymortests/*
+
+management:
+  - AUTHORS.md
+  - CONTRIBUTING.md
+  - LICENSE.txt
+

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,8 +1,4 @@
-algorithms:
-  - src/pymortests/algorithms/*
-  - src/pymor/algorithms/*
-
-buildsystem:
+infrastructure:
   - .ci/*
   - .github/*
   - .binder/*
@@ -15,25 +11,7 @@ buildsystem:
   - setup.*
   - versioneer.py
 
-bindings:
-  - src/pymor/bindings/*
-
-builtin-models:
-  - src/pymor/discretizers/*
-  - src/pymor/playground/discretizers/*
-  - src/pymortests/model.py
-  - src/pymortests/fixtures/model.py
-  - src/pymor/models/*
-
-docs:
-  - docs/*
-  - notebooks/*
-
-testing:
-  - src/pymortests/*
-
 management:
-  - AUTHORS.md
   - CONTRIBUTING.md
   - LICENSE.txt
 

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,0 +1,19 @@
+# This workflow will triage pull requests and apply a label based on the
+# paths that are modified in the pull request.
+#
+# To use this workflow, you will need to set up a .github/labeler.yml
+# file with configuration.  For more information, see:
+# https://github.com/actions/labeler/blob/master/README.md
+
+name: Labeler
+on: [pull_request]
+
+jobs:
+  label:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/labeler@v2
+      with:
+        repo-token: "${{ secrets.GH_TOKEN }}"


### PR DESCRIPTION
This adds automatic labeling to PRs via Github actions and configurable path matching. 
I've seeded the `.github/labeler.yml` with a few labels and would welcome additional commits to this branch that expand that config before merging. 