### PR TITLE
[line-search] implement Armijo line search algorithm

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -16,6 +16,9 @@
 * Tim Keil, tim.keil@uni-muenster.de
     * second order derivatives for parameters
 
+* Hendrik Kleikamp, hendrik.kleikamp@uni-muenster.de
+    * Armijo line search algorithm
+
 ## pyMOR 2019.2
 
 * Linus Balicki, linus.balicki@ovgu.de

--- a/docs/source/bibliography.rst
+++ b/docs/source/bibliography.rst
@@ -102,6 +102,12 @@ Bibliography
            IEEE Transactions on Automatic Control, 36(6), 668-682,
            1991.
 
+.. [NW06] J. Nocedal and S. J. Wright,
+          Numerical optimization,
+          Springer Series in Operations Research and Financial
+          Engineering,
+          Second Edition, Springer New-York, 2006
+
 .. [OJ88]  P. C. Opdenacker, E. A. Jonckheere, A Contraction Mapping
            Preserving Balanced Reduction Scheme and Its Infinity Norm
            Error Bounds,

--- a/src/pymor/algorithms/line_search.py
+++ b/src/pymor/algorithms/line_search.py
@@ -7,8 +7,8 @@ from pymor.core.logger import getLogger
 
 
 @defaults('alpha_init', 'tau', 'beta', 'maxiter')
-def armijo(f, starting_point, direction, grad=None,
-           alpha_init=1.0, tau=0.5, beta=0.0001, maxiter=100):
+def armijo(f, starting_point, direction, grad=None, initial_value=None,
+           alpha_init=1.0, tau=0.5, beta=0.0001, maxiter=10):
     """Armijo line search algorithm.
 
     This method computes a step size such that the Armijo condition (see [NW06]_, p. 33)
@@ -21,10 +21,11 @@ def armijo(f, starting_point, direction, grad=None,
     starting_point
         A |VectorArray| of length 1 containing the starting point of the line search.
     direction
-        Descent direction of `f` in the point `starting_point` along which the line
-        search is performed.
+        Descent direction along which the line search is performed.
     grad
         Gradient of `f` in the point `starting_point`.
+    initial_value
+        Value of `f` in the point `starting_point`.
     alpha_init
         Initial step size that is gradually reduced.
     tau
@@ -32,8 +33,8 @@ def armijo(f, starting_point, direction, grad=None,
     beta
         Control parameter to adjust the required decrease of the function value of `f`.
     maxiter
-        Fail if the iteration count reaches this value without finding a point fulfilling
-        the Armijo condition.
+        Use `alpha_init` as default if the iteration count reaches this value without
+        finding a point fulfilling the Armijo condition.
 
     Returns
     -------
@@ -48,7 +49,8 @@ def armijo(f, starting_point, direction, grad=None,
     alpha = alpha_init
 
     # Compute initial function value
-    initial_value = f(starting_point)
+    if initial_value is None:
+        initial_value = f(starting_point)
 
     iteration = 0
     slope = 0.0
@@ -68,8 +70,8 @@ def armijo(f, starting_point, direction, grad=None,
             # Use default value as step size
             alpha = alpha_init
             # Log warning
-            logger = getLogger('pymor.algorithms.line_search')
-            logger.warning('Reached maximum number of line search steps')
+            logger = getLogger('pymor.algorithms.line_search.armijo')
+            logger.warning(f'Reached maximum number of line search steps; using initial step size of {alpha_init} instead')
             break
         iteration += 1
         # Adjust step size

--- a/src/pymor/algorithms/line_search.py
+++ b/src/pymor/algorithms/line_search.py
@@ -10,8 +10,8 @@ def armijo(f, starting_point, direction, grad=None,
            alpha_init=1.0, tau=0.5, beta=0.0001, maxiter=100):
     """Armijo line search algorithm.
 
-    This method computes a step size such that the Armijo-Goldstein condition is
-    fulfilled.
+    This method computes a step size such that the Armijo condition (see [NW06]_, p. 33)
+    is fulfilled.
 
     Parameters
     ----------
@@ -32,12 +32,12 @@ def armijo(f, starting_point, direction, grad=None,
         Control parameter to adjust the required decrease of the function value of `f`.
     maxiter
         Fail if the iteration count reaches this value without finding a point fulfilling
-        the Armijo-Goldstein condition.
+        the Armijo condition.
 
     Returns
     -------
     alpha
-        Step size computed according to the Armijo-Goldstein condition.
+        Step size computed according to the Armijo condition.
     """
     assert alpha_init > 0
     assert 0 < tau < 1
@@ -59,7 +59,7 @@ def armijo(f, starting_point, direction, grad=None,
     while True:
         # Compute new function value
         current_value = f(starting_point + alpha * direction)
-        # Check the Armijo-Goldstein condition
+        # Check the Armijo condition
         if current_value < initial_value + alpha * beta * slope:
             break
         # Check if maxiter is reached

--- a/src/pymor/algorithms/line_search.py
+++ b/src/pymor/algorithms/line_search.py
@@ -6,7 +6,7 @@ from pymor.core.defaults import defaults
 
 
 @defaults('alpha_init', 'tau', 'beta', 'maxiter')
-def armijo(r, starting_point, correction, grad=None,
+def armijo(f, starting_point, direction, grad=None,
            alpha_init=1.0, tau=0.5, beta=0.0001, maxiter=100):
     """Armijo line search algorithm.
 
@@ -15,21 +15,21 @@ def armijo(r, starting_point, correction, grad=None,
 
     Parameters
     ----------
-    r
+    f
         Real-valued function that can be evaluated for its value.
     starting_point
         A |VectorArray| of length 1 containing the starting point of the line search.
-    correction
-        Descent direction of `r` in the point `starting_point` along which the line
+    direction
+        Descent direction of `f` in the point `starting_point` along which the line
         search is performed.
     grad
-        Gradient of `r` in the point `starting_point`.
+        Gradient of `f` in the point `starting_point`.
     alpha_init
         Initial step size that is gradually reduced.
     tau
         The fraction by which the step size is reduced in each iteration.
     beta
-        Control parameter to adjust the required decrease of the function value of `r`.
+        Control parameter to adjust the required decrease of the function value of `f`.
     maxiter
         Fail if the iteration count reaches this value without finding a point fulfilling
         the Armijo-Goldstein condition.
@@ -47,20 +47,20 @@ def armijo(r, starting_point, correction, grad=None,
     alpha = alpha_init
 
     # Compute initial function value
-    initial_residual = r(starting_point)
+    initial_value = f(starting_point)
 
     iteration = 0
     slope = 0.0
 
     # Compute slope if gradient is provided
     if grad:
-        slope = min(grad.dot(correction), 0.0)
+        slope = min(grad.dot(direction), 0.0)
 
     while True:
         # Compute new function value
-        current_residual = r(starting_point + alpha * correction)
+        current_value = f(starting_point + alpha * direction)
         # Check the Armijo-Goldstein condition
-        if current_residual < initial_residual + alpha * beta * slope:
+        if current_value < initial_value + alpha * beta * slope:
             break
         # Check if maxiter is reached
         if iteration >= maxiter:

--- a/src/pymor/algorithms/line_search.py
+++ b/src/pymor/algorithms/line_search.py
@@ -1,0 +1,73 @@
+# This file is part of the pyMOR project (http://www.pymor.org).
+# Copyright 2013-2020 pyMOR developers and contributors. All rights reserved.
+# License: BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+
+from pymor.core.defaults import defaults
+
+
+@defaults('alpha_init', 'tau', 'beta', 'maxiter')
+def armijo(r, starting_point, correction, grad=None,
+           alpha_init=1.0, tau=0.5, beta=0.0001, maxiter=100):
+    """Armijo line search algorithm.
+
+    This method computes a step size such that the Armijo-Goldstein condition is
+    fulfilled.
+
+    Parameters
+    ----------
+    r
+        Real-valued function that can be evaluated for its value.
+    starting_point
+        A |VectorArray| of length 1 containing the starting point of the line search.
+    correction
+        Descent direction of `r` in the point `starting_point` along which the line
+        search is performed.
+    grad
+        Gradient of `r` in the point `starting_point`.
+    alpha_init
+        Initial step size that is gradually reduced.
+    tau
+        The fraction by which the step size is reduced in each iteration.
+    beta
+        Control parameter to adjust the required decrease of the function value of `r`.
+    maxiter
+        Fail if the iteration count reaches this value without finding a point fulfilling
+        the Armijo-Goldstein condition.
+
+    Returns
+    -------
+    alpha
+        Step size computed according to the Armijo-Goldstein condition.
+    """
+    assert alpha_init > 0
+    assert 0 < tau < 1
+    assert maxiter > 0
+
+    # Start line search with step size of alpha_init
+    alpha = alpha_init
+
+    # Compute initial function value
+    initial_residual = r(starting_point)
+
+    iteration = 0
+    slope = 0.0
+
+    # Compute slope if gradient is provided
+    if grad:
+        slope = min(grad.dot(correction), 0.0)
+
+    while True:
+        # Compute new function value
+        current_residual = r(starting_point + alpha * correction)
+        # Check the Armijo-Goldstein condition
+        if current_residual < initial_residual + alpha * beta * slope:
+            break
+        # Check if maxiter is reached
+        if iteration >= maxiter:
+            alpha = alpha_init
+            break
+        iteration += 1
+        # Adjust step size
+        alpha *= tau
+
+    return alpha

--- a/src/pymor/algorithms/line_search.py
+++ b/src/pymor/algorithms/line_search.py
@@ -3,6 +3,7 @@
 # License: BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
 
 from pymor.core.defaults import defaults
+from pymor.core.logger import getLogger
 
 
 @defaults('alpha_init', 'tau', 'beta', 'maxiter')
@@ -64,7 +65,11 @@ def armijo(f, starting_point, direction, grad=None,
             break
         # Check if maxiter is reached
         if iteration >= maxiter:
+            # Use default value as step size
             alpha = alpha_init
+            # Log warning
+            logger = getLogger('pymor.algorithms.line_search')
+            logger.warning('Reached maximum number of line search steps')
             break
         iteration += 1
         # Adjust step size

--- a/src/pymor/algorithms/newton.py
+++ b/src/pymor/algorithms/newton.py
@@ -129,6 +129,7 @@ def newton(operator, rhs, initial_guess=None, mu=None, error_norm=None, least_sq
         except InversionError:
             raise NewtonError('Could not invert jacobian')
         if line_search_method is not None:
+            logger.info(f'Using {line_search_method} as line search method')
             if line_search_method == 'armijo':
                 def res(x):
                     residual_vec = rhs - operator.apply(x, mu=mu)

--- a/src/pymor/algorithms/newton.py
+++ b/src/pymor/algorithms/newton.py
@@ -136,7 +136,7 @@ def newton(operator, rhs, initial_guess=None, mu=None, error_norm=None, least_sq
                 grad = 2.0 * jacobian.apply(residual) if error_norm is None else None
                 relax = armijo(res, U, correction, grad=grad)
             else:
-                raise NewtonError('Unknown line search method')
+                raise ValueError('Unknown line search method')
         U.axpy(relax, correction)
         residual = rhs - operator.apply(U, mu=mu)
 

--- a/src/pymor/algorithms/newton.py
+++ b/src/pymor/algorithms/newton.py
@@ -2,6 +2,8 @@
 # Copyright 2013-2020 pyMOR developers and contributors. All rights reserved.
 # License: BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
 
+from numbers import Number
+
 import numpy as np
 
 from pymor.algorithms.line_search import armijo
@@ -51,8 +53,9 @@ def newton(operator, rhs, initial_guess=None, mu=None, error_product=None, least
     atol
         Finish when the residual norm is below this threshold.
     relax
-        If real valued, relaxation factor for Newton updates; otherwise the name of a line
-        search method (for instance 'armijo').
+        If real valued, relaxation factor for Newton updates; otherwise 'armijo' to
+        indicate that the :func:~pymor.algorithms.line_search.armijo line search algorithm
+        shall be used.
     line_search_params
         Dictionary of additional parameters passed to the line search method.
     stagnation_window
@@ -99,8 +102,7 @@ def newton(operator, rhs, initial_guess=None, mu=None, error_product=None, least
     U = initial_guess.copy()
     residual = rhs - operator.apply(U, mu=mu)
 
-    err = residual.dot(residual)[0][0] if error_product is None else error_product.apply2(residual, residual)[0][0]
-    print(err)
+    err = residual.norm(error_product)[0]
     logger.info(f'      Initial Residual: {err:5e}')
 
     iteration = 0
@@ -130,19 +132,24 @@ def newton(operator, rhs, initial_guess=None, mu=None, error_product=None, least
             correction = jacobian.apply_inverse(residual, least_squares=least_squares)
         except InversionError:
             raise NewtonError('Could not invert jacobian')
-        if relax == 'armijo':
+        if isinstance(relax, Number):
+            step_size = relax
+        elif relax == 'armijo':
             logger.info(f'Using Armijo as line search method')
             def res(x):
                 residual_vec = rhs - operator.apply(x, mu=mu)
-                return residual_vec.dot(residual_vec)[0][0] if error_product is None else error_product.apply2(residual_vec, residual_vec)[0][0]
-            grad = - (jacobian.apply(residual) + jacobian.apply_adjoint(residual)) if error_product is None else - (jacobian.apply_adjoint(error_product.apply(residual)) + jacobian.apply(error_product.apply_adjoint(residual)))
-            step_size = armijo(res, U, correction, grad=grad, **(line_search_params or {}))
+                return residual_vec.norm(error_product)[0]
+            if error_product is None:
+                grad = - (jacobian.apply(residual) + jacobian.apply_adjoint(residual))
+            else:
+                grad = - (jacobian.apply_adjoint(error_product.apply(residual)) + jacobian.apply(error_product.apply_adjoint(residual)))
+            step_size = armijo(res, U, correction, grad=grad, initial_value=err, **(line_search_params or {}))
         else:
-            step_size = relax
+            raise ValueError('Unknown line search method')
         U.axpy(step_size, correction)
         residual = rhs - operator.apply(U, mu=mu)
 
-        err = residual.dot(residual)[0][0] if error_product is None else error_product.apply2(residual, residual)[0][0]
+        err = residual.norm(error_product)[0]
         logger.info(f'Iteration {iteration:2}: Residual: {err:5e},  '
                     f'Reduction: {err / error_sequence[-1]:5e}, Total Reduction: {err / error_sequence[0]:5e}')
         error_sequence.append(err)

--- a/src/pymortests/algorithms/stuff.py
+++ b/src/pymortests/algorithms/stuff.py
@@ -13,34 +13,36 @@ from pymortests.base import runmodule
 from pymortests.fixtures.operator import MonomOperator
 
 
-def _newton(order, initial_value=1.0, **kwargs):
-    mop = MonomOperator(order)
+def _newton(mop, initial_value=1.0, **kwargs):
     rhs = NumpyVectorSpace.from_numpy([0.0])
     guess = NumpyVectorSpace.from_numpy([initial_value])
     return newton(mop, rhs, initial_guess=guess, **kwargs)
 
 @pytest.mark.parametrize("order", list(range(1, 8)))
 def test_newton(order):
-    U, _ = _newton(order, atol=1e-15)
-    assert float_cmp(U.to_numpy(), 0.0)
+    mop = MonomOperator(order)
+    U, _ = _newton(mop, atol=1e-15)
+    assert float_cmp(mop.apply(U).to_numpy(), 0.0)
 
 def test_newton_fail():
+    mop = MonomOperator(0)
     with pytest.raises(NewtonError):
-        _ = _newton(0, maxiter=10, stagnation_threshold=np.inf)
+        _ = _newton(mop, maxiter=10, stagnation_threshold=np.inf)
 
-@pytest.mark.parametrize("order", list(range(1, 8)))
-def test_newton_with_line_search(order):
-    U, _ = _newton(order, initial_value=0.5, atol=1e-15, relax='armijo')
-    assert float_cmp(U.to_numpy(), 0.0)
+def test_newton_with_line_search():
+    mop = MonomOperator(3) - 2 * MonomOperator(1) + 2 * MonomOperator(0)
+    U, _ = _newton(mop, initial_value=0.0, atol=1e-15, relax='armijo')
+    assert float_cmp(mop.apply(U).to_numpy(), 0.0)
 
-@pytest.mark.parametrize("order", list(range(1, 8)))
-def test_newton_fail_without_line_search(order):
+def test_newton_fail_without_line_search():
+    mop = MonomOperator(3) - 2 * MonomOperator(1) + 2 * MonomOperator(0)
     with pytest.raises(NewtonError):
-        _ = _newton(order, initial_value=0.5, atol=1e-15)
+        _ = _newton(mop, initial_value=0.0, atol=1e-15)
 
 def test_newton_residual_is_zero(order=5):
-    U, _ = _newton(order, initial_value=0.0)
-    assert float_cmp(U.to_numpy(), 0.0)
+    mop = MonomOperator(order)
+    U, _ = _newton(mop, initial_value=0.0)
+    assert float_cmp(mop.apply(U).to_numpy(), 0.0)
 
 
 if __name__ == "__main__":

--- a/src/pymortests/algorithms/stuff.py
+++ b/src/pymortests/algorithms/stuff.py
@@ -39,6 +39,11 @@ def test_newton_fail_without_line_search():
     with pytest.raises(NewtonError):
         _ = _newton(mop, initial_value=0.0, atol=1e-15)
 
+def test_newton_unknown_line_search():
+    mop = MonomOperator(1)
+    with pytest.raises(ValueError):
+        _ = _newton(mop, relax='armo')
+
 def test_newton_residual_is_zero(order=5):
     mop = MonomOperator(order)
     U, _ = _newton(mop, initial_value=0.0)

--- a/src/pymortests/algorithms/stuff.py
+++ b/src/pymortests/algorithms/stuff.py
@@ -19,17 +19,24 @@ def _newton(order, initial_value=1.0, **kwargs):
     guess = NumpyVectorSpace.from_numpy([initial_value])
     return newton(mop, rhs, initial_guess=guess, **kwargs)
 
-
 @pytest.mark.parametrize("order", list(range(1, 8)))
 def test_newton(order):
     U, _ = _newton(order, atol=1e-15)
     assert float_cmp(U.to_numpy(), 0.0)
 
-
 def test_newton_fail():
     with pytest.raises(NewtonError):
         _ = _newton(0, maxiter=10, stagnation_threshold=np.inf)
 
+@pytest.mark.parametrize("order", list(range(1, 8)))
+def test_newton_with_line_search(order):
+    U, _ = _newton(order, initial_value=0.5, atol=1e-15, relax='armijo')
+    assert float_cmp(U.to_numpy(), 0.0)
+
+@pytest.mark.parametrize("order", list(range(1, 8)))
+def test_newton_fail_without_line_search(order):
+    with pytest.raises(NewtonError):
+        _ = _newton(order, initial_value=0.5, atol=1e-15)
 
 def test_newton_residual_is_zero(order=5):
     U, _ = _newton(order, initial_value=0.0)

--- a/src/pymortests/fixtures/operator.py
+++ b/src/pymortests/fixtures/operator.py
@@ -25,6 +25,9 @@ class MonomOperator(Operator):
     def apply(self, U, mu=None):
         return self.source.make_array(self.monom(U.to_numpy()))
 
+    def apply_adjoint(self, U, mu=None):
+        return self.apply(U, mu=None)
+
     def jacobian(self, U, mu=None):
         return MonomOperator(self.order - 1, self.derivative)
 

--- a/src/pymortests/fixtures/operator.py
+++ b/src/pymortests/fixtures/operator.py
@@ -29,6 +29,7 @@ class MonomOperator(Operator):
         return self.apply(U, mu=None)
 
     def jacobian(self, U, mu=None):
+        assert len(U) == 1
         return NumpyMatrixOperator(self.derivative(U.to_numpy()).reshape((1,1)))
 
     def apply_inverse(self, V, mu=None, least_squares=False):

--- a/src/pymortests/fixtures/operator.py
+++ b/src/pymortests/fixtures/operator.py
@@ -29,7 +29,7 @@ class MonomOperator(Operator):
         return self.apply(U, mu=None)
 
     def jacobian(self, U, mu=None):
-        return MonomOperator(self.order - 1, self.derivative)
+        return NumpyMatrixOperator(self.derivative(U.to_numpy()).reshape((1,1)))
 
     def apply_inverse(self, V, mu=None, least_squares=False):
         return self.range.make_array(1. / V.to_numpy())

--- a/src/pymortests/operators.py
+++ b/src/pymortests/operators.py
@@ -62,11 +62,15 @@ def test_lincomb_op():
     p0 = p1 - p1
     x = np.linspace(-1., 1., num=3)
     vx = p1.source.make_array((x[:, np.newaxis]))
+    one = p1.source.make_array([1])
     assert np.allclose(p0.apply(vx).to_numpy(), [0.])
     assert np.allclose(p12.apply(vx).to_numpy(), (x * x + x)[:, np.newaxis])
     assert np.allclose((p1 * 2.).apply(vx).to_numpy(), (x * 2.)[:, np.newaxis])
-    assert almost_equal(p2.jacobian(vx).apply(vx), p1.apply(vx) * 2.).all()
-    assert almost_equal(p0.jacobian(vx).apply(vx), vx * 0.).all()
+    with pytest.raises(AssertionError):
+        p2.jacobian(vx)
+    for i in range(len(vx)):
+        assert almost_equal(p2.jacobian(vx[i]).apply(one), p1.apply(vx[i]) * 2.)
+        assert almost_equal(p0.jacobian(vx[i]).apply(one), vx[i] * 0.)
     with pytest.raises(TypeError):
         p2.as_vector()
     p1.as_vector()


### PR DESCRIPTION
When solving nonlinear problems for several different parameters, finding a proper value for the `relax` parameter of the Newton solver that works for every parameter is quite difficult. Thus, I implemented a (very) simple line search algorithm that, at least in my application, led to convergence of the Newton method for every parameter.

To check the original Armijo-Goldstein condition, one needs the gradient of the objective function. Thus, if no gradient is provided, a weaker version of this condition is checked; namely that the function value is decreasing, no matter to what extend.

To be able to compute the gradient of the error function in the Newton method, we switched from `error_norm` to `error_product` in the Newton. Thus, we can derive the gradient for any `error_product`. Certainly, this restricts us to the Hilbert space case; non-Hilbert norms are no longer supported.

Furthermore, we had to make some adjustments in the tests of the Newton method; the Jacobian of the `MonomOperator`s was not implemented properly. We added a test case for the line search algorithm, in which the Newton without line search starts oscillating between two values.