### PR TITLE
Avoid nested parameter functionals and functions for sums and products

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -14,6 +14,7 @@
 * Tim Keil, tim.keil@uni-muenster.de
     * Energy product in elliptic discretizer
     * rename estimate --> estimate_error and estimator -> error_estimator
+    * avoid nested Product and Lincomb Functionals and Functions
 
 ## pyMOR 2020.1
 

--- a/src/pymor/analyticalproblems/functions.py
+++ b/src/pymor/analyticalproblems/functions.py
@@ -52,7 +52,7 @@ class Function(ParametricObject):
         """Shorthand for :meth:`~Function.evaluate`."""
         return self.evaluate(x, mu)
 
-    def __add__(self, other):
+    def _add_sub(self, other, sign):
         if isinstance(other, Number) and other == 0:
             return self
         elif not isinstance(other, Function):
@@ -61,27 +61,75 @@ class Function(ParametricObject):
             if np.all(other == 0.):
                 return self
             other = ConstantFunction(other, dim_domain=self.dim_domain)
-        return LincombFunction([self, other], [1., 1.])
 
-    __radd__ = __add__
+        if not isinstance(self, LincombFunction):
+            if isinstance(other, LincombFunction):
+                functions = (self,) + other.functions
+                coefficients = (1.,) + (other.coefficients if sign == 1. else tuple(-c for c in other.coefficients))
+            else:
+                functions, coefficients = (self, other), (1., sign)
+        elif isinstance(other, LincombFunction):
+            functions = self.functions + other.functions
+            coefficients = self.coefficients + (other.coefficients if sign == 1.
+                                                else tuple(-c for c in other.coefficients))
+        else:
+            functions, coefficients = self.functions + (other,), self.coefficients + (sign,)
+
+        return LincombFunction(functions, coefficients)
+
+    def _radd_sub(self, other, sign):
+        if isinstance(other, Number) and other == 0:
+            return self
+        elif not isinstance(other, Function):
+            other = np.array(other)
+            assert other.shape == self.shape_range
+            if np.all(other == 0.):
+                return self
+            other = ConstantFunction(other, dim_domain=self.dim_domain)
+
+        # note that 'other' can never be a LincombFunction
+        if not isinstance(self, LincombFunction):
+            functions, coefficients = (other, self), (1., sign)
+        else:
+            functions = (other,) + self.functions
+            coefficients = (1.,) + (self.coefficients if sign == 1. else tuple(-c for c in self.coefficients))
+
+        return LincombFunction(functions, coefficients)
+
+    def __add__(self, other):
+        return self._add_sub(other, 1.)
 
     def __sub__(self, other):
-        if isinstance(other, Function):
-            return LincombFunction([self, other], [1., -1.])
-        else:
-            return self + (- np.array(other))
+        return self._add_sub(other, -1.)
+
+    def __radd__(self, other):
+        return self._radd_sub(other, 1.)
+
+    def __rsub__(self, other):
+        return self._radd_sub(other, -1.)
 
     def __mul__(self, other):
-        if isinstance(other, (Number, ParameterFunctional)):
+        if not isinstance(other, (Number, ParameterFunctional, Function)):
+            return NotImplemented
+        if isinstance(other, ParameterFunctional):
             return LincombFunction([self], [other])
-        if isinstance(other, Function):
-            return ProductFunction([self, other])
-        return NotImplemented
+        elif isinstance(other, Number):
+            other = ConstantFunction(other)
+        if not isinstance(self, ProductFunction):
+            if isinstance(other, ProductFunction):
+                return other.with_(functions=other.functions + [self])
+            else:
+                return ProductFunction([self, other])
+        elif isinstance(other, ProductFunction):
+            functions = self.functions + other.functions
+            return ProductFunction(functions)
+        else:
+            return self.with_(functions=self.functions + [other])
 
     __rmul__ = __mul__
 
     def __neg__(self):
-        return LincombFunction([self], [-1.])
+        return self * (-1.)
 
 
 class ConstantFunction(Function):

--- a/src/pymor/analyticalproblems/functions.py
+++ b/src/pymor/analyticalproblems/functions.py
@@ -111,10 +111,8 @@ class Function(ParametricObject):
     def __mul__(self, other):
         if not isinstance(other, (Number, ParameterFunctional, Function)):
             return NotImplemented
-        if isinstance(other, ParameterFunctional):
+        if isinstance(other, (Number, ParameterFunctional)):
             return LincombFunction([self], [other])
-        elif isinstance(other, Number):
-            other = ConstantFunction(other)
         if not isinstance(self, ProductFunction):
             if isinstance(other, ProductFunction):
                 return other.with_(functions=other.functions + [self])
@@ -129,7 +127,7 @@ class Function(ParametricObject):
     __rmul__ = __mul__
 
     def __neg__(self):
-        return self * (-1.)
+        return LincombFunction([self], [-1.])
 
 
 class ConstantFunction(Function):

--- a/src/pymor/analyticalproblems/functions.py
+++ b/src/pymor/analyticalproblems/functions.py
@@ -62,8 +62,7 @@ class Function(ParametricObject):
                 return self
             other = ConstantFunction(other, dim_domain=self.dim_domain)
 
-        if self.name != 'LincombFunction' or (self.name == 'LincombFunction'
-                                              and not isinstance(self, LincombFunction)):
+        if self.name != 'LincombFunction' or not isinstance(self, LincombFunction):
             if other.name == 'LincombFunction' and isinstance(other, LincombFunction):
                 functions = (self,) + other.functions
                 coefficients = (1.,) + (other.coefficients if sign == 1. else tuple(-c for c in other.coefficients))
@@ -89,8 +88,7 @@ class Function(ParametricObject):
             return self
         other = ConstantFunction(other, dim_domain=self.dim_domain)
 
-        if self.name != 'LincombFunction' or (self.name == 'LincombFunction'
-                                              and not isinstance(self, LincombFunction)):
+        if self.name != 'LincombFunction' or not isinstance(self, LincombFunction):
             functions, coefficients = (other, self), (1., sign)
         else:
             functions = (other,) + self.functions

--- a/src/pymor/analyticalproblems/functions.py
+++ b/src/pymor/analyticalproblems/functions.py
@@ -62,21 +62,18 @@ class Function(ParametricObject):
                 return self
             other = ConstantFunction(other, dim_domain=self.dim_domain)
 
-        if self.name != 'LincombFunction':
-            if other.name == 'LincombFunction':
-                assert isinstance(other, LincombFunction)
+        if self.name != 'LincombFunction' or (self.name == 'LincombFunction'
+                                              and not isinstance(self, LincombFunction)):
+            if other.name == 'LincombFunction' and isinstance(other, LincombFunction):
                 functions = (self,) + other.functions
                 coefficients = (1.,) + (other.coefficients if sign == 1. else tuple(-c for c in other.coefficients))
             else:
                 functions, coefficients = (self, other), (1., sign)
-        elif other.name == 'LincombFunction':
-            assert isinstance(self, LincombFunction)
-            assert isinstance(other, LincombFunction)
+        elif other.name == 'LincombFunction' and isinstance(other, LincombFunction):
             functions = self.functions + other.functions
             coefficients = self.coefficients + (other.coefficients if sign == 1.
                                                 else tuple(-c for c in other.coefficients))
         else:
-            assert isinstance(self, LincombFunction)
             functions, coefficients = self.functions + (other,), self.coefficients + (sign,)
 
         return LincombFunction(functions, coefficients)
@@ -92,10 +89,10 @@ class Function(ParametricObject):
             other = ConstantFunction(other, dim_domain=self.dim_domain)
 
         # note that 'other' can never be a LincombFunction
-        if self.name != 'LincombFunction':
+        if self.name != 'LincombFunction' or (self.name == 'LincombFunction'
+                                              and not isinstance(self, LincombFunction)):
             functions, coefficients = (other, self), (1., sign)
         else:
-            assert isinstance(self, LincombFunction)
             functions = (other,) + self.functions
             coefficients = (1.,) + (self.coefficients if sign == 1. else tuple(-c for c in self.coefficients))
 

--- a/src/pymor/analyticalproblems/functions.py
+++ b/src/pymor/analyticalproblems/functions.py
@@ -62,13 +62,13 @@ class Function(ParametricObject):
                 return self
             other = ConstantFunction(other, dim_domain=self.dim_domain)
 
-        if not isinstance(self, LincombFunction):
-            if isinstance(other, LincombFunction):
+        if self.name != 'LincombFunction':
+            if isinstance(other, LincombFunction) and other.name == 'LincombFunction':
                 functions = (self,) + other.functions
                 coefficients = (1.,) + (other.coefficients if sign == 1. else tuple(-c for c in other.coefficients))
             else:
                 functions, coefficients = (self, other), (1., sign)
-        elif isinstance(other, LincombFunction):
+        elif isinstance(other, LincombFunction) and other.name == 'LincombFunction':
             functions = self.functions + other.functions
             coefficients = self.coefficients + (other.coefficients if sign == 1.
                                                 else tuple(-c for c in other.coefficients))
@@ -88,7 +88,7 @@ class Function(ParametricObject):
             other = ConstantFunction(other, dim_domain=self.dim_domain)
 
         # note that 'other' can never be a LincombFunction
-        if not isinstance(self, LincombFunction):
+        if self.name != 'LincombFunction':
             functions, coefficients = (other, self), (1., sign)
         else:
             functions = (other,) + self.functions
@@ -113,12 +113,12 @@ class Function(ParametricObject):
             return NotImplemented
         if isinstance(other, (Number, ParameterFunctional)):
             return LincombFunction([self], [other])
-        if not isinstance(self, ProductFunction):
-            if isinstance(other, ProductFunction):
+        if self.name != 'ProductFunction':
+            if isinstance(other, ProductFunction) and other.name == 'ProductFunction':
                 return other.with_(functions=other.functions + [self])
             else:
                 return ProductFunction([self, other])
-        elif isinstance(other, ProductFunction):
+        elif isinstance(other, ProductFunction) and other.name == 'ProductFunction':
             functions = self.functions + other.functions
             return ProductFunction(functions)
         else:

--- a/src/pymor/analyticalproblems/functions.py
+++ b/src/pymor/analyticalproblems/functions.py
@@ -69,10 +69,12 @@ class Function(ParametricObject):
             else:
                 functions, coefficients = (self, other), (1., sign)
         elif isinstance(other, LincombFunction) and other.name == 'LincombFunction':
+            assert isinstance(self, LincombFunction)
             functions = self.functions + other.functions
             coefficients = self.coefficients + (other.coefficients if sign == 1.
                                                 else tuple(-c for c in other.coefficients))
         else:
+            assert isinstance(self, LincombFunction)
             functions, coefficients = self.functions + (other,), self.coefficients + (sign,)
 
         return LincombFunction(functions, coefficients)
@@ -91,6 +93,7 @@ class Function(ParametricObject):
         if self.name != 'LincombFunction':
             functions, coefficients = (other, self), (1., sign)
         else:
+            assert isinstance(self, LincombFunction)
             functions = (other,) + self.functions
             coefficients = (1.,) + (self.coefficients if sign == 1. else tuple(-c for c in self.coefficients))
 
@@ -119,9 +122,11 @@ class Function(ParametricObject):
             else:
                 return ProductFunction([self, other])
         elif isinstance(other, ProductFunction) and other.name == 'ProductFunction':
+            assert isinstance(self, ProductFunction)
             functions = self.functions + other.functions
             return ProductFunction(functions)
         else:
+            assert isinstance(self, ProductFunction)
             return self.with_(functions=self.functions + [other])
 
     __rmul__ = __mul__

--- a/src/pymor/analyticalproblems/functions.py
+++ b/src/pymor/analyticalproblems/functions.py
@@ -63,13 +63,15 @@ class Function(ParametricObject):
             other = ConstantFunction(other, dim_domain=self.dim_domain)
 
         if self.name != 'LincombFunction':
-            if isinstance(other, LincombFunction) and other.name == 'LincombFunction':
+            if other.name == 'LincombFunction':
+                assert isinstance(other, LincombFunction)
                 functions = (self,) + other.functions
                 coefficients = (1.,) + (other.coefficients if sign == 1. else tuple(-c for c in other.coefficients))
             else:
                 functions, coefficients = (self, other), (1., sign)
-        elif isinstance(other, LincombFunction) and other.name == 'LincombFunction':
+        elif other.name == 'LincombFunction':
             assert isinstance(self, LincombFunction)
+            assert isinstance(other, LincombFunction)
             functions = self.functions + other.functions
             coefficients = self.coefficients + (other.coefficients if sign == 1.
                                                 else tuple(-c for c in other.coefficients))

--- a/src/pymor/analyticalproblems/functions.py
+++ b/src/pymor/analyticalproblems/functions.py
@@ -293,6 +293,9 @@ class LincombFunction(Function):
         assert all(isinstance(c, (ParameterFunctional, Number)) for c in coefficients)
         assert all(f.dim_domain == functions[0].dim_domain for f in functions[1:])
         assert all(f.shape_range == functions[0].shape_range for f in functions[1:])
+        functions = tuple(functions)
+        coefficients = tuple(coefficients)
+
         self.__auto_init(locals())
         self.dim_domain = functions[0].dim_domain
         self.shape_range = functions[0].shape_range

--- a/src/pymor/analyticalproblems/functions.py
+++ b/src/pymor/analyticalproblems/functions.py
@@ -79,16 +79,16 @@ class Function(ParametricObject):
         return LincombFunction(functions, coefficients)
 
     def _radd_sub(self, other, sign):
+        assert not isinstance(other, Function)  # handled by __add__/__sub__
         if isinstance(other, Number) and other == 0:
             return self
-        elif not isinstance(other, Function):
-            other = np.array(other)
-            assert other.shape == self.shape_range
-            if np.all(other == 0.):
-                return self
-            other = ConstantFunction(other, dim_domain=self.dim_domain)
 
-        # note that 'other' can never be a LincombFunction
+        other = np.array(other)
+        assert other.shape == self.shape_range
+        if np.all(other == 0.):
+            return self
+        other = ConstantFunction(other, dim_domain=self.dim_domain)
+
         if self.name != 'LincombFunction' or (self.name == 'LincombFunction'
                                               and not isinstance(self, LincombFunction)):
             functions, coefficients = (other, self), (1., sign)

--- a/src/pymor/analyticalproblems/functions.py
+++ b/src/pymor/analyticalproblems/functions.py
@@ -115,17 +115,15 @@ class Function(ParametricObject):
             return NotImplemented
         if isinstance(other, (Number, ParameterFunctional)):
             return LincombFunction([self], [other])
-        if self.name != 'ProductFunction':
+        if self.name != 'ProductFunction' or not isinstance(self, ProductFunction):
             if isinstance(other, ProductFunction) and other.name == 'ProductFunction':
                 return other.with_(functions=other.functions + [self])
             else:
                 return ProductFunction([self, other])
         elif isinstance(other, ProductFunction) and other.name == 'ProductFunction':
-            assert isinstance(self, ProductFunction)
             functions = self.functions + other.functions
             return ProductFunction(functions)
         else:
-            assert isinstance(self, ProductFunction)
             return self.with_(functions=self.functions + [other])
 
     __rmul__ = __mul__

--- a/src/pymor/operators/constructions.py
+++ b/src/pymor/operators/constructions.py
@@ -221,57 +221,6 @@ class LincombOperator(Operator):
     def as_source_array(self, mu=None):
         return self._as_array(True, mu)
 
-    def _add_sub(self, other, sign):
-        if not isinstance(other, Operator):
-            return NotImplemented
-
-        if self.name != 'LincombOperator':
-            if isinstance(other, LincombOperator) and other.name == 'LincombOperator':
-                operators = (self,) + other.operators
-                coefficients = (1.,) + (other.coefficients if sign == 1. else tuple(-c for c in other.coefficients))
-            else:
-                operators, coefficients = (self, other), (1., sign)
-        elif isinstance(other, LincombOperator) and other.name == 'LincombOperator':
-            operators = self.operators + other.operators
-            coefficients = self.coefficients + (other.coefficients if sign == 1.
-                                                else tuple(-c for c in other.coefficients))
-        else:
-            operators, coefficients = self.operators + (other,), self.coefficients + (sign,)
-
-        return LincombOperator(operators, coefficients, solver_options=self.solver_options)
-
-    def _radd_sub(self, other, sign):
-        if not isinstance(other, Operator):
-            return NotImplemented
-
-        # note that 'other' can never be a LincombOperator
-        if self.name != 'LincombOperator':
-            operators, coefficients = (other, self), (1., sign)
-        else:
-            operators = (other,) + self.operators
-            coefficients = (1.,) + (self.coefficients if sign == 1. else tuple(-c for c in self.coefficients))
-
-        return LincombOperator(operators, coefficients, solver_options=other.solver_options)
-
-    def __add__(self, other):
-        return self._add_sub(other, 1.)
-
-    def __sub__(self, other):
-        return self._add_sub(other, -1.)
-
-    def __radd__(self, other):
-        return self._radd_sub(other, 1.)
-
-    def __rsub__(self, other):
-        return self._radd_sub(other, -1.)
-
-    def __mul__(self, other):
-        assert isinstance(other, (Number, ParameterFunctional))
-        if self.name != 'LincombOperator':
-            return LincombOperator((self,), (other,))
-        else:
-            return self.with_(coefficients=tuple(c * other for c in self.coefficients))
-
 
 class ConcatenationOperator(Operator):
     """|Operator| representing the concatenation of two |Operators|.

--- a/src/pymor/operators/interface.py
+++ b/src/pymor/operators/interface.py
@@ -524,8 +524,7 @@ class Operator(ParametricObject):
         if not isinstance(other, Operator):
             return NotImplemented
         from pymor.operators.constructions import LincombOperator
-        if self.name != 'LincombOperator' or (self.name == 'LincombOperator'
-                                              and not isinstance(self, LincombOperator)):
+        if self.name != 'LincombOperator' or not isinstance(self, LincombOperator):
             if other.name == 'LincombOperator' and isinstance(other, LincombOperator):
                 operators = (self,) + other.operators
                 coefficients = (1.,) + (other.coefficients if sign == 1. else tuple(-c for c in other.coefficients))
@@ -545,8 +544,7 @@ class Operator(ParametricObject):
             return NotImplemented
         from pymor.operators.constructions import LincombOperator
         # note that 'other' can never be a LincombOperator
-        if self.name != 'LincombOperator' or (self.name == 'LincombOperator'
-                                              and not isinstance(self, LincombOperator)):
+        if self.name != 'LincombOperator' or not isinstance(self, LincombOperator)):
             operators, coefficients = (other, self), (1., sign)
         else:
             operators = (other,) + self.operators
@@ -569,8 +567,7 @@ class Operator(ParametricObject):
     def __mul__(self, other):
         assert isinstance(other, (Number, ParameterFunctional))
         from pymor.operators.constructions import LincombOperator
-        if self.name != 'LincombOperator' or (self.name == 'LincombOperator'
-                                              and not isinstance(self, LincombOperator)):
+        if self.name != 'LincombOperator' or not isinstance(self, LincombOperator):
             return LincombOperator((self,), (other,))
         else:
             return self.with_(coefficients=tuple(c * other for c in self.coefficients))

--- a/src/pymor/operators/interface.py
+++ b/src/pymor/operators/interface.py
@@ -524,21 +524,18 @@ class Operator(ParametricObject):
         if not isinstance(other, Operator):
             return NotImplemented
         from pymor.operators.constructions import LincombOperator
-        if self.name != 'LincombOperator':
-            if other.name == 'LincombOperator':
-                assert isinstance(other, LincombOperator)
+        if self.name != 'LincombOperator' or (self.name == 'LincombOperator'
+                                              and not isinstance(self, LincombOperator)):
+            if other.name == 'LincombOperator' and isinstance(other, LincombOperator):
                 operators = (self,) + other.operators
                 coefficients = (1.,) + (other.coefficients if sign == 1. else tuple(-c for c in other.coefficients))
             else:
                 operators, coefficients = (self, other), (1., sign)
-        elif other.name == 'LincombOperator':
-            assert isinstance(self, LincombOperator)
-            assert isinstance(other, LincombOperator)
+        elif other.name == 'LincombOperator' and isinstance(other, LincombOperator):
             operators = self.operators + other.operators
             coefficients = self.coefficients + (other.coefficients if sign == 1.
                                                 else tuple(-c for c in other.coefficients))
         else:
-            assert isinstance(self, LincombOperator)
             operators, coefficients = self.operators + (other,), self.coefficients + (sign,)
 
         return LincombOperator(operators, coefficients, solver_options=self.solver_options)
@@ -548,10 +545,10 @@ class Operator(ParametricObject):
             return NotImplemented
         from pymor.operators.constructions import LincombOperator
         # note that 'other' can never be a LincombOperator
-        if self.name != 'LincombOperator':
+        if self.name != 'LincombOperator' or (self.name == 'LincombOperator'
+                                              and not isinstance(self, LincombOperator)):
             operators, coefficients = (other, self), (1., sign)
         else:
-            assert isinstance(self, LincombOperator)
             operators = (other,) + self.operators
             coefficients = (1.,) + (self.coefficients if sign == 1. else tuple(-c for c in self.coefficients))
 
@@ -572,10 +569,10 @@ class Operator(ParametricObject):
     def __mul__(self, other):
         assert isinstance(other, (Number, ParameterFunctional))
         from pymor.operators.constructions import LincombOperator
-        if self.name != 'LincombOperator':
+        if self.name != 'LincombOperator' or (self.name == 'LincombOperator'
+                                              and not isinstance(self, LincombOperator)):
             return LincombOperator((self,), (other,))
         else:
-            assert isinstance(self, LincombOperator)
             return self.with_(coefficients=tuple(c * other for c in self.coefficients))
 
     def __rmul__(self, other):

--- a/src/pymor/operators/interface.py
+++ b/src/pymor/operators/interface.py
@@ -540,17 +540,10 @@ class Operator(ParametricObject):
         return LincombOperator(operators, coefficients, solver_options=self.solver_options)
 
     def _radd_sub(self, other, sign):
+        if other == 0:
+             return self
         if not isinstance(other, Operator):
             return NotImplemented
-        from pymor.operators.constructions import LincombOperator
-        # note that 'other' can never be a LincombOperator
-        if self.name != 'LincombOperator' or not isinstance(self, LincombOperator)):
-            operators, coefficients = (other, self), (1., sign)
-        else:
-            operators = (other,) + self.operators
-            coefficients = (1.,) + (self.coefficients if sign == 1. else tuple(-c for c in self.coefficients))
-
-        return LincombOperator(operators, coefficients, solver_options=other.solver_options)
 
     def __add__(self, other):
         return self._add_sub(other, 1.)

--- a/src/pymor/operators/interface.py
+++ b/src/pymor/operators/interface.py
@@ -525,13 +525,15 @@ class Operator(ParametricObject):
             return NotImplemented
         from pymor.operators.constructions import LincombOperator
         if self.name != 'LincombOperator':
-            if isinstance(other, LincombOperator) and other.name == 'LincombOperator':
+            if other.name == 'LincombOperator':
+                assert isinstance(other, LincombOperator)
                 operators = (self,) + other.operators
                 coefficients = (1.,) + (other.coefficients if sign == 1. else tuple(-c for c in other.coefficients))
             else:
                 operators, coefficients = (self, other), (1., sign)
-        elif isinstance(other, LincombOperator) and other.name == 'LincombOperator':
+        elif other.name == 'LincombOperator':
             assert isinstance(self, LincombOperator)
+            assert isinstance(other, LincombOperator)
             operators = self.operators + other.operators
             coefficients = self.coefficients + (other.coefficients if sign == 1.
                                                 else tuple(-c for c in other.coefficients))

--- a/src/pymor/parameters/functionals.py
+++ b/src/pymor/parameters/functionals.py
@@ -54,8 +54,7 @@ class ParameterFunctional(ParametricObject):
                 return self
             other = ConstantParameterFunctional(other)
 
-        if self.name != 'LincombParameterFunctional' or (self.name == 'LincombParameterFunctional'
-                                                         and not isinstance(self, LincombParameterFunctional)):
+        if self.name != 'LincombParameterFunctional' or not isinstance(self, LincombParameterFunctional):
             if other.name == 'LincombParameterFunctional' and isinstance(other, LincombParameterFunctional):
                 functionals = (self,) + other.functionals
                 coefficients = (1.,) + (other.coefficients if sign == 1. else tuple(-c for c in other.coefficients))
@@ -79,8 +78,7 @@ class ParameterFunctional(ParametricObject):
             return self
         other = ConstantParameterFunctional(other)
 
-        if self.name != 'LincombParameterFunctional' or (self.name == 'LincombParameterFunctional'
-                                                         and not isinstance(self, LincombParameterFunctional)):
+        if self.name != 'LincombParameterFunctional' or not isinstance(self, LincombParameterFunctional):
             functionals, coefficients = (other, self), (1., sign)
         else:
             functionals = (other,) + self.functionals
@@ -103,8 +101,7 @@ class ParameterFunctional(ParametricObject):
     def __mul__(self, other):
         if not isinstance(other, (Number, ParameterFunctional)):
             return NotImplemented
-        if self.name != 'ProductParameterFunctional' or (self.name == 'LincombParameterFunctional'
-                                                         and not isinstance(self, LincombParameterFunctional)):
+        if self.name != 'ProductParameterFunctional' or not isinstance(self, ProductParameterFunctional):
             if isinstance(other, ProductParameterFunctional) and other.name == 'ProductParameterFunctional':
                 return other.with_(factors=other.factors + [self])
             else:

--- a/src/pymor/parameters/functionals.py
+++ b/src/pymor/parameters/functionals.py
@@ -51,7 +51,11 @@ class ParameterFunctional(ParametricObject):
                 return self
             other = ConstantParameterFunctional(other)
         if isinstance(other, ParameterFunctional):
-            return LincombParameterFunctional([self, other], [1., 1.])
+            if isinstance(self, LincombParameterFunctional):
+                return self.with_(functionals=self.functionals + (other,),
+                        coefficients=self.coefficients + (1,))
+            else:
+                return LincombParameterFunctional([self, other], [1., 1.])
         else:
             return NotImplemented        
 
@@ -59,14 +63,21 @@ class ParameterFunctional(ParametricObject):
 
     def __sub__(self, other):
         if isinstance(other, ParameterFunctional):
-            return LincombParameterFunctional([self, other], [1., -1.])
+            if isinstance(self, LincombParameterFunctional):
+                return self.with_(functionals=self.functionals + (other,),
+                        coefficients=self.coefficients + (-1,))
+            else:
+                return LincombParameterFunctional([self, other], [1., -1.])
         else:
             return self + (- other)
 
     def __mul__(self, other):
         if not isinstance(other, (Number, ParameterFunctional)):
             return NotImplemented
-        return ProductParameterFunctional([self, other])
+        if isinstance(self, ProductParameterFunctional):
+            return self.with_(factors=self.factors + [other])
+        else:
+            return ProductParameterFunctional([self, other])
 
     __rmul__ = __mul__
 

--- a/src/pymor/parameters/functionals.py
+++ b/src/pymor/parameters/functionals.py
@@ -54,13 +54,13 @@ class ParameterFunctional(ParametricObject):
                 return self
             other = ConstantParameterFunctional(other)
 
-        if not isinstance(self, LincombParameterFunctional):
-            if isinstance(other, LincombParameterFunctional):
+        if self.name != 'LincombParameterFunctional':
+            if isinstance(other, LincombParameterFunctional) and other.name == 'LincombParameterFunctional':
                 functionals = (self,) + other.functionals
                 coefficients = (1.,) + (other.coefficients if sign == 1. else tuple(-c for c in other.coefficients))
             else:
                 functionals, coefficients = (self, other), (1., sign)
-        elif isinstance(other, LincombParameterFunctional):
+        elif isinstance(other, LincombParameterFunctional) and other.name == 'LincombParameterFunctional':
             functionals = self.functionals + other.functionals
             coefficients = self.coefficients + (other.coefficients if sign == 1.
                                                 else tuple(-c for c in other.coefficients))
@@ -79,7 +79,7 @@ class ParameterFunctional(ParametricObject):
             other = ConstantParameterFunctional(other)
 
         # note that 'other' can never be a LincombParameterFunctional
-        if not isinstance(self, LincombParameterFunctional):
+        if self.name != 'LincombParameterFunctional':
             functionals, coefficients = (other, self), (1., sign)
         else:
             functionals = (other,) + self.functionals
@@ -102,12 +102,12 @@ class ParameterFunctional(ParametricObject):
     def __mul__(self, other):
         if not isinstance(other, (Number, ParameterFunctional)):
             return NotImplemented
-        if not isinstance(self, ProductParameterFunctional):
-            if isinstance(other, ProductParameterFunctional):
+        if self.name != 'ProductParameterFunctional':
+            if isinstance(other, ProductParameterFunctional) and other.name == 'ProductParameterFunctional':
                 return other.with_(factors=other.factors + [self])
             else:
                 return ProductParameterFunctional([self, other])
-        elif isinstance(other, ProductParameterFunctional):
+        elif isinstance(other, ProductParameterFunctional) and other.name == 'ProductParameterFunctional':
             factors = self.factors + other.factors
             return ProductParameterFunctional(factors)
         else:

--- a/src/pymor/parameters/functionals.py
+++ b/src/pymor/parameters/functionals.py
@@ -55,13 +55,15 @@ class ParameterFunctional(ParametricObject):
             other = ConstantParameterFunctional(other)
 
         if self.name != 'LincombParameterFunctional':
-            if isinstance(other, LincombParameterFunctional) and other.name == 'LincombParameterFunctional':
+            if other.name == 'LincombParameterFunctional':
+                assert isinstance(other, LincombParameterFunctional)
                 functionals = (self,) + other.functionals
                 coefficients = (1.,) + (other.coefficients if sign == 1. else tuple(-c for c in other.coefficients))
             else:
                 functionals, coefficients = (self, other), (1., sign)
-        elif isinstance(other, LincombParameterFunctional) and other.name == 'LincombParameterFunctional':
+        elif other.name == 'LincombParameterFunctional':
             assert isinstance(self, LincombParameterFunctional)
+            assert isinstance(other, LincombParameterFunctional)
             functionals = self.functionals + other.functionals
             coefficients = self.coefficients + (other.coefficients if sign == 1.
                                                 else tuple(-c for c in other.coefficients))

--- a/src/pymor/parameters/functionals.py
+++ b/src/pymor/parameters/functionals.py
@@ -61,10 +61,12 @@ class ParameterFunctional(ParametricObject):
             else:
                 functionals, coefficients = (self, other), (1., sign)
         elif isinstance(other, LincombParameterFunctional) and other.name == 'LincombParameterFunctional':
+            assert isinstance(self, LincombParameterFunctional)
             functionals = self.functionals + other.functionals
             coefficients = self.coefficients + (other.coefficients if sign == 1.
                                                 else tuple(-c for c in other.coefficients))
         else:
+            assert isinstance(self, LincombParameterFunctional)
             functionals, coefficients = self.functionals + (other,), self.coefficients + (sign,)
 
         return LincombParameterFunctional(functionals, coefficients)
@@ -82,6 +84,7 @@ class ParameterFunctional(ParametricObject):
         if self.name != 'LincombParameterFunctional':
             functionals, coefficients = (other, self), (1., sign)
         else:
+            assert isinstance(self, LincombParameterFunctional)
             functionals = (other,) + self.functionals
             coefficients = (1.,) + (self.coefficients if sign == 1. else tuple(-c for c in self.coefficients))
 
@@ -108,9 +111,11 @@ class ParameterFunctional(ParametricObject):
             else:
                 return ProductParameterFunctional([self, other])
         elif isinstance(other, ProductParameterFunctional) and other.name == 'ProductParameterFunctional':
+            assert isinstance(self, ProductParameterFunctional)
             factors = self.factors + other.factors
             return ProductParameterFunctional(factors)
         else:
+            assert isinstance(self, ProductParameterFunctional)
             return self.with_(factors=self.factors + [other])
 
     __rmul__ = __mul__

--- a/src/pymor/parameters/functionals.py
+++ b/src/pymor/parameters/functionals.py
@@ -54,21 +54,18 @@ class ParameterFunctional(ParametricObject):
                 return self
             other = ConstantParameterFunctional(other)
 
-        if self.name != 'LincombParameterFunctional':
-            if other.name == 'LincombParameterFunctional':
-                assert isinstance(other, LincombParameterFunctional)
+        if self.name != 'LincombParameterFunctional' or (self.name == 'LincombParameterFunctional'
+                                                         and not isinstance(self, LincombParameterFunctional)):
+            if other.name == 'LincombParameterFunctional' and isinstance(other, LincombParameterFunctional):
                 functionals = (self,) + other.functionals
                 coefficients = (1.,) + (other.coefficients if sign == 1. else tuple(-c for c in other.coefficients))
             else:
                 functionals, coefficients = (self, other), (1., sign)
-        elif other.name == 'LincombParameterFunctional':
-            assert isinstance(self, LincombParameterFunctional)
-            assert isinstance(other, LincombParameterFunctional)
+        elif other.name == 'LincombParameterFunctional' and isinstance(other, LincombParameterFunctional):
             functionals = self.functionals + other.functionals
             coefficients = self.coefficients + (other.coefficients if sign == 1.
                                                 else tuple(-c for c in other.coefficients))
         else:
-            assert isinstance(self, LincombParameterFunctional)
             functionals, coefficients = self.functionals + (other,), self.coefficients + (sign,)
 
         return LincombParameterFunctional(functionals, coefficients)
@@ -83,10 +80,10 @@ class ParameterFunctional(ParametricObject):
             other = ConstantParameterFunctional(other)
 
         # note that 'other' can never be a LincombParameterFunctional
-        if self.name != 'LincombParameterFunctional':
+        if self.name != 'LincombParameterFunctional' or (self.name == 'LincombParameterFunctional'
+                                                         and not isinstance(self, LincombParameterFunctional)):
             functionals, coefficients = (other, self), (1., sign)
         else:
-            assert isinstance(self, LincombParameterFunctional)
             functionals = (other,) + self.functionals
             coefficients = (1.,) + (self.coefficients if sign == 1. else tuple(-c for c in self.coefficients))
 
@@ -107,17 +104,16 @@ class ParameterFunctional(ParametricObject):
     def __mul__(self, other):
         if not isinstance(other, (Number, ParameterFunctional)):
             return NotImplemented
-        if self.name != 'ProductParameterFunctional':
+        if self.name != 'ProductParameterFunctional' or (self.name == 'LincombParameterFunctional'
+                                                         and not isinstance(self, LincombParameterFunctional)):
             if isinstance(other, ProductParameterFunctional) and other.name == 'ProductParameterFunctional':
                 return other.with_(factors=other.factors + [self])
             else:
                 return ProductParameterFunctional([self, other])
         elif isinstance(other, ProductParameterFunctional) and other.name == 'ProductParameterFunctional':
-            assert isinstance(self, ProductParameterFunctional)
             factors = self.factors + other.factors
             return ProductParameterFunctional(factors)
         else:
-            assert isinstance(self, ProductParameterFunctional)
             return self.with_(factors=self.factors + [other])
 
     __rmul__ = __mul__

--- a/src/pymor/parameters/functionals.py
+++ b/src/pymor/parameters/functionals.py
@@ -71,15 +71,14 @@ class ParameterFunctional(ParametricObject):
         return LincombParameterFunctional(functionals, coefficients)
 
     def _radd_sub(self, other, sign):
-        if not isinstance(other, (ParameterFunctional, Number)):
+        assert not isinstance(other, ParameterFunctional)  # handled by __add__/__sub__
+        if not isinstance(other, Number):
             return NotImplemented
 
-        if isinstance(other, Number):
-            if other == 0:
-                return self
-            other = ConstantParameterFunctional(other)
+        if other == 0:
+            return self
+        other = ConstantParameterFunctional(other)
 
-        # note that 'other' can never be a LincombParameterFunctional
         if self.name != 'LincombParameterFunctional' or (self.name == 'LincombParameterFunctional'
                                                          and not isinstance(self, LincombParameterFunctional)):
             functionals, coefficients = (other, self), (1., sign)

--- a/src/pymortests/function.py
+++ b/src/pymortests/function.py
@@ -41,15 +41,17 @@ def test_lincomb_function():
                      GenericFunction(lambda X: np.zeros(X.shape[:-1]), dim_domain=steps)):
             for one in (ConstantFunction(1.0, dim_domain=steps),
                         GenericFunction(lambda X: np.ones(X.shape[:-1]), dim_domain=steps), 1.0):
-                add = (zero + one) + 0
+                add = (zero + one) + 1 - 1
                 sub = (zero - one) + np.zeros(())
                 neg = - zero
                 assert np.allclose(sub(x), [-1])
                 assert np.allclose(add(x), [1.0])
                 assert np.allclose(neg(x), [0.0])
                 (repr(add), str(add), repr(one), str(one))  # just to cover the respective special funcs too
-                mul = neg * 1.
+                mul = neg * 1. * 1.
+                mul_ = 1. * 1. * neg
                 assert np.allclose(mul(x), [0.0])
+                assert np.allclose(mul_(x), [0.0])
         with pytest.raises(AssertionError):
             zero + ConstantFunction(dim_domain=steps + 1)
     with pytest.raises(AssertionError):

--- a/src/pymortests/function.py
+++ b/src/pymortests/function.py
@@ -42,10 +42,12 @@ def test_lincomb_function():
             for one in (ConstantFunction(1.0, dim_domain=steps),
                         GenericFunction(lambda X: np.ones(X.shape[:-1]), dim_domain=steps), 1.0):
                 add = (zero + one) + 1 - 1
+                add_ =  1 - 1 + (zero + one)
                 sub = (zero - one) + np.zeros(())
                 neg = - zero
                 assert np.allclose(sub(x), [-1])
                 assert np.allclose(add(x), [1.0])
+                assert np.allclose(add_(x), [1.0])
                 assert np.allclose(neg(x), [0.0])
                 (repr(add), str(add), repr(one), str(one))  # just to cover the respective special funcs too
                 mul = neg * 1. * 1.

--- a/src/pymortests/parameter_functionals.py
+++ b/src/pymortests/parameter_functionals.py
@@ -24,15 +24,23 @@ def test_LincombParameterFunctional():
     zero = pf - pf 
     two_pf = pf + pf
     three_pf = pf + 2*pf
+    three_pf_ = pf + two_pf
     pf_plus_one = pf + 1
+    pf_plus_one_ = 1 + pf
     sum_ = epf + pf + 1 - 3
+    pf_squared_ = pf * pf
+    pf_times_pf_squared = pf * pf_squared_
     pf_squared =  (pf + 2*epf) * (pf - 2*epf) + 4 * epf * epf * 1
 
     assert zero(mu) == 0
     assert two_pf(mu) == 2 * pf(mu)
     assert three_pf(mu) == 3 * pf(mu)
+    assert three_pf_(mu) == 3 * pf(mu)
     assert pf_plus_one(mu) == pf(mu) + 1
+    assert pf_plus_one_(mu) == pf(mu) + 1
     assert sum_(mu) == epf(mu) + pf(mu) + 1 - 3
+    assert pf_squared_(mu) == pf(mu) * pf(mu)
+    assert pf_times_pf_squared(mu) == pf(mu) * pf(mu) * pf(mu)
     assert pf_squared(mu) == pf(mu) * pf(mu)
     assert sum_.d_mu('mu', 0)(mu) == epf.d_mu('mu', 0)(mu) + pf.d_mu('mu', 0)(mu)
     assert sum_.d_mu('mu', 1)(mu) == epf.d_mu('mu', 1)(mu) + pf.d_mu('mu', 1)(mu)

--- a/src/pymortests/parameter_functionals.py
+++ b/src/pymortests/parameter_functionals.py
@@ -23,14 +23,18 @@ def test_LincombParameterFunctional():
 
     zero = pf - pf 
     two_pf = pf + pf
+    two_pf_named = two_pf.with_(name='some_interesting_quantity')
     three_pf = pf + 2*pf
     three_pf_ = pf + two_pf
+    three_pf_named = pf + two_pf_named
     pf_plus_one = pf + 1
     pf_plus_one_ = 1 + pf
     sum_ = epf + pf + 1 - 3
     pf_squared_ = pf * pf
+    pf_squared_named = pf_squared_.with_(name='some_interesting_quantity')
     pf_times_pf_squared = pf * pf_squared_
-    pf_squared =  (pf + 2*epf) * (pf - 2*epf) + 4 * epf * epf * 1
+    pf_times_pf_squared_named = pf * pf_squared_named
+    pf_squared =  4 * epf * epf * 1 + (pf + 2*epf) * (pf - 2*epf)
 
     assert zero(mu) == 0
     assert two_pf(mu) == 2 * pf(mu)
@@ -40,8 +44,17 @@ def test_LincombParameterFunctional():
     assert pf_plus_one_(mu) == pf(mu) + 1
     assert sum_(mu) == epf(mu) + pf(mu) + 1 - 3
     assert pf_squared_(mu) == pf(mu) * pf(mu)
-    assert pf_times_pf_squared(mu) == pf(mu) * pf(mu) * pf(mu)
     assert pf_squared(mu) == pf(mu) * pf(mu)
+    assert pf_times_pf_squared(mu) == pf(mu) * pf(mu) * pf(mu)
+    # derivatives are linear
     assert sum_.d_mu('mu', 0)(mu) == epf.d_mu('mu', 0)(mu) + pf.d_mu('mu', 0)(mu)
     assert sum_.d_mu('mu', 1)(mu) == epf.d_mu('mu', 1)(mu) + pf.d_mu('mu', 1)(mu)
     assert sum_.d_mu('nu', 0)(mu) == epf.d_mu('nu', 0)(mu) + pf.d_mu('nu', 0)(mu)
+    # sums and products are not nested
+    assert len(sum_.coefficients) == 4
+    assert len(pf_squared.functionals[0].factors) == 4
+    # named functions will not be merged and still be nested
+    assert three_pf_named(mu) == three_pf_(mu)
+    assert len(three_pf_named.coefficients) != len(three_pf_.coefficients)
+    assert pf_times_pf_squared_named(mu) == pf_times_pf_squared(mu)
+    assert len(pf_times_pf_squared_named.factors) != len(pf_times_pf_squared.factors)

--- a/src/pymortests/parameter_functionals.py
+++ b/src/pymortests/parameter_functionals.py
@@ -25,14 +25,14 @@ def test_LincombParameterFunctional():
     two_pf = pf + pf
     three_pf = pf + 2*pf
     pf_plus_one = pf + 1
-    sum_ = epf + pf 
-    pf_squared =  (pf + 2*epf) * (pf - 2*epf) + 4 * epf * epf  
+    sum_ = epf + pf + 1 - 3
+    pf_squared =  (pf + 2*epf) * (pf - 2*epf) + 4 * epf * epf * 1
 
     assert zero(mu) == 0
     assert two_pf(mu) == 2 * pf(mu)
     assert three_pf(mu) == 3 * pf(mu)
     assert pf_plus_one(mu) == pf(mu) + 1
-    assert sum_(mu) == epf(mu) + pf(mu)
+    assert sum_(mu) == epf(mu) + pf(mu) + 1 - 3
     assert pf_squared(mu) == pf(mu) * pf(mu)
     assert sum_.d_mu('mu', 0)(mu) == epf.d_mu('mu', 0)(mu) + pf.d_mu('mu', 0)(mu)
     assert sum_.d_mu('mu', 1)(mu) == epf.d_mu('mu', 1)(mu) + pf.d_mu('mu', 1)(mu)


### PR DESCRIPTION
Currently '+', '-' and '*' produce nested functionals which I find a little bit difficult to read and has potential to be a lot slower in evaluating the functional. 

In particular, suppose that a, b, c and d are `ParameterFunctionals`, then 

product = a * b * c * d 

would currently result in 

`ProductParameterFunctional ( [ProductParameterFunctional( [ ProductParameterFunctional( [a, b] ) , c ]) , d] ) `

which will now be changed to

`ProductParameterFunctional ( [ a, b, c ,d ] )`

Same goes for `LincombParameterFunctional`. 

In addition, I think the same goes for `LincombFunction` and `LincombOperator`. I propose to also avoid nesting in these functions. Do you agree ? 