### PR TITLE
Remove S parameter from Riccati equation solvers

### DIFF
--- a/src/pymor/algorithms/lrradi.py
+++ b/src/pymor/algorithms/lrradi.py
@@ -55,7 +55,7 @@ def ricc_lrcf_solver_options(lrradi_tol=1e-10,
                                                'subspace_columns': hamiltonian_shifts_subspace_columns}}}}
 
 
-def solve_ricc_lrcf(A, E, B, C, R=None, S=None, trans=False, options=None):
+def solve_ricc_lrcf(A, E, B, C, R=None, trans=False, options=None):
     """Compute an approximate low-rank solution of a Riccati equation.
 
     See :func:`pymor.algorithms.riccati.solve_ricc_lrcf` for a
@@ -75,8 +75,6 @@ def solve_ricc_lrcf(A, E, B, C, R=None, S=None, trans=False, options=None):
         The operator C as a |VectorArray| from `A.source`.
     R
         The operator R as a 2D |NumPy array| or `None`.
-    S
-        The operator S as a |VectorArray| from `A.source` or `None`.
     trans
         Whether the first |Operator| in the Riccati equation is
         transposed.
@@ -91,7 +89,7 @@ def solve_ricc_lrcf(A, E, B, C, R=None, S=None, trans=False, options=None):
         |VectorArray| from `A.source`.
     """
 
-    _solve_ricc_check_args(A, E, B, C, None, None, trans)
+    _solve_ricc_check_args(A, E, B, C, R, trans)
     options = _parse_options(options, ricc_lrcf_solver_options(), 'lrradi', None, False)
     logger = getLogger('pymor.algorithms.lrradi.solve_ricc_lrcf')
 
@@ -104,9 +102,6 @@ def solve_ricc_lrcf(A, E, B, C, R=None, S=None, trans=False, options=None):
 
     if E is None:
         E = IdentityOperator(A.source)
-
-    if S is not None:
-        raise NotImplementedError
 
     if R is not None:
         Rc = spla.cholesky(R)                                 # R = Rc^T * Rc

--- a/src/pymor/algorithms/riccati.py
+++ b/src/pymor/algorithms/riccati.py
@@ -18,7 +18,7 @@ _DEFAULT_RICC_LRCF_DENSE_SOLVER_BACKEND = ('pymess' if config.HAVE_PYMESS else
 
 
 @defaults('default_sparse_solver_backend', 'default_dense_solver_backend')
-def solve_ricc_lrcf(A, E, B, C, R=None, S=None, trans=False, options=None,
+def solve_ricc_lrcf(A, E, B, C, R=None, trans=False, options=None,
                     default_sparse_solver_backend=_DEFAULT_RICC_LRCF_SPARSE_SOLVER_BACKEND,
                     default_dense_solver_backend=_DEFAULT_RICC_LRCF_DENSE_SOLVER_BACKEND):
     """Compute an approximate low-rank solution of a Riccati equation.
@@ -31,28 +31,25 @@ def solve_ricc_lrcf(A, E, B, C, R=None, S=None, trans=False, options=None,
 
       .. math::
           A X E^T + E X A^T
-          - (E X C^T + S) R^{-1} (E X C^T + S)^T
+          - E X C^T R^{-1} C X E^T
           + B B^T = 0.
 
     - if trans is `True`
 
       .. math::
           A^T X E + E^T X A
-          - (E^T X B + S) R^{-1} (E^T X B + S)^T
+          - E^T X B R^{-1} B^T X E
           + C^T C = 0.
 
     If E is None, it is taken to be identity, and similarly for R.
-    If S is None, it is taken to be zero.
 
     We assume:
 
     - A and E are real |Operators|,
-    - B, C and S are real |VectorArrays| from `A.source`,
+    - B and C are real |VectorArrays| from `A.source`,
     - R is a real |NumPy array|,
-    - (E, A, B, C) is stabilizable and detectable,
-    - R is symmetric positive definite, and
-    - :math:`B B^T - S R^{-1} S^T` (:math:`C^T C - S R^{-1} S^T`) is
-      positive semi-definite trans is `False` (`True`).
+    - (E, A, B, C) is stabilizable and detectable, and
+    - R is symmetric positive definite.
 
     For large-scale problems, we additionally assume that `len(B)` and
     `len(C)` are small.
@@ -85,8 +82,6 @@ def solve_ricc_lrcf(A, E, B, C, R=None, S=None, trans=False, options=None,
         The operator C as a |VectorArray| from `A.source`.
     R
         The operator R as a 2D |NumPy array| or `None`.
-    S
-        The operator S as a |VectorArray| from `A.source` or `None`.
     trans
         Whether the first |Operator| in the Riccati equation is
         transposed.
@@ -111,7 +106,7 @@ def solve_ricc_lrcf(A, E, B, C, R=None, S=None, trans=False, options=None,
         |VectorArray| from `A.source`.
     """
 
-    _solve_ricc_check_args(A, E, B, C, R, S, trans)
+    _solve_ricc_check_args(A, E, B, C, R, trans)
     if options:
         solver = options if isinstance(options, str) else options['type']
         backend = solver.split('_')[0]
@@ -130,7 +125,7 @@ def solve_ricc_lrcf(A, E, B, C, R=None, S=None, trans=False, options=None,
         from pymor.algorithms.lrradi import solve_ricc_lrcf as solve_ricc_impl
     else:
         raise ValueError(f'Unknown solver backend ({backend}).')
-    return solve_ricc_impl(A, E, B, C, R, S, trans=trans, options=options)
+    return solve_ricc_impl(A, E, B, C, R, trans=trans, options=options)
 
 
 _DEFAULT_POS_RICC_LRCF_DENSE_SOLVER_BACKEND = ('pymess' if config.HAVE_PYMESS else
@@ -139,7 +134,7 @@ _DEFAULT_POS_RICC_LRCF_DENSE_SOLVER_BACKEND = ('pymess' if config.HAVE_PYMESS el
 
 
 @defaults('default_dense_solver_backend')
-def solve_pos_ricc_lrcf(A, E, B, C, R=None, S=None, trans=False, options=None,
+def solve_pos_ricc_lrcf(A, E, B, C, R=None, trans=False, options=None,
                         default_dense_solver_backend=_DEFAULT_RICC_LRCF_DENSE_SOLVER_BACKEND):
     """Compute an approximate low-rank solution of a positive Riccati equation.
 
@@ -151,18 +146,17 @@ def solve_pos_ricc_lrcf(A, E, B, C, R=None, S=None, trans=False, options=None,
 
       .. math::
           A X E^T + E X A^T
-          + (E X C^T + S) R^{-1} (E X C^T + S)^T
+          + E X C^T R^{-1} C X E^T
           + B B^T = 0.
 
     - if trans is `True`
 
       .. math::
           A^T X E + E^T X A
-          + (E^T X B + S) R^{-1} (E^T X B + S)^T
+          + E^T X B R^{-1} B^T X E
           + C^T C = 0.
 
     If E is None, it is taken to be identity, and similarly for R.
-    If S is None, it is taken to be zero.
 
     If the solver is not specified using the options argument, a solver
     backend is chosen based on availability in the following order:
@@ -183,8 +177,6 @@ def solve_pos_ricc_lrcf(A, E, B, C, R=None, S=None, trans=False, options=None,
         The operator C as a |VectorArray| from `A.source`.
     R
         The operator R as a 2D |NumPy array| or `None`.
-    S
-        The operator S as a |VectorArray| from `A.source` or `None`.
     trans
         Whether the first |Operator| in the positive Riccati equation is
         transposed.
@@ -206,7 +198,7 @@ def solve_pos_ricc_lrcf(A, E, B, C, R=None, S=None, trans=False, options=None,
         solution, |VectorArray| from `A.source`.
     """
 
-    _solve_ricc_check_args(A, E, B, C, R, S, trans)
+    _solve_ricc_check_args(A, E, B, C, R, trans)
     if options:
         solver = options if isinstance(options, str) else options['type']
         backend = solver.split('_')[0]
@@ -220,10 +212,10 @@ def solve_pos_ricc_lrcf(A, E, B, C, R=None, S=None, trans=False, options=None,
         from pymor.bindings.pymess import solve_pos_ricc_lrcf as solve_ricc_impl
     else:
         raise ValueError(f'Unknown solver backend ({backend}).')
-    return solve_ricc_impl(A, E, B, C, R, S, trans=trans, options=options)
+    return solve_ricc_impl(A, E, B, C, R, trans=trans, options=options)
 
 
-def _solve_ricc_check_args(A, E, B, C, R, S, trans):
+def _solve_ricc_check_args(A, E, B, C, R, trans):
     assert isinstance(A, Operator) and A.linear
     assert not A.parametric
     assert A.source == A.range
@@ -240,9 +232,3 @@ def _solve_ricc_check_args(A, E, B, C, R, S, trans):
             assert R.shape[0] == len(C)
         else:
             assert R.shape[0] == len(B)
-    if S is not None:
-        assert S in A.source
-        if not trans:
-            assert len(S) == len(C)
-        else:
-            assert len(S) == len(B)

--- a/src/pymor/bindings/scipy.py
+++ b/src/pymor/bindings/scipy.py
@@ -435,7 +435,7 @@ def ricc_lrcf_solver_options():
     return {'scipy': {'type': 'scipy'}}
 
 
-def solve_ricc_lrcf(A, E, B, C, R=None, S=None, trans=False, options=None):
+def solve_ricc_lrcf(A, E, B, C, R=None, trans=False, options=None):
     """Compute an approximate low-rank solution of a Riccati equation.
 
     See :func:`pymor.algorithms.riccati.solve_ricc_lrcf` for a general
@@ -460,8 +460,6 @@ def solve_ricc_lrcf(A, E, B, C, R=None, S=None, trans=False, options=None):
         The operator C as a |VectorArray| from `A.source`.
     R
         The operator R as a 2D |NumPy array| or `None`.
-    S
-        The operator S as a |VectorArray| from `A.source` or `None`.
     trans
         Whether the first |Operator| in the Riccati equation is
         transposed.
@@ -475,7 +473,7 @@ def solve_ricc_lrcf(A, E, B, C, R=None, S=None, trans=False, options=None):
         |VectorArray| from `A.source`.
     """
 
-    _solve_ricc_check_args(A, E, B, C, R, S, trans)
+    _solve_ricc_check_args(A, E, B, C, R, trans)
     options = _parse_options(options, ricc_lrcf_solver_options(), 'scipy', None, False)
     if options['type'] != 'scipy':
         raise ValueError(f"Unexpected Riccati equation solver ({options['type']}).")
@@ -485,15 +483,14 @@ def solve_ricc_lrcf(A, E, B, C, R=None, S=None, trans=False, options=None):
     E = to_matrix(E, format='dense') if E else None
     B = B.to_numpy().T
     C = C.to_numpy()
-    S = S.to_numpy().T if S else None
     if R is None:
         R = np.eye(C.shape[0] if not trans else B.shape[1])
     if not trans:
         if E is not None:
             E = E.T
-        X = solve_continuous_are(A.T, C.T, B.dot(B.T), R, E, S)
+        X = solve_continuous_are(A.T, C.T, B.dot(B.T), R, E)
     else:
-        X = solve_continuous_are(A, B, C.T.dot(C), R, E, S)
+        X = solve_continuous_are(A, B, C.T.dot(C), R, E)
 
     return A_source.from_numpy(_chol(X).T)
 
@@ -509,7 +506,7 @@ def pos_ricc_lrcf_solver_options():
     return {'scipy': {'type': 'scipy'}}
 
 
-def solve_pos_ricc_lrcf(A, E, B, C, R=None, S=None, trans=False, options=None):
+def solve_pos_ricc_lrcf(A, E, B, C, R=None, trans=False, options=None):
     """Compute an approximate low-rank solution of a positive Riccati equation.
 
     See :func:`pymor.algorithms.riccati.solve_pos_ricc_lrcf` for a
@@ -534,8 +531,6 @@ def solve_pos_ricc_lrcf(A, E, B, C, R=None, S=None, trans=False, options=None):
         The operator C as a |VectorArray| from `A.source`.
     R
         The operator R as a 2D |NumPy array| or `None`.
-    S
-        The operator S as a |VectorArray| from `A.source` or `None`.
     trans
         Whether the first |Operator| in the positive Riccati equation is
         transposed.
@@ -550,11 +545,11 @@ def solve_pos_ricc_lrcf(A, E, B, C, R=None, S=None, trans=False, options=None):
         solution, |VectorArray| from `A.source`.
     """
 
-    _solve_ricc_check_args(A, E, B, C, R, S, trans)
+    _solve_ricc_check_args(A, E, B, C, R, trans)
     options = _parse_options(options, pos_ricc_lrcf_solver_options(), 'scipy', None, False)
     if options['type'] != 'scipy':
         raise ValueError(f"Unexpected positive Riccati equation solver ({options['type']}).")
 
     if R is None:
         R = np.eye(len(C) if not trans else len(B))
-    return solve_ricc_lrcf(A, E, B, C, -R, S, trans, options)
+    return solve_ricc_lrcf(A, E, B, C, -R, trans, options)


### PR DESCRIPTION
I have a few reasons for removing `S`.

- A Riccati equation with `S` can be converted, just by rearranging the terms, into one without `S`, in which case `A` becomes a low-rank updated operator (and, since recently, we have `LowRankUpdatedOperators`).
- Py-M.E.S.S. and `pymor.algorithms.lrradi` do not have (direct) support for `S`.
- For MOR applications, it seems beneficial to use the form without `S`. E.g., LQGBT with nonzero `D` needs to solve APE<sup>T</sup> + EPA<sup>T</sup> - (EPC<sup>T</sup> + BD<sup>T</sup>) (I + DD<sup>T</sup>)<sup>-1</sup> (EPC<sup>T</sup> + BD<sup>T</sup>)<sup>T</sup> + BB<sup>T</sup> = 0</center>, i.e., without the `S` term, (A - BD<sup>T</sup>(I + DD<sup>T</sup>)<sup>-1</sup>C)PE<sup>T</sup> + EP(A - BD<sup>T</sup>(I + DD<sup>T</sup>)<sup>-1</sup>C)<sup>T</sup> - EPC<sup>T</sup>(I + DD<sup>T</sup>)<sup>-1</sup>CPE<sup>T</sup> + B(I + D<sup>T</sup>D)<sup>-1</sup>B<sup>T</sup> = 0. In particular, the last term in the equation (the one without P) can be simplified such that it is clearly positive semidefinite. (It works similarly for BRBT, PRBT, and BST.)