### PR TITLE
[newton] fixed bugs with residual being exactly 0

### DIFF
--- a/src/pymor/algorithms/newton.py
+++ b/src/pymor/algorithms/newton.py
@@ -11,7 +11,7 @@ from pymor.core.logger import getLogger
 
 @defaults('miniter', 'maxiter', 'rtol', 'atol', 'relax', 'stagnation_window', 'stagnation_threshold')
 def newton(operator, rhs, initial_guess=None, mu=None, error_norm=None, least_squares=False,
-           miniter=0, maxiter=100, rtol=-1., atol=-1., relax=1.,
+           miniter=0, maxiter=100, rtol=0., atol=0., relax=1.,
            stagnation_window=3, stagnation_threshold=np.inf,
            return_stages=False, return_residuals=False):
     """Basic Newton algorithm.
@@ -99,12 +99,6 @@ def newton(operator, rhs, initial_guess=None, mu=None, error_norm=None, least_sq
 
     iteration = 0
     error_sequence = [err]
-
-    if err == 0.0:
-        logger.info(f'Initial Residual is already 0. Stopping.')
-        data['error_sequence'] = np.array(error_sequence)
-        return U, data
-
     while True:
         if iteration >= miniter:
             if err <= atol:
@@ -134,11 +128,8 @@ def newton(operator, rhs, initial_guess=None, mu=None, error_norm=None, least_sq
         residual = rhs - operator.apply(U, mu=mu)
 
         err = residual.l2_norm()[0] if error_norm is None else error_norm(residual)[0]
-        if error_sequence[-1] == 0.0:
-            logger.info(f'Iteration {iteration:2}: Residual: {err:5e}')
-        else:
-            logger.info(f'Iteration {iteration:2}: Residual: {err:5e},  '
-                        f'Reduction: {err / error_sequence[-1]:5e}, Total Reduction: {err / error_sequence[0]:5e}')
+        logger.info(f'Iteration {iteration:2}: Residual: {err:5e},  '
+                    f'Reduction: {err / error_sequence[-1]:5e}, Total Reduction: {err / error_sequence[0]:5e}')
         error_sequence.append(err)
         if not np.isfinite(err):
             raise NewtonError('Failed to converge')

--- a/src/pymor/algorithms/newton.py
+++ b/src/pymor/algorithms/newton.py
@@ -99,6 +99,12 @@ def newton(operator, rhs, initial_guess=None, mu=None, error_norm=None, least_sq
 
     iteration = 0
     error_sequence = [err]
+
+    if err == 0.0:
+        logger.info(f'Initial Residual is already 0. Stopping.')
+        data['error_sequence'] = np.array(error_sequence)
+        return U, data
+
     while True:
         if iteration >= miniter:
             if err <= atol:
@@ -128,8 +134,11 @@ def newton(operator, rhs, initial_guess=None, mu=None, error_norm=None, least_sq
         residual = rhs - operator.apply(U, mu=mu)
 
         err = residual.l2_norm()[0] if error_norm is None else error_norm(residual)[0]
-        logger.info(f'Iteration {iteration:2}: Residual: {err:5e},  '
-                    f'Reduction: {err / error_sequence[-1]:5e}, Total Reduction: {err / error_sequence[0]:5e}')
+        if error_sequence[-1] == 0.0:
+            logger.info(f'Iteration {iteration:2}: Residual: {err:5e}')
+        else:
+            logger.info(f'Iteration {iteration:2}: Residual: {err:5e},  '
+                        f'Reduction: {err / error_sequence[-1]:5e}, Total Reduction: {err / error_sequence[0]:5e}')
         error_sequence.append(err)
         if not np.isfinite(err):
             raise NewtonError('Failed to converge')

--- a/src/pymortests/algorithms/stuff.py
+++ b/src/pymortests/algorithms/stuff.py
@@ -13,10 +13,10 @@ from pymortests.base import runmodule
 from pymortests.fixtures.operator import MonomOperator
 
 
-def _newton(order, **kwargs):
+def _newton(order, initial_value=1.0, **kwargs):
     mop = MonomOperator(order)
     rhs = NumpyVectorSpace.from_numpy([0.0])
-    guess = NumpyVectorSpace.from_numpy([1.0])
+    guess = NumpyVectorSpace.from_numpy([initial_value])
     return newton(mop, rhs, initial_guess=guess, **kwargs)
 
 
@@ -29,6 +29,11 @@ def test_newton(order):
 def test_newton_fail():
     with pytest.raises(NewtonError):
         _ = _newton(0, maxiter=10, stagnation_threshold=np.inf)
+
+
+def test_newton_residual_is_zero(order=5):
+    U, _ = _newton(order, initial_value=0.0)
+    assert float_cmp(U.to_numpy(), 0.0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Addresses #927.

This merge request fixes a bug that occurred when the residual in the Newton algorithm becomes exactly 0.