### PR TITLE
[Operators] Speed up apply methods for LincombOperator

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -15,6 +15,10 @@
 
 * Tim Keil, tim.keil@uni-muenster.de
     * second order derivatives for parameters
+    * speed up of lincomb operators
+
+* Luca Mechelli, luca.mechelli@uni-konstanz.de
+    * speed up of lincomb operators
 
 ## pyMOR 2019.2
 

--- a/src/pymor/operators/constructions.py
+++ b/src/pymor/operators/constructions.py
@@ -84,14 +84,13 @@ class LincombOperator(Operator):
         if not coeffs.any():
             R = self.range.zeros()
         else:
-            where_nonzero = list(coeffs.nonzero()[0])
-            if 0 in where_nonzero:
-                where_nonzero.pop(0)
+            where_nonzero = coeffs.nonzero()[0]
+            if where_nonzero[0]==0:
                 R = self.operators[0].apply(U, mu=mu)
                 R.scal(coeffs[0])
             else:
                 R = self.range.zeros()
-            for idx in where_nonzero:
+            for idx in where_nonzero[1:]:
                 R.axpy(coeffs[idx], self.operators[idx].apply(U, mu=mu))
         return R
 
@@ -100,9 +99,8 @@ class LincombOperator(Operator):
         if not coeffs.any():
             R = np.ndarray((1,1),buffer= np.array([0.0]))  
         else:
-            where_nonzero = list(coeffs.nonzero()[0])
-            if 0 in where_nonzero:
-                where_nonzero.pop(0)
+            where_nonzero = coeffs.nonzero()[0]
+            if where_nonzero[0]==0:
                 coeffs_dtype = reduce(np.promote_types, (type(c) for c in coeffs))
                 m = self.operators[0].apply2(V, U, mu=mu)
                 R = coeffs[0]*m
@@ -112,7 +110,7 @@ class LincombOperator(Operator):
                 common_dtype = reduce(np.promote_types, (type(c) for c in coeffs))
             if R.dtype != common_dtype:
                 R = R.astype(common_dtype)
-            for idx in where_nonzero:
+            for idx in where_nonzero[1:]:
                 m = self.operators[idx].apply2(V,U,mu=mu)
                 common_dtype = np.promote_types(common_dtype,m.dtype)
                 R += coeffs[idx]*m
@@ -125,9 +123,8 @@ class LincombOperator(Operator):
         if not coeffs.any():
             R = np.ndarray((1,1),buffer= np.array([0.0]))  
         else:
-            where_nonzero = list(coeffs.nonzero()[0])
-            if 0 in where_nonzero:
-                where_nonzero.pop(0)
+            where_nonzero = coeffs.nonzero()[0]
+            if where_nonzero[0]==0:
                 coeffs_dtype = reduce(np.promote_types, (type(c) for c in coeffs))
                 v = self.operators[0].pairwise_apply2(V, U, mu=mu)
                 R = coeffs[0]*v
@@ -137,7 +134,7 @@ class LincombOperator(Operator):
                 common_dtype = reduce(np.promote_types, (type(c) for c in coeffs))
             if R.dtype!= common_dtype:
                 R = R.astype(common_dtype)
-            for idx in where_nonzero:
+            for idx in where_nonzero[1:]:
                 v = self.operators[idx].pairwise_apply2(V, U, mu= mu)
                 common_dtype = np.promote_types(common_dtype,v.dtype)
                 R += coeffs[idx] * v
@@ -150,14 +147,13 @@ class LincombOperator(Operator):
         if not coeffs.any():
             R = self.source.zeros()
         else:
-            where_nonzero = list(coeffs.nonzero()[0])
-            if 0 in where_nonzero:
-                where_nonzero.pop(0)
+            where_nonzero = coeffs.nonzero()[0]
+            if where_nonzero[0]==0:
                 R = self.operators[0].apply_adjoint(V, mu=mu)
                 R.scal(np.conj(coeffs[0]))
             else:
                 R = self.source.zeros()
-            for idx in where_nonzero:
+            for idx in where_nonzero[1:]:
                 R.axpy(np.conj(coeffs[idx]), self.operators[idx].apply_adjoint(V, mu=mu))
         return R
 

--- a/src/pymor/operators/constructions.py
+++ b/src/pymor/operators/constructions.py
@@ -85,7 +85,7 @@ class LincombOperator(Operator):
             R = self.operators[0].apply(U, mu=mu)
             R.scal(coeffs[0])
         else:
-            R = self.range.zeros()
+            R = self.range.zeros(len(U))
         for op, c in zip(self.operators[1:], coeffs[1:]):
             if c:
                 R.axpy(c, op.apply(U, mu=mu))
@@ -127,7 +127,7 @@ class LincombOperator(Operator):
             R = self.operators[0].apply_adjoint(V, mu=mu)
             R.scal(np.conj(coeffs[0]))
         else:
-            R = self.source.zeros()
+            R = self.source.zeros(len(V))
         for op, c in zip(self.operators[1:], coeffs[1:]):
             if c:
                 R.axpy(np.conj(c), op.apply_adjoint(V, mu=mu))

--- a/src/pymor/operators/constructions.py
+++ b/src/pymor/operators/constructions.py
@@ -90,7 +90,7 @@ class LincombOperator(Operator):
                 R.scal(coeffs[0])
             else:
                 R = self.range.zeros()
-            for idx in where_nonzero[1:]:
+            for idx in where_nonzero[max(0,1-where_nonzero[0]):]:
                 R.axpy(coeffs[idx], self.operators[idx].apply(U, mu=mu))
         return R
 
@@ -110,7 +110,7 @@ class LincombOperator(Operator):
                 common_dtype = reduce(np.promote_types, (type(c) for c in coeffs))
             if R.dtype != common_dtype:
                 R = R.astype(common_dtype)
-            for idx in where_nonzero[1:]:
+            for idx in where_nonzero[max(0,1-where_nonzero[0]):]:
                 m = self.operators[idx].apply2(V,U,mu=mu)
                 common_dtype = np.promote_types(common_dtype,m.dtype)
                 R += coeffs[idx]*m
@@ -134,7 +134,7 @@ class LincombOperator(Operator):
                 common_dtype = reduce(np.promote_types, (type(c) for c in coeffs))
             if R.dtype!= common_dtype:
                 R = R.astype(common_dtype)
-            for idx in where_nonzero[1:]:
+            for idx in where_nonzero[max(0,1-where_nonzero[0]):]:
                 v = self.operators[idx].pairwise_apply2(V, U, mu= mu)
                 common_dtype = np.promote_types(common_dtype,v.dtype)
                 R += coeffs[idx] * v
@@ -153,7 +153,7 @@ class LincombOperator(Operator):
                 R.scal(np.conj(coeffs[0]))
             else:
                 R = self.source.zeros()
-            for idx in where_nonzero[1:]:
+            for idx in where_nonzero[max(0,1-where_nonzero[0]):]:
                 R.axpy(np.conj(coeffs[idx]), self.operators[idx].apply_adjoint(V, mu=mu))
         return R
 

--- a/src/pymor/operators/constructions.py
+++ b/src/pymor/operators/constructions.py
@@ -5,7 +5,6 @@
 """Module containing some constructions to obtain new operators from old ones."""
 
 from functools import reduce
-from itertools import chain
 from numbers import Number
 
 import numpy as np
@@ -94,7 +93,7 @@ class LincombOperator(Operator):
     def apply2(self, V, U, mu=None):
         coeffs = self.evaluate_coefficients(mu)
         coeffs_and_matrices = [(c, self.operators[i].apply2(V, U, mu=mu))
-                                        for i, c in enumerate(coeffs) if c]
+                               for i, c in enumerate(coeffs) if c]
         if not coeffs_and_matrices:
             return np.zeros((len(V), len(U)))
         else:
@@ -110,7 +109,7 @@ class LincombOperator(Operator):
     def pairwise_apply2(self, V, U, mu=None):
         coeffs = self.evaluate_coefficients(mu)
         coeffs_and_matrices = [(c, self.operators[i].pairwise_apply2(V, U, mu=mu))
-                                        for i, c in enumerate(coeffs) if c]
+                               for i, c in enumerate(coeffs) if c]
         if not coeffs_and_matrices:
             return np.zeros((len(V), len(U)))
         else:

--- a/src/pymor/operators/constructions.py
+++ b/src/pymor/operators/constructions.py
@@ -93,11 +93,12 @@ class LincombOperator(Operator):
 
     def apply2(self, V, U, mu=None):
         coeffs = self.evaluate_coefficients(mu)
-        try:
-            coeffs, matrices = zip(*[(c, self.operators[i].apply2(V, U, mu=mu))
-                                        for i, c in enumerate(coeffs) if c])
-        except ValueError:
+        coeffs_and_matrices = [(c, self.operators[i].apply2(V, U, mu=mu))
+                                        for i, c in enumerate(coeffs) if c]
+        if not coeffs_and_matrices:
             return np.zeros((len(V), len(U)))
+        else:
+            coeffs, matrices = zip(*coeffs_and_matrices)
         coeffs_dtype = reduce(np.promote_types, (type(c) for c in coeffs))
         matrices_dtype = reduce(np.promote_types, (m.dtype for m in matrices))
         common_dtype = np.promote_types(coeffs_dtype, matrices_dtype)
@@ -108,11 +109,12 @@ class LincombOperator(Operator):
 
     def pairwise_apply2(self, V, U, mu=None):
         coeffs = self.evaluate_coefficients(mu)
-        try:
-            coeffs, matrices = zip(*[(c, self.operators[i].pairwise_apply2(V, U, mu=mu))
-                                        for i, c in enumerate(coeffs) if c])
-        except ValueError:
+        coeffs_and_matrices = [(c, self.operators[i].pairwise_apply2(V, U, mu=mu))
+                                        for i, c in enumerate(coeffs) if c]
+        if not coeffs_and_matrices:
             return np.zeros((len(V), len(U)))
+        else:
+            coeffs, matrices = zip(*coeffs_and_matrices)
         coeffs_dtype = reduce(np.promote_types, (type(c) for c in coeffs))
         matrices_dtype = reduce(np.promote_types, (m.dtype for m in matrices))
         common_dtype = np.promote_types(coeffs_dtype, matrices_dtype)

--- a/src/pymor/operators/constructions.py
+++ b/src/pymor/operators/constructions.py
@@ -93,10 +93,10 @@ class LincombOperator(Operator):
 
     def apply2(self, V, U, mu=None):
         coeffs = self.evaluate_coefficients(mu)
-        coeffs, matrices = zip(
-            *[(c, self.operators[i].apply2(V, U, mu=mu))
-            for i, c in enumerate(coeffs) if c])
-        if not coeffs:
+        try:
+            coeffs, matrices = zip(*[(c, self.operators[i].apply2(V, U, mu=mu))
+                                        for i, c in enumerate(coeffs) if c])
+        except ValueError:
             return np.zeros((len(V), len(U)))
         coeffs_dtype = reduce(np.promote_types, (type(c) for c in coeffs))
         matrices_dtype = reduce(np.promote_types, (m.dtype for m in matrices))
@@ -108,10 +108,10 @@ class LincombOperator(Operator):
 
     def pairwise_apply2(self, V, U, mu=None):
         coeffs = self.evaluate_coefficients(mu)
-        coeffs, matrices = zip(
-            *[(c, self.operators[i].pairwise_apply2(V, U, mu=mu))
-            for i, c in enumerate(coeffs) if c])
-        if not coeffs:
+        try:
+            coeffs, matrices = zip(*[(c, self.operators[i].pairwise_apply2(V, U, mu=mu))
+                                        for i, c in enumerate(coeffs) if c])
+        except ValueError:
             return np.zeros((len(V), len(U)))
         coeffs_dtype = reduce(np.promote_types, (type(c) for c in coeffs))
         matrices_dtype = reduce(np.promote_types, (m.dtype for m in matrices))

--- a/src/pymor/operators/constructions.py
+++ b/src/pymor/operators/constructions.py
@@ -82,13 +82,13 @@ class LincombOperator(Operator):
     def apply(self, U, mu=None):
         coeffs = self.evaluate_coefficients(mu)
         if np.linalg.norm(coeffs) == 0:
-            R = NumpyVectorArray(np.ndarray((1,self.operators[0].range.dim),buffer= np.zeros(self.operators[0].range.dim)),self.operators[0].range) 
+            R = self.range.zeros()
         else:
             if coeffs[0]!= 0.0:
                 R = self.operators[0].apply(U, mu=mu)
                 R.scal(coeffs[0])
             else:
-                R = NumpyVectorArray(np.ndarray((1,self.operators[0].range.dim),buffer= np.zeros(self.operators[0].range.dim)),self.operators[0].range) 
+                R = self.range.zeros()
             for op, c in zip(self.operators[1:], coeffs[1:]):
                 if c!= 0.0:
                     R.axpy(c, op.apply(U, mu=mu))
@@ -149,13 +149,13 @@ class LincombOperator(Operator):
     def apply_adjoint(self, V, mu=None):
         coeffs = self.evaluate_coefficients(mu)
         if np.linalg.norm(coeffs) == 0:
-            R = NumpyVectorArray(np.ndarray((1,self.operators[0].source.dim),buffer= np.zeros(self.operators[0].source.dim)),self.operators[0].source) 
+            R = self.source.zeros()
         else:
             if coeffs[0]!= 0.0:
                 R = self.operators[0].apply_adjoint(V, mu=mu)
                 R.scal(np.conj(coeffs[0]))
             else:
-                R= NumpyVectorArray(np.ndarray((1,self.operators[0].source.dim),buffer= np.zeros(self.operators[0].source.dim)),self.operators[0].source) 
+                R = self.source.zeros()
             for op, c in zip(self.operators[1:], coeffs[1:]):
                 if c!= 0.0:
                     R.axpy(np.conj(c), op.apply_adjoint(V, mu=mu))

--- a/src/pymor/operators/constructions.py
+++ b/src/pymor/operators/constructions.py
@@ -17,7 +17,7 @@ from pymor.operators.interface import Operator
 from pymor.parameters.base import ParametricObject
 from pymor.parameters.functionals import ParameterFunctional, ConjugateParameterFunctional
 from pymor.vectorarrays.interface import VectorArray, VectorSpace
-from pymor.vectorarrays.numpy import NumpyVectorArray, NumpyVectorSpace
+from pymor.vectorarrays.numpy import NumpyVectorSpace
 
 
 class LincombOperator(Operator):

--- a/src/pymortests/operators.py
+++ b/src/pymortests/operators.py
@@ -79,6 +79,36 @@ def test_lincomb_op():
         assert almost_equal(pa, p.apply(vx)).all()
 
 
+def test_lincomb_op_with_zero_coefficients():
+    p1 = MonomOperator(1)
+    p2 = MonomOperator(2)
+    p10 = p1 + 0 * p2
+    p0 = 0 * p1 + 0 * p1
+    x = np.linspace(-1., 1., num=3)
+    vx = p1.source.make_array((x[:, np.newaxis]))
+
+    pc1 = NumpyMatrixOperator(np.eye(p1.source.dim))
+    pc2 = NumpyMatrixOperator(2*np.eye(p1.source.dim))
+    pc10 = pc1 + 0 * pc2
+    pc0 = 0 * pc1 + 0 * pc2
+
+    assert np.allclose(p0.apply(vx).to_numpy(), [0.])
+    assert len(p0.apply(vx)) == len(vx)
+    assert almost_equal(p10.apply(vx), p1.apply(vx)).all()
+
+    assert np.allclose(p0.apply2(vx,vx), [0.])
+    assert len(p0.apply2(vx,vx)) == len(vx)
+    assert np.allclose(p10.apply2(vx,vx), p1.apply2(vx,vx))
+
+    assert np.allclose(p0.pairwise_apply2(vx,vx), [0.])
+    assert len(p0.pairwise_apply2(vx,vx)) == len(vx)
+    assert np.allclose(p10.pairwise_apply2(vx,vx), p1.pairwise_apply2(vx,vx))
+
+    assert np.allclose(pc0.apply_adjoint(vx).to_numpy(), [0.])
+    assert len(pc0.apply_adjoint(vx)) == len(vx)
+    assert almost_equal(pc10.apply_adjoint(vx), pc1.apply_adjoint(vx)).all()
+
+
 def test_lincomb_adjoint():
     op = LincombOperator([NumpyMatrixOperator(np.eye(10)), NumpyMatrixOperator(np.eye(10))],
                          [1+3j, ExpressionParameterFunctional('c[0] + 3', {'c': 1})])


### PR DESCRIPTION
Especially while using the derivative of parameter functionals with the `d_mu()` method, it is very likely to happen that most of the evaluated coefficients in the `LincombOperator` are just zero. All operators that are multiplied by zero are thus wasted time. 
For large dimensions of the parameter space (for example 30), this would mean that we waste 29 `apply` methods (or `apply2`, `apply_adjoint`, `pairwise_apply`). Especially for high resolutions this waste of time is large. 
Thus, we propose to check the value of the coefficients before applying.   