### PR TITLE
[parameters/functionals] Add LincombParameterFunctional

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -18,6 +18,7 @@
 * Tim Keil, tim.keil@uni-muenster.de
     * second order derivatives for parameters
     * speed up of lincomb operators
+    * add LincombParameterFunctional
 
 * Luca Mechelli, luca.mechelli@uni-konstanz.de
     * speed up of lincomb operators

--- a/src/pymor/parameters/functionals.py
+++ b/src/pymor/parameters/functionals.py
@@ -46,11 +46,14 @@ class ParameterFunctional(ParametricObject):
         return self.evaluate(mu)
 
     def __add__(self, other):
-        if isinstance(other, Number) and other == 0:
-            return self
-        elif not isinstance(other, ParameterFunctional):
+        if isinstance(other, Number):
+            if other == 0:
+                return self
             other = ConstantParameterFunctional(other)
-        return LincombParameterFunctional([self, other], [1., 1.])
+        if isinstance(other, ParameterFunctional):
+            return LincombParameterFunctional([self, other], [1., 1.])
+        else:
+            return NotImplemented        
 
     __radd__ = __add__
 

--- a/src/pymor/parameters/functionals.py
+++ b/src/pymor/parameters/functionals.py
@@ -64,11 +64,9 @@ class ParameterFunctional(ParametricObject):
             return self + (- other)
 
     def __mul__(self, other):
-        if isinstance(other, Number):
-            return LincombParameterFunctional([self], [other])
-        if isinstance(other, ParameterFunctional):
-            return ProductParameterFunctional([self, other])
-        return NotImplemented
+        if not isinstance(other, (Number, ParameterFunctional)):
+            return NotImplemented
+        return ProductParameterFunctional([self, other])
 
     __rmul__ = __mul__
 

--- a/src/pymor/parameters/functionals.py
+++ b/src/pymor/parameters/functionals.py
@@ -334,7 +334,7 @@ class ConstantParameterFunctional(ParameterFunctional):
 class LincombParameterFunctional(ParameterFunctional):
     """A |ParameterFunctional| representing a linear combination of |ParameterFunctionals|.
 
-    The coefficients must be provided as scalars or as.
+    The coefficients must be provided as scalars.
 
     Parameters
     ----------
@@ -356,6 +356,8 @@ class LincombParameterFunctional(ParameterFunctional):
         assert len(functionals) == len(coefficients)
         assert all(isinstance(f, ParameterFunctional) for f in functionals)
         assert all(isinstance(c, Number) for c in coefficients)
+        functionals = tuple(functionals)
+        coefficients = tuple(coefficients)
         self.__auto_init(locals())
 
     def evaluate(self, mu=None):

--- a/src/pymor/parameters/functionals.py
+++ b/src/pymor/parameters/functionals.py
@@ -314,6 +314,42 @@ class ConstantParameterFunctional(ParameterFunctional):
         return self.with_(constant_value=0, name=self.name + '_d_mu')
 
 
+class LincombParameterFunctional(ParameterFunctional):
+    """A |ParameterFunctional| representing a linear combination of |ParameterFunctionals|.
+
+    The coefficients must be provided as scalars or as.
+
+    Parameters
+    ----------
+    functionals
+        List of |ParameterFunctionals| whose linear combination is formed.
+    coefficients
+        A list of scalar coefficients.
+    name
+        Name of the functionial.
+
+    Attributes
+    ----------
+    functionals
+    coefficients
+    """
+
+    def __init__(self, functionals, coefficients, name=None):
+        assert len(functionals) > 0
+        assert len(functionals) == len(coefficients)
+        assert all(isinstance(f, ParameterFunctional) for f in functionals)
+        assert all(isinstance(c, Number) for c in coefficients)
+        self.__auto_init(locals())
+
+    def evaluate(self, mu=None):
+        assert self.parameters.assert_compatible(mu)
+        return sum(c * f(mu) for c, f in zip(self.coefficients, self.functionals))
+
+    def d_mu(self, parameter, index=0):
+        functionals_d_mu = [f.d_mu(parameter, index) for f in self.functionals]
+        return self.with_(functionals=functionals_d_mu, name=self.name + '_d_mu')
+
+
 class MinThetaParameterFunctional(ParameterFunctional):
     """|ParameterFunctional| implementing the min-theta approach from [Haa17]_ (Proposition 2.35).
 

--- a/src/pymor/parameters/functionals.py
+++ b/src/pymor/parameters/functionals.py
@@ -45,11 +45,27 @@ class ParameterFunctional(ParametricObject):
     def __call__(self, mu=None):
         return self.evaluate(mu)
 
+    def __add__(self, other):
+        if isinstance(other, Number) and other == 0:
+            return self
+        elif not isinstance(other, ParameterFunctional):
+            other = ConstantParameterFunctional(other)
+        return LincombParameterFunctional([self, other], [1., 1.])
+
+    __radd__ = __add__
+
+    def __sub__(self, other):
+        if isinstance(other, ParameterFunctional):
+            return LincombParameterFunctional([self, other], [1., -1.])
+        else:
+            return self + (- other)
+
     def __mul__(self, other):
-        from pymor.parameters.functionals import ProductParameterFunctional
-        if not isinstance(other, (Number, ParameterFunctional)):
-            return NotImplemented
-        return ProductParameterFunctional([self, other])
+        if isinstance(other, Number):
+            return LincombParameterFunctional([self], [other])
+        if isinstance(other, ParameterFunctional):
+            return ProductParameterFunctional([self, other])
+        return NotImplemented
 
     __rmul__ = __mul__
 

--- a/src/pymor/parameters/functionals.py
+++ b/src/pymor/parameters/functionals.py
@@ -342,7 +342,7 @@ class LincombParameterFunctional(ParameterFunctional):
     coefficients
         A list of scalar coefficients.
     name
-        Name of the functionial.
+        Name of the functional.
 
     Attributes
     ----------

--- a/src/pymortests/parameter_functionals.py
+++ b/src/pymortests/parameter_functionals.py
@@ -1,0 +1,39 @@
+# This file is part of the pyMOR project (http://www.pymor.org).
+# Copyright 2013-2020 pyMOR developers and contributors. All rights reserved.
+# License: BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+
+from pymortests.base import runmodule
+import pytest
+
+import numpy as np
+
+from pymor.parameters.functionals import ProjectionParameterFunctional, ExpressionParameterFunctional, LincombParameterFunctional
+from pymor.basic import Mu
+
+
+def test_LincombParameterFunctional():
+    dict_of_d_mus = {'mu': ['200 * mu[0]', '2 * mu[0]'], 'nu': ['cos(nu[0])']}
+
+    epf = ExpressionParameterFunctional('100 * mu[0]**2 + 2 * mu[1] * mu[0] + sin(nu[0])',
+                                        {'mu': 2, 'nu': 1},
+                                        'functional_with_derivative_and_second_derivative',
+                                        dict_of_d_mus)
+    pf = ProjectionParameterFunctional('mu', 2, 0)
+    mu = Mu({'mu': [10,2], 'nu': [3]})
+
+    zero = pf - pf 
+    two_pf = pf + pf
+    three_pf = pf + 2*pf
+    pf_plus_one = pf + 1
+    sum_ = epf + pf 
+    pf_squared =  (pf + 2*epf) * (pf - 2*epf) + 4 * epf * epf  
+
+    assert zero(mu) == 0
+    assert two_pf(mu) == 2 * pf(mu)
+    assert three_pf(mu) == 3 * pf(mu)
+    assert pf_plus_one(mu) == pf(mu) + 1
+    assert sum_(mu) == epf(mu) + pf(mu)
+    assert pf_squared(mu) == pf(mu) * pf(mu)
+    assert sum_.d_mu('mu', 0)(mu) == epf.d_mu('mu', 0)(mu) + pf.d_mu('mu', 0)(mu)
+    assert sum_.d_mu('mu', 1)(mu) == epf.d_mu('mu', 1)(mu) + pf.d_mu('mu', 1)(mu)
+    assert sum_.d_mu('nu', 0)(mu) == epf.d_mu('nu', 0)(mu) + pf.d_mu('nu', 0)(mu)


### PR DESCRIPTION
This PR implements a `LincombParameterFunctional`. 
Moreover this enables to use + and - operators for `ParameterFunctional.` Moreover, it is now possible to multiply `ParameterFunctional` by numbers. 

Also, a small test is added to a new file. (Didn't we have a test file for parameters/functionals.py yet?) 

This PR is of much interest for the product rule in https://github.com/pymor/pymor/pull/934