### PR TITLE
Remove l1_norm from VectorArrayInterface

### DIFF
--- a/docs/source/tutorial_external_solver.rst
+++ b/docs/source/tutorial_external_solver.rst
@@ -236,9 +236,6 @@ with using just a stub that raises an :class:`~NotImplementedError` in some meth
       def inner(self, other):
           return self._impl.inner(other._impl)
 
-      def l1_norm(self):
-          raise NotImplementedError
-
       def l2_norm(self):
           return math.sqrt(self.inner(self))
 

--- a/src/pymor/bindings/fenics.py
+++ b/src/pymor/bindings/fenics.py
@@ -48,9 +48,6 @@ if config.HAVE_FENICS:
         def inner(self, other):
             return self.impl.inner(other.impl)
 
-        def l1_norm(self):
-            return self.impl.norm('l1')
-
         def l2_norm(self):
             return self.impl.norm('l2')
 

--- a/src/pymor/bindings/ngsolve.py
+++ b/src/pymor/bindings/ngsolve.py
@@ -16,9 +16,6 @@ if config.HAVE_NGSOLVE:
     from pymor.vectorarrays.list import CopyOnWriteVector, ComplexifiedVector, ComplexifiedListVectorSpace
 
     class NGSolveVectorCommon:
-        def l1_norm(self):
-            return np.linalg.norm(self.to_numpy(), ord=1)
-
         def amax(self):
             A = np.abs(self.to_numpy())
             max_ind = np.argmax(A)

--- a/src/pymor/vectorarrays/block.py
+++ b/src/pymor/vectorarrays/block.py
@@ -128,9 +128,6 @@ class BlockVectorArray(VectorArray):
         lincombs = [block.lincomb(coefficients) for block in self._blocks]
         return BlockVectorArray(lincombs, self.space)
 
-    def l1_norm(self):
-        return np.sum(np.array([block.l1_norm() for block in self._blocks]), axis=0)
-
     def l2_norm(self):
         return np.sqrt(np.sum(np.array([block.l2_norm2() for block in self._blocks]), axis=0))
 

--- a/src/pymor/vectorarrays/interface.py
+++ b/src/pymor/vectorarrays/interface.py
@@ -470,17 +470,6 @@ class VectorArray(BasicObject):
             return norm_squared.real
 
     @abstractmethod
-    def l1_norm(self):
-        """The l1-norms of the vectors contained in the array.
-
-        Returns
-        -------
-        A |NumPy array| `result` such that `result[i]` contains the norm
-        of `self[i]`.
-        """
-        pass
-
-    @abstractmethod
     def l2_norm(self):
         """The l2-norms of the vectors contained in the array.
 

--- a/src/pymor/vectorarrays/list.py
+++ b/src/pymor/vectorarrays/list.py
@@ -35,10 +35,6 @@ class Vector(BasicObject):
         raise NotImplementedError
 
     @abstractmethod
-    def l1_norm(self):
-        pass
-
-    @abstractmethod
     def l2_norm(self):
         pass
 
@@ -216,11 +212,6 @@ class ComplexifiedVector(Vector):
             result += self.imag_part.inner(other.imag_part)
         return result
 
-    def l1_norm(self):
-        if self.imag_part is not None:
-            raise NotImplementedError
-        return self.real_part.l1_norm()
-
     def l2_norm(self):
         result = self.real_part.l2_norm()
         if self.imag_part is not None:
@@ -323,9 +314,6 @@ class NumpyVector(CopyOnWriteVector):
     def inner(self, other):
         assert self.dim == other.dim
         return np.sum(self._array.conj() * other._array)
-
-    def l1_norm(self):
-        return np.sum(np.abs(self._array))
 
     def l2_norm(self):
         return np.linalg.norm(self._array)
@@ -504,9 +492,6 @@ class ListVectorArray(VectorArray):
             RL.append(R)
 
         return ListVectorArray(RL, self.space)
-
-    def l1_norm(self):
-        return np.array([v.l1_norm() for v in self._list])
 
     def l2_norm(self):
         return np.array([v.l2_norm() for v in self._list])

--- a/src/pymor/vectorarrays/numpy.py
+++ b/src/pymor/vectorarrays/numpy.py
@@ -209,11 +209,6 @@ class NumpyVectorArray(VectorArray):
 
         return NumpyVectorArray(coefficients.dot(self._array[_ind]), self.space)
 
-    def l1_norm(self, *, _ind=None):
-        if _ind is None:
-            _ind = slice(0, self._len)
-        return np.linalg.norm(self._array[_ind], ord=1, axis=1)
-
     def l2_norm(self, *, _ind=None):
         if _ind is None:
             _ind = slice(0, self._len)
@@ -497,9 +492,6 @@ class NumpyVectorArrayView(NumpyVectorArray):
 
     def lincomb(self, coefficients):
         return self.base.lincomb(coefficients, _ind=self.ind)
-
-    def l1_norm(self):
-        return self.base.l1_norm(_ind=self.ind)
 
     def l2_norm(self):
         return self.base.l2_norm(_ind=self.ind)

--- a/src/pymordemos/minimal_cpp_demo/wrapper.py
+++ b/src/pymordemos/minimal_cpp_demo/wrapper.py
@@ -38,9 +38,6 @@ class WrappedVector(CopyOnWriteVector):
     def inner(self, other):
         return self._impl.inner(other._impl)
 
-    def l1_norm(self):
-        raise NotImplementedError
-
     def l2_norm(self):
         return math.sqrt(self.inner(self))
 

--- a/src/pymortests/algorithms/basic.py
+++ b/src/pymortests/algorithms/basic.py
@@ -38,13 +38,7 @@ def test_almost_equal(vector_arrays, tolerances, norms):
     except NotImplementedError:
         dv1 = dv2 = None
     for ind1, ind2 in valid_inds_of_same_length(v1, v2):
-        try:
-            r = almost_equal(v1[ind1], v2[ind2], norm=n, rtol=rtol, atol=atol)
-        except NotImplementedError as e:
-            if n == 'l1':
-                pytest.xfail('l1_norm not implemented')
-            else:
-                raise e
+        r = almost_equal(v1[ind1], v2[ind2], norm=n, rtol=rtol, atol=atol)
         assert isinstance(r, np.ndarray)
         assert r.shape == (v1.len_ind(ind1),)
         if dv1 is not None:
@@ -85,13 +79,7 @@ def test_almost_equal_self(vectors_and_indices, tolerances, norm):
     v, (ind,_) = vectors_and_indices
     rtol, atol = tolerances
     n = norm
-    try:
-        r = almost_equal(v[ind], v[ind], norm=n)
-    except NotImplementedError as e:
-        if n == 'l1':
-            pytest.xfail('l1_norm not implemented')
-        else:
-            raise e
+    r = almost_equal(v[ind], v[ind], norm=n)
     assert isinstance(r, np.ndarray)
     assert r.shape == (v.len_ind(ind),)
     assert np.all(r)

--- a/src/pymortests/algorithms/basic.py
+++ b/src/pymortests/algorithms/basic.py
@@ -27,7 +27,7 @@ import pymortests.strategies as pyst
 
 @pyst.given_vector_arrays(count=2,
                           tolerances=hyst.sampled_from([(1e-5, 1e-8), (1e-10, 1e-12), (0., 1e-8), (1e-5, 1e-8)]),
-                          norms=hyst.sampled_from([('sup', np.inf), ('l1', 1), ('l2', 2)]))
+                          norms=hyst.sampled_from([('sup', np.inf), ('l2', 2)]))
 def test_almost_equal(vector_arrays, tolerances, norms):
     v1, v2 = vector_arrays
     rtol, atol = tolerances
@@ -73,7 +73,7 @@ def test_almost_equal_product(operator_with_arrays_and_products):
 
 @pyst.given_vector_arrays(count=1, index_strategy=pyst.pairs_same_length,
                           tolerances=hyst.sampled_from([(1e-5, 1e-8), (1e-10, 1e-12), (0., 1e-8), (1e-5, 1e-8), (1e-12, 0.)]),
-                          norm=hyst.sampled_from(['sup', 'l1', 'l2']))
+                          norm=hyst.sampled_from(['sup', 'l2']))
 @settings(print_blob=True)
 def test_almost_equal_self(vectors_and_indices, tolerances, norm):
     v, (ind,_) = vectors_and_indices
@@ -176,7 +176,7 @@ def test_almost_equal_self_product(operator_with_arrays_and_products):
 def test_almost_equal_incompatible(vector_arrays):
     v1, v2 = vector_arrays
     for ind1, ind2 in valid_inds_of_same_length(v1, v2):
-        for n in ['sup', 'l1', 'l2']:
+        for n in ['sup', 'l2']:
             c1, c2 = v1.copy(), v2.copy()
             with pytest.raises(Exception):
                 almost_equal(c1[ind1], c2[ind2], norm=n)

--- a/src/pymortests/vectorarray.py
+++ b/src/pymortests/vectorarray.py
@@ -674,31 +674,6 @@ def test_lincomb_wrong_coefficients(vectors_and_indices, random):
 
 
 @pyst.given_vector_arrays(index_strategy=pyst.valid_indices)
-def test_l1_norm(vectors_and_indices):
-    v, ind = vectors_and_indices
-    c = v.copy()
-    try:
-        norm = c[ind].l1_norm()
-    except NotImplementedError:
-        pytest.xfail('l1_norm not implemented')
-    assert isinstance(norm, np.ndarray)
-    assert norm.shape == (v.len_ind(ind),)
-    assert np.all(norm >= 0)
-    if v.dim == 0:
-        assert np.all(norm == 0)
-    try:
-        assert np.allclose(norm, np.sum(np.abs(indexed(v.to_numpy(), ind)), axis=1))
-    except NotImplementedError:
-        pass
-    c.scal(4.)
-    assert np.allclose(c[ind].l1_norm(), norm * 4)
-    c.scal(-4.)
-    assert np.allclose(c[ind].l1_norm(), norm * 16)
-    c.scal(0.)
-    assert np.allclose(c[ind].l1_norm(), 0)
-
-
-@pyst.given_vector_arrays(index_strategy=pyst.valid_indices)
 def test_l2_norm(vectors_and_indices):
     v, ind = vectors_and_indices
     c = v.copy()


### PR DESCRIPTION
I don't know a single example, where this method has been used. 