### PR TITLE
[ci] add a github action to replace the external buildozer app

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,33 @@
+name: automerge
+on:
+  pull_request:
+    types:
+      - labeled
+      - unlabeled
+      - synchronize
+      - opened
+      - edited
+      - ready_for_review
+      - reopened
+      - unlocked
+  pull_request_review:
+    types:
+      - submitted
+  check_suite: 
+    types:
+      - completed
+  status: {}
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: automerge
+        uses: "pascalgn/automerge-action@135f0bdb927d9807b5446f7ca9ecc2c51de03c4a"
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          UPDATE_METHOD: "rebase"
+          MERGE_METHOD: "rebase"
+          UPDATE_LABELS: "automerge"
+          MERGE_LABELS: "automerge"
+          MERGE_FORKS: "false"
+          MERGE_DELETE_BRANCH: "true"


### PR DESCRIPTION
After I ran into _very_ subtle problems with the buildozer auto merge app I've decided to get rid of it in favor of a Github "built-in". You can use the new label "automerge" just the same way as you could comment "merge when ready" before. 