### PR TITLE
Add initial_guess parameter to apply_inverse

### DIFF
--- a/src/pymor/algorithms/timestepping.py
+++ b/src/pymor/algorithms/timestepping.py
@@ -171,7 +171,7 @@ def implicit_euler(A, F, M, U0, t0, t1, nt, mu=None, num_values=None, solver_opt
             dt_F = F.as_vector(mu) * dt
         if F:
             rhs += dt_F
-        U = M_dt_A.apply_inverse(rhs, mu=mu)
+        U = M_dt_A.apply_inverse(rhs, mu=mu, initial_guess=U)
         while t - t0 + (min(dt, DT) * 0.5) >= len(R) * DT:
             R.append(U)
 

--- a/src/pymor/bindings/fenics.py
+++ b/src/pymor/bindings/fenics.py
@@ -185,10 +185,12 @@ if config.HAVE_FENICS:
             self.matrix.transpmult(v.impl, r.impl)
             return r
 
-        def _real_apply_inverse_one_vector(self, v, mu=None, least_squares=False, prepare_data=None):
+        def _real_apply_inverse_one_vector(self, v, mu=None, initial_guess=None,
+                                           least_squares=False, prepare_data=None):
             if least_squares:
                 raise NotImplementedError
-            r = self.source.real_zero_vector()
+            r = (self.source.real_zero_vector() if initial_guess is None else
+                 initial_guess.copy(deep=True))
             options = self.solver_options.get('inverse') if self.solver_options else None
             _apply_inverse(self.matrix, r.impl, v.impl, options)
             return r

--- a/src/pymor/bindings/ngsolve.py
+++ b/src/pymor/bindings/ngsolve.py
@@ -134,7 +134,8 @@ if config.HAVE_NGSOLVE:
             mat.Mult(v.impl.vec, u.impl.vec)
             return u
 
-        def _real_apply_inverse_one_vector(self, v, mu=None, least_squares=False, prepare_data=None):
+        def _real_apply_inverse_one_vector(self, v, mu=None, initial_guess=None,
+                                           least_squares=False, prepare_data=None):
             inv = prepare_data
             r = self.source.real_zero_vector()
             r.impl.vec.data = inv * v.impl.vec

--- a/src/pymor/bindings/pyamg.py
+++ b/src/pymor/bindings/pyamg.py
@@ -152,17 +152,22 @@ if config.HAVE_PYAMG:
                                 'maxiter': sa_maxiter}}
 
     @defaults('check_finite', 'default_solver')
-    def apply_inverse(op, V, options=None, least_squares=False, check_finite=True, default_solver='pyamg_solve'):
+    def apply_inverse(op, V, initial_guess=None, options=None, least_squares=False,
+                      check_finite=True, default_solver='pyamg_solve'):
         """Solve linear equation system.
 
-        Applies the inverse of `op` to the vectors in `rhs` using PyAMG.
+        Applies the inverse of `op` to the vectors in `V` using PyAMG.
 
         Parameters
         ----------
         op
             The linear, non-parametric |Operator| to invert.
-        rhs
+        V
             |VectorArray| of right-hand sides for the equation system.
+        initial_guess
+            |VectorArray| with the same length as `V` containing initial guesses
+            for the solution.  Some implementations of `apply_inverse` may
+            ignore this parameter.  If `None` a solver-dependent default is used.
         options
             The |solver_options| to use (see :func:`solver_options`).
         least_squares
@@ -178,6 +183,7 @@ if config.HAVE_PYAMG:
         """
 
         assert V in op.range
+        assert initial_guess is None or initial_guess in op.source and len(initial_guess) == len(V)
 
         if least_squares:
             raise NotImplementedError

--- a/src/pymor/operators/mpi.py
+++ b/src/pymor/operators/mpi.py
@@ -133,21 +133,29 @@ class MPIOperator(Operator):
         else:
             return mpi.call(mpi.method_call, self.obj_id, 'apply_adjoint', V, mu=mu)
 
-    def apply_inverse(self, V, mu=None, least_squares=False):
+    def apply_inverse(self, V, mu=None, initial_guess=None, least_squares=False):
         if not self.mpi_source or not self.mpi_range:
             raise NotImplementedError
         assert V in self.range
+        assert initial_guess is None or initial_guess in self.source and len(initial_guess) == len(V)
         assert self.parameters.assert_compatible(mu)
         return self.source.make_array(mpi.call(mpi.method_call_manage, self.obj_id, 'apply_inverse',
-                                               V.obj_id, mu=mu, least_squares=least_squares))
+                                               V.obj_id, mu=mu,
+                                               initial_guess=(initial_guess.obj_id if initial_guess is not None
+                                                              else None),
+                                               least_squares=least_squares))
 
-    def apply_inverse_adjoint(self, U, mu=None, least_squares=False):
+    def apply_inverse_adjoint(self, U, mu=None, initial_guess=None, least_squares=False):
         if not self.mpi_source or not self.mpi_range:
             raise NotImplementedError
         assert U in self.source
+        assert initial_guess is None or initial_guess in self.range and len(initial_guess) == len(U)
         assert self.parameters.assert_compatible(mu)
         return self.source.make_array(mpi.call(mpi.method_call_manage, self.obj_id, 'apply_inverse_adjoint',
-                                               U.obj_id, mu=mu, least_squares=least_squares))
+                                               U.obj_id, mu=mu,
+                                               initial_guess=(initial_guess.obj_id if initial_guess is not None
+                                                              else None),
+                                               least_squares=least_squares))
 
     def jacobian(self, U, mu=None):
         assert U in self.source

--- a/src/pymortests/fixtures/operator.py
+++ b/src/pymortests/fixtures/operator.py
@@ -29,7 +29,7 @@ class MonomOperator(Operator):
     def jacobian(self, U, mu=None):
         return MonomOperator(self.order - 1, self.derivative)
 
-    def apply_inverse(self, V, mu=None, least_squares=False):
+    def apply_inverse(self, V, mu=None, initial_guess=None, least_squares=False):
         return self.range.make_array(1. / V.to_numpy())
 
 


### PR DESCRIPTION
and apply_inverse_adjoint.

It is used in the following places:

- `Operator.apply_inverse` passes `initial_guess` to `newton` in case of a nonlinear operator.
- Generic `lgmres`, as well as SciPy `bicgstab`, `lgmres`, `lsmr`, `lsqr`.
- The FEniCS bindings pass `initial_guess` to the backend.
- `implicit_euler` sets `initial_guess` to the solution of the last time step.

Fixes #924.