### PR TITLE
[parameters/functionals] Add derivative of products

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -19,6 +19,7 @@
     * second order derivatives for parameters
     * speed up of lincomb operators
     * add LincombParameterFunctional
+    * pruduct rule for ProductParameterFunctional
 
 * Luca Mechelli, luca.mechelli@uni-konstanz.de
     * speed up of lincomb operators

--- a/src/pymor/parameters/functionals.py
+++ b/src/pymor/parameters/functionals.py
@@ -292,10 +292,10 @@ class ProductParameterFunctional(ParameterFunctional):
                 summands[i].append(f.d_mu(component, index))
             else:
                 summands[i].append(0)
-            for index in indices: 
-                if index != i:
-                    summands[index].append(f)
-        non_zero_parts = []
+            for idx in indices:
+                if idx != i:
+                    summands[idx].append(f)
+        non_zero_summands = []
         trigger = 0
         for i, summand in enumerate(summands):
             if 0 not in summand:
@@ -306,13 +306,13 @@ class ProductParameterFunctional(ParameterFunctional):
                 if trigger:
                     trigger = 0
                     continue
-                non_zero_parts.append(i)
-        if len(non_zero_parts) == 0:
+                non_zero_summands.append(summand)
+        if not non_zero_summands:
             return ConstantParameterFunctional(0, name=self.name + '_d_mu')
-        elif len(non_zero_parts) == 1:
-            return self.with_(factors = summands[non_zero_parts[0]], name=self.name + '_d_mu')
         else:
-            raise NotImplementedError
+            return LincombParameterFunctional(functionals=[self.with_(factors=summand) for summand in non_zero_summands],
+                    coefficients=[1 for summand in non_zero_summands], name=self.name + '_d_mu')
+
 
 
 class ConjugateParameterFunctional(ParameterFunctional):

--- a/src/pymor/parameters/functionals.py
+++ b/src/pymor/parameters/functionals.py
@@ -310,8 +310,7 @@ class ProductParameterFunctional(ParameterFunctional):
         if not non_zero_summands:
             return ConstantParameterFunctional(0, name=self.name + '_d_mu')
         else:
-            return LincombParameterFunctional(functionals=[self.with_(factors=summand) for summand in non_zero_summands],
-                    coefficients=[1 for summand in non_zero_summands], name=self.name + '_d_mu')
+            return LincombParameterFunctional(summands, [1] * len(summands), name=self.name + '_d_mu')
 
 
 

--- a/src/pymor/parameters/functionals.py
+++ b/src/pymor/parameters/functionals.py
@@ -294,8 +294,9 @@ class ProductParameterFunctional(ParameterFunctional):
         if sum_of_parametric == 0:
             return ConstantParameterFunctional(0, name=self.name + '_d_mu')
         elif sum_of_parametric == 1:
-            return self.factors[at].d_mu(component, index) * self.with_(factors = [f for f in self.factors if not
-                                                                                   isinstance(f, ParameterFunctional)])
+            factors = [self.factors[at].d_mu(component, index)]
+            factors.extend([f for f in self.factors if not isinstance(f ,ParameterFunctional)])
+            return self.with_(factors = factors)
         else:
             raise NotImplementedError
 

--- a/src/pymor/parameters/functionals.py
+++ b/src/pymor/parameters/functionals.py
@@ -296,7 +296,7 @@ class ProductParameterFunctional(ParameterFunctional):
             summands.append(
                 ProductParameterFunctional([f_d_mu if j == i else g for j, g in enumerate(self.factors)])
             )
-        if summands:
+        if not summands:
             return ConstantParameterFunctional(0, name=self.name + '_d_mu')
         else:
             return LincombParameterFunctional(summands, [1] * len(summands), name=self.name + '_d_mu')

--- a/src/pymor/parameters/functionals.py
+++ b/src/pymor/parameters/functionals.py
@@ -284,18 +284,16 @@ class ProductParameterFunctional(ParameterFunctional):
         assert self.parameters.assert_compatible(mu)
         return np.array([f.evaluate(mu) if hasattr(f, 'evaluate') else f for f in self.factors]).prod()
 
-    def d_mu(self, component, index=()):
-        sum_of_parametric = 0
-        at = 0
+    def d_mu(self, component, index=0):
+        parametric_at = []
         for i, f in enumerate(self.factors):
-            if isinstance(f, ParameterFunctional):
-                sum_of_parametric += 1
-                at = i
-        if sum_of_parametric == 0:
+            if hasattr(f, 'evaluate'):
+                parametric_at.append(i)
+        if len(parametric_at) == 0:
             return ConstantParameterFunctional(0, name=self.name + '_d_mu')
-        elif sum_of_parametric == 1:
-            factors = [self.factors[at].d_mu(component, index)]
-            factors.extend([f for f in self.factors if not isinstance(f ,ParameterFunctional)])
+        elif len(parametric_at) == 1:
+            factors = [self.factors[parametric_at[0]].d_mu(component, index)]
+            factors.extend([f for f in self.factors if not hasattr(f , 'evaluate')])
             return self.with_(factors = factors)
         else:
             raise NotImplementedError

--- a/src/pymor/parameters/functionals.py
+++ b/src/pymor/parameters/functionals.py
@@ -294,7 +294,7 @@ class ProductParameterFunctional(ParameterFunctional):
         elif len(parametric_at) == 1:
             factors = [self.factors[parametric_at[0]].d_mu(component, index)]
             factors.extend([f for f in self.factors if not hasattr(f , 'evaluate')])
-            return self.with_(factors = factors)
+            return self.with_(factors = factors, name=self.name + '_d_mu')
         else:
             raise NotImplementedError
 

--- a/src/pymor/parameters/functionals.py
+++ b/src/pymor/parameters/functionals.py
@@ -284,6 +284,21 @@ class ProductParameterFunctional(ParameterFunctional):
         assert self.parameters.assert_compatible(mu)
         return np.array([f.evaluate(mu) if hasattr(f, 'evaluate') else f for f in self.factors]).prod()
 
+    def d_mu(self, component, index=()):
+        sum_of_parametric = 0
+        at = 0
+        for i, f in enumerate(self.factors):
+            if isinstance(f, ParameterFunctional):
+                sum_of_parametric += 1
+                at = i
+        if sum_of_parametric == 0:
+            return ConstantParameterFunctional(0, name=self.name + '_d_mu')
+        elif sum_of_parametric == 1:
+            return self.factors[at].d_mu(component, index) * self.with_(factors = [f for f in self.factors if not
+                                                                                   isinstance(f, ParameterFunctional)])
+        else:
+            raise NotImplementedError
+
 
 class ConjugateParameterFunctional(ParameterFunctional):
     """Conjugate of a given |ParameterFunctional|

--- a/src/pymortests/mu_derivatives.py
+++ b/src/pymortests/mu_derivatives.py
@@ -99,6 +99,60 @@ def test_ExpressionParameterFunctional():
     assert hes_nu_nu == -0
 
 
+def test_ProductParameterFunctional():
+    pf = ProjectionParameterFunctional('mu', 2, 0)
+    mu = Mu({'mu': (10,2)})
+    productf = pf * 2 * 3
+
+    derivative_to_first_index = productf.d_mu('mu', 0)
+    derivative_to_second_index = productf.d_mu('mu', 1)
+
+    second_derivative_first_first = productf.d_mu('mu', 0).d_mu('mu', 0)
+    second_derivative_first_second = productf.d_mu('mu', 0).d_mu('mu', 1)
+    second_derivative_second_first = productf.d_mu('mu', 1).d_mu('mu', 0)
+    second_derivative_second_second = productf.d_mu('mu', 1).d_mu('mu', 1)
+
+    der_mu_1 = derivative_to_first_index.evaluate(mu)
+    der_mu_2 = derivative_to_second_index.evaluate(mu)
+
+    hes_mu_1_mu_1 = second_derivative_first_first.evaluate(mu)
+    hes_mu_1_mu_2 = second_derivative_first_second.evaluate(mu)
+    hes_mu_2_mu_1 = second_derivative_second_first.evaluate(mu)
+    hes_mu_2_mu_2 = second_derivative_second_second.evaluate(mu)
+
+    assert der_mu_1 == 2 * 3
+    assert der_mu_2 == 0
+    assert hes_mu_1_mu_1 == 0
+    assert hes_mu_1_mu_2 == 0
+    assert hes_mu_2_mu_1 == 0
+    assert hes_mu_2_mu_2 == 0
+
+    dict_of_d_mus = {'mu': ['2*mu']}
+
+    dict_of_second_derivative = {'mu': [{'mu': ['2']}]}
+
+    epf = ExpressionParameterFunctional('mu**2',
+                                        {'mu': 1},
+                                        'functional_with_derivative_and_second_derivative',
+                                        dict_of_d_mus, dict_of_second_derivative)
+
+    productf = epf * 2
+    mu = Mu({'mu': 3})
+
+    derivative_to_first_index = productf.d_mu('mu')
+
+    second_derivative_first_first = productf.d_mu('mu').d_mu('mu')
+
+    der_mu = derivative_to_first_index.evaluate(mu)
+
+    hes_mu_mu = second_derivative_first_first.evaluate(mu)
+
+    assert productf.evaluate(mu) == 2 * 3 ** 2
+    assert der_mu == 2 * 2 * 3
+    assert hes_mu_mu == 2 * 2
+
+    pp = productf * productf
+
 def test_d_mu_of_LincombOperator():
     dict_of_d_mus = {'mu': ['100', '2 * mu[0]'], 'nu': ['cos(nu[0])']}
 


### PR DESCRIPTION
If the `ProductParameterFunctional` is simply a number times a `ParameterFunctional`, we can easily compute the `d_mu` for this. However, it is required to automatically detect this case. So, we first count the actual number of `ParameterFunctional`s in the product and compute the derivative in case, there is only one  `ParameterFunctional` . 
With this code, one can then go ahead and implement product rules and generalizations for more parameters, if needed. 