### PR TITLE
Add norm of update vector as error measure in Newton algorithm

### DIFF
--- a/src/pymor/algorithms/newton.py
+++ b/src/pymor/algorithms/newton.py
@@ -122,7 +122,7 @@ def newton(operator, rhs, initial_guess=None, mu=None, error_product=None, least
     err_scale_factor = err
     errs = residual_norms if error_measure == 'residual' else update_norms
 
-    logger.info(f'     res:{residual_norm:.3e}                                 norm:{solution_norm:.3e}')
+    logger.info(f'     norm:{solution_norm:.3e}                                 res:{residual_norm:.3e}')
 
     iteration = 0
     while True:
@@ -197,12 +197,12 @@ def newton(operator, rhs, initial_guess=None, mu=None, error_product=None, least
             err_scale_factor = solution_norm
 
         logger.info(f'it:{iteration} '
-                    f'res:{residual_norm:.3e} '
-                    f'red:{residual_norm / residual_norms[-2]:.3e} '
-                    f'tot_red:{residual_norm / residual_norms[0]:.3e} '
                     f'norm:{solution_norm:.3e} '
                     f'upd:{update_norm:.3e} '
-                    f'rel_upd:{update_norm / solution_norm:.3e}')
+                    f'rel_upd:{update_norm / solution_norm:.3e} '
+                    f'res:{residual_norm:.3e} '
+                    f'red:{residual_norm / residual_norms[-2]:.3e} '
+                    f'tot_red:{residual_norm / residual_norms[0]:.3e}')
 
         if not np.isfinite(residual_norm) or not np.isfinite(solution_norm):
             raise NewtonError('Failed to converge')

--- a/src/pymor/algorithms/newton.py
+++ b/src/pymor/algorithms/newton.py
@@ -118,7 +118,7 @@ def newton(operator, rhs, initial_guess=None, mu=None, error_product=None, least
     residual_norms = [residual_norm]
 
     # select error measure for convergence criteria
-    err = residual_norm if error_measure == 'residual' else solution_norm
+    err = residual_norm if error_measure == 'residual' else np.inf
     err_scale_factor = err
     errs = residual_norms if error_measure == 'residual' else update_norms
 

--- a/src/pymor/algorithms/newton.py
+++ b/src/pymor/algorithms/newton.py
@@ -18,7 +18,7 @@ def newton(operator, rhs, initial_guess=None, mu=None, range_product=None, sourc
            miniter=0, maxiter=100, atol=0., rtol=1e-7, relax='armijo', line_search_params=None,
            stagnation_window=3, stagnation_threshold=np.inf, error_measure='update',
            return_stages=False, return_residuals=False):
-    """Basic Newton algorithm.
+    """Newton algorithm.
 
     This method solves the nonlinear equation ::
 
@@ -63,14 +63,14 @@ def newton(operator, rhs, initial_guess=None, mu=None, range_product=None, sourc
         shall be used.
     line_search_params
         Dictionary of additional parameters passed to the line search method.
-    error_measure
-        If `'residual'`, convergence depends on the norm of the residual. If
-        `'update'`, convergence depends on the norm of the update vector.
     stagnation_window
         Finish when the error measure has not been reduced by a factor of
         `stagnation_threshold` during the last `stagnation_window` iterations.
     stagnation_threshold
         See `stagnation_window`.
+    error_measure
+        If `'residual'`, convergence depends on the norm of the residual. If
+        `'update'`, convergence depends on the norm of the update vector.
     return_stages
         If `True`, return a |VectorArray| of the intermediate approximations of `U`
         after each iteration.

--- a/src/pymor/algorithms/newton.py
+++ b/src/pymor/algorithms/newton.py
@@ -58,14 +58,14 @@ def newton(operator, rhs, initial_guess=None, mu=None, range_product=None, sourc
         Finish when the error measure has been reduced by this factor
         relative to the norm of the initial residual resp. the norm of the current solution.
     relax
-        If real valued, relaxation factor for Newton updates; otherwise 'armijo' to
-        indicate that the :func:~pymor.algorithms.line_search.armijo line search algorithm
+        If real valued, relaxation factor for Newton updates; otherwise `'armijo'` to
+        indicate that the :func:`~pymor.algorithms.line_search.armijo` line search algorithm
         shall be used.
     line_search_params
         Dictionary of additional parameters passed to the line search method.
     error_measure
-        If 'residual', convergence depends on the norm of the residual. If
-        'update', convergence depends on the norm of the update vector.
+        If `'residual'`, convergence depends on the norm of the residual. If
+        `'update'`, convergence depends on the norm of the update vector.
     stagnation_window
         Finish when the error measure has not been reduced by a factor of
         `stagnation_threshold` during the last `stagnation_window` iterations.
@@ -94,7 +94,7 @@ def newton(operator, rhs, initial_guess=None, mu=None, range_product=None, sourc
     Raises
     ------
     NewtonError
-        Raised if the Netwon algorithm failed to converge.
+        Raised if the Newton algorithm failed to converge.
     """
     assert error_measure in ('residual', 'update')
 

--- a/src/pymor/algorithms/newton.py
+++ b/src/pymor/algorithms/newton.py
@@ -209,7 +209,6 @@ def newton(operator, rhs, initial_guess=None, mu=None, error_product=None, least
 
     logger.info('')
 
-
     data['solution_norms'] = np.array(solution_norms)
     data['update_norms']   = np.array(update_norms)
     data['residual_norms'] = np.array(residual_norms)

--- a/src/pymor/algorithms/newton.py
+++ b/src/pymor/algorithms/newton.py
@@ -15,8 +15,8 @@ from pymor.core.logger import getLogger
 
 @defaults('miniter', 'maxiter', 'rtol', 'atol', 'relax', 'stagnation_window', 'stagnation_threshold')
 def newton(operator, rhs, initial_guess=None, mu=None, error_product=None, least_squares=False,
-           miniter=0, maxiter=100, atol=0., rtol=0., relax=1., line_search_params=None,
-           stagnation_window=3, stagnation_threshold=np.inf, error_measure='residual',
+           miniter=0, maxiter=100, atol=0., rtol=1e-7, relax='armijo', line_search_params=None,
+           stagnation_window=3, stagnation_threshold=np.inf, error_measure='update',
            return_stages=False, return_residuals=False):
     """Basic Newton algorithm.
 

--- a/src/pymor/algorithms/newton.py
+++ b/src/pymor/algorithms/newton.py
@@ -174,7 +174,6 @@ def newton(operator, rhs, initial_guess=None, mu=None, error_product=None, least
         if not np.isfinite(residual_norm):
             raise NewtonError('Failed to converge')
 
-    data['error_sequence'] = np.array(error_sequence)
     data['solution_norms'] = np.array(solution_norms)
     data['update_norms']   = np.array(correction_norms)
     data['residual_norms'] = np.array(residual_norms)

--- a/src/pymor/algorithms/newton.py
+++ b/src/pymor/algorithms/newton.py
@@ -126,7 +126,7 @@ def newton(operator, rhs, initial_guess=None, mu=None, error_product=None, least
             if err < atol:
                 logger.info(f'Absolute limit of {atol} reached. Stopping.')
                 break
-            if residual_norm < rtol * err_scale_factor:
+            if err < rtol * err_scale_factor:
                 logger.info(f'Prescribed total reduction of {rtol} reached. Stopping.')
                 break
             if (len(error_sequence) >= stagnation_window + 1
@@ -165,7 +165,7 @@ def newton(operator, rhs, initial_guess=None, mu=None, error_product=None, least
 
         solution_norm = U.norm(error_product)[0]
         solution_norms.append(solution_norm)
-        correction_norm = correction.norm(error_product)[0]
+        correction_norm = correction.norm(error_product)[0] * step_size
         correction_norms.append(correction_norm)
         residual_norm = residual.norm(error_product)[0]
         residual_norms.append(residual_norm)

--- a/src/pymor/algorithms/newton.py
+++ b/src/pymor/algorithms/newton.py
@@ -128,6 +128,11 @@ def newton(operator, rhs, initial_guess=None, mu=None, error_product=None, least
     while True:
         # check for convergence / failure of convergence
         if iteration >= miniter:
+            if residual_norm == 0:
+                # handle the corner case where error_norm == update, U is the exact solution
+                # and the jacobian of operator is not invertible at the exact solution
+                logger.info(f'Norm of residual exactly zero. Converged.')
+                break
             if err < atol:
                 logger.info(f'Absolute tolerance of {atol} for norm of {error_measure} reached. Converged.')
                 break

--- a/src/pymor/algorithms/newton.py
+++ b/src/pymor/algorithms/newton.py
@@ -39,8 +39,9 @@ def newton(operator, rhs, initial_guess=None, mu=None, error_product=None, least
     mu
         The |parameter values| for which to solve the equation.
     error_norm
-        The product with which the norm of the residual is computed. If `None`, the
-        Euclidean product is used.
+        The inner product with which the error measure norm (norm of the
+        residual/update vector) is computed. If `None`, the Euclidean inner product
+        is used.
     least_squares
         If `True`, use a least squares linear solver (e.g. for residual minimization).
     miniter
@@ -48,10 +49,10 @@ def newton(operator, rhs, initial_guess=None, mu=None, error_product=None, least
     maxiter
         Fail if the iteration count reaches this value without converging.
     atol
-        Finish when the residual norm is below this threshold.
+        Finish when the the error measure is below this threshold.
     rtol
-        Finish when the residual norm has been reduced by this factor relative to the
-        norm of the initial residual.
+        Finish when the error measure has been reduced by this factor
+        relative to the norm of the initial residual resp. the norm of the current solution.
     relax
         If real valued, relaxation factor for Newton updates; otherwise 'armijo' to
         indicate that the :func:~pymor.algorithms.line_search.armijo line search algorithm
@@ -59,10 +60,10 @@ def newton(operator, rhs, initial_guess=None, mu=None, error_product=None, least
     line_search_params
         Dictionary of additional parameters passed to the line search method.
     error_measure
-        If 'resdiual', convergence depends on the norm of the residual. If
+        If 'residual', convergence depends on the norm of the residual. If
         'update', convergence depends on the norm of the update vector.
     stagnation_window
-        Finish when the residual norm has not been reduced by a factor of
+        Finish when the error measure has not been reduced by a factor of
         `stagnation_threshold` during the last `stagnation_window` iterations.
     stagnation_threshold
         See `stagnation_window`.
@@ -80,7 +81,9 @@ def newton(operator, rhs, initial_guess=None, mu=None, error_product=None, least
     data
         Dict containing the following fields:
 
-            :error_sequence:  |NumPy array| containing the residual norms after each iteration.
+            :solution_norms:  |NumPy array| of the solution norms after each iteration.
+            :update_norms:    |NumPy array| of the norms of the update vectors for each iteration.
+            :residual_norms:  |NumPy array| of the residual norms after each iteration.
             :stages:          See `return_stages`.
             :residuals:       See `return_residuals`.
 

--- a/src/pymor/algorithms/newton.py
+++ b/src/pymor/algorithms/newton.py
@@ -15,7 +15,7 @@ from pymor.core.logger import getLogger
 
 @defaults('miniter', 'maxiter', 'rtol', 'atol', 'relax', 'stagnation_window', 'stagnation_threshold')
 def newton(operator, rhs, initial_guess=None, mu=None, error_product=None, least_squares=False,
-           miniter=0, maxiter=100, rtol=0., atol=0., relax=1., line_search_params=None,
+           miniter=0, maxiter=100, atol=0., rtol=0., relax=1., line_search_params=None,
            stagnation_window=3, stagnation_threshold=np.inf, error_measure='residual',
            return_stages=False, return_residuals=False):
     """Basic Newton algorithm.
@@ -47,11 +47,11 @@ def newton(operator, rhs, initial_guess=None, mu=None, error_product=None, least
         Minimum amount of iterations to perform.
     maxiter
         Fail if the iteration count reaches this value without converging.
+    atol
+        Finish when the residual norm is below this threshold.
     rtol
         Finish when the residual norm has been reduced by this factor relative to the
         norm of the initial residual.
-    atol
-        Finish when the residual norm is below this threshold.
     relax
         If real valued, relaxation factor for Newton updates; otherwise 'armijo' to
         indicate that the :func:~pymor.algorithms.line_search.armijo line search algorithm

--- a/src/pymor/algorithms/newton.py
+++ b/src/pymor/algorithms/newton.py
@@ -49,7 +49,7 @@ def newton(operator, rhs, initial_guess=None, mu=None, error_product=None, least
     maxiter
         Fail if the iteration count reaches this value without converging.
     atol
-        Finish when the the error measure is below this threshold.
+        Finish when the error measure is below this threshold.
     rtol
         Finish when the error measure has been reduced by this factor
         relative to the norm of the initial residual resp. the norm of the current solution.

--- a/src/pymor/operators/interface.py
+++ b/src/pymor/operators/interface.py
@@ -233,13 +233,16 @@ class Operator(ParametricObject):
                 options = {}
             options['least_squares'] = least_squares
 
-            R = V.empty(reserve=len(V))
-            for i in range(len(V)):
-                try:
-                    R.append(newton(self, V[i], initial_guess=initial_guess[i] if initial_guess is not None else None,
-                                    mu=mu, **options)[0])
-                except NewtonError as e:
-                    raise InversionError(e)
+            with self.logger.block('Solving nonlinear problem using newton algorithm ...'):
+                R = V.empty(reserve=len(V))
+                for i in range(len(V)):
+                    try:
+                        R.append(newton(self, V[i],
+                                        initial_guess=initial_guess[i] if initial_guess is not None else None,
+                                        mu=mu,
+                                        **options)[0])
+                    except NewtonError as e:
+                        raise InversionError(e)
             return R
 
     def apply_inverse_adjoint(self, U, mu=None, initial_guess=None, least_squares=False):

--- a/src/pymortests/algorithms/stuff.py
+++ b/src/pymortests/algorithms/stuff.py
@@ -19,9 +19,13 @@ def _newton(mop, initial_value=1.0, **kwargs):
     return newton(mop, rhs, initial_guess=guess, **kwargs)
 
 @pytest.mark.parametrize("order", list(range(1, 8)))
-def test_newton(order):
+@pytest.mark.parametrize("error_measure", ['update', 'residual'])
+def test_newton(order, error_measure):
     mop = MonomOperator(order)
-    U, _ = _newton(mop, atol=1e-15)
+    U, _ = _newton(mop,
+                   atol=1e-15 if error_measure == 'residual' else 1e-7,
+                   rtol=0.,
+                   error_measure=error_measure)
     assert float_cmp(mop.apply(U).to_numpy(), 0.0)
 
 def test_newton_fail():
@@ -37,7 +41,7 @@ def test_newton_with_line_search():
 def test_newton_fail_without_line_search():
     mop = MonomOperator(3) - 2 * MonomOperator(1) + 2 * MonomOperator(0)
     with pytest.raises(NewtonError):
-        _ = _newton(mop, initial_value=0.0, atol=1e-15)
+        _ = _newton(mop, initial_value=0.0, atol=1e-15, relax=1.)
 
 def test_newton_unknown_line_search():
     mop = MonomOperator(1)


### PR DESCRIPTION
This PR improves/extends `pymor.algorithms.newton.newton` in the following ways:

- The new `error_measure` parameter allows choosing between the norm of the `'residual'` and the norm of the `'update'` vector as a measure for the error. In the case of the update vector, the realtive tolerance is to be understood in relation to the norm of the current solution.
- The defaults were changed to use the norm of the update vector with a relative tolerance of `1e-7` (about half machine precision).
- Armijo line search is enabled by default.
- `error_product` has been replaced with `range_product` and `source_product` as different inner products may be needed for computing the norm of the residual and the norm of the solution/update vector.
- The `atol` and `rtol` arguments have switched places in agreement with other functions in pyMOR.
- Logging has been improved and now also reports the norms of the solution and of the update vector.
- The implementation has been cleaned up a bit.

Arguments for the new defaults:
- The desired absolute value for the residual norm is impossible to know without knowing the application. A relative tolerance does not really improve the situation, as the initial norm of the residual is highly dependent on the intial guess. Both are useless in the context of residual minimization, where the residual never goes to zero. The stagnation criterion is too lax and produces solutions without the algorithm converging to anything.
- On the other hand, it can be expected for a converging newton algorithms, that the updates are by a significant factor smaller than the norm of the current approximation. What can happen is that the algorithm converges to a local optimum, in which case a criterion based on the norm of the update will fail. However, this is less dangerous than the stagnation criterion, which will also report convergence when the solution oscillates. Overalls specifying a relatively low rtol for the update vector seems to be a good compromise to me for a default. It also works for resdiual minimization.
- Armijo line search may be unnecessarily expensive in some cases, but I would prefer a more robust algorithm by default.

Fixes #896.