### PR TITLE
Add Bode plot

### DIFF
--- a/docs/source/tutorial_bt.rst
+++ b/docs/source/tutorial_bt.rst
@@ -112,7 +112,7 @@ We can also see some basic information from `fom`'s string representation
     print(fom)
 
 To visualize the behavior of the `fom`, we can draw its magnitude plot, i.e.,
-a visualization of the mapping :math:`\omega \mapsto H(i \omega)`, where
+a visualization of the mapping :math:`\omega \mapsto H(\imath \omega)`, where
 :math:`H(s) = C (s E - A)^{-1} B + D` is the transfer function of the system.
 
 .. jupyter-execute::
@@ -121,7 +121,11 @@ a visualization of the mapping :math:`\omega \mapsto H(i \omega)`, where
     fom.mag_plot(w)
     plt.grid()
 
-Instead, we can also see the Bode plot
+We can also see the Bode plot, which shows the magnitude and phase of the
+components of the transfer function.
+In particular, :math:`\lvert H_{ij}(\imath \omega) \rvert` is in subplot
+:math:`(2 i - 1, j)` and :math:`\arg(H_{ij}(\imath \omega))` is in subplot
+:math:`(2 i, j)`.
 
 .. jupyter-execute::
 

--- a/docs/source/tutorial_bt.rst
+++ b/docs/source/tutorial_bt.rst
@@ -129,7 +129,7 @@ In particular, :math:`\lvert H_{ij}(\imath \omega) \rvert` is in subplot
 
 .. jupyter-execute::
 
-    fig, axs = plt.subplots(6, 2, figsize=(10, 20))
+    fig, axs = plt.subplots(6, 2, figsize=(10, 20), constrained_layout=True)
     fom.bode_plot(w, ax=axs)
     for ax in axs.flatten():
         ax.grid()

--- a/docs/source/tutorial_bt.rst
+++ b/docs/source/tutorial_bt.rst
@@ -121,6 +121,15 @@ a visualization of the mapping :math:`\omega \mapsto H(i \omega)`, where
     fom.mag_plot(w)
     plt.grid()
 
+Instead, we can also see the Bode plot
+
+.. jupyter-execute::
+
+    fig, axs = plt.subplots(6, 2, figsize=(10, 20))
+    fom.bode_plot(w, ax=axs)
+    for ax in axs.flatten():
+        ax.grid()
+
 Plotting the Hankel singular values shows us how well an LTI system can be
 approximated by a reduced-order model
 

--- a/docs/source/tutorial_bt.rst
+++ b/docs/source/tutorial_bt.rst
@@ -252,19 +252,34 @@ models
     rom.mag_plot(w, ax=ax, linestyle='--', label='ROM')
     _ = ax.legend()
 
-and plot the magnitude plot of the error system
+as well as Bode plots
 
 .. jupyter-execute::
 
-    _ = (fom - rom).mag_plot(w)
+    fig, axs = plt.subplots(6, 2, figsize=(12, 24), sharex=True, constrained_layout=True)
+    fom.bode_plot(w, ax=axs)
+    _ = rom.bode_plot(w, ax=axs, linestyle='--')
+
+Also, we can plot the magnitude plot of the error system
+
+.. jupyter-execute::
+
+    err = fom - rom
+    _ = err.mag_plot(w)
+
+and its Bode plot
+
+.. jupyter-execute::
+
+    _ = err.bode_plot(w)
 
 We can compute the relative errors in :math:`\mathcal{H}_\infty` or
 :math:`\mathcal{H}_2` (or Hankel) norm
 
 .. jupyter-execute::
 
-    print(f'Relative Hinf error: {(fom - rom).hinf_norm() / fom.hinf_norm():.3e}')
-    print(f'Relative H2 error:   {(fom - rom).h2_norm() / fom.h2_norm():.3e}')
+    print(f'Relative Hinf error: {err.hinf_norm() / fom.hinf_norm():.3e}')
+    print(f'Relative H2 error:   {err.h2_norm() / fom.h2_norm():.3e}')
 
 .. note::
 

--- a/docs/source/tutorial_bt.rst
+++ b/docs/source/tutorial_bt.rst
@@ -54,7 +54,7 @@ In particular, we will use the
 :meth:`~pymor.models.iosys.LTIModel.from_matrices` method of |LTIModel|, which
 instantiates an |LTIModel| from NumPy or SciPy matrices.
 
-First, we do the necessary imports.
+First, we do the necessary imports and some matplotlib style choices.
 
 .. jupyter-execute::
 
@@ -63,6 +63,8 @@ First, we do the necessary imports.
     import scipy.sparse as sps
     from pymor.models.iosys import LTIModel
     from pymor.reductors.bt import BTReductor
+
+    plt.rcParams['axes.grid'] = True
 
 Next, we can assemble the matrices based on a centered finite difference
 approximation:
@@ -118,8 +120,7 @@ a visualization of the mapping :math:`\omega \mapsto H(\imath \omega)`, where
 .. jupyter-execute::
 
     w = np.logspace(-2, 8, 50)
-    fom.mag_plot(w)
-    plt.grid()
+    _ = fom.mag_plot(w)
 
 We can also see the Bode plot, which shows the magnitude and phase of the
 components of the transfer function.
@@ -130,9 +131,7 @@ In particular, :math:`\lvert H_{ij}(\imath \omega) \rvert` is in subplot
 .. jupyter-execute::
 
     fig, axs = plt.subplots(6, 2, figsize=(10, 20), constrained_layout=True)
-    fom.bode_plot(w, ax=axs)
-    for ax in axs.flatten():
-        ax.grid()
+    _ = fom.bode_plot(w, ax=axs)
 
 Plotting the Hankel singular values shows us how well an LTI system can be
 approximated by a reduced-order model
@@ -142,8 +141,7 @@ approximated by a reduced-order model
     hsv = fom.hsv()
     fig, ax = plt.subplots()
     ax.semilogy(range(1, len(hsv) + 1), hsv, '.-')
-    ax.set_title('Hankel singular values')
-    ax.grid()
+    _ = ax.set_title('Hankel singular values')
 
 As expected for a heat equation, the Hankel singular values decay rapidly.
 
@@ -231,8 +229,7 @@ based on the Hankel singular values:
     ax.semilogy(range(1, len(error_bounds) + 1), error_bounds, '.-')
     ax.semilogy(range(1, len(hsv)), hsv[1:], '.-')
     ax.set_xlabel('Reduced order')
-    ax.set_title(r'Upper and lower $\mathcal{H}_\infty$ error bounds')
-    ax.grid()
+    _ = ax.set_title(r'Upper and lower $\mathcal{H}_\infty$ error bounds')
 
 To get a reduced-order model of order 10, we call the `reduce` method with the
 appropriate argument:
@@ -254,15 +251,13 @@ models
     fig, ax = plt.subplots()
     fom.mag_plot(w, ax=ax, label='FOM')
     rom.mag_plot(w, ax=ax, linestyle='--', label='ROM')
-    ax.legend()
-    ax.grid()
+    _ = ax.legend()
 
 and plot the magnitude plot of the error system
 
 .. jupyter-execute::
 
-    (fom - rom).mag_plot(w)
-    plt.grid()
+    _ = (fom - rom).mag_plot(w)
 
 We can compute the relative errors in :math:`\mathcal{H}_\infty` or
 :math:`\mathcal{H}_2` (or Hankel) norm

--- a/docs/source/tutorial_bt.rst
+++ b/docs/source/tutorial_bt.rst
@@ -130,8 +130,7 @@ In particular, :math:`\lvert H_{ij}(\imath \omega) \rvert` is in subplot
 
 .. jupyter-execute::
 
-    fig, axs = plt.subplots(6, 2, figsize=(10, 20), constrained_layout=True)
-    _ = fom.bode_plot(w, ax=axs)
+    _ = fom.bode_plot(w)
 
 Plotting the Hankel singular values shows us how well an LTI system can be
 approximated by a reduced-order model

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -16,8 +16,7 @@ from pymor.operators.block import (BlockOperator, BlockRowOperator, BlockColumnO
                                    SecondOrderModelOperator)
 from pymor.operators.constructions import IdentityOperator, LincombOperator, ZeroOperator
 from pymor.operators.numpy import NumpyMatrixOperator
-from pymor.parameters.base import Mu, Parameters
-from pymor.tools.formatrepr import indent_value
+from pymor.parameters.base import Mu
 from pymor.vectorarrays.block import BlockVectorSpace
 
 

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -81,6 +81,31 @@ class InputOutputModel(Model):
         assert self.parameters.assert_compatible(mu)
         return np.stack([self.eval_tf(1j * wi, mu=mu) for wi in w])
 
+    def bode(self, w, mu=None):
+        """Compute magnitudes and phases.
+
+        Parameters
+        ----------
+        w
+            A sequence of angular frequencies at which to compute the transfer function.
+        mu
+            |Parameter values| for which to evaluate the transfer function.
+
+        Returns
+        -------
+        mag
+            Transfer function magnitudes at frequencies in `w`, |NumPy array| of shape
+            `(len(w), self.output_dim, self.input_dim)`.
+        phase
+            Transfer function phases (in radians) at frequencies in `w`, |NumPy array| of shape
+            `(len(w), self.output_dim, self.input_dim)`.
+        """
+        w = np.asarray(w)
+        mag = np.abs(self.freq_resp(w, mu=mu))
+        phase = np.angle(self.freq_resp(w, mu=mu))
+        phase = np.unwrap(phase, axis=0)
+        return mag, phase
+
     def bode_plot(self, w, mu=None, ax=None, Hz=False, dB=False, deg=True, **mpl_kwargs):
         """Draw the Bode plot for all input-output pairs.
 
@@ -117,9 +142,7 @@ class InputOutputModel(Model):
 
         w = np.asarray(w)
         freq = w / (2 * np.pi) if Hz else w
-        mag = np.abs(self.freq_resp(w, mu=mu))
-        phase = np.angle(self.freq_resp(w, mu=mu))
-        phase = np.unwrap(phase, axis=0)
+        mag, phase = self.bode(w, mu=mu)
         if deg:
             phase *= 180 / np.pi
 

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -134,6 +134,9 @@ class InputOutputModel(Model):
         if ax is None:
             import matplotlib.pyplot as plt
             fig = plt.gcf()
+            width, height = plt.rcParams['figure.figsize']
+            fig.set_size_inches(self.input_dim * width, 2 * self.output_dim * height)
+            fig.set_constrained_layout(True)
             ax = fig.subplots(2 * self.output_dim, self.input_dim, sharex=True, squeeze=False)
         else:
             assert isinstance(ax, np.ndarray) and ax.shape == (2 * self.output_dim, self.input_dim)

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -119,13 +119,7 @@ class InputOutputModel(Model):
         freq = w / (2 * np.pi) if Hz else w
         mag = np.abs(self.freq_resp(w, mu=mu))
         phase = np.angle(self.freq_resp(w, mu=mu))
-        for i in range(self.output_dim):
-            for j in range(self.input_dim):
-                for k in range(1, len(w)):
-                    while phase[k, i, j] > phase[k - 1, i, j] + np.pi:
-                        phase[k, i, j] -= 2 * np.pi
-                    while phase[k, i, j] <= phase[k - 1, i, j] - np.pi:
-                        phase[k, i, j] += 2 * np.pi
+        phase = np.unwrap(phase, axis=0)
         if deg:
             phase *= 180 / np.pi
 


### PR DESCRIPTION
This PR adds the `bode_plot` method to `InputOutputModel` for drawing the Bode plot (with both magnitude and phases).

Also, an example is added to the BT tutorial. I used the [`constrained_layout`](https://matplotlib.org/3.3.0/tutorials/intermediate/constrainedlayout_guide.html) option since the suptitle is otherwise too high, but it is an experimental feature. The documentation suggests getting axes positions and setting them explicitly for reproducibility, but I guess this would have to be done for all 12 subplots...

See #389.

_Update_: This PR also adds the `bode` method that returns magnitudes and phases used in `bode_plot`.