### PR TITLE
Add caching for LQGBTReductor and BRBTReductor Gramians

### DIFF
--- a/docs/source/tutorial_unstable_lti_systems.md
+++ b/docs/source/tutorial_unstable_lti_systems.md
@@ -42,8 +42,8 @@ If the system is asymptotically stable, i.e., all eigenvalues of the
 matrix pair {math}`(A, E)` lie in the open left half plane, methods like
 balanced truncation (see {doc}`tutorial_bt`) can be used for model
 order reduction. Asymptotic stability of the LTI system is a crucial
-assumption for balanced truncation because the observability and
-controllability Gramians are not defined if the matrix pair {math}`(A, E)` has
+assumption for balanced truncation because the controllability and
+observability Gramians are not defined if the matrix pair {math}`(A, E)` has
 eigenvalues with a positive real part (in this case we call the LTI system
 unstable). Additionally, commonly used system norms like the
 {math}`\mathcal{H}_2` norm, the {math}`\mathcal{H}_\infty` norm, and
@@ -70,7 +70,7 @@ one input {math}`u(t)` and one output {math}`y(t)`:
 \end{align}
 ```
 
-Depending on the choice of the parameter {math}`\lambda` the discretization of
+Depending on the choice of the parameter {math}`\lambda`, the discretization of
 the above partial differential equation is an unstable LTI system. In order to
 build the {{ LTIModel }} we follow the lines of {doc}`tutorial_lti_systems`.
 
@@ -115,9 +115,9 @@ print(ast_spectrum[1])
 In the code snippet above, all eigenvalues of the matrix pair {math}`(A, E)` are
 computed using dense methods. This works well for systems with a small state space
 dimension. For large-scale systems it is wiser to rely on iterative methods for
-computing eigenvalues. The code below computes 10 system poles which are
-close to 0 using pyMOR's iterative eigensolver and filters the result for
-values with a positive real part.
+computing eigenvalues. The code below redefines `fom` to compute 10 system poles
+that are close to 0 using pyMOR's iterative eigensolver and filters the result
+for values with a positive real part.
 
 ```{code-cell}
 fom = fom.with_(ast_pole_data={'k': 10, 'sigma': 0})
@@ -127,7 +127,7 @@ print(ast_spectrum[1])
 
 ## Frequency domain balanced truncation
 
-The observability and controllability Gramians (defined in the time-domain)
+The controllability and observability Gramians (defined in the time-domain)
 introduced in {doc}`tutorial_lti_systems` do not exist for unstable systems.
 However, the frequency domain representations of these Gramians are defined for
 systems with no poles on the imaginary axis. Hence, for most unstable systems we
@@ -164,11 +164,13 @@ fdbt = FDBTReductor(fom)
 ```
 
 In order to perform a Bernoulli stabilization, knowledge about the anti-stable
-subset of system poles is required. With the `ast_pole_data` argument we can provide
-information about the system poles to the reductor (i.e. list of anti-stable
-eigenvalues with or without corresponding eigenvectors) or specify how eigenvalues
-should be computed (i.e. `None` for computing all eigenvalues using dense methods
-or arguments for pyMOR's iterative eigensolver like in the code above).
+subset of system poles is required. Therefore,
+{class}`~pymor.reductors.bt.FDBTReductor` internally calls
+`fom.get_ast_spectrum` using the `ast_pole_data` attribute, which can be a list
+of anti-stable eigenvalues (with or without corresponding eigenvectors) or
+specifying how eigenvalues should be computed (`None` for computing all
+eigenvalues using dense methods or arguments for pyMOR's iterative eigensolver
+like in the code above).
 
 Before we use the {meth}`~pymor.reductors.bt.FDBTReductor.reduce` method to
 obtain a reduced-order model, we take a look at some a priori error bounds for

--- a/docs/source/tutorial_unstable_lti_systems.md
+++ b/docs/source/tutorial_unstable_lti_systems.md
@@ -120,7 +120,8 @@ close to 0 using pyMOR's iterative eigensolver and filters the result for
 values with a positive real part.
 
 ```{code-cell}
-ast_spectrum = fom.get_ast_spectrum(ast_pole_data={'k': 10, 'sigma': 0})
+fom = fom.with_(ast_pole_data={'k': 10, 'sigma': 0})
+ast_spectrum = fom.get_ast_spectrum()
 print(ast_spectrum[1])
 ```
 
@@ -159,7 +160,7 @@ Let us start with initializing a reductor object
 
 ```{code-cell}
 from pymor.reductors.bt import FDBTReductor
-fdbt = FDBTReductor(fom, ast_pole_data={'k': 10, 'sigma': 0})
+fdbt = FDBTReductor(fom)
 ```
 
 In order to perform a Bernoulli stabilization, knowledge about the anti-stable

--- a/docs/source/unstable_heat_equation.py
+++ b/docs/source/unstable_heat_equation.py
@@ -3,16 +3,16 @@ import scipy.sparse as sps
 
 k = 50
 n = 2 * k + 1
-l = 50
+lam = 50
 
 E = sps.eye(n, format='lil')
 E[0, 0] = E[-1, -1] = 0.5
 E = E.tocsc()
 
-d0 = n * [-2 * (n - 1)**2 + l]
+d0 = n * [-2 * (n - 1)**2 + lam]
 d1 = (n - 1) * [(n - 1)**2]
 A = sps.diags([d1, d0, d1], [-1, 0, 1], format='lil')
-A[0, 0] = A[-1, -1] = -n * (n - 1) + l / 2
+A[0, 0] = A[-1, -1] = -n * (n - 1) + lam / 2
 A = A.tocsc()
 
 B = np.zeros((n, 1))

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -78,6 +78,14 @@ class LTIModel(Model):
         :math:`\mathcal{H}_\infty/\mathcal{L}_\infty` norm is attained can be preset with `fpeak`.
     solver_options
         The solver options to use to solve matrix equations.
+    ast_pole_data
+        Can be:
+
+        - dictionary of parameters for :func:`~pymor.algorithms.eigs.eigs`,
+        - list of anti-stable eigenvalues (scalars),
+        - tuple `(lev, ew, rev)` where `ew` contains the sorted anti-stable eigenvalues
+            and `lev` and `rev` are |VectorArrays| representing the eigenvectors.
+        - `None` if anti-stable eigenvalues should be computed via dense methods.
     error_estimator
         An error estimator for the problem. This can be any object with an
         `estimate_error(U, mu, model)` method. If `error_estimator` is not `None`, an
@@ -114,7 +122,8 @@ class LTIModel(Model):
     """
 
     def __init__(self, A, B, C, D=None, E=None, sampling_time=0, presets=None,
-                 solver_options=None, error_estimator=None, visualizer=None, name=None):
+                 solver_options=None, ast_pole_data=None,
+                 error_estimator=None, visualizer=None, name=None):
 
         assert A.linear
         assert A.source == A.range

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -1493,7 +1493,7 @@ class PHLTIModel(Model):
         """
         assert typ in ('c_lrcf', 'o_lrcf', 'c_dense', 'o_dense')
 
-        return self.to_lti().gramian(typ, mu)
+        return self.to_lti().gramian(typ, mu=mu)
 
     def _sv_U_V(self, typ='lyap', mu=None):
         """Compute (Hankel) singular values and vectors.

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -121,6 +121,8 @@ class LTIModel(Model):
         The transfer function.
     """
 
+    cache_region = 'memory'
+
     def __init__(self, A, B, C, D=None, E=None, sampling_time=0, presets=None,
                  solver_options=None, ast_pole_data=None,
                  error_estimator=None, visualizer=None, name=None):
@@ -1251,6 +1253,8 @@ class PHLTIModel(Model):
         The transfer function.
     """
 
+    cache_region = 'memory'
+
     def __init__(self, J, R, G, P=None, S=None, N=None, E=None,
                  solver_options=None, error_estimator=None, visualizer=None, name=None):
         assert J.linear
@@ -1755,6 +1759,8 @@ class SecondOrderModel(Model):
     transfer_function
         The transfer function.
     """
+
+    cache_region = 'memory'
 
     def __init__(self, M, E, K, B, Cp, Cv=None, D=None, sampling_time=0,
                  solver_options=None, error_estimator=None, visualizer=None, name=None):
@@ -2439,6 +2445,8 @@ class LinearDelayModel(Model):
         The transfer function.
     """
 
+    cache_region = 'memory'
+
     def __init__(self, A, Ad, tau, B, C, D=None, E=None, sampling_time=0,
                  error_estimator=None, visualizer=None, name=None):
 
@@ -2703,6 +2711,8 @@ class LinearStochasticModel(Model):
         The |Operator| E.
     """
 
+    cache_region = 'memory'
+
     def __init__(self, A, As, B, C, D=None, E=None, sampling_time=0,
                  error_estimator=None, visualizer=None, name=None):
 
@@ -2829,6 +2839,8 @@ class BilinearModel(Model):
     E
         The |Operator| E.
     """
+
+    cache_region = 'memory'
 
     def __init__(self, A, N, B, C, D, E=None, sampling_time=0,
                  error_estimator=None, visualizer=None, name=None):

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -11,7 +11,7 @@ from pymor.algorithms.bernoulli import bernoulli_stabilize
 from pymor.algorithms.eigs import eigs
 from pymor.algorithms.lyapunov import (_chol, solve_cont_lyap_lrcf, solve_disc_lyap_lrcf, solve_cont_lyap_dense,
                                        solve_disc_lyap_dense)
-from pymor.algorithms.riccati import solve_ricc_lrcf
+from pymor.algorithms.riccati import solve_ricc_lrcf, solve_pos_ricc_lrcf
 from pymor.algorithms.to_matrix import to_matrix
 from pymor.core.cache import cached
 from pymor.core.config import config
@@ -606,6 +606,7 @@ class LTIModel(Model):
         options_lrcf = self.solver_options.get('lyap_lrcf') if self.solver_options else None
         options_dense = self.solver_options.get('lyap_dense') if self.solver_options else None
         options_ricc_lrcf = self.solver_options.get('ricc_lrcf') if self.solver_options else None
+        options_ricc_pos_lrcf = self.solver_options.get('ricc_pos_lrcf') if self.solver_options else None
         solve_lyap_lrcf = solve_cont_lyap_lrcf if self.sampling_time == 0 else solve_disc_lyap_lrcf
         solve_lyap_dense = solve_cont_lyap_dense if self.sampling_time == 0 else solve_disc_lyap_dense
 
@@ -625,6 +626,18 @@ class LTIModel(Model):
         elif typ == 'lqg_o_lrcf':
             return solve_ricc_lrcf(A, E, B.as_range_array(mu=mu), C.as_source_array(mu=mu),
                                    trans=True, options=options_ricc_lrcf)
+        elif typ[0] == 'br_c_lrcf':
+            return solve_pos_ricc_lrcf(A, E, B.as_range_array(), C.as_source_array(),
+                                       R=(typ[1]**2 * np.eye(self.dim_output)
+                                          if typ[1] != 1
+                                          else None),
+                                       trans=False, options=options_ricc_pos_lrcf)
+        elif typ[0] == 'br_o_lrcf':
+            return solve_pos_ricc_lrcf(A, E, B.as_range_array(), C.as_source_array(),
+                                       R=(typ[1]**2 * np.eye(self.dim_input)
+                                          if typ[1] != 1
+                                          else None),
+                                       trans=True, options=options_ricc_pos_lrcf)
 
     def gramian(self, typ, mu=None):
         """Compute a Gramian.
@@ -639,7 +652,11 @@ class LTIModel(Model):
             - `'c_dense'`: dense controllability Gramian,
             - `'o_dense'`: dense observability Gramian,
             - `'lqg_c_lrcf'`: low-rank Cholesky factor of the "controllability" LQG Gramian,
-            - `'lqg_o_lrcf'`: low-rank Cholesky factor of the "observability" LQG Gramian.
+            - `'lqg_o_lrcf'`: low-rank Cholesky factor of the "observability" LQG Gramian,
+            - `('br_c_lrcf', gamma)`: low-rank Cholesky factor of the "controllability" bounded real
+              Gramian,
+            - `('br_o_lrcf', gamma)`: low-rank Cholesky factor of the "observability" bounded real
+              Gramian.
 
             .. note::
                 For `'*_lrcf'` types, the method assumes the system is asymptotically stable.
@@ -655,9 +672,11 @@ class LTIModel(Model):
         If typ ends with `'_lrcf'`, then the Gramian factor as a |VectorArray| from `self.A.source`.
         If typ ends with `'_dense'`, then the Gramian as a |NumPy array|.
         """
-        assert typ in ('c_lrcf', 'o_lrcf', 'c_dense', 'o_dense', 'lqg_c_lrcf', 'lqg_o_lrcf')
+        assert (typ in ('c_lrcf', 'o_lrcf', 'c_dense', 'o_dense', 'lqg_c_lrcf', 'lqg_o_lrcf')
+                or isinstance(typ, tuple) and len(typ) == 2 and typ[0] in ('br_c_lrcf', 'br_o_lrcf'))
 
-        if typ.startswith('lqg') and self.sampling_time > 0:
+        if ((isinstance(typ, str) and typ.startswith('lqg') or isinstance(typ, tuple))
+                and self.sampling_time > 0):
             raise NotImplementedError
 
         if not isinstance(mu, Mu):
@@ -667,10 +686,10 @@ class LTIModel(Model):
         gramian = self.presets[typ] if typ in self.presets else self._gramian(typ, mu=mu)
 
         # assert correct return types
-        if typ.endswith('_lrcf'):
-            assert gramian in self.A.source
-        else:
-            assert isinstance(gramian, np.ndarray) and gramian.shape == (self.A.source.dim, self.A.source.dim)
+        assert ((isinstance(typ, str) and typ.endswith('_lrcf') or isinstance(typ, tuple))
+                and gramian in self.A.source
+                or isinstance(gramian, np.ndarray)
+                and gramian.shape == (self.A.source.dim, self.A.source.dim))
 
         return gramian
 

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -616,10 +616,10 @@ class LTIModel(Model):
             return solve_lyap_lrcf(A, E, C.as_source_array(mu=mu), trans=True, options=options_lrcf)
         elif typ == 'c_dense':
             return solve_lyap_dense(to_matrix(A, format='dense'), to_matrix(E, format='dense') if E else None,
-                                    to_matrix(B, format='dense'), trans=False, options=options_dense)
+                                    to_matrix(B, format='dense', mu=mu), trans=False, options=options_dense)
         elif typ == 'o_dense':
             return solve_lyap_dense(to_matrix(A, format='dense'), to_matrix(E, format='dense') if E else None,
-                                    to_matrix(C, format='dense'), trans=True, options=options_dense)
+                                    to_matrix(C, format='dense', mu=mu), trans=True, options=options_dense)
         elif typ == 'lqg_c_lrcf':
             return solve_ricc_lrcf(A, E, B.as_range_array(mu=mu), C.as_source_array(mu=mu),
                                    trans=False, options=options_ricc_lrcf)

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -650,13 +650,13 @@ class LTIModel(Model):
             return solve_ricc_lrcf(A, E, B.as_range_array(mu=mu), C.as_source_array(mu=mu),
                                    trans=True, options=options_ricc_lrcf)
         elif typ[0] == 'br_c_lrcf':
-            return solve_pos_ricc_lrcf(A, E, B.as_range_array(), C.as_source_array(),
+            return solve_pos_ricc_lrcf(A, E, B.as_range_array(mu=mu), C.as_source_array(mu=mu),
                                        R=(typ[1]**2 * np.eye(self.dim_output)
                                           if typ[1] != 1
                                           else None),
                                        trans=False, options=options_ricc_pos_lrcf)
         elif typ[0] == 'br_o_lrcf':
-            return solve_pos_ricc_lrcf(A, E, B.as_range_array(), C.as_source_array(),
+            return solve_pos_ricc_lrcf(A, E, B.as_range_array(mu=mu), C.as_source_array(mu=mu),
                                        R=(typ[1]**2 * np.eye(self.dim_input)
                                           if typ[1] != 1
                                           else None),

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -77,7 +77,7 @@ class LTIModel(Model):
         `h2_norm`, `hinf_norm`, `l2_norm` and `linf_norm`. Additionally, the frequency at which the
         :math:`\mathcal{H}_\infty/\mathcal{L}_\infty` norm is attained can be preset with `fpeak`.
     solver_options
-        The solver options to use to solve the Lyapunov equations.
+        The solver options to use to solve matrix equations.
     error_estimator
         An error estimator for the problem. This can be any object with an
         `estimate_error(U, mu, model)` method. If `error_estimator` is not `None`, an

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -74,7 +74,7 @@ class LTIModel(Model):
     presets
         A `dict` of preset attributes or `None`. The dict must only contain keys that correspond to
         attributes of |LTIModel| such as `poles`, `c_lrcf`, `o_lrcf`, `c_dense`, `o_dense`, `hsv`,
-        `h2_norm`, `hinf_norm`, `l2_norm` and `linf_norm`. Additionaly, the frequency at which the
+        `h2_norm`, `hinf_norm`, `l2_norm` and `linf_norm`. Additionally, the frequency at which the
         :math:`\mathcal{H}_\infty/\mathcal{L}_\infty` norm is attained can be preset with `fpeak`.
     solver_options
         The solver options to use to solve the Lyapunov equations.

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -79,7 +79,7 @@ class LTIModel(Model):
     solver_options
         The solver options to use to solve matrix equations.
     ast_pole_data
-        Can be:
+        Used in :meth:`get_ast_spectrum`. Can be:
 
         - dictionary of parameters for :func:`~pymor.algorithms.eigs.eigs`,
         - list of anti-stable eigenvalues (scalars),
@@ -1010,6 +1010,7 @@ class LTIModel(Model):
             assert linf_norm >= 0
             return linf_norm
 
+    @cached
     def get_ast_spectrum(self, mu=None):
         """Compute anti-stable subset of the poles of the |LTIModel|.
 

--- a/src/pymor/reductors/bt.py
+++ b/src/pymor/reductors/bt.py
@@ -8,7 +8,7 @@ import scipy.linalg as spla
 from pymor.algorithms.bernoulli import bernoulli_stabilize
 from pymor.algorithms.gram_schmidt import gram_schmidt, gram_schmidt_biorth
 from pymor.algorithms.lyapunov import solve_cont_lyap_lrcf
-from pymor.algorithms.riccati import solve_ricc_lrcf, solve_pos_ricc_lrcf
+from pymor.algorithms.riccati import solve_pos_ricc_lrcf
 from pymor.core.base import BasicObject
 from pymor.models.iosys import LTIModel
 from pymor.operators.constructions import IdentityOperator, LowRankOperator
@@ -219,17 +219,7 @@ class LQGBTReductor(GenericBTReductor):
         if self.fom.sampling_time > 0:
             raise NotImplementedError
 
-        A, B, C, E = (getattr(self.fom, op).assemble(mu=self.mu)
-                      for op in ['A', 'B', 'C', 'E'])
-        if isinstance(E, IdentityOperator):
-            E = None
-        options = self.solver_options
-
-        cf = solve_ricc_lrcf(A, E, B.as_range_array(), C.as_source_array(),
-                             trans=False, options=options)
-        of = solve_ricc_lrcf(A, E, B.as_range_array(), C.as_source_array(),
-                             trans=True, options=options)
-        return cf, of
+        return self.fom.gramian('lqg_c_lrcf', mu=self.mu), self.fom.gramian('lqg_o_lrcf', mu=self.mu)
 
     def error_bounds(self):
         sv = self._sv_U_V()[0]

--- a/src/pymor/reductors/bt.py
+++ b/src/pymor/reductors/bt.py
@@ -211,10 +211,6 @@ class LQGBTReductor(GenericBTReductor):
         The solver options to use to solve the Riccati equations.
     """
 
-    def __init__(self, fom, mu=None, solver_options=None):
-        super().__init__(fom, mu=mu)
-        self.solver_options = solver_options
-
     def _gramians(self):
         if self.fom.sampling_time > 0:
             raise NotImplementedError

--- a/src/pymor/reductors/bt.py
+++ b/src/pymor/reductors/bt.py
@@ -51,7 +51,7 @@ class GenericBTReductor(BasicObject):
         return self._sv_U_V_cache
 
     def error_bounds(self):
-        """Returns error bounds for all possible reduced orders."""
+        """Return error bounds for all possible reduced orders."""
         raise NotImplementedError
 
     def reduce(self, r=None, tol=None, projection='bfsr'):

--- a/src/pymor/reductors/bt.py
+++ b/src/pymor/reductors/bt.py
@@ -3,14 +3,10 @@
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
 import numpy as np
-import scipy.linalg as spla
 
-from pymor.algorithms.bernoulli import bernoulli_stabilize
 from pymor.algorithms.gram_schmidt import gram_schmidt, gram_schmidt_biorth
-from pymor.algorithms.lyapunov import solve_cont_lyap_lrcf
 from pymor.core.base import BasicObject
 from pymor.models.iosys import LTIModel
-from pymor.operators.constructions import LowRankOperator
 from pymor.parameters.base import Mu
 from pymor.reductors.basic import LTIPGReductor
 

--- a/src/pymor/reductors/bt.py
+++ b/src/pymor/reductors/bt.py
@@ -183,10 +183,12 @@ class LQGBTReductor(GenericBTReductor):
         |Parameter values|.
     """
 
-    def _gramians(self):
-        if self.fom.sampling_time > 0:
+    def __init__(self, fom, mu=None):
+        if fom.sampling_time > 0:
             raise NotImplementedError
+        super().__init__(fom, mu=mu)
 
+    def _gramians(self):
         return self.fom.gramian('lqg_c_lrcf', mu=self.mu), self.fom.gramian('lqg_o_lrcf', mu=self.mu)
 
     def _sv_U_V(self):
@@ -213,13 +215,12 @@ class BRBTReductor(GenericBTReductor):
     """
 
     def __init__(self, fom, gamma=1, mu=None):
+        if fom.sampling_time > 0:
+            raise NotImplementedError
         super().__init__(fom, mu=mu)
         self.gamma = gamma
 
     def _gramians(self):
-        if self.fom.sampling_time > 0:
-            raise NotImplementedError
-
         cf = self.fom.gramian(('br_c_lrcf', self.gamma), mu=self.mu)
         of = self.fom.gramian(('br_o_lrcf', self.gamma), mu=self.mu)
         return cf, of

--- a/src/pymordemos/heat.py
+++ b/src/pymordemos/heat.py
@@ -185,7 +185,7 @@ def main(
     # Model order reduction
     run_mor_method(lti, w, BTReductor(lti), 'BT', r, tol=1e-5)
     run_mor_method(lti, w, LQGBTReductor(lti), 'LQGBT', r, tol=1e-5)
-    run_mor_method(lti, w, BRBTReductor(lti), 'BRBT', r, tol=1e-5)
+    run_mor_method(lti, w, BRBTReductor(lti, gamma=0.2), 'BRBT', r, tol=1e-5)
     run_mor_method(lti, w, IRKAReductor(lti), 'IRKA', r)
     run_mor_method(lti, w, IRKAReductor(lti), 'IRKA (with Arnoldi)', r, projection='arnoldi')
     run_mor_method(lti, w, TSIAReductor(lti), 'TSIA', r)


### PR DESCRIPTION
So far, only the Gramians from `BTReductor` were cached, which was done by the `LTIModel`.