### PR TITLE
Fix non-hom. Dirichlet BC for parabolic MOR demo

### DIFF
--- a/src/pymor/discretizers/builtin/cg.py
+++ b/src/pymor/discretizers/builtin/cg.py
@@ -1270,6 +1270,11 @@ def discretize_instationary_cg(analytical_problem, diameter=None, domain_discret
 
     p = analytical_problem
 
+    if p.stationary_part.dirichlet_data is not None and 't' in p.stationary_part.dirichlet_data.parameters:
+        # we choose both mass and operator to be invertible.
+        # this leads to wrong results when the dirichlet values depend on time.
+        raise NotImplementedError('Time-dependent Dirichlet values not supported.')
+
     m, data = discretize_stationary_cg(p.stationary_part, diameter=diameter, domain_discretizer=domain_discretizer,
                                        grid_type=grid_type, grid=grid, boundary_info=boundary_info)
 

--- a/src/pymordemos/parabolic_mor.py
+++ b/src/pymordemos/parabolic_mor.py
@@ -175,10 +175,9 @@ def _discretize_fenics():
     # assemble matrices and vectors
     l2_mat = df.assemble(df.inner(u, v) * df.dx)
     l2_0_mat = l2_mat.copy()
+    mass_mat = l2_0_mat.copy()
     h1_mat = df.assemble(df.inner(df.nabla_grad(u), df.nabla_grad(v)) * df.dx)
     h1_0_mat = h1_mat.copy()
-    mat0 = h1_mat.copy()
-    mat0.zero()
     bottom_mat = df.assemble(bottom_diffusion * df.inner(df.nabla_grad(u), df.nabla_grad(v)) * df.dx)
     top_mat = df.assemble(top_diffusion * df.inner(df.nabla_grad(u), df.nabla_grad(v)) * df.dx)
     u0 = df.project(initial_data, V).vector()
@@ -191,8 +190,8 @@ def _discretize_fenics():
 
     bc = df.DirichletBC(V, df.Constant(0.), dirichlet_boundary)
     bc.apply(l2_0_mat)
+    bc.zero(mass_mat)
     bc.apply(h1_0_mat)
-    bc.apply(mat0)
     bc.zero(bottom_mat)
     bc.zero(top_mat)
     bc.apply(f)
@@ -208,18 +207,16 @@ def _discretize_fenics():
 
         initial_data=FenicsVectorSpace(V).make_array([u0]),
 
-        operator=LincombOperator([FenicsMatrixOperator(mat0, V, V),
-                                  FenicsMatrixOperator(h1_0_mat, V, V),
+        operator=LincombOperator([FenicsMatrixOperator(h1_0_mat, V, V),
                                   FenicsMatrixOperator(bottom_mat, V, V),
                                   FenicsMatrixOperator(top_mat, V, V)],
                                  [1.,
-                                  1.,
                                   100. - 1.,
                                   ExpressionParameterFunctional('top[0] - 1.', {'top': 1})]),
 
         rhs=VectorOperator(FenicsVectorSpace(V).make_array([f])),
 
-        mass=FenicsMatrixOperator(l2_0_mat, V, V, name='l2'),
+        mass=FenicsMatrixOperator(mass_mat, V, V, name='mass'),
 
         products={'l2': FenicsMatrixOperator(l2_mat, V, V, name='l2'),
                   'l2_0': FenicsMatrixOperator(l2_0_mat, V, V, name='l2_0'),


### PR DESCRIPTION
Two issues were cleared:
  1.) With mat0 and h0_1_mat, two matrices had identity for Dirichlet DOFs, i.e. mat0 was dispensable.
  2.) A new mass matrix was generated with zero rows for the Dirichlet DOFs respecting the algebraic equations in time-integration.
The issue can be tested by shifting the Dirichlet BC and the initial value by one
```
bc = df.DirichletBC(V, df.Constant(1.), dirichlet_boundary)
u0 = df.project(initial_data, V).vector() + 1
```
and looking at the Dirichlet values with 'Plot over line' in Paraview