### PR TITLE
Documentation for 2020.1 Release

### DIFF
--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -230,7 +230,7 @@ For the reduced basis we have:
    print(RB.dim)
 
 Let us check if the reduced basis really is orthonormal with respect to
-the H1-product. For this we use the :meth:`~pymor.operators.interface.Operator.apply2`
+the H1-product. For this we use the :meth:`~pymor.vectorarrays.interface.VectorArray.gramian`
 method:
 
 .. jupyter-execute::


### PR DESCRIPTION
I generated the documentation by running "make docs" and only found some minor inconsistencies that I fix in this PR. One thing I noticed though is that the images after calling `fom.visualize` in the "Getting started" section are flipped, but the results seem to be correct. Is there any part of the documentation that needs to be double checked?