### PR TITLE
Set gram_schmidt tolerances in POD to 0 to never truncate pod modes

### DIFF
--- a/.ci/gitlab/ci.yml
+++ b/.ci/gitlab/ci.yml
@@ -44,6 +44,7 @@ stages:
             - src/pymortests/testdata/check_results/*/*_changed
             - coverage.xml
             - memory_usage.txt
+            - .hypothesis
         reports:
             junit: test_results*.xml
 

--- a/.ci/gitlab/template.ci.py
+++ b/.ci/gitlab/template.ci.py
@@ -46,6 +46,7 @@ stages:
             - src/pymortests/testdata/check_results/*/*_changed
             - coverage.xml
             - memory_usage.txt
+            - .hypothesis
         reports:
             junit: test_results*.xml
 

--- a/src/pymor/algorithms/pod.py
+++ b/src/pymor/algorithms/pod.py
@@ -87,8 +87,6 @@ def pod(A, product=None, modes=None, rtol=4e-8, atol=0., l2_err=0.,
         err = np.max(np.abs(POD.inner(POD, product) - np.eye(len(POD))))
         if err >= orth_tol:
             logger.info('Reorthogonalizing POD modes ...')
-            gram_schmidt(POD, product=product, copy=False)
-            # adjust length of SVALS in case gram_schmidt has removed vectors
-            SVALS = SVALS[:len(POD)]
+            gram_schmidt(POD, product=product, atol=0., rtol=0., copy=False)
 
     return POD, SVALS


### PR DESCRIPTION
Fixes #961.