### PR TITLE
add BaseMaxThetaParameterFunctional to generalize max-theta approach 

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -17,12 +17,13 @@
 
 * Tim Keil, tim.keil@uni-muenster.de
     * second order derivatives for parameters
-    * speed up of lincomb operators
+    * speed up of LincombOperators
     * add LincombParameterFunctional
     * pruduct rule for ProductParameterFunctional
+    * BaseMaxThetaParameterFunctional
 
 * Luca Mechelli, luca.mechelli@uni-konstanz.de
-    * speed up of lincomb operators
+    * speed up of LincombOperators
 
 * Hendrik Kleikamp, hendrik.kleikamp@uni-muenster.de
     * Armijo line search algorithm

--- a/src/pymor/parameters/functionals.py
+++ b/src/pymor/parameters/functionals.py
@@ -476,12 +476,12 @@ class BaseMaxThetaParameterFunctional(ParameterFunctional):
     Given a list of the thetas, the |parameter values| mu_bar and the constant gamma_mu_bar, this functional thus evaluates
     to ::
 
-      |gamma_mu_bar * max{q = 1}^Q theta_prime_q(mu)/theta_q(mu_bar)|
+      |gamma_mu_bar * max_{q = 1}^Q theta_prime_q(mu)/theta_q(mu_bar)|
 
     Note that we also get an upper bound if theta_prime_q(mu) == 0 for any q. However, if theta_prime_q(mu) == 0 for
-    at least one q, we need to use the absolute value in the denominator, i.e.
+    at least one q, we need to use the absolute value in the denominator, i.e. ::
 
-      |gamma_mu_bar * max{q = 1}^Q theta_prime_q(mu)/|theta_q(mu_bar)||
+      |gamma_mu_bar * max_{q = 1}^Q theta_prime_q(mu)/|theta_q(mu_bar)| |
 
     Parameters
     ----------

--- a/src/pymortests/min_max_theta_functionals.py
+++ b/src/pymortests/min_max_theta_functionals.py
@@ -4,6 +4,7 @@ from pymor.parameters.functionals import (
         ConstantParameterFunctional,
         ExpressionParameterFunctional,
         MinThetaParameterFunctional,
+        BaseMaxThetaParameterFunctional,
         MaxThetaParameterFunctional,
         ParameterFunctional)
 from pymortests.base import runmodule
@@ -47,6 +48,28 @@ def test_max_theta_parameter_functional():
     mu = theta.parameters.parse(1)
     mu_bar = theta.parameters.parse(mu_bar)
     expected_value = gamma_mu_bar * np.abs(np.max(np.array([t(mu) for t in thetas])/np.array([t(mu_bar) for t in
+        thetas])))
+    actual_value = theta.evaluate(mu)
+    assert expected_value == actual_value
+
+
+def test_base_max_theta_parameter_functional():
+    thetas = (ExpressionParameterFunctional('2*mu[0]', {'mu': 1}, derivative_expressions={'mu': ['2']}),
+              ConstantParameterFunctional(1))
+
+    # theta prime can for example be the derivatives of all theta
+    thetas_prime = tuple([theta.d_mu('mu', 0) for theta in thetas])
+
+    mu_bar = -3
+    gamma_mu_bar = 10
+    theta = BaseMaxThetaParameterFunctional(thetas_prime, thetas, mu_bar, gamma_mu_bar)
+    thetas = [ConstantParameterFunctional(t) if not isinstance(t, ParameterFunctional) else t
+              for t in thetas]
+    thetas_prime = [ConstantParameterFunctional(t) if not isinstance(t, ParameterFunctional) else t
+              for t in thetas_prime]
+    mu = theta.parameters.parse(1)
+    mu_bar = theta.parameters.parse(mu_bar)
+    expected_value = gamma_mu_bar * np.abs(np.max(np.array([t(mu) for t in thetas_prime])/np.array([np.abs(t(mu_bar)) for t in
         thetas])))
     actual_value = theta.evaluate(mu)
     assert expected_value == actual_value


### PR DESCRIPTION
As discussed in https://github.com/pymor/pymor/issues/935 and first proposed in https://github.com/pymor/pymor/pull/861 , we can add a generalization for the max theta approach.  

This is a generalization of the max theta approach from https://github.com/pymor/pymor/pull/861 . It introduces a lower bound for a bilinear form which reads

gamma_UB_new(mu) = gamma_mu_bar * max{q = 1}^Q theta_prime_q(mu)/theta_q(mu_bar).

This enables to bound the continuity with the continuity constants of a bilinear form which has the same affine decomposition and only differs in terms of 'theta_q'. Note that before it was only possible to evaluate 

gamma_UB_standard(mu) = gamma_mu_bar * max{q = 1}^Q theta_q(mu)/theta_q(mu_bar).

Note, however, that I have also further generalized gamma_UB_new(mu) to the case that theta_prime_q(mu) = 0 for some q (which for example happens for derivatives). Then, it is still possible to derive an upper bound, but one has to take the absolute value in the denominator, and we have 

gamma_UB_new(mu) = gamma_mu_bar * max{q = 1}^Q theta_prime_q(mu)/|theta_q(mu_bar)|. 

Let me know what you think about it.

Cheers,
Tim 