### PR TITLE
Doc build warning fixes

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,2 @@
-[report]
-omit = */playground/*
-
 [paths]
 source = src/pymor src/pymordemos

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -10,7 +10,7 @@ BUILDDIR      = _build
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4
 PAPEROPT_letter = -D latex_paper_size=letter
-ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) 
+ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS)
 # the i18n builder cannot share the environment and doctrees with the others
 I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 
@@ -40,6 +40,7 @@ help:
 
 clean:
 	-rm -rf $(BUILDDIR)/*
+	-rm -f source/generated/*.rst
 
 html:
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html


### PR DESCRIPTION
Running `make docs` on my machine raised a lot of warnings of the form `failed to import pymor.some.module`. It seems the issue were leftover ReST files in `docs/source/generated/` from before the moving of different subpackages. With this PR, running `make clean` in `docs/` will also remove these files.

I also noticed that `playground/` was referenced in `.coveragerc`, so I removed that part.

Sphinx still complains about instance attributes documented in the `Attributes` sections of classes:
<details>
<summary>The list of warnings</summary>

```
Didn't find CircleDomain.domain in pymor.analyticalproblems.domaindescriptions
Didn't find CircularSectorDomain.angle in pymor.analyticalproblems.domaindescriptions
Didn't find CircularSectorDomain.radius in pymor.analyticalproblems.domaindescriptions
Didn't find CircularSectorDomain.arc in pymor.analyticalproblems.domaindescriptions
Didn't find CircularSectorDomain.radii in pymor.analyticalproblems.domaindescriptions
Didn't find CircularSectorDomain.num_points in pymor.analyticalproblems.domaindescriptions
Didn't find CylindricalDomain.domain in pymor.analyticalproblems.domaindescriptions
Didn't find CylindricalDomain.top in pymor.analyticalproblems.domaindescriptions
Didn't find CylindricalDomain.bottom in pymor.analyticalproblems.domaindescriptions
Didn't find DiscDomain.radius in pymor.analyticalproblems.domaindescriptions
Didn't find DiscDomain.boundary in pymor.analyticalproblems.domaindescriptions
Didn't find DiscDomain.num_points in pymor.analyticalproblems.domaindescriptions
Didn't find LineDomain.domain in pymor.analyticalproblems.domaindescriptions
Didn't find LineDomain.left in pymor.analyticalproblems.domaindescriptions
Didn't find LineDomain.right in pymor.analyticalproblems.domaindescriptions
Didn't find PolygonalDomain.points in pymor.analyticalproblems.domaindescriptions
Didn't find PolygonalDomain.holes in pymor.analyticalproblems.domaindescriptions
Didn't find RectDomain.domain in pymor.analyticalproblems.domaindescriptions
Didn't find RectDomain.left in pymor.analyticalproblems.domaindescriptions
Didn't find RectDomain.right in pymor.analyticalproblems.domaindescriptions
Didn't find RectDomain.top in pymor.analyticalproblems.domaindescriptions
Didn't find RectDomain.bottom in pymor.analyticalproblems.domaindescriptions
Didn't find TorusDomain.domain in pymor.analyticalproblems.domaindescriptions
Didn't find StationaryProblem.domain in pymor.analyticalproblems.elliptic
Didn't find StationaryProblem.rhs in pymor.analyticalproblems.elliptic
Didn't find StationaryProblem.diffusion in pymor.analyticalproblems.elliptic
Didn't find StationaryProblem.advection in pymor.analyticalproblems.elliptic
Didn't find StationaryProblem.nonlinear_advection in pymor.analyticalproblems.elliptic
Didn't find StationaryProblem.nonlinear_advection_derivative in pymor.analyticalproblems.elliptic
Didn't find StationaryProblem.reaction in pymor.analyticalproblems.elliptic
Didn't find StationaryProblem.nonlinear_reaction in pymor.analyticalproblems.elliptic
Didn't find StationaryProblem.nonlinear_reaction_derivative in pymor.analyticalproblems.elliptic
Didn't find StationaryProblem.dirichlet_data in pymor.analyticalproblems.elliptic
Didn't find StationaryProblem.neumann_data in pymor.analyticalproblems.elliptic
Didn't find StationaryProblem.robin_data in pymor.analyticalproblems.elliptic
Didn't find StationaryProblem.outputs in pymor.analyticalproblems.elliptic
Didn't find Function.dim_domain in pymor.analyticalproblems.functions
Didn't find Function.shape_range in pymor.analyticalproblems.functions
Didn't find LincombFunction.functions in pymor.analyticalproblems.functions
Didn't find LincombFunction.coefficients in pymor.analyticalproblems.functions
Didn't find ProductFunction.functions in pymor.analyticalproblems.functions
Didn't find InstationaryProblem.T in pymor.analyticalproblems.instationary
Didn't find InstationaryProblem.stationary_part in pymor.analyticalproblems.instationary
Didn't find InstationaryProblem.parameter_ranges in pymor.analyticalproblems.instationary
Didn't find BilinearModel.A in pymor.models.iosys
Didn't find BilinearModel.N in pymor.models.iosys
Didn't find BilinearModel.B in pymor.models.iosys
Didn't find BilinearModel.C in pymor.models.iosys
Didn't find BilinearModel.D in pymor.models.iosys
Didn't find BilinearModel.E in pymor.models.iosys
Didn't find LTIModel.A in pymor.models.iosys
Didn't find LTIModel.B in pymor.models.iosys
Didn't find LTIModel.C in pymor.models.iosys
Didn't find LTIModel.D in pymor.models.iosys
Didn't find LTIModel.E in pymor.models.iosys
Didn't find LinearDelayModel.q in pymor.models.iosys
Didn't find LinearDelayModel.tau in pymor.models.iosys
Didn't find LinearDelayModel.A in pymor.models.iosys
Didn't find LinearDelayModel.Ad in pymor.models.iosys
Didn't find LinearDelayModel.B in pymor.models.iosys
Didn't find LinearDelayModel.C in pymor.models.iosys
Didn't find LinearDelayModel.D in pymor.models.iosys
Didn't find LinearDelayModel.E in pymor.models.iosys
Didn't find LinearStochasticModel.q in pymor.models.iosys
Didn't find LinearStochasticModel.A in pymor.models.iosys
Didn't find LinearStochasticModel.As in pymor.models.iosys
Didn't find LinearStochasticModel.B in pymor.models.iosys
Didn't find LinearStochasticModel.C in pymor.models.iosys
Didn't find LinearStochasticModel.D in pymor.models.iosys
Didn't find LinearStochasticModel.E in pymor.models.iosys
Didn't find SecondOrderModel.M in pymor.models.iosys
Didn't find SecondOrderModel.E in pymor.models.iosys
Didn't find SecondOrderModel.K in pymor.models.iosys
Didn't find SecondOrderModel.B in pymor.models.iosys
Didn't find SecondOrderModel.Cp in pymor.models.iosys
Didn't find SecondOrderModel.Cv in pymor.models.iosys
Didn't find SecondOrderModel.D in pymor.models.iosys
Didn't find TransferFunction.tf in pymor.models.iosys
Didn't find TransferFunction.dtf in pymor.models.iosys
Didn't find VectorArray.space in pymor.vectorarrays.interface
Didn't find LincombParameterFunctional.functionals in pymor.parameters.functionals
Didn't find LincombParameterFunctional.coefficients in pymor.parameters.functionals
Didn't find ConformalTopologicalGrid.dim in pymor.discretizers.builtin.grids.interfaces
Didn't find rule.action in pymor.algorithms.rules
Didn't find Operator.linear in pymor.operators.interface
Didn't find Operator.source in pymor.operators.interface
Didn't find Operator.range in pymor.operators.interface
```
</details>

I'm not sure if or how can this be fixed.