### PR TITLE
Fix of Newton error output

### DIFF
--- a/src/pymor/algorithms/line_search.py
+++ b/src/pymor/algorithms/line_search.py
@@ -71,7 +71,7 @@ def armijo(f, starting_point, direction, grad=None, initial_value=None,
             alpha = alpha_init
             # Log warning
             logger = getLogger('pymor.algorithms.line_search.armijo')
-            logger.warning(f'Reached maximum number of line search steps; using initial step size of {alpha_init} instead')
+            logger.warning(f'Reached maximum number of line search steps; using initial step size of {alpha_init} instead.')
             break
         iteration += 1
         # Adjust step size

--- a/src/pymor/algorithms/newton.py
+++ b/src/pymor/algorithms/newton.py
@@ -135,7 +135,7 @@ def newton(operator, rhs, initial_guess=None, mu=None, range_product=None, sourc
             if residual_norm == 0:
                 # handle the corner case where error_norm == update, U is the exact solution
                 # and the jacobian of operator is not invertible at the exact solution
-                logger.info(f'Norm of residual exactly zero. Converged.')
+                logger.info('Norm of residual exactly zero. Converged.')
                 break
             if err < atol:
                 logger.info(f'Absolute tolerance of {atol} for norm of {error_measure} reached. Converged.')
@@ -149,7 +149,7 @@ def newton(operator, rhs, initial_guess=None, mu=None, range_product=None, sourc
                             f'window: {stagnation_window}). Converged.')
                 break
             if iteration >= maxiter:
-                raise NewtonError('Failed to converge after {iteration} iterations.')
+                raise NewtonError(f'Failed to converge after {iteration} iterations.')
 
         iteration += 1
 
@@ -164,7 +164,7 @@ def newton(operator, rhs, initial_guess=None, mu=None, range_product=None, sourc
         try:
             update = jacobian.apply_inverse(residual, least_squares=least_squares)
         except InversionError:
-            raise NewtonError('Could not invert jacobian')
+            raise NewtonError('Could not invert jacobian.')
 
         # compute step size
         if isinstance(relax, Number):
@@ -181,7 +181,7 @@ def newton(operator, rhs, initial_guess=None, mu=None, range_product=None, sourc
                           + jacobian.apply(range_product.apply_adjoint(residual)))
             step_size = armijo(res, U, update, grad=grad, initial_value=residual_norm, **(line_search_params or {}))
         else:
-            raise ValueError('Unknown line search method')
+            raise ValueError('Unknown line search method.')
 
         # update solution and residual
         U.axpy(step_size, update)
@@ -209,7 +209,7 @@ def newton(operator, rhs, initial_guess=None, mu=None, range_product=None, sourc
                     f'tot_red:{residual_norm / residual_norms[0]:.3e}')
 
         if not np.isfinite(residual_norm) or not np.isfinite(solution_norm):
-            raise NewtonError('Failed to converge')
+            raise NewtonError('Failed to converge.')
 
     logger.info('')
 


### PR DESCRIPTION
When the maximum number of iterations in the Newton algorithm was exceeded, the number of iterations was not replaced by the actual number in the output. This is fixed within this PR. Furthermore, the output of the algorithms is made slightly more consistent.