### PR TITLE
[parameters] prevent a wrong user input for derivative_expressions

### DIFF
--- a/src/pymor/parameters/functionals.py
+++ b/src/pymor/parameters/functionals.py
@@ -232,6 +232,8 @@ class ExpressionParameterFunctional(GenericParameterFunctional):
         if derivative_expressions is not None:
             derivative_mappings = derivative_expressions.copy()
             for (key,exp) in derivative_mappings.items():
+                if isinstance(exp, str):
+                    exp = [exp]
                 exp_array = np.array(exp, dtype=object)
                 for exp in np.nditer(exp_array, op_flags=['readwrite'], flags= ['refs_ok']):
                     exp_code = compile(str(exp), '<expression>', 'eval')
@@ -243,9 +245,13 @@ class ExpressionParameterFunctional(GenericParameterFunctional):
         if second_derivative_expressions is not None:
             second_derivative_mappings = second_derivative_expressions.copy()
             for (key_i,key_dicts) in second_derivative_mappings.items():
+                if isinstance(key_dicts, dict):
+                    key_dicts = [key_dicts]
                 key_dicts_array = np.array(key_dicts, dtype=object)
                 for key_dict in np.nditer(key_dicts_array, op_flags=['readwrite'], flags= ['refs_ok']):
                     for (key_j, exp) in key_dict[()].items():
+                        if isinstance(exp, str):
+                            exp = [exp]
                         exp_array = np.array(exp, dtype=object)
                         for exp in np.nditer(exp_array, op_flags=['readwrite'], flags= ['refs_ok']):
                             exp_code = compile(str(exp), '<expression>', 'eval')


### PR DESCRIPTION
With the new parameter handling the index `()` changed to `0` which has the effect that it is very likely to instantiate `ExpressionParameterFunctional` in the wrong way. However, currently the user only realizes this while calling the `d_mu('mu',  0)` method. 

To be precise: 
```
ExpressionParameterFunctional('mu ** 2' , {'mu': 1}, derivative_expressions={'mu': '2*mu'}) 
```
currently results in an index error because a `numpy.ndarray` with shape `()` can not be called with `0`. The correct call is 
```
ExpressionParameterFunctional('mu ** 2' , {'mu': 1}, derivative_expressions={'mu': ['2*mu']}) 
```
Note the brackets in `derivative_expressions`. 
This error is very likely to happen and thus one could either 
1. `assert` the wrong call 
2. just catch it with an `if` statement. 

In this PR, I suggest to go for option 2. and thus allow both calls from above resulting in the same implementation. 

Same holds for the second derivative