### PR TITLE
Fix __str__ for VectorArray views

### DIFF
--- a/src/pymor/vectorarrays/list.py
+++ b/src/pymor/vectorarrays/list.py
@@ -549,7 +549,7 @@ class ListVectorArray(VectorArray):
         return self.__class__([v.conj() for v in self._list], self.space)
 
     def __str__(self):
-        return f'ListVectorArray of {len(self._list)} vectors of space {self.space}'
+        return f'{type(self).__name__} of {len(self._list)} vectors of space {self.space}'
 
 
 class ListVectorSpace(VectorSpace):
@@ -741,9 +741,6 @@ class ListVectorArrayView(ListVectorArray):
         if x is self.base or x.is_view and x.base is self.base:
             x = x.copy()
         super().axpy(alpha, x)
-
-    def __str__(self):
-        return f'ListVectorArrayView of {len(self._list)} vectors of dimension {self.dim}'
 
 
 class ListVectorArrayNumpyView:

--- a/src/pymor/vectorarrays/list.py
+++ b/src/pymor/vectorarrays/list.py
@@ -549,7 +549,7 @@ class ListVectorArray(VectorArray):
         return self.__class__([v.conj() for v in self._list], self.space)
 
     def __str__(self):
-        return f'ListVectorArray of {len(self._list)} of space {self.space}'
+        return f'ListVectorArray of {len(self._list)} vectors of space {self.space}'
 
 
 class ListVectorSpace(VectorSpace):
@@ -743,7 +743,7 @@ class ListVectorArrayView(ListVectorArray):
         super().axpy(alpha, x)
 
     def __str__(self):
-        return f'ListVectorArrayView of {len(self._list)} of dimension {self.dim}'
+        return f'ListVectorArrayView of {len(self._list)} vectors of dimension {self.dim}'
 
 
 class ListVectorArrayNumpyView:

--- a/src/pymor/vectorarrays/list.py
+++ b/src/pymor/vectorarrays/list.py
@@ -743,7 +743,7 @@ class ListVectorArrayView(ListVectorArray):
         super().axpy(alpha, x)
 
     def __str__(self):
-        return f'ListVectorArrayView of {len(self._list)} {str(self.vector_type)}s of dimension {self.dim}'
+        return f'ListVectorArrayView of {len(self._list)} of dimension {self.dim}'
 
 
 class ListVectorArrayNumpyView:

--- a/src/pymor/vectorarrays/numpy.py
+++ b/src/pymor/vectorarrays/numpy.py
@@ -506,6 +506,9 @@ class NumpyVectorArrayView(NumpyVectorArray):
     def amax(self):
         return self.base.amax(_ind=self.ind)
 
+    def __str__(self):
+        return self.base.__str__()
+
     def __add__(self, other):
         if isinstance(other, Number):
             assert other == 0

--- a/src/pymor/vectorarrays/numpy.py
+++ b/src/pymor/vectorarrays/numpy.py
@@ -507,7 +507,7 @@ class NumpyVectorArrayView(NumpyVectorArray):
         return self.base.amax(_ind=self.ind)
 
     def __str__(self):
-        return self.base.__str__()
+        return self.base._array[:self.base._len][self.ind].__str__()
 
     def __add__(self, other):
         if isinstance(other, Number):

--- a/src/pymortests/vectorarray.py
+++ b/src/pymortests/vectorarray.py
@@ -64,6 +64,15 @@ def test_empty(vector_array):
             pass
 
 
+@pyst.given_vector_arrays(index_strategy=pyst.valid_indices)
+def test_print(vectors_and_indices):
+    v, ind = vectors_and_indices
+    assert len(str(v))
+    assert len(repr(v))
+    assert len(str(v[ind]))
+    assert len(repr(v[ind]))
+
+
 @pyst.given_vector_arrays()
 def test_zeros(vector_array):
     with pytest.raises(Exception):


### PR DESCRIPTION
This fixes `__str__` for `NumpyVectorArrayView` and `ListVectorArrayView`. Maybe the CI finds some more bugs.

The `__str__` methods for `ListVectorArray` and `ListVectorArrayView` could probably be improved, e.g., one is referring to the space and the other to the dimension. Also `ListVectorArrayView` used `self.vector_type` for some reason, which does not exist anywhere.

Closes #1057.