### PR TITLE
[parameters] Fix a serious bug in Parameters.parse()

### DIFF
--- a/src/pymor/parameters/base.py
+++ b/src/pymor/parameters/base.py
@@ -140,7 +140,7 @@ class Parameters(FrozenDict):
             all(isinstance(v, Number) for v in mu) or fail('not every element a number')
             len(mu) == sum(v for v in self.values()) or fail('wrong size')
             parsed_mu = {}
-            for k, v in self.items():
+            for k, v in sorted(self.items()):
                 p, mu = mu[:v], mu[v:]
                 parsed_mu[k] = p
             return Mu(parsed_mu)

--- a/src/pymortests/parameters.py
+++ b/src/pymortests/parameters.py
@@ -29,6 +29,11 @@ def test_randomly(space):
     for value in values:
         assert space.contains(value)
 
+def test_parse_parameter():
+    parameters = Parameters(b=2, a=1)
+    mu_as_list = [1,2,3]
+    mu_as_parameter_and_back = list(parameters.parse(mu_as_list).to_numpy())
+    assert mu_as_list == mu_as_parameter_and_back
 
 if __name__ == "__main__":
     runmodule(filename=__file__)


### PR DESCRIPTION
I noticed that the explanation in https://github.com/pymor/pymor/blob/781dfe63414807e6d761989729fab0fdceb2eaaa/src/pymor/parameters/base.py#L96 is not true. 
it is user input dependent how `Parameters` are parsed. In particular, 

`Parameters(b=2, a=1)`
`Parameters(a=1, b=2)`

will parse input lists differently. The `parse` method will first fill the 'b' part although `__str__` shows the alphabetical order. This can be easily fixed by also considering a sorted dict in the parse method. 