### PR TITLE
Implement VectorArray.__deepcopy__ via VectorArray.copy(deep=True)

### DIFF
--- a/src/pymor/vectorarrays/interface.py
+++ b/src/pymor/vectorarrays/interface.py
@@ -250,6 +250,9 @@ class VectorArray(BasicObject):
         """
         pass
 
+    def __deepcopy__(self, memo):
+        return self.copy(deep=True)
+
     @abstractmethod
     def scal(self, alpha):
         """BLAS SCAL operation (in-place scalar multiplication).


### PR DESCRIPTION
This is primarily needed for `DummyPool` which will fail to push unpicklable `VectorArrays`.

Fixes #893.