### PR TITLE
Ci hotfix

### DIFF
--- a/.ci/gitlab/ci.yml
+++ b/.ci/gitlab/ci.yml
@@ -75,6 +75,9 @@ stages:
     variables:
         DOCKER_HOST: tcp://docker:2375/
         DOCKER_DRIVER: overlay2
+        PYPI_MIRROR_TAG: d740c7196b6901aab305e4445b27ac18a18661ff
+        CI_IMAGE_TAG: d740c7196b6901aab305e4445b27ac18a18661ff
+        PYMOR_HYPOTHESIS_PROFILE: ci
     before_script:
         - 'export SHARED_PATH="${CI_PROJECT_DIR}/shared"'
         - mkdir -p ${SHARED_PATH}

--- a/.ci/gitlab/common_test_setup.bash
+++ b/.ci/gitlab/common_test_setup.bash
@@ -6,6 +6,7 @@ else
     export PULL_REQUEST=${CI_MERGE_REQUEST_ID}
 fi
 
+export PYTHONPATH_PRE=${PYTHONPATH}
 export PYTHONPATH=${CI_PROJECT_DIR}/src:${PYTHONPATH}
 export PATH=~/.local/bin:${PATH}
 

--- a/.ci/gitlab/common_test_setup.bash
+++ b/.ci/gitlab/common_test_setup.bash
@@ -9,7 +9,7 @@ fi
 export PYTHONPATH=${CI_PROJECT_DIR}/src:${PYTHONPATH}
 export PATH=~/.local/bin:${PATH}
 
-PYMOR_ROOT="$(cd "$(dirname ${BASH_SOURCE[0]})" ; cd ../../ ; pwd -P )"
+export PYMOR_ROOT="$(cd "$(dirname ${BASH_SOURCE[0]})" ; cd ../../ ; pwd -P )"
 cd "${PYMOR_ROOT}"
 # any failure here should fail the whole test
 set -eux
@@ -29,4 +29,6 @@ export PYTHONHASHSEED=0
 python setup.py build_ext -i
 
 PYMOR_VERSION=$(python -c 'import pymor;print(pymor.__version__)')
-COMMON_PYTEST_OPTS="--junitxml=test_results_${PYMOR_VERSION}.xml --cov=src/pymor --cov-report=xml  --memprof-top-n 50 --memprof-csv-file=memory_usage.txt"
+COMMON_PYTEST_OPTS="--junitxml=test_results_${PYMOR_VERSION}.xml --cov=src/pymor --cov-report=xml  \
+  --memprof-top-n 50 --memprof-csv-file=memory_usage.txt\
+  --hypothesis-profile ${PYMOR_HYPOTHESIS_PROFILE}"

--- a/.ci/gitlab/template.ci.py
+++ b/.ci/gitlab/template.ci.py
@@ -77,6 +77,9 @@ stages:
     variables:
         DOCKER_HOST: tcp://docker:2375/
         DOCKER_DRIVER: overlay2
+        PYPI_MIRROR_TAG: {{pypi_mirror_tag}}
+        CI_IMAGE_TAG: {{ci_image_tag}}
+        PYMOR_HYPOTHESIS_PROFILE: ci
     before_script:
         - 'export SHARED_PATH="${CI_PROJECT_DIR}/shared"'
         - mkdir -p ${SHARED_PATH}

--- a/.ci/gitlab/test_pip_installed.bash
+++ b/.ci/gitlab/test_pip_installed.bash
@@ -24,6 +24,13 @@ pushd ${SDIST_DIR}
 pip install $(ls ${SDIST_DIR})
 popd
 
-xvfb-run -a py.test ${COMMON_PYTEST_OPTS} --pyargs pymortests -c .ci/installed_pytest.ini
+# make sure pytest does not pick up anything from the source tree
+export PYTHONPATH=${PYTHONPATH_PRE}
+tmpdir=$(mktemp -d)
+pushd ${tmpdir}
+# for some reason the installed conftest plugin is not picked up
+cp ${PYMOR_ROOT}/conftest.py .
+xvfb-run -a pytest ${COMMON_PYTEST_OPTS} --pyargs pymortests -c ${PYMOR_ROOT}/.ci/installed_pytest.ini
 # make sure the demo script was instaled and is usable
 pymor-demo -h
+popd

--- a/.ci/installed_pytest.ini
+++ b/.ci/installed_pytest.ini
@@ -5,3 +5,4 @@ python_files = pymortests/*.py
 python_class = Test
 pep8maxlinelength = 120
 pep8ignore = E221,E226,E241,E242
+junit_family=xunit2

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,1 @@
+src/pymortests/conftest.py

--- a/src/pymortests/vectorarray.py
+++ b/src/pymortests/vectorarray.py
@@ -430,7 +430,7 @@ def test_axpy(vector_arrays, random):
 
 @pyst.given_vector_arrays(count=2, random=hyst.random_module())
 # TODO replace indices loop
-@settings(deadline=None, suppress_health_check=(HealthCheck.filter_too_much,HealthCheck.too_slow))
+@settings(deadline=None)
 def test_axpy_one_x(vector_arrays, random):
     v1, v2 = vector_arrays
     for ind1, ind2 in product(pyst.valid_inds(v1, random_module=False), pyst.valid_inds(v2, 1, random_module=False)):


### PR DESCRIPTION
The current problems in CI pipelines stem from the hypothesis profile, defined in the conftest plugin, not being loaded. (Mostly) Following the (current) pytest I've linked the plugin to the project root (where we always invoke pytest from). 

I have no clue why this started happening yet.

This does not yet fix the case where we test our pip installed module. 