### PR TITLE
Deprecate dot/pairwise_dot in favor of inner/pairwise_inner

### DIFF
--- a/docs/source/minimal_cpp_demo/model.cc
+++ b/docs/source/minimal_cpp_demo/model.cc
@@ -21,7 +21,7 @@ void Vector::axpy(double a, const Vector& x) {
   }
 }
 
-double Vector::dot(const Vector& other) const {
+double Vector::inner(const Vector& other) const {
   assert(other.dim == dim);
   double result = 0;
   for (int i = 0; i < dim; i++) {
@@ -70,7 +70,7 @@ PYBIND11_MODULE(model, m)
     vec.def_readonly("dim", &Vector::dim);
     vec.def("scal", &Vector::scal);
     vec.def("axpy", &Vector::axpy);
-    vec.def("dot", &Vector::dot);
+    vec.def("inner", &Vector::inner);
     vec.def("data", &Vector::data);
 
     vec.def_buffer([](Vector& vec) -> py::buffer_info {

--- a/docs/source/minimal_cpp_demo/model.hh
+++ b/docs/source/minimal_cpp_demo/model.hh
@@ -12,7 +12,7 @@ public:
   const int dim;
   void scal(double val);
   void axpy(double a, const Vector& x);
-  double dot(const Vector& other) const;
+  double inner(const Vector& other) const;
   double* data();
 private:
   std::vector<double> _data;

--- a/docs/source/tutorial_external_solver.rst
+++ b/docs/source/tutorial_external_solver.rst
@@ -233,17 +233,17 @@ with using just a stub that raises an :class:`~NotImplementedError` in some meth
       def _axpy(self, alpha, x):
           self._impl.axpy(alpha, x._impl)
 
-      def dot(self, other):
-          return self._impl.dot(other._impl)
+      def inner(self, other):
+          return self._impl.inner(other._impl)
 
       def l1_norm(self):
           raise NotImplementedError
 
       def l2_norm(self):
-          return math.sqrt(self.dot(self))
+          return math.sqrt(self.inner(self))
 
       def l2_norm2(self):
-          return self.dot(self)
+          return self.inner(self)
 
       def sup_norm(self):
           raise NotImplementedError

--- a/src/pymor/algorithms/genericsolvers.py
+++ b/src/pymor/algorithms/genericsolvers.py
@@ -313,7 +313,7 @@ def lgmres(A, b, x0=None, tol=1e-5, maxiter=1000, M=None, callback=None,
             #     ++ orthogonalize
             hcur = []
             for v in vs:
-                alpha = v.dot(v_new)[0, 0]
+                alpha = v.inner(v_new)[0, 0]
                 hcur.append(alpha)
                 v_new.axpy(-alpha, v)  # v_new -= alpha*v
             hcur.append(v_new.l2_norm()[0])

--- a/src/pymor/algorithms/line_search.py
+++ b/src/pymor/algorithms/line_search.py
@@ -57,7 +57,7 @@ def armijo(f, starting_point, direction, grad=None, initial_value=None,
 
     # Compute slope if gradient is provided
     if grad:
-        slope = min(grad.dot(direction), 0.0)
+        slope = min(grad.inner(direction), 0.0)
 
     while True:
         # Compute new function value

--- a/src/pymor/algorithms/lrradi.py
+++ b/src/pymor/algorithms/lrradi.py
@@ -145,13 +145,13 @@ def solve_ricc_lrcf(A, E, B, C, R=None, trans=False, options=None):
                 LN = AsE.apply_inverse_adjoint(cat_arrays([RF, K]))
             L = LN[:len(RF)]
             N = LN[-len(K):]
-            ImBN = np.eye(len(K)) - B.dot(N)
-            ImBNKL = spla.solve(ImBN, B.dot(L))
+            ImBN = np.eye(len(K)) - B.inner(N)
+            ImBNKL = spla.solve(ImBN, B.inner(L))
             V = (L + N.lincomb(ImBNKL.T)) * np.sqrt(-2 * shifts[j_shift].real)
 
         if np.imag(shifts[j_shift]) == 0:
             Z.append(V)
-            VB = V.dot(B)
+            VB = V.inner(B)
             Yt = np.eye(len(C)) - (VB @ VB.T) / (2 * shifts[j_shift].real)
             Y = spla.block_diag(Y, Yt)
             if not trans:
@@ -164,8 +164,8 @@ def solve_ricc_lrcf(A, E, B, C, R=None, trans=False, options=None):
         else:
             Z.append(V.real)
             Z.append(V.imag)
-            Vr = V.real.dot(B)
-            Vi = V.imag.dot(B)
+            Vr = V.real.inner(B)
+            Vi = V.imag.inner(B)
             sa = np.abs(shifts[j_shift])
             F1 = np.vstack((
                 -shifts[j_shift].real/sa * Vr - shifts[j_shift].imag/sa * Vi,
@@ -231,9 +231,9 @@ def hamiltonian_shifts_init(A, E, B, C, shift_options):
     for _ in range(shift_options['init_maxiter']):
         Q = gram_schmidt(C, atol=0, rtol=0)
         Ap = A.apply2(Q, Q)
-        QB = Q.dot(B)
+        QB = Q.inner(B)
         Gp = QB.dot(QB.T)
-        QR = Q.dot(C)
+        QR = Q.inner(C)
         Rp = QR.dot(QR.T)
         Hp = np.block([
             [Ap, Gp],
@@ -310,11 +310,11 @@ def hamiltonian_shifts(A, E, B, R, K, Z, shift_options):
 
     Q = gram_schmidt(Z[-l:], atol=0, rtol=0)
     Ap = A.apply2(Q, Q)
-    KBp = Q.dot(K) @ Q.dot(B).T
+    KBp = Q.inner(K) @ Q.inner(B).T
     AAp = Ap - KBp
-    QB = Q.dot(B)
+    QB = Q.inner(B)
     Gp = QB.dot(QB.T)
-    QR = Q.dot(R)
+    QR = Q.inner(R)
     Rp = QR.dot(QR.T)
     Hp = np.block([
         [AAp, Gp],

--- a/src/pymor/algorithms/projection.py
+++ b/src/pymor/algorithms/projection.py
@@ -101,7 +101,7 @@ class ProjectRules(RuleTable):
     def action_ConstantOperator(self, op):
         range_basis, source_basis = self.range_basis, self.source_basis
         if range_basis is not None:
-            projected_value = NumpyVectorSpace.make_array(range_basis.dot(op.value).T)
+            projected_value = NumpyVectorSpace.make_array(range_basis.inner(op.value).T)
         else:
             projected_value = op.value
         if source_basis is None:
@@ -179,7 +179,7 @@ class ProjectRules(RuleTable):
         elif not hasattr(op, 'restricted_operator') or source_basis is None:
             raise RuleNotMatchingError('Has no restricted operator or source_basis is None')
         if range_basis is not None:
-            projected_collateral_basis = NumpyVectorSpace.make_array(op.collateral_basis.dot(range_basis))
+            projected_collateral_basis = NumpyVectorSpace.make_array(op.collateral_basis.inner(range_basis))
         else:
             projected_collateral_basis = op.collateral_basis
 

--- a/src/pymor/algorithms/samdp.py
+++ b/src/pymor/algorithms/samdp.py
@@ -134,7 +134,7 @@ def samdp(A, E, B, C, nwanted, init_shifts=None, which='LR', tol=1e-10, imagtol=
 
         sEmA = st * E - A
         sEmAB = sEmA.apply_inverse(B_defl)
-        Hs = C_defl.dot(sEmAB)
+        Hs = C_defl.inner(sEmAB)
 
         y_all, _, u_all = spla.svd(Hs)
 
@@ -152,12 +152,12 @@ def samdp(A, E, B, C, nwanted, init_shifts=None, which='LR', tol=1e-10, imagtol=
         AX.append(A.apply(X[k-1]))
 
         if k > 1:
-            H = np.hstack((H, V[0:k-1].dot(AX[k-1])))
-        H = np.vstack((H, V[k-1].dot(AX)))
+            H = np.hstack((H, V[0:k-1].inner(AX[k-1])))
+        H = np.vstack((H, V[k-1].inner(AX)))
         EX = E.apply(X)
         if k > 1:
-            G = np.hstack((G, V[0:k-1].dot(EX[k-1])))
-        G = np.vstack((G, V[k-1].dot(EX)))
+            G = np.hstack((G, V[0:k-1].inner(EX[k-1])))
+        G = np.vstack((G, V[k-1].inner(EX)))
 
         SH, UR, URt, res = _select_max_eig(H, G, X, V, B_defl, C_defl, which)
 
@@ -216,7 +216,7 @@ def samdp(A, E, B, C, nwanted, init_shifts=None, which='LR', tol=1e-10, imagtol=
                 Qs.append(Esch)
                 Qts.append(E.apply_adjoint(lschurvec))
 
-                nqqt = lschurvec.dot(Esch)[0][0]
+                nqqt = lschurvec.inner(Esch)[0][0]
                 Q[-1].scal(1 / nqqt)
                 Qs[-1].scal(1 / nqqt)
 
@@ -233,8 +233,8 @@ def samdp(A, E, B, C, nwanted, init_shifts=None, which='LR', tol=1e-10, imagtol=
                     gram_schmidt(V, atol=0, rtol=0, copy=False)
                     gram_schmidt(X, atol=0, rtol=0, copy=False)
 
-                B_defl -= E.apply(Q[-1].lincomb(Qt[-1].dot(B_defl).T))
-                C_defl -= E.apply_adjoint(Qt[-1].lincomb(Q[-1].dot(C_defl).T))
+                B_defl -= E.apply(Q[-1].lincomb(Qt[-1].inner(B_defl).T))
+                C_defl -= E.apply_adjoint(Qt[-1].lincomb(Q[-1].inner(C_defl).T))
 
                 k -= 1
 
@@ -258,20 +258,20 @@ def samdp(A, E, B, C, nwanted, init_shifts=None, which='LR', tol=1e-10, imagtol=
                         Qs.append(Esch)
                         Qts.append(E.apply_adjoint(ccvt))
 
-                        nqqt = ccvt.dot(E.apply(ccv))[0][0]
+                        nqqt = ccvt.inner(E.apply(ccv))[0][0]
                         Q[-1].scal(1 / nqqt)
                         Qs[-1].scal(1 / nqqt)
 
                         gram_schmidt(V, atol=0, rtol=0, copy=False)
                         gram_schmidt(X, atol=0, rtol=0, copy=False)
 
-                        B_defl -= E.apply(Q[-1].lincomb(Qt[-1].dot(B_defl).T))
-                        C_defl -= E.apply_adjoint(Qt[-1].lincomb(Q[-1].dot(C_defl).T))
+                        B_defl -= E.apply(Q[-1].lincomb(Qt[-1].inner(B_defl).T))
+                        C_defl -= E.apply_adjoint(Qt[-1].lincomb(Q[-1].inner(C_defl).T))
 
                 AX = A.apply(X)
                 if k > 0:
-                    G = V.dot(E.apply(X))
-                    H = V.dot(AX)
+                    G = V.inner(E.apply(X))
+                    H = V.inner(AX)
                     SH, UR, URt, residues = _select_max_eig(H, G, X, V, B_defl, C_defl, which)
                     found = np.any(res >= np.finfo(float).eps)
                 else:
@@ -302,9 +302,9 @@ def samdp(A, E, B, C, nwanted, init_shifts=None, which='LR', tol=1e-10, imagtol=
                 gram_schmidt(V, atol=0, rtol=0, copy=False)
                 gram_schmidt(X, atol=0, rtol=0, copy=False)
 
-                G = V.dot(E.apply(X))
+                G = V.inner(E.apply(X))
                 AX = A.apply(X)
-                H = V.dot(AX)
+                H = V.inner(AX)
                 nrestart += 1
 
         if k >= krestart:
@@ -321,9 +321,9 @@ def samdp(A, E, B, C, nwanted, init_shifts=None, which='LR', tol=1e-10, imagtol=
             gram_schmidt(V, atol=0, rtol=0, copy=False)
             gram_schmidt(X, atol=0, rtol=0, copy=False)
 
-            G = V.dot(E.apply(X))
+            G = V.inner(E.apply(X))
             AX = A.apply(X)
-            H = V.dot(AX)
+            H = V.inner(AX)
             nrestart += 1
 
         if nr_converged == nwanted or nrestart == maxrestart:
@@ -332,8 +332,8 @@ def samdp(A, E, B, C, nwanted, init_shifts=None, which='LR', tol=1e-10, imagtol=
             absres = np.empty(len(poles))
             residues = []
             for i in range(len(poles)):
-                leftev[i].scal(1 / leftev[i].dot(E.apply(rightev[i]))[0][0])
-                residues.append(C.dot(rightev[i]) @ leftev[i].dot(B))
+                leftev[i].scal(1 / leftev[i].inner(E.apply(rightev[i]))[0][0])
+                residues.append(C.inner(rightev[i]) @ leftev[i].inner(B))
                 absres[i] = spla.norm(residues[-1], ord=2)
             residues = np.array(residues)
 
@@ -409,7 +409,7 @@ def _twosided_rqi(A, E, x, y, theta, init_res, imagtol, rqitol, maxiter):
         Ax_rqi = A.apply(x_rqi)
         Ex_rqi = E.apply(x_rqi)
 
-        x_rq = (v_rqi.dot(Ax_rqi) / v_rqi.dot(Ex_rqi))[0][0]
+        x_rq = (v_rqi.inner(Ax_rqi) / v_rqi.inner(Ex_rqi))[0][0]
         if not np.isfinite(x_rq):
             x_rqi = x
             v_rqi = y
@@ -486,7 +486,7 @@ def _select_max_eig(H, G, X, V, B, C, which):
 
     V.scal(1 / V.norm())
     X.scal(1 / X.norm())
-    residue = spla.norm(C.dot(X), axis=0) * spla.norm(V.dot(B), axis=1)
+    residue = spla.norm(C.inner(X), axis=0) * spla.norm(V.inner(B), axis=1)
 
     if which == 'LR':
         idx = np.argsort(-residue / np.abs(np.real(DP)))

--- a/src/pymor/bindings/fenics.py
+++ b/src/pymor/bindings/fenics.py
@@ -45,7 +45,7 @@ if config.HAVE_FENICS:
             else:
                 self.impl.axpy(alpha, x.impl)
 
-        def dot(self, other):
+        def inner(self, other):
             return self.impl.inner(other.impl)
 
         def l1_norm(self):

--- a/src/pymor/bindings/ngsolve.py
+++ b/src/pymor/bindings/ngsolve.py
@@ -55,7 +55,7 @@ if config.HAVE_NGSOLVE:
         def _axpy(self, alpha, x):
             self.impl.vec.data = self.impl.vec + float(alpha) * x.impl.vec
 
-        def dot(self, other):
+        def inner(self, other):
             return self.impl.vec.InnerProduct(other.impl.vec)
 
         def l2_norm(self):

--- a/src/pymor/operators/interface.py
+++ b/src/pymor/operators/interface.py
@@ -86,15 +86,16 @@ class Operator(ParametricObject):
         pass
 
     def apply2(self, V, U, mu=None):
-        """Treat the operator as a 2-form by computing ``V.dot(self.apply(U))``.
+        """Treat the operator as a 2-form and apply it to V and U.
 
-        If the operator is a linear operator given by multiplication with a matrix
-        M, then `apply2` is given as::
+        This method is usually implemented as ``V.inner(self.apply(U))``.
+        In particular, if the operator is a linear operator given by multiplication
+        with a matrix M, then `apply2` is given as::
 
             op.apply2(V, U) = V^T*M*U.
 
         In the case of complex numbers, note that `apply2` is anti-linear in the
-        first variable by definition of `dot`.
+        first variable by definition of `inner`.
 
         Parameters
         ----------
@@ -114,13 +115,20 @@ class Operator(ParametricObject):
         assert isinstance(V, VectorArray)
         assert isinstance(U, VectorArray)
         AU = self.apply(U, mu=mu)
-        return V.dot(AU)
+        return V.inner(AU)
 
     def pairwise_apply2(self, V, U, mu=None):
-        """Treat the operator as a 2-form by computing ``V.dot(self.apply(U))``.
+        """Treat the operator as a 2-form and apply it to V and U in pairs.
 
-        Same as :meth:`Operator.apply2`, except that vectors from `V`
-        and `U` are applied in pairs.
+        This method is usually implemented as ``V.pairwise_inner(self.apply(U))``.
+        In particular, if the operator is a linear operator given by multiplication
+        with a matrix M, then `apply2` is given as::
+
+            op.apply2(V, U)[i] = V[i]^T*M*U[i].
+
+        In the case of complex numbers, note that `pairwirse_apply2` is anti-linear in the
+        first variable by definition of `pairwise_inner`.
+
 
         Parameters
         ----------
@@ -141,7 +149,7 @@ class Operator(ParametricObject):
         assert isinstance(U, VectorArray)
         assert len(U) == len(V)
         AU = self.apply(U, mu=mu)
-        return V.pairwise_dot(AU)
+        return V.pairwise_inner(AU)
 
     def apply_adjoint(self, V, mu=None):
         """Apply the adjoint operator.
@@ -150,7 +158,7 @@ class Operator(ParametricObject):
         |VectorArrays| `U`, `V` in the :attr:`~Operator.source`
         resp. :attr:`~Operator.range` we have::
 
-            op.apply_adjoint(V, mu).dot(U) == V.dot(op.apply(U, mu))
+            op.apply_adjoint(V, mu).dot(U) == V.inner(op.apply(U, mu))
 
         Thus, when `op` is represented by a matrix `M`, `apply_adjoint` is
         given by left-multplication of (the complex conjugate of) `M` with `V`.
@@ -370,7 +378,7 @@ class Operator(ParametricObject):
         `mu` a |VectorArray| `V` in the operator's :attr:`~Operator.source`,
         such that ::
 
-            self.range.make_array(V.dot(U).T) == self.apply(U, mu)
+            self.range.make_array(V.inner(U).T) == self.apply(U, mu)
 
         for all |VectorArrays| `U`.
 

--- a/src/pymor/operators/mpi.py
+++ b/src/pymor/operators/mpi.py
@@ -41,7 +41,7 @@ class MPIOperator(Operator):
         Set to `True` if the operator implementation has its own
         MPI aware implementation of `apply2` and `pairwise_apply2`.
         Otherwise, the default implementations using `apply` and
-        :meth:`~pymor.vectorarrays.interface.VectorArray.dot`
+        :meth:`~pymor.vectorarrays.interface.VectorArray.inner`
         will be used.
     pickle_local_spaces
         If `pickle_local_spaces` is `False`, a unique identifier

--- a/src/pymor/reductors/coercive.py
+++ b/src/pymor/reductors/coercive.py
@@ -180,9 +180,9 @@ class SimpleCoerciveRBReductor(StationaryRBReductor):
                     append_vector(-op.apply(RB[i]), R_O, RR_O)
 
         # compute Gram matrix of the residuals
-        R_RR = RR_R.dot(R_R)
-        R_RO = np.hstack([RR_R.dot(R_O) for R_O in R_Os])
-        R_OO = np.vstack([np.hstack([RR_O.dot(R_O) for R_O in R_Os]) for RR_O in RR_Os])
+        R_RR = RR_R.inner(R_R)
+        R_RO = np.hstack([RR_R.inner(R_O) for R_O in R_Os])
+        R_OO = np.vstack([np.hstack([RR_O.inner(R_O) for R_O in R_Os]) for RR_O in RR_Os])
 
         estimator_matrix = np.empty((len(R_RR) + len(R_OO),) * 2)
         estimator_matrix[:len(R_RR), :len(R_RR)] = R_RR

--- a/src/pymor/reductors/residual.py
+++ b/src/pymor/reductors/residual.py
@@ -153,7 +153,7 @@ class NonProjectedResidualOperator(ResidualOperator):
                 # divide by norm, except when norm is zero:
                 inversel2 = 1./R_riesz.l2_norm()
                 inversel2 = np.nan_to_num(inversel2)
-                R_riesz.scal(np.sqrt(R_riesz.pairwise_dot(R)) * inversel2)
+                R_riesz.scal(np.sqrt(R_riesz.pairwise_inner(R)) * inversel2)
                 return R_riesz
             else:
                 # divide by norm, except when norm is zero:
@@ -306,7 +306,7 @@ class NonProjectedImplicitEulerResidualOperator(ImplicitEulerResidualOperator):
             # divide by norm, except when norm is zero:
             inversel2 = 1./R_riesz.l2_norm()
             inversel2 = np.nan_to_num(inversel2)
-            R_riesz.scal(np.sqrt(R_riesz.pairwise_dot(R)) * inversel2)
+            R_riesz.scal(np.sqrt(R_riesz.pairwise_inner(R)) * inversel2)
             return R_riesz
         else:
             return R

--- a/src/pymor/vectorarrays/block.py
+++ b/src/pymor/vectorarrays/block.py
@@ -97,25 +97,31 @@ class BlockVectorArray(VectorArray):
         else:
             assert len(self) == 0
 
-    def dot(self, other):
+    def inner(self, other, product=None):
         assert other in self.space
-        dots = [block.dot(other_block) for block, other_block in zip(self._blocks, other._blocks)]
-        assert all([dot.shape == dots[0].shape for dot in dots])
-        common_dtype = reduce(np.promote_types, (dot.dtype for dot in dots))
-        ret = np.zeros(dots[0].shape, dtype=common_dtype)
-        for dot in dots:
-            ret += dot
+        if product is not None:
+            return product.apply2(self, other)
+
+        prods = [block.inner(other_block) for block, other_block in zip(self._blocks, other._blocks)]
+        assert all([prod.shape == prods[0].shape for prod in prods])
+        common_dtype = reduce(np.promote_types, (prod.dtype for prod in prods))
+        ret = np.zeros(prods[0].shape, dtype=common_dtype)
+        for prod in prods:
+            ret += prod
         return ret
 
-    def pairwise_dot(self, other):
+    def pairwise_inner(self, other, product=None):
         assert other in self.space
-        dots = [block.pairwise_dot(other_block)
-                for block, other_block in zip(self._blocks, other._blocks)]
-        assert all([dot.shape == dots[0].shape for dot in dots])
-        common_dtype = reduce(np.promote_types, (dot.dtype for dot in dots))
-        ret = np.zeros(dots[0].shape, dtype=common_dtype)
-        for dot in dots:
-            ret += dot
+        if product is not None:
+            return product.pairwise_apply2(self, other)
+
+        prods = [block.pairwise_inner(other_block)
+                 for block, other_block in zip(self._blocks, other._blocks)]
+        assert all([prod.shape == prods[0].shape for prod in prods])
+        common_dtype = reduce(np.promote_types, (prod.dtype for prod in prods))
+        ret = np.zeros(prods[0].shape, dtype=common_dtype)
+        for prod in prods:
+            ret += prod
         return ret
 
     def lincomb(self, coefficients):

--- a/src/pymor/vectorarrays/interface.py
+++ b/src/pymor/vectorarrays/interface.py
@@ -296,6 +296,18 @@ class VectorArray(BasicObject):
     def inner(self, other, product=None):
         """Returns the inner products between |VectorArray| elements.
 
+        If `product` is `None`, the Euclidean inner product between
+        the :meth:`dofs` of `self` and `other` are returned, i.e. ::
+
+            U.inner(V)
+
+        is equivalent to::
+
+            U.dofs(np.arange(U.dim)) @ V.dofs(np.arange(V.dim)).T
+
+        (Note, that :meth:`dofs` is only intended to be called for a
+        small number of DOF indices.)
+
         If a `product` |Operator| is specified, this |Operator| is
         used to compute the inner products using
         :meth:`~pymor.operators.inerface.Operator.apply2`, i.e.
@@ -303,7 +315,7 @@ class VectorArray(BasicObject):
 
             product.apply2(U, V)
 
-        which in turn is usually implemented as::
+        which in turn is, by default, implemented as::
 
             U.inner(product.apply(V))
 
@@ -341,6 +353,18 @@ class VectorArray(BasicObject):
     def pairwise_inner(self, other, product=None):
         """Returns the pairwise inner products between |VectorArray| elements.
 
+        If `product` is `None`, the Euclidean inner product between
+        the :meth:`dofs` of `self` and `other` are returned, i.e. ::
+
+            U.pairwise_inner(V)
+
+        is equivalent to::
+
+            np.sum(U.dofs(np.arange(U.dim)) * V.dofs(np.arange(V.dim)), axis=-1)
+
+        (Note, that :meth:`dofs` is only intended to be called for a
+        small number of DOF indices.)
+
         If a `product` |Operator| is specified, this |Operator| is
         used to compute the inner products using
         :meth:`~pymor.operators.inerface.Operator.pairwise_apply2`, i.e.
@@ -348,9 +372,9 @@ class VectorArray(BasicObject):
 
             product.pairwise_apply2(U, V)
 
-        which in turn is usually implemented as::
+        which in turn is, by default, implemented as::
 
-            U.pariwise_inner(product.apply(V))
+            U.pairwise_inner(product.apply(V))
 
         In the case of complex numbers, this is antilinear in the
         first argument, i.e. in 'self'.

--- a/src/pymordemos/minimal_cpp_demo/model.cc
+++ b/src/pymordemos/minimal_cpp_demo/model.cc
@@ -21,7 +21,7 @@ void Vector::axpy(double a, const Vector& x) {
   }
 }
 
-double Vector::dot(const Vector& other) const {
+double Vector::inner(const Vector& other) const {
   assert(other.dim == dim);
   double result = 0;
   for (int i = 0; i < dim; i++) {
@@ -70,7 +70,7 @@ PYBIND11_MODULE(model, m)
     vec.def_readonly("dim", &Vector::dim);
     vec.def("scal", &Vector::scal);
     vec.def("axpy", &Vector::axpy);
-    vec.def("dot", &Vector::dot);
+    vec.def("inner", &Vector::inner);
     vec.def("data", &Vector::data);
 
     vec.def_buffer([](Vector& vec) -> py::buffer_info {

--- a/src/pymordemos/minimal_cpp_demo/model.hh
+++ b/src/pymordemos/minimal_cpp_demo/model.hh
@@ -12,7 +12,7 @@ public:
   const int dim;
   void scal(double val);
   void axpy(double a, const Vector& x);
-  double dot(const Vector& other) const;
+  double inner(const Vector& other) const;
   double* data();
 private:
   std::vector<double> _data;

--- a/src/pymordemos/minimal_cpp_demo/wrapper.py
+++ b/src/pymordemos/minimal_cpp_demo/wrapper.py
@@ -35,17 +35,17 @@ class WrappedVector(CopyOnWriteVector):
     def _axpy(self, alpha, x):
         self._impl.axpy(alpha, x._impl)
 
-    def dot(self, other):
-        return self._impl.dot(other._impl)
+    def inner(self, other):
+        return self._impl.inner(other._impl)
 
     def l1_norm(self):
         raise NotImplementedError
 
     def l2_norm(self):
-        return math.sqrt(self.dot(self))
+        return math.sqrt(self.inner(self))
 
     def l2_norm2(self):
-        return self.dot(self)
+        return self.inner(self)
 
     def sup_norm(self):
         raise NotImplementedError

--- a/src/pymortests/algorithms/gram_schmidt.py
+++ b/src/pymortests/algorithms/gram_schmidt.py
@@ -27,9 +27,9 @@ def test_gram_schmidt(vector_array):
     V = U.copy()
     onb = gram_schmidt(U, copy=True)
     assert np.all(almost_equal(U, V))
-    assert np.allclose(onb.dot(onb), np.eye(len(onb)))
+    assert np.allclose(onb.inner(onb), np.eye(len(onb)))
     # TODO maybe raise tolerances again
-    assert np.all(almost_equal(U, onb.lincomb(onb.dot(U).T), atol=1e-13, rtol=1e-13))
+    assert np.all(almost_equal(U, onb.lincomb(onb.inner(U).T), atol=1e-13, rtol=1e-13))
 
     onb2 = gram_schmidt(U, copy=False)
     assert np.all(almost_equal(onb, onb2))
@@ -47,8 +47,8 @@ def test_gram_schmidt_with_R(vector_array):
     V = U.copy()
     onb, R = gram_schmidt(U, return_R=True, copy=True)
     assert np.all(almost_equal(U, V))
-    assert np.allclose(onb.dot(onb), np.eye(len(onb)))
-    lc = onb.lincomb(onb.dot(U).T)
+    assert np.allclose(onb.inner(onb), np.eye(len(onb)))
+    lc = onb.lincomb(onb.inner(U).T)
     rtol = atol = 1e-13
     assert np.all(almost_equal(U, lc, rtol=rtol, atol=atol))
     assert np.all(almost_equal(V, onb.lincomb(R.T), rtol=rtol, atol=atol))
@@ -103,10 +103,10 @@ def test_gram_schmidt_biorth(vector_arrays):
         A1, A2 = gram_schmidt_biorth(U1, U2, copy=True, check_tol=check_tol)
     assert np.all(almost_equal(U1, V1))
     assert np.all(almost_equal(U2, V2))
-    assert np.allclose(A2.dot(A1), np.eye(len(A1)), atol=check_tol)
+    assert np.allclose(A2.inner(A1), np.eye(len(A1)), atol=check_tol)
     c = np.linalg.cond(A1.to_numpy()) * np.linalg.cond(A2.to_numpy())
-    assert np.all(almost_equal(U1, A1.lincomb(A2.dot(U1).T), rtol=c * 1e-14))
-    assert np.all(almost_equal(U2, A2.lincomb(A1.dot(U2).T), rtol=c * 1e-14))
+    assert np.all(almost_equal(U1, A1.lincomb(A2.inner(U1).T), rtol=c * 1e-14))
+    assert np.all(almost_equal(U2, A2.lincomb(A1.inner(U2).T), rtol=c * 1e-14))
 
     with log_levels({'pymor.algorithms.gram_schmidt.gram_schmidt_biorth': 'ERROR'}):
         B1, B2 = gram_schmidt_biorth(U1, U2, copy=False)

--- a/src/pymortests/complex_values.py
+++ b/src/pymortests/complex_values.py
@@ -104,15 +104,15 @@ def test_axpy():
     assert y.to_numpy()[0, 0] == -1j
 
 
-def test_dot():
+def test_inner():
     x = NumpyVectorSpace.from_numpy(np.array([1 + 1j]))
     y = NumpyVectorSpace.from_numpy(np.array([1 - 1j]))
-    z = x.dot(y)
+    z = x.inner(y)
     assert z[0, 0] == -2j
 
 
-def test_pairwise_dot():
+def test_pairwise_inner():
     x = NumpyVectorSpace.from_numpy(np.array([1 + 1j]))
     y = NumpyVectorSpace.from_numpy(np.array([1 - 1j]))
-    z = x.pairwise_dot(y)
+    z = x.pairwise_inner(y)
     assert z == -2j

--- a/src/pymortests/operators.py
+++ b/src/pymortests/operators.py
@@ -208,7 +208,7 @@ def test_apply2(operator_with_arrays):
         for V_ind in valid_inds(V):
             M = op.apply2(V[V_ind], U[U_ind], mu=mu)
             assert M.shape == (V.len_ind(V_ind), U.len_ind(U_ind))
-            M2 = V[V_ind].dot(op.apply(U[U_ind], mu=mu))
+            M2 = V[V_ind].inner(op.apply(U[U_ind], mu=mu))
             assert np.allclose(M, M2)
 
 
@@ -217,7 +217,7 @@ def test_pairwise_apply2(operator_with_arrays):
     for U_ind, V_ind in valid_inds_of_same_length(U, V):
         M = op.pairwise_apply2(V[V_ind], U[U_ind], mu=mu)
         assert M.shape == (V.len_ind(V_ind),)
-        M2 = V[V_ind].pairwise_dot(op.apply(U[U_ind], mu=mu))
+        M2 = V[V_ind].pairwise_inner(op.apply(U[U_ind], mu=mu))
         assert np.allclose(M, M2)
 
 
@@ -245,7 +245,7 @@ def test_apply_adjoint_2(operator_with_arrays):
         ATV = op.apply_adjoint(V, mu=mu)
     except NotImplementedError:
         return
-    assert np.allclose(V.dot(op.apply(U, mu=mu)), ATV.dot(U))
+    assert np.allclose(V.inner(op.apply(U, mu=mu)), ATV.inner(U))
 
 
 def test_H(operator_with_arrays):
@@ -256,7 +256,7 @@ def test_H(operator_with_arrays):
         op.H.apply(V, mu=mu)
     except NotImplementedError:
         return
-    assert np.allclose(V.dot(op.apply(U, mu=mu)), op.H.apply(V, mu=mu).dot(U))
+    assert np.allclose(V.inner(op.apply(U, mu=mu)), op.H.apply(V, mu=mu).inner(U))
 
 
 def test_apply_inverse(operator_with_arrays):
@@ -296,7 +296,7 @@ def test_project(operator_with_arrays):
     np.random.seed(4711 + U.dim + len(V))
     coeffs = np.random.random(len(U))
     X = op_UV.apply(op_UV.source.make_array(coeffs), mu=mu)
-    Y = op_UV.range.make_array(V.dot(op.apply(U.lincomb(coeffs), mu=mu)).T)
+    Y = op_UV.range.make_array(V.inner(op.apply(U.lincomb(coeffs), mu=mu)).T)
     assert np.all(almost_equal(X, Y))
 
 

--- a/src/pymortests/vectorarray.py
+++ b/src/pymortests/vectorarray.py
@@ -545,13 +545,13 @@ def test_axpy_self(vectors_and_indices, random):
 
 
 @pyst.given_vector_arrays(count=2)
-def test_pairwise_dot(vector_arrays):
+def test_pairwise_inner(vector_arrays):
     v1, v2 = vector_arrays
     for ind1, ind2 in pyst.valid_inds_of_same_length(v1, v2):
-        r = v1[ind1].pairwise_dot(v2[ind2])
+        r = v1[ind1].pairwise_inner(v2[ind2])
         assert isinstance(r, np.ndarray)
         assert r.shape == (v1.len_ind(ind1),)
-        r2 = v2[ind2].pairwise_dot(v1[ind1])
+        r2 = v2[ind2].pairwise_inner(v1[ind1])
         assert np.allclose, (r, r2)
         assert np.all(r <= v1[ind1].l2_norm() * v2[ind2].l2_norm() * (1. + 1e-10))
         try:
@@ -561,12 +561,12 @@ def test_pairwise_dot(vector_arrays):
 
 
 @pyst.given_vector_arrays(index_strategy=pyst.pairs_same_length)
-def test_pairwise_dot_self(vectors_and_indices):
+def test_pairwise_inner_self(vectors_and_indices):
     v, (ind1, ind2) = vectors_and_indices
-    r = v[ind1].pairwise_dot(v[ind2])
+    r = v[ind1].pairwise_inner(v[ind2])
     assert isinstance(r, np.ndarray)
     assert r.shape == (v.len_ind(ind1),)
-    r2 = v[ind2].pairwise_dot(v[ind1])
+    r2 = v[ind2].pairwise_inner(v[ind1])
     assert np.allclose(r, r2.T.conj())
     assert np.all(r <= v[ind1].l2_norm() * v[ind2].l2_norm() * (1. + 1e-10))
     try:
@@ -574,13 +574,13 @@ def test_pairwise_dot_self(vectors_and_indices):
     except NotImplementedError:
         pass
     ind = ind1
-    r = v[ind].pairwise_dot(v[ind])
+    r = v[ind].pairwise_inner(v[ind])
     assert np.allclose(r, v[ind].l2_norm() ** 2)
 
 
 @settings(deadline=None, print_blob=True)
 @pyst.given_vector_arrays(count=2, index_strategy=pyst.pairs_both_lengths)
-def test_dot(vectors_and_indices):
+def test_inner(vectors_and_indices):
     vectors, indices = vectors_and_indices
     v1, v2 = vectors
     ind1, ind2 = indices
@@ -588,10 +588,10 @@ def test_dot(vectors_and_indices):
     # TODO
     assume_old_slicing(indices)
 
-    r = v1[ind1].dot(v2[ind2])
+    r = v1[ind1].inner(v2[ind2])
     assert isinstance(r, np.ndarray)
     assert r.shape == (v1.len_ind(ind1), v2.len_ind(ind2))
-    r2 = v2[ind2].dot(v1[ind1])
+    r2 = v2[ind2].inner(v1[ind1])
     assert np.allclose(r, r2.T.conj())
     assert np.all(r <= v1[ind1].l2_norm()[:, np.newaxis] * v2[ind2].l2_norm()[np.newaxis, :] * (1. + 1e-10))
     try:
@@ -612,19 +612,19 @@ def assume_old_slicing(indices):
 
 @settings(deadline=None)
 @pyst.given_vector_arrays(index_strategy=pyst.pairs_both_lengths)
-def test_dot_self(vectors_and_indices):
+def test_inner_self(vectors_and_indices):
     v, (ind1, ind2) = vectors_and_indices
-    r = v[ind1].dot(v[ind2])
+    r = v[ind1].inner(v[ind2])
     assert isinstance(r, np.ndarray)
     assert r.shape == (v.len_ind(ind1), v.len_ind(ind2))
-    r2 = v[ind2].dot(v[ind1])
+    r2 = v[ind2].inner(v[ind1])
     assert np.allclose(r, r2.T.conj())
     assert np.all(r <= v[ind1].l2_norm()[:, np.newaxis] * v[ind2].l2_norm()[np.newaxis, :] * (1. + 1e-10))
     try:
             assert np.allclose(r, indexed(v.to_numpy(), ind1).conj().dot(indexed(v.to_numpy(), ind2).T))
     except NotImplementedError:
         pass
-    r = v[ind1].dot(v[ind1])
+    r = v[ind1].inner(v[ind1])
     assert np.allclose(r, r.T.conj())
 
 
@@ -835,7 +835,7 @@ def test_amax(vectors_and_indices):
 @settings(deadline=None)
 def test_gramian(vectors_and_indices):
     v, ind = vectors_and_indices
-    assert np.allclose(v[ind].gramian(), v[ind].dot(v[ind]))
+    assert np.allclose(v[ind].gramian(), v[ind].inner(v[ind]))
 
 
 @pyst.given_vector_arrays(count=2, length=pyst.equal_tuples(pyst.hy_lengths, count=2))
@@ -965,21 +965,21 @@ def test_axpy_incompatible(vector_arrays):
 
 
 @pyst.given_vector_arrays(count=2, compatible=False)
-def test_dot_incompatible(vector_arrays):
+def test_inner_incompatible(vector_arrays):
     v1, v2 = vector_arrays
     for ind1, ind2 in pyst.valid_inds_of_same_length(v1, v2, random_module=False):
         c1, c2 = v1.copy(), v2.copy()
         with pytest.raises(Exception):
-            c1[ind1].dot(c2[ind2])
+            c1[ind1].inner(c2[ind2])
 
 
 @pyst.given_vector_arrays(count=2, compatible=False)
-def test_pairwise_dot_incompatible(vector_arrays):
+def test_pairwise_inner_incompatible(vector_arrays):
     v1, v2 = vector_arrays
     for ind1, ind2 in pyst.valid_inds_of_same_length(v1, v2, random_module=False):
         c1, c2 = v1.copy(), v2.copy()
         with pytest.raises(Exception):
-            c1[ind1].pairwise_dot(c2[ind2])
+            c1[ind1].pairwise_inner(c2[ind2])
 
 
 @pyst.given_vector_arrays(count=2, compatible=False)


### PR DESCRIPTION
As proposed in #930, this PR deprecates the `dot` and `pairwise_dot` methods of `VectorArray` which are equivalent to calling `inner` or `pairwise_inner` without a `product` argument.

Any reservations @pymor/pymor-devs?

Note that currently we don't explicitly state anywhere that `inner` without a `product` is the Euclidean inner product. I would like to keep it that way as there might be use cases, where you want to implement `inner` with some 'special' product. (We already had several discussion about removing the `product` arguments and equipping `VectorSpaces` with `products`. I'm still not convinced that this is the right thing to do, but I at least want to have an open door for hacks in that direction.)