### PR TITLE
[ci] use new pip resolver for installs

### DIFF
--- a/.ci/gitlab/common_test_setup.bash
+++ b/.ci/gitlab/common_test_setup.bash
@@ -20,9 +20,9 @@ set -eux
 cp /usr/local/share/ci.pip.conf ~/.config/pip/pip.conf
 
 # most of these should be baked into the docker image already
-pip install -r requirements.txt
-pip install -r requirements-ci.txt
-pip install -r requirements-optional.txt
+pip install --use-feature=2020-resolver -r requirements.txt
+pip install --use-feature=2020-resolver -r requirements-ci.txt
+pip install --use-feature=2020-resolver -r requirements-optional.txt
 
 #allow xdist to work by fixing parametrization order
 export PYTHONHASHSEED=0

--- a/.ci/gitlab/test_pip_installed.bash
+++ b/.ci/gitlab/test_pip_installed.bash
@@ -10,17 +10,17 @@ PIP_CLONE_URL="git+${CI_PROJECT_URL}@${CI_COMMIT_SHA}"
 # pip install virtualenv
 # virtualenv /tmp/venv
 # source /tmp/venv/bin/activate
-pip install ${PIP_CLONE_URL}
+pip install --use-feature=2020-resolver ${PIP_CLONE_URL}
 pip uninstall -y pymor
 
 # this is currently disabled because it erroneously pulls in pyqt5
 # pip install ${PIP_CLONE_URL}#egg=pymor[full]
 # pip uninstall -y pymor
 
-pip install .[full]
+pip install --use-feature=2020-resolver .[full]
 pip uninstall -y pymor
 # other requirements are installed from pymor[full]
-pip install -r requirements-ci.txt
+pip install --use-feature=2020-resolver -r requirements-ci.txt
 
 python setup.py sdist -d ${SDIST_DIR}/ --format=gztar
 twine check ${SDIST_DIR}/*


### PR DESCRIPTION
So for once we not seem to be hit with negative effects of a new pip feature. The new dependency resolver that will become the default some time after october seems to work fine for us. 