### PR TITLE
Fix solve_lyap_dense to always return a NumPy array

### DIFF
--- a/src/pymor/bindings/pymess.py
+++ b/src/pymor/bindings/pymess.py
@@ -218,6 +218,7 @@ if config.HAVE_PYMESS:
             Y = B.dot(B.T) if not trans else B.T.dot(B)
             op = pymess.MESS_OP_NONE if not trans else pymess.MESS_OP_TRANSPOSE
             X = pymess.glyap(A, E, Y, op=op)[0]
+            X = np.asarray(X)
         else:
             raise ValueError(f'Unexpected Lyapunov equation solver ({options["type"]}).')
 

--- a/src/pymortests/lyapunov.py
+++ b/src/pymortests/lyapunov.py
@@ -139,5 +139,6 @@ def test_dense(n, m, with_E, trans, lyap_solver):
         B = B.T
 
     X = solve_lyap_dense(A, E, B, trans=trans, options=lyap_solver)
+    assert type(X) is np.ndarray
 
     assert relative_residual(A, E, B, X, trans=trans) < 1e-10

--- a/src/pymortests/lyapunov.py
+++ b/src/pymortests/lyapunov.py
@@ -86,11 +86,16 @@ def relative_residual(A, E, B, X, trans=False):
 
 
 def _check_availability(lyap_solver):
-    if lyap_solver.startswith('slycot') and not os.environ.get('DOCKER_PYMOR', False) and not config.HAVE_SLYCOT:
+    if (lyap_solver.startswith('slycot')
+            and not os.environ.get('DOCKER_PYMOR', False)
+            and not config.HAVE_SLYCOT):
         pytest.skip('slycot not available')
     # TODO: re-enable pymess checks for 3.8 once wheels are available
     # https://github.com/pymor/pymor/issues/891
-    if lyap_solver.startswith('pymess') and (not os.environ.get('DOCKER_PYMOR', False) or sys.version_info>=(3,8,0)) and not config.HAVE_PYMESS:
+    if (lyap_solver.startswith('pymess')
+            and (not os.environ.get('DOCKER_PYMOR', False)
+                 or sys.version_info >= (3, 8, 0))
+            and not config.HAVE_PYMESS):
         pytest.skip('pymess not available')
 
 


### PR DESCRIPTION
I found out recently that `pymess.glyap` returns a NumPy matrix. This PR fixes it.

I guess it might be good to backport it to 2020.1.x.