### PR TITLE
Ensure that Parameters and Mu instances are always ordered alphabetically

### DIFF
--- a/src/pymor/__init__.py
+++ b/src/pymor/__init__.py
@@ -7,14 +7,15 @@ import platform
 import sys
 
 
-if sys.version_info.major != 3:
-    raise RuntimeError('pyMOR requires Python 3')
-if sys.version_info.minor < 6:
-    raise RuntimeError('pyMOR requires Python 3.6 or newer.')
-if sys.version_info.minor == 6 and platform.python_implementation() != 'CPython':
-    # dicts are only guaranteed to be insertion ordered for Python 3.7 or newer.
-    # For CPython this is already the case for Python 3.6.
-    raise RuntimeError('pyMOR requires Python 3.7 or newer for non-CPython interpreters.')
+if sys.version_info.major < 3:
+    raise RuntimeError('pyMOR requires Python 3.6 or newer')
+elif sys.version_info.major == 3:
+    if sys.version_info.minor < 6:
+        raise RuntimeError('pyMOR requires Python 3.6 or newer.')
+    if sys.version_info.minor == 6 and platform.python_implementation() != 'CPython':
+        # dicts are only guaranteed to be insertion ordered for Python 3.7 or newer.
+        # For CPython this is already the case for Python 3.6.
+        raise RuntimeError('pyMOR requires Python 3.7 or newer for non-CPython interpreters.')
 
 
 def _init_mpi():

--- a/src/pymor/__init__.py
+++ b/src/pymor/__init__.py
@@ -3,6 +3,18 @@
 # License: BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
 
 import os
+import platform
+import sys
+
+
+if sys.version_info.major != 3:
+    raise RuntimeError('pyMOR requires Python 3')
+if sys.version_info.minor < 6:
+    raise RuntimeError('pyMOR requires Python 3.6 or newer.')
+if sys.version_info.minor == 6 and platform.python_implementation() != 'CPython':
+    # dicts are only guaranteed to be insertion ordered for Python 3.7 or newer.
+    # For CPython this is already the case for Python 3.6.
+    raise RuntimeError('pyMOR requires Python 3.7 or newer for non-CPython interpreters.')
 
 
 def _init_mpi():

--- a/src/pymor/core/cache.py
+++ b/src/pymor/core/cache.py
@@ -396,6 +396,8 @@ def build_cache_key(obj):
             return tuple(transform_obj(o) for o in obj)
         elif t in (set, frozenset):
             return tuple(transform_obj(o) for o in sorted(obj))
+        elif t in (Mu, Parameters):
+            return tuple((transform_obj(k), transform_obj(v)) for k, v in obj.items())
         elif t in (dict, Mu, Parameters):
             return tuple((transform_obj(k), transform_obj(v)) for k, v in sorted(obj.items()))
         elif isinstance(obj, Number):

--- a/src/pymor/parameters/base.py
+++ b/src/pymor/parameters/base.py
@@ -19,12 +19,12 @@ import numpy as np
 
 from pymor.core.base import ImmutableObject
 from pymor.tools.floatcmp import float_cmp_all
-from pymor.tools.frozendict import FrozenDict
+from pymor.tools.frozendict import FrozenDict, SortedFrozenDict
 from pymor.tools.pprint import format_array
 from pymor.tools.random import get_random_state
 
 
-class Parameters(FrozenDict):
+class Parameters(SortedFrozenDict):
     """Immutable dict mapping parameter names to parameter dimensions.
 
     Each key of a |Parameters| dict is a string specifying the
@@ -140,7 +140,7 @@ class Parameters(FrozenDict):
             all(isinstance(v, Number) for v in mu) or fail('not every element a number')
             len(mu) == sum(v for v in self.values()) or fail('wrong size')
             parsed_mu = {}
-            for k, v in sorted(self.items()):
+            for k, v in self.items():
                 p, mu = mu[:v], mu[v:]
                 parsed_mu[k] = p
             return Mu(parsed_mu)
@@ -235,16 +235,16 @@ class Parameters(FrozenDict):
             return NotImplemented
 
     def __str__(self):
-        return '{' + ', '.join(f'{k}: {v}' for k, v in sorted(self.items())) + '}'
+        return '{' + ', '.join(f'{k}: {v}' for k, v in self.items()) + '}'
 
     def __repr__(self):
         return 'Parameters(' + str(self) + ')'
 
     def __hash__(self):
-        return hash(tuple(sorted(self.items())))
+        return hash(tuple(self.items()))
 
 
-class Mu(FrozenDict):
+class Mu(SortedFrozenDict):
     """Immutable mapping of |Parameter| names to parameter values.
 
     Parameters
@@ -293,7 +293,7 @@ class Mu(FrozenDict):
 
     def to_numpy(self):
         """All parameter values as a NumPy array, ordered alphabetically."""
-        return np.hstack([v for k, v in sorted(self.items())])
+        return np.hstack([v for k, v in self.items()])
 
     def copy(self):
         return self
@@ -307,7 +307,7 @@ class Mu(FrozenDict):
         return self.keys() == mu.keys() and all(np.array_equal(v, mu[k]) for k, v in self.items())
 
     def __str__(self):
-        return '{' + ', '.join(f'{k}: {format_array(v)}' for k, v in sorted(self.items())) + '}'
+        return '{' + ', '.join(f'{k}: {format_array(v)}' for k, v in self.items()) + '}'
 
     def __repr__(self):
         return f'Mu({self})'
@@ -445,7 +445,7 @@ class ParameterSpace(ParametricObject):
                    and ranges[k][0] <= ranges[k][1]
                    for k in parameters)
         self.parameters = parameters
-        self.ranges = FrozenDict((k, tuple(v)) for k, v in ranges.items())
+        self.ranges = SortedFrozenDict((k, tuple(v)) for k, v in ranges.items())
 
     def sample_uniformly(self, counts):
         """Uniformly sample |parameter values| from the space.

--- a/src/pymor/tools/frozendict.py
+++ b/src/pymor/tools/frozendict.py
@@ -34,3 +34,17 @@ class FrozenDict(dict):
 
     def __reduce__(self):
         return (type(self), (dict(self),))
+
+
+class SortedFrozenDict(FrozenDict):
+    """A sorted immutable dictionary."""
+
+    def __new__(cls, *args, **kwargs):
+        new = dict.__new__(cls)
+        # the following only works on Python >= 3.7 or CPython >= 3.6
+        dict.__init__(new, sorted(dict(*args, **kwargs).items()))
+        new._post_init()
+        return new
+
+    def __repr__(self):
+        return f'SortedFrozenDict({dict.__repr__(self)})'


### PR DESCRIPTION
In the past, there have been several issues with parameters not being ordered, e.g. #977. With this PR all `Parameters` and `Mu` instances will always be ordered alphabetically.

The implementation relies on Python >= 3.7 and CPython >= 3.6 dicts being insertion ordered.

Obviously this may have some impact on performance. (Creating a `Frozendict(b=3, a=2)` takes 1.5 microseconds on my machine whereas creating a `SortedFrozenDict(b=3, a=2)` takes 2.5 microseconds.) But I would assume that this is negligible in most cases, and avoiding subtle bugs due to invalid implicit assumptions seems more important. 