### PR TITLE
Refactor builtin cg discretizer

### DIFF
--- a/src/pymor/discretizers/builtin/cg.py
+++ b/src/pymor/discretizers/builtin/cg.py
@@ -484,7 +484,7 @@ class DiffusionOperatorP1(NumpyMatrixBasedOperator):
         else:
             raise NotImplementedError
 
-        self.logger.info('Calulate gradients of shape functions transformed by reference map ...')
+        self.logger.info('Calculate gradients of shape functions transformed by reference map ...')
         SF_GRADS = np.einsum('eij,pj->epi', g.jacobian_inverse_transposed(0), SF_GRAD)
 
         self.logger.info('Calculate all local scalar products between gradients ...')
@@ -595,10 +595,10 @@ class DiffusionOperatorQ1(NumpyMatrixBasedOperator):
         else:
             raise NotImplementedError
 
-        self.logger.info('Calulate gradients of shape functions transformed by reference map ...')
+        self.logger.info('Calculate gradients of shape functions transformed by reference map ...')
         SF_GRADS = np.einsum('eij,pjc->epic', g.jacobian_inverse_transposed(0), SF_GRAD)
 
-        self.logger.info('Calculate all local scalar products beween gradients ...')
+        self.logger.info('Calculate all local scalar products between gradients ...')
         if self.diffusion_function is not None and self.diffusion_function.shape_range == ():
             D = self.diffusion_function(self.grid.centers(0), mu=mu)
             SF_INTS = np.einsum('epic,eqic,c,e,e->epq', SF_GRADS, SF_GRADS, w, g.integration_elements(0), D).ravel()
@@ -652,7 +652,7 @@ class AdvectionOperatorP1(NumpyMatrixBasedOperator):
 
         (Lu)(x) = c ∇ ⋅ [ v(x) u(x) ]
 
-    The function `v` is vector-valued.
+    The function `v` has to be vector-valued.
 
     Parameters
     ----------
@@ -709,14 +709,14 @@ class AdvectionOperatorP1(NumpyMatrixBasedOperator):
 
         q, w = g.reference_element.quadrature(order=1)
 
-        self.logger.info('Calulate gradients of shape functions transformed by reference map ...')
+        self.logger.info('Calculate gradients of shape functions transformed by reference map ...')
         SF_GRADS = np.einsum('eij,pj->epi', g.jacobian_inverse_transposed(0), SF_GRAD)
         # SF_GRADS(element, function, component)
 
         SFQ = np.array(tuple(f(q) for f in SF))
         # SFQ(function, quadraturepoint)
 
-        self.logger.info('Calculate all local scalar products beween gradients ...')
+        self.logger.info('Calculate all local scalar products between gradients ...')
         D = self.advection_function(self.grid.centers(0), mu=mu)
         SF_INTS = - np.einsum('pc,eqi,c,e,ei->eqp', SFQ, SF_GRADS, w, g.integration_elements(0), D).ravel()
         del D
@@ -819,14 +819,14 @@ class AdvectionOperatorQ1(NumpyMatrixBasedOperator):
         else:
             raise NotImplementedError
 
-        self.logger.info('Calulate gradients of shape functions transformed by reference map ...')
+        self.logger.info('Calculate gradients of shape functions transformed by reference map ...')
         SF_GRADS = np.einsum('eij,pjc->epic', g.jacobian_inverse_transposed(0), SF_GRAD)
         # SF_GRADS(element,function,component,quadraturepoint)
 
         SFQ = np.array(tuple(f(q) for f in SF))
         # SFQ(function, quadraturepoint)
 
-        self.logger.info('Calculate all local scalar products beween gradients ...')
+        self.logger.info('Calculate all local scalar products between gradients ...')
 
         D = self.advection_function(self.grid.centers(0), mu=mu)
         SF_INTS = - np.einsum('pc,eqic,c,e,ei->eqp', SFQ, SF_GRADS, w, g.integration_elements(0), D).ravel()

--- a/src/pymor/discretizers/builtin/cg.py
+++ b/src/pymor/discretizers/builtin/cg.py
@@ -378,7 +378,7 @@ class L2ProductQ1(NumpyMatrixBasedOperator):
 
         # evaluate the shape functions on the quadrature points
         q, w = square.quadrature(order=2)
-        SF = LagrangeShapeFunctions[grid.reference_element][1]
+        SF = LagrangeShapeFunctions[g.reference_element][1]
         SF = np.array(tuple(f(q) for f in SF))
 
         self.logger.info('Integrate the products of the shape functions on each element')
@@ -390,7 +390,7 @@ class L2ProductQ1(NumpyMatrixBasedOperator):
         else:
             SF_INTS = np.einsum('iq,jq,q,e->eij', SF, SF, w, g.integration_elements(0)).ravel()
 
-        del SFQ
+        del SF
 
         self.logger.info('Determine global dofs ...')
         SF_I0 = np.repeat(g.subentities(0, g.dim), 4, axis=1).ravel()
@@ -776,10 +776,12 @@ class AdvectionOperatorQ1(NumpyMatrixBasedOperator):
         bi = self.boundary_info
 
         self.logger.info('Calculate gradients of shape functions transformed by reference map ...')
-        SF_GRAD = LagrangeShapeFunctionsGrads[g.reference_element][1]
+        q, w = g.reference_element.quadrature(order=2)
+        SF_GRAD = LagrangeShapeFunctionsGrads[g.reference_element][1](q)
         SF_GRADS = np.einsum('eij,pjc->epic', g.jacobian_inverse_transposed(0), SF_GRAD)
         # SF_GRADS(element,function,component,quadraturepoint)
 
+        SF = LagrangeShapeFunctions[g.reference_element][1]
         SFQ = np.array(tuple(f(q) for f in SF))
         # SFQ(function, quadraturepoint)
 


### PR DESCRIPTION
This started as a simple fix for the advection operator, but I got annoyed at the code duplication involving the shape functions, which lead to exactly these kind of errors. I do not like my solution too much, but it could be a start. Once we are there, there would also be much more code that could be share between the different Pk and Qk variants (only the mapping might differ, did not look at that).