### PR TITLE
Simplify debugging of RuleTables

### DIFF
--- a/src/pymor/algorithms/rules.py
+++ b/src/pymor/algorithms/rules.py
@@ -165,15 +165,7 @@ class RuleTableMeta(UberMeta):
         return super().__new__(cls, name, parents, dct)
 
     def __repr__(cls):
-        rows = [['Pos', 'Match Type', 'Condition', 'Action Name / Action Description', 'Stop']]
-        for i, r in enumerate(cls.rules):
-            for ii in range(r.num_rules):
-                rows.append(['' if ii else str(i),
-                             r.condition_type,
-                             r.condition_description,
-                             '' if ii else r.action_description])
-                r = r.next_rule
-        return format_table(rows)
+        return format_rules(cls.rules)
 
     def __getitem__(cls, idx):
         return cls.rules[idx]
@@ -340,6 +332,9 @@ class RuleTable(BasicObject, metaclass=RuleTableMeta):
                 pass
         return children
 
+    def __repr__(self):
+        return super().__repr__() + "\n\n" + format_rules(self.rules)
+
 
 def print_children(obj):
     def build_tree(obj):
@@ -361,3 +356,19 @@ def print_children(obj):
     except ImportError:
         from pprint import pprint
         pprint({obj.name: build_tree(obj)})
+
+
+def format_rules(rules):
+    rows = [['Pos', 'Match Type', 'Condition', 'Action Name / Action Description', 'Stop']]
+    for i, r in enumerate(rules):
+        for ii in range(r.num_rules):
+            rows.append(['' if ii else str(i),
+                         r.condition_type,
+                         r.condition_description,
+                         '' if ii else r.action_description])
+            r = r.next_rule
+    return format_table(rows)
+
+
+def print_rules(rules):
+    print(format_rules(rules))


### PR DESCRIPTION
This pull request contains some minor improvements to the `RuleTable` mechanism to make it easier to debug:

- Fix the `repr` of `RuleTable` instances to also print a summary of all rules. So when I am with the debugger in `RuleTable.apply` I can just write `print(self)` to get a table of all rules. `print_rules(failed_rules)` will give me a summary of all rules which have failed to apply so far.
- Refactor `RuleTable.apply` to make it faster to step through with a debugger.
- Provide hooks to set conditional breakpoints for `RuleTable.apply`. For instance I can now write
  ```python
  from pymor.algorithms.projection import ProjectRules
  ProjectRules.breakpoint_for_obj(fom.operator)
  ProjectRules.breakpoint_for_name('diffusion')
  ```
  This will cause `ProjectRule.apply` to break when it encounters `fom.operator` or an object with name 'diffusion'.

Fixes #546.