### PR TITLE
Implement VectorArrayOperator.apply_inverse

### DIFF
--- a/src/pymor/operators/constructions.py
+++ b/src/pymor/operators/constructions.py
@@ -841,6 +841,24 @@ class VectorArrayOperator(Operator):
         else:
             return self.range.make_array(self.array.dot(U).T)
 
+    def apply_inverse(self, V, mu=None, least_squares=False):
+        if not least_squares and len(V) != V.dim:
+            raise InversionError
+
+        from pymor.algorithms.gram_schmidt import gram_schmidt
+        from numpy.linalg import lstsq
+
+        Q, R = gram_schmidt(self.array, return_R=True, reiterate=False)
+        if self.adjoint:
+            v = lstsq(R.T.conj(), V.to_numpy().T)[0]
+            U = Q.lincomb(v.T)
+        else:
+            v = Q.dot(V)
+            u = lstsq(R, v)[0]
+            U = self.source.make_array(u.T)
+
+        return U
+
     def apply_adjoint(self, V, mu=None):
         assert V in self.range
         if not self.adjoint:

--- a/src/pymor/operators/constructions.py
+++ b/src/pymor/operators/constructions.py
@@ -842,7 +842,7 @@ class VectorArrayOperator(Operator):
             return self.range.make_array(self.array.dot(U).T)
 
     def apply_inverse(self, V, mu=None, least_squares=False):
-        if not least_squares and len(V) != V.dim:
+        if not least_squares and len(self.array) != self.array.dim:
             raise InversionError
 
         from pymor.algorithms.gram_schmidt import gram_schmidt


### PR DESCRIPTION
This PR implements `VectorArrayOperator.apply_inverse` via a QR decomposition of the corresponding `VectorArray` (using `gram_schmidt`).

In particular this is relevant for nonlinear least-squares ROMs without hyperreduction, in which case the projected Jacobians are `VectorArrayOperators` and `apply_inverse` is called with `least_squares=True`.