### PR TITLE
Deprecate l2_norm/l2_norm2 in favor of norm/norm2

### DIFF
--- a/docs/source/tutorial_external_solver.rst
+++ b/docs/source/tutorial_external_solver.rst
@@ -236,10 +236,10 @@ with using just a stub that raises an :class:`~NotImplementedError` in some meth
       def inner(self, other):
           return self._impl.inner(other._impl)
 
-      def l2_norm(self):
+      def norm(self):
           return math.sqrt(self.inner(self))
 
-      def l2_norm2(self):
+      def norm2(self):
           return self.inner(self)
 
       def sup_norm(self):
@@ -384,7 +384,7 @@ Those wrapped classes are only directly used in the `discretize` call.
   for mu in parameter_space.sample_randomly(10):
       U_RB = reductor.reconstruct(rom.solve(mu))
       U = fom.solve(mu)
-      err = np.max((U_RB-U).l2_norm())
+      err = np.max((U_RB-U).norm())
       if err > err_max:
           err_max = err
           mu_max = mu

--- a/docs/source/tutorial_mor_with_anns.rst
+++ b/docs/source/tutorial_mor_with_anns.rst
@@ -242,8 +242,8 @@ We can now derive the absolute and relative errors on the training set as
 
 .. jupyter-execute::
 
-    absolute_errors = (U - U_red).l2_norm()
-    relative_errors = (U - U_red).l2_norm() / U.l2_norm()
+    absolute_errors = (U - U_red).norm()
+    relative_errors = (U - U_red).norm() / U.norm()
 
 The average absolute error amounts to
 

--- a/src/pymor/algorithms/basic.py
+++ b/src/pymor/algorithms/basic.py
@@ -37,7 +37,7 @@ def almost_equal(U, V, product=None, norm=None, rtol=1e-14, atol=1e-14):
         `product` and `norm` are mutually exclusive.
     norm
         If specified, must be a callable which is used to compute the norm
-        or, alternatively, one of the strings 'l1', 'l2', 'sup', in which case the
+        or, alternatively, one of the strings 'l2', 'sup', in which case the
         respective |VectorArray| norm methods are used.
         `product` and `norm` are mutually exclusive. If neither is specified,
         `norm='l2'` is assumed.
@@ -48,13 +48,15 @@ def almost_equal(U, V, product=None, norm=None, rtol=1e-14, atol=1e-14):
     """
 
     assert product is None or norm is None
-    assert not isinstance(norm, str) or norm in ('l1', 'l2', 'sup')
+    assert not isinstance(norm, str) or norm in ('l2', 'sup')
     norm = induced_norm(product) if product is not None else norm
     if norm is None:
         norm = 'l2'
     if isinstance(norm, str):
-        norm_str = norm
-        norm = lambda U: getattr(U, norm_str + '_norm')()
+        if norm == 'l2':
+            norm = lambda U: U.norm()
+        else:
+            norm = lambda U: U.sup_norm()
 
     X = V.copy()
     V_norm = norm(X)

--- a/src/pymor/algorithms/basic.py
+++ b/src/pymor/algorithms/basic.py
@@ -35,7 +35,7 @@ def almost_equal(U, V, product=None, sup_norm=False, rtol=1e-14, atol=1e-14):
         If specified, use this inner product |Operator| to compute the norm.
         Otherwise, the Euclidean norm is used.
     sup_norm
-        If specified, use the sup norm to compute the error.
+        If `True`, use the sup norm to compute the error.
     rtol
         The relative tolerance.
     atol

--- a/src/pymor/algorithms/ei.py
+++ b/src/pymor/algorithms/ei.py
@@ -95,7 +95,7 @@ def ei_greedy(U, error_norm=None, atol=None, rtol=None, max_interpolation_dofs=N
 
     ERR = U
 
-    errs = ERR.l2_norm() if error_norm is None else error_norm(ERR)
+    errs = ERR.norm() if error_norm is None else error_norm(ERR)
     max_err_ind = np.argmax(errs)
     initial_max_err = max_err = errs[max_err_ind]
 
@@ -136,7 +136,7 @@ def ei_greedy(U, error_norm=None, atol=None, rtol=None, max_interpolation_dofs=N
         # update U and ERR
         new_dof_values = U.dofs([new_dof])
         U.axpy(-new_dof_values[:, 0], new_vec)
-        errs = ERR.l2_norm() if error_norm is None else error_norm(ERR)
+        errs = ERR.norm() if error_norm is None else error_norm(ERR)
         max_err_ind = np.argmax(errs)
         max_err = errs[max_err_ind]
 
@@ -429,7 +429,7 @@ def _parallel_ei_greedy_initialize(U=None, error_norm=None, copy=None, data=None
         U = U.copy()
     data['U'] = U
     data['error_norm'] = error_norm
-    errs = U.l2_norm() if error_norm is None else error_norm(U)
+    errs = U.norm() if error_norm is None else error_norm(U)
     data['max_err_ind'] = max_err_ind = np.argmax(errs)
     return errs[max_err_ind]
 
@@ -445,7 +445,7 @@ def _parallel_ei_greedy_update(new_vec=None, new_dof=None, data=None):
     new_dof_values = U.dofs([new_dof])
     U.axpy(-new_dof_values[:, 0], new_vec)
 
-    errs = U.l2_norm() if error_norm is None else error_norm(U)
+    errs = U.norm() if error_norm is None else error_norm(U)
     data['max_err_ind'] = max_err_ind = np.argmax(errs)
     return errs[max_err_ind]
 

--- a/src/pymor/algorithms/eigs.py
+++ b/src/pymor/algorithms/eigs.py
@@ -130,7 +130,7 @@ def eigs(A, E=None, k=3, which='LM', b=None, l=None, maxiter=1000, tol=1e-13,
         ews = ew[idx]
         evs = ev[:, idx]
 
-        rres = f.l2_norm()[0] * np.abs(evs[l - 1]) / np.abs(ews)
+        rres = f.norm()[0] * np.abs(evs[l - 1]) / np.abs(ews)
 
         # increase k by one in order to keep complex conjugate pairs together
         if ews[k - 1].imag != 0 and ews[k - 1].imag + ews[k].imag < complex_pair_tol:
@@ -171,7 +171,7 @@ def eigs(A, E=None, k=3, which='LM', b=None, l=None, maxiter=1000, tol=1e-13,
 def _arnoldi(A, E, l, b):
     """Compute an Arnoldi factorization."""
 
-    v = b * (1 / b.l2_norm()[0])
+    v = b * (1 / b.norm()[0])
 
     H = np.zeros((l, l))
     V = A.source.empty(reserve=l)
@@ -194,7 +194,7 @@ def _extend_arnoldi(A, E, V, H, f, p):
 
     k = len(V)
 
-    res = f.l2_norm()[0]
+    res = f.norm()[0]
     H = np.pad(H, ((0, p), (0, p)))
     H[k, k - 1] = res
     v = f * (1 / res)

--- a/src/pymor/algorithms/genericsolvers.py
+++ b/src/pymor/algorithms/genericsolvers.py
@@ -179,7 +179,7 @@ def apply_inverse(op, V, initial_guess=None, options=None, least_squares=False, 
         raise ValueError('Unknown solver type')
 
     if check_finite:
-        if not np.isfinite(np.all(R.l2_norm())):
+        if not np.isfinite(np.all(R.norm())):
             raise InversionError('Result contains non-finite values')
 
     return R
@@ -227,7 +227,7 @@ def lgmres(A, b, x0=None, tol=1e-5, maxiter=1000, M=None, callback=None,
     if outer_v is None:
         outer_v = []
 
-    b_norm = b.l2_norm()[0]
+    b_norm = b.norm()[0]
     if b_norm == 0:
         b_norm = 1
 
@@ -239,16 +239,16 @@ def lgmres(A, b, x0=None, tol=1e-5, maxiter=1000, M=None, callback=None,
             callback(x)
 
         # -- check stopping condition
-        r_norm = r_outer.l2_norm()[0]
+        r_norm = r_outer.norm()[0]
         if r_norm < tol * b_norm or r_norm < tol:
             break
 
         # -- inner LGMRES iteration
         vs0 = -r_outer   # -psolve(r_outer)
-        inner_res_0 = vs0.l2_norm()[0]
+        inner_res_0 = vs0.norm()[0]
 
         if inner_res_0 == 0:
-            rnorm = r_outer.l2_norm()[0]
+            rnorm = r_outer.norm()[0]
             raise RuntimeError("Preconditioner returned a zero vector; "
                                "|v| ~ %.1g, |M v| = 0" % rnorm)
 
@@ -316,7 +316,7 @@ def lgmres(A, b, x0=None, tol=1e-5, maxiter=1000, M=None, callback=None,
                 alpha = v.inner(v_new)[0, 0]
                 hcur.append(alpha)
                 v_new.axpy(-alpha, v)  # v_new -= alpha*v
-            hcur.append(v_new.l2_norm()[0])
+            hcur.append(v_new.norm()[0])
 
             if hcur[-1] == 0:
                 # Exact solution found; bail out.
@@ -362,7 +362,7 @@ def lgmres(A, b, x0=None, tol=1e-5, maxiter=1000, M=None, callback=None,
             dx.axpy(yc, w)  # dx += w*yc
 
         # -- Store LGMRES augmentation vectors
-        nx = dx.l2_norm()[0]
+        nx = dx.norm()[0]
         if store_outer_Av:
             q = np.dot(hess, y)
             ax = vs[0]*q[0]
@@ -513,13 +513,13 @@ def lsqr(A, b, damp=0.0, atol=1e-8, btol=1e-8, conlim=1e8,
     u = b.copy()
     x = A.source.zeros()
     alfa = 0
-    beta = u.l2_norm()[0]
+    beta = u.norm()[0]
     w = A.source.zeros()
 
     if beta > 0:
         u.scal(1/beta)
         v = A.apply_adjoint(u)
-        alfa = v.l2_norm()[0]
+        alfa = v.norm()[0]
 
     if alfa > 0:
         v.scal(1/alfa)
@@ -562,13 +562,13 @@ def lsqr(A, b, damp=0.0, atol=1e-8, btol=1e-8, conlim=1e8,
         %                alfa*v  =  A'*u  -  beta*v.
         """
         u = A.apply(v) - u * alfa
-        beta = u.l2_norm()[0]
+        beta = u.norm()[0]
 
         if beta > 0:
             u.scal(1/beta)
             anorm = np.sqrt(anorm**2 + alfa**2 + beta**2 + damp**2)
             v = A.apply_adjoint(u) - v * beta
-            alfa = v.l2_norm()[0]
+            alfa = v.norm()[0]
             if alfa > 0:
                 v.scal(1 / alfa)
 
@@ -597,7 +597,7 @@ def lsqr(A, b, damp=0.0, atol=1e-8, btol=1e-8, conlim=1e8,
 
         x = x + w * t1
         w = v + w * t2
-        ddnorm = ddnorm + dk.l2_norm2()[0]
+        ddnorm = ddnorm + dk.norm2()[0]
 
         # Use a plane rotation on the right to eliminate the
         # super-diagonal element (theta) of the upper-bidiagonal matrix.
@@ -766,7 +766,7 @@ def lsmr(A, b, damp=0.0, atol=1e-6, btol=1e-6, conlim=1e8,
         print(f'btol = {btol:8.2e}             maxiter = {maxiter:8g}\n')
 
     u = b.copy()
-    beta = u.l2_norm()[0]
+    beta = u.norm()[0]
 
     v = A.source.zeros()
     alpha = 0
@@ -774,7 +774,7 @@ def lsmr(A, b, damp=0.0, atol=1e-6, btol=1e-6, conlim=1e8,
     if beta > 0:
         u.scal(1 / beta)
         v = A.apply_adjoint(u)
-        alpha = v.l2_norm()[0]
+        alpha = v.norm()[0]
 
     if alpha > 0:
         v.scal(1 / alpha)
@@ -848,12 +848,12 @@ def lsmr(A, b, damp=0.0, atol=1e-6, btol=1e-6, conlim=1e8,
         #        alpha*v  =  A'*u  -  beta*v.
 
         u = A.apply(v) - u * alpha
-        beta = u.l2_norm()[0]
+        beta = u.norm()[0]
 
         if beta > 0:
             u.scal(1 / beta)
             v = A.apply_adjoint(u) - v * beta
-            alpha = v.l2_norm()[0]
+            alpha = v.norm()[0]
             if alpha > 0:
                 v.scal(1 / alpha)
 
@@ -928,7 +928,7 @@ def lsmr(A, b, damp=0.0, atol=1e-6, btol=1e-6, conlim=1e8,
 
         # Compute norms for convergence testing.
         normar = abs(zetabar)
-        normx = x.l2_norm()[0]
+        normx = x.norm()[0]
 
         # Now use these norms to estimate certain other quantities,
         # some of which will be small near a solution.

--- a/src/pymor/algorithms/greedy.py
+++ b/src/pymor/algorithms/greedy.py
@@ -269,7 +269,7 @@ def _rb_surrogate_evaluate(rom=None, fom=None, reductor=None, mus=None, error_no
     elif error_norm is not None:
         errors = [error_norm(fom.solve(mu) - reductor.reconstruct(rom.solve(mu))) for mu in mus]
     else:
-        errors = [(fom.solve(mu) - reductor.reconstruct(rom.solve(mu))).l2_norm() for mu in mus]
+        errors = [(fom.solve(mu) - reductor.reconstruct(rom.solve(mu))).norm() for mu in mus]
     # most error_norms will return an array of length 1 instead of a number, so we extract the numbers
     # if necessary
     errors = [x[0] if hasattr(x, '__len__') else x for x in errors]

--- a/src/pymor/algorithms/krylov.py
+++ b/src/pymor/algorithms/krylov.py
@@ -80,7 +80,7 @@ def rational_arnoldi(A, E, b, sigma, trans=False):
     V = A.source.empty(reserve=r)
 
     v = b.as_vector()
-    v.scal(1 / v.l2_norm()[0])
+    v.scal(1 / v.norm()[0])
 
     for i in range(r):
         if sigma[i].imag < 0:

--- a/src/pymor/bindings/fenics.py
+++ b/src/pymor/bindings/fenics.py
@@ -48,10 +48,10 @@ if config.HAVE_FENICS:
         def inner(self, other):
             return self.impl.inner(other.impl)
 
-        def l2_norm(self):
+        def norm(self):
             return self.impl.norm('l2')
 
-        def l2_norm2(self):
+        def norm2(self):
             return self.impl.norm('l2') ** 2
 
         def sup_norm(self):

--- a/src/pymor/bindings/ngsolve.py
+++ b/src/pymor/bindings/ngsolve.py
@@ -55,10 +55,10 @@ if config.HAVE_NGSOLVE:
         def inner(self, other):
             return self.impl.vec.InnerProduct(other.impl.vec)
 
-        def l2_norm(self):
+        def norm(self):
             return self.impl.vec.Norm()
 
-        def l2_norm2(self):
+        def norm2(self):
             return self.impl.vec.Norm() ** 2
 
     class ComplexifiedNGSolveVector(NGSolveVectorCommon, ComplexifiedVector):

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -863,10 +863,10 @@ class LTIModel(InputStateOutputModel):
         assert self.parameters.assert_compatible(mu)
         if self.input_dim <= self.output_dim:
             cf = self.gramian('c_lrcf', mu=mu)
-            return np.sqrt(self.C.apply(cf, mu=mu).l2_norm2().sum())
+            return np.sqrt(self.C.apply(cf, mu=mu).norm2().sum())
         else:
             of = self.gramian('o_lrcf', mu=mu)
-            return np.sqrt(self.B.apply_adjoint(of, mu=mu).l2_norm2().sum())
+            return np.sqrt(self.B.apply_adjoint(of, mu=mu).norm2().sum())
 
     @cached
     def hinf_norm(self, mu=None, return_fpeak=False, ab13dd_equilibrate=False):

--- a/src/pymor/reductors/coercive.py
+++ b/src/pymor/reductors/coercive.py
@@ -66,7 +66,7 @@ class CoerciveRBEstimator(ImmutableObject):
         self.__auto_init(locals())
 
     def estimate(self, U, mu, m):
-        est = self.residual.apply(U, mu=mu).l2_norm()
+        est = self.residual.apply(U, mu=mu).norm()
         if self.coercivity_estimator:
             est /= self.coercivity_estimator(mu)
         return est

--- a/src/pymor/reductors/interpolation.py
+++ b/src/pymor/reductors/interpolation.py
@@ -110,8 +110,8 @@ class GenericBHIReductor(BasicObject):
         assert projection in ('orth', 'biorth')
 
         # rescale tangential directions (to avoid overflow or underflow)
-        b = b * (1 / b.l2_norm()) if b.dim > 1 else self.fom.input_space.ones(r)
-        c = c * (1 / c.l2_norm()) if c.dim > 1 else self.fom.output_space.ones(r)
+        b = b * (1 / b.norm()) if b.dim > 1 else self.fom.input_space.ones(r)
+        c = c * (1 / c.norm()) if c.dim > 1 else self.fom.output_space.ones(r)
 
         # compute projection matrices
         self.V = self.fom.solution_space.empty(reserve=r)
@@ -374,8 +374,8 @@ class TFBHIReductor(BasicObject):
         assert c in self.fom.output_space and len(c) == r
 
         # rescale tangential directions (to avoid overflow or underflow)
-        b = b * (1 / b.l2_norm()) if b.dim > 1 else self.fom.input_space.ones(r)
-        c = c * (1 / c.l2_norm()) if c.dim > 1 else self.fom.output_space.ones(r)
+        b = b * (1 / b.norm()) if b.dim > 1 else self.fom.input_space.ones(r)
+        c = c * (1 / c.norm()) if c.dim > 1 else self.fom.output_space.ones(r)
 
         b = b.to_numpy()
         c = c.to_numpy()

--- a/src/pymor/reductors/parabolic.py
+++ b/src/pymor/reductors/parabolic.py
@@ -106,15 +106,15 @@ class ParabolicRBEstimator(ImmutableObject):
         C = self.coercivity_estimator(mu) if self.coercivity_estimator else 1.
 
         est = np.empty(len(U))
-        est[0] = (1./C) * self.initial_residual.apply(U[0], mu=mu).l2_norm2()[0]
+        est[0] = (1./C) * self.initial_residual.apply(U[0], mu=mu).norm2()[0]
         if 't' in self.residual.parameters:
             t = 0
             for n in range(1, m.time_stepper.nt + 1):
                 t += dt
                 mu = mu.with_(t=t)
-                est[n] = self.residual.apply(U[n], U[n-1], mu=mu).l2_norm2()
+                est[n] = self.residual.apply(U[n], U[n-1], mu=mu).norm2()
         else:
-            est[1:] = self.residual.apply(U[1:], U[:-1], mu=mu).l2_norm2()
+            est[1:] = self.residual.apply(U[1:], U[:-1], mu=mu).norm2()
         est[1:] *= (dt/C**2)
         est = np.sqrt(np.cumsum(est))
 

--- a/src/pymor/reductors/residual.py
+++ b/src/pymor/reductors/residual.py
@@ -8,7 +8,6 @@ from pymor.algorithms.image import estimate_image_hierarchical
 from pymor.algorithms.projection import project, project_to_subbasis
 from pymor.core.base import BasicObject
 from pymor.core.exceptions import ImageCollectionError
-from pymor.operators.constructions import induced_norm
 from pymor.operators.interface import Operator
 
 
@@ -37,7 +36,7 @@ class ResidualReductor(BasicObject):
     of the residual operator. Given a reduced basis coefficient vector `u`, w.r.t.
     `RB`, the (dual) norm of the residual can then be computed as ::
 
-        projected_residual.apply(u, mu).l2_norm()
+        projected_residual.apply(u, mu).norm()
 
     Moreover, a `reconstruct` method is provided such that ::
 
@@ -101,8 +100,7 @@ class ResidualReductor(BasicObject):
         """Reconstruct high-dimensional residual vector from reduced vector `u`."""
         if self.residual_range is False:
             if self.product:
-                norm = induced_norm(self.product)
-                return u * (u.l2_norm() / norm(u))[0]
+                return u * (u.norm() / u.norm(self.product))[0]
             else:
                 return u
         else:
@@ -151,13 +149,13 @@ class NonProjectedResidualOperator(ResidualOperator):
             if self.riesz_representatives:
                 R_riesz = self.product.apply_inverse(R)
                 # divide by norm, except when norm is zero:
-                inversel2 = 1./R_riesz.l2_norm()
+                inversel2 = 1./R_riesz.norm()
                 inversel2 = np.nan_to_num(inversel2)
                 R_riesz.scal(np.sqrt(R_riesz.pairwise_inner(R)) * inversel2)
                 return R_riesz
             else:
                 # divide by norm, except when norm is zero:
-                inversel2 = 1./R.l2_norm()
+                inversel2 = 1./R.norm()
                 inversel2 = np.nan_to_num(inversel2)
                 R.scal(np.sqrt(self.product.pairwise_apply2(R, R)) * inversel2)
                 return R
@@ -189,7 +187,7 @@ class ImplicitEulerResidualReductor(BasicObject):
     of the `riesz_residual` operator. Given reduced basis coefficient vectors `u` and `u_old`,
     the dual norm of the residual can then be computed as ::
 
-        projected_riesz_residual.apply(u, u_old, mu).l2_norm()
+        projected_riesz_residual.apply(u, u_old, mu).norm()
 
     Moreover, a `reconstruct` method is provided such that ::
 
@@ -251,8 +249,7 @@ class ImplicitEulerResidualReductor(BasicObject):
         """Reconstruct high-dimensional residual vector from reduced vector `u`."""
         if self.residual_range is False:
             if self.product:
-                norm = induced_norm(self.product)
-                return u * (u.l2_norm() / norm(u))[0]
+                return u * (u.norm() / u.norm(self.product))[0]
             else:
                 return u
         else:
@@ -304,7 +301,7 @@ class NonProjectedImplicitEulerResidualOperator(ImplicitEulerResidualOperator):
         if self.product:
             R_riesz = self.product.apply_inverse(R)
             # divide by norm, except when norm is zero:
-            inversel2 = 1./R_riesz.l2_norm()
+            inversel2 = 1./R_riesz.norm()
             inversel2 = np.nan_to_num(inversel2)
             R_riesz.scal(np.sqrt(R_riesz.pairwise_inner(R)) * inversel2)
             return R_riesz

--- a/src/pymor/vectorarrays/block.py
+++ b/src/pymor/vectorarrays/block.py
@@ -128,11 +128,11 @@ class BlockVectorArray(VectorArray):
         lincombs = [block.lincomb(coefficients) for block in self._blocks]
         return BlockVectorArray(lincombs, self.space)
 
-    def l2_norm(self):
-        return np.sqrt(np.sum(np.array([block.l2_norm2() for block in self._blocks]), axis=0))
+    def _norm(self):
+        return np.sqrt(self.norm2())
 
-    def l2_norm2(self):
-        return np.sum(np.array([block.l2_norm2() for block in self._blocks]), axis=0)
+    def _norm2(self):
+        return np.sum(np.array([block.norm2() for block in self._blocks]), axis=0)
 
     def sup_norm(self):
         return np.max(np.array([block.sup_norm() for block in self._blocks]), axis=0)

--- a/src/pymor/vectorarrays/list.py
+++ b/src/pymor/vectorarrays/list.py
@@ -35,11 +35,11 @@ class Vector(BasicObject):
         raise NotImplementedError
 
     @abstractmethod
-    def l2_norm(self):
+    def norm(self):
         pass
 
     @abstractmethod
-    def l2_norm2(self):
+    def norm2(self):
         pass
 
     def sup_norm(self):
@@ -212,16 +212,16 @@ class ComplexifiedVector(Vector):
             result += self.imag_part.inner(other.imag_part)
         return result
 
-    def l2_norm(self):
-        result = self.real_part.l2_norm()
+    def norm(self):
+        result = self.real_part.norm()
         if self.imag_part is not None:
-            result = np.linalg.norm([result, self.imag_part.l2_norm()])
+            result = np.linalg.norm([result, self.imag_part.norm()])
         return result
 
-    def l2_norm2(self):
-        result = self.real_part.l2_norm2()
+    def norm2(self):
+        result = self.real_part.norm2()
         if self.imag_part is not None:
-            result += self.imag_part.l2_norm2()
+            result += self.imag_part.norm2()
         return result
 
     def sup_norm(self):
@@ -315,10 +315,10 @@ class NumpyVector(CopyOnWriteVector):
         assert self.dim == other.dim
         return np.sum(self._array.conj() * other._array)
 
-    def l2_norm(self):
+    def norm(self):
         return np.linalg.norm(self._array)
 
-    def l2_norm2(self):
+    def norm2(self):
         return np.sum((self._array * self._array.conj()).real)
 
     def dofs(self, dof_indices):
@@ -493,11 +493,11 @@ class ListVectorArray(VectorArray):
 
         return ListVectorArray(RL, self.space)
 
-    def l2_norm(self):
-        return np.array([v.l2_norm() for v in self._list])
+    def _norm(self):
+        return np.array([v.norm() for v in self._list])
 
-    def l2_norm2(self):
-        return np.array([v.l2_norm2() for v in self._list])
+    def _norm2(self):
+        return np.array([v.norm2() for v in self._list])
 
     def sup_norm(self):
         if self.dim == 0:

--- a/src/pymor/vectorarrays/numpy.py
+++ b/src/pymor/vectorarrays/numpy.py
@@ -209,12 +209,12 @@ class NumpyVectorArray(VectorArray):
 
         return NumpyVectorArray(coefficients.dot(self._array[_ind]), self.space)
 
-    def l2_norm(self, *, _ind=None):
+    def _norm(self, *, _ind=None):
         if _ind is None:
             _ind = slice(0, self._len)
         return np.linalg.norm(self._array[_ind], axis=1)
 
-    def l2_norm2(self, *, _ind=None):
+    def _norm2(self, *, _ind=None):
         if _ind is None:
             _ind = slice(0, self._len)
         A = self._array[_ind]
@@ -493,11 +493,11 @@ class NumpyVectorArrayView(NumpyVectorArray):
     def lincomb(self, coefficients):
         return self.base.lincomb(coefficients, _ind=self.ind)
 
-    def l2_norm(self):
-        return self.base.l2_norm(_ind=self.ind)
+    def _norm(self):
+        return self.base._norm(_ind=self.ind)
 
-    def l2_norm2(self):
-        return self.base.l2_norm2(_ind=self.ind)
+    def _norm2(self):
+        return self.base._norm2(_ind=self.ind)
 
     def sup_norm(self):
         return self.base.sup_norm(_ind=self.ind)

--- a/src/pymordemos/analyze_pickle.py
+++ b/src/pymordemos/analyze_pickle.py
@@ -90,7 +90,7 @@ def analyze_pickle_histogram(args):
             if args['--error-norm']:
                 errs.append(np.max(getattr(fom, args['--error-norm'] + '_norm')(err)))
             else:
-                errs.append(np.max(err.l2_norm()))
+                errs.append(np.max(err.norm()))
             print('done')
 
         print()
@@ -227,7 +227,7 @@ def analyze_pickle_convergence(args):
             if args['--error-norm']:
                 errs.append(np.max(getattr(fom, args['--error-norm'] + '_norm')(err)))
             else:
-                errs.append(np.max(err.l2_norm()))
+                errs.append(np.max(err.norm()))
         ERRS.append(max(errs))
 
         print()

--- a/src/pymordemos/fenics_nonlinear.py
+++ b/src/pymordemos/fenics_nonlinear.py
@@ -127,7 +127,7 @@ def fenics_nonlinear_demo(args):
         t_rom = time.time() - tic
 
         U_red = reductor.reconstruct(u_red)
-        errs.append(((U - U_red).l2_norm() / U.l2_norm())[0])
+        errs.append(((U - U_red).norm() / U.norm())[0])
         speedups.append(t_fom / t_rom)
     print(f'Maximum relative ROM error: {max(errs)}')
     print(f'Median of ROM speedup: {np.median(speedups)}')

--- a/src/pymordemos/minimal_cpp_demo/demo.py
+++ b/src/pymordemos/minimal_cpp_demo/demo.py
@@ -69,7 +69,7 @@ err_max = -1.
 for mu in parameter_space.sample_randomly(10):
     U_RB = (reductor.reconstruct(rom.solve(mu)))
     U = fom.solve(mu)
-    err = np.max((U_RB-U).l2_norm())
+    err = np.max((U_RB-U).norm())
     if err > err_max:
         err_max = err
         mu_max = mu

--- a/src/pymordemos/minimal_cpp_demo/wrapper.py
+++ b/src/pymordemos/minimal_cpp_demo/wrapper.py
@@ -38,10 +38,10 @@ class WrappedVector(CopyOnWriteVector):
     def inner(self, other):
         return self._impl.inner(other._impl)
 
-    def l2_norm(self):
+    def norm(self):
         return math.sqrt(self.inner(self))
 
-    def l2_norm2(self):
+    def norm2(self):
         return self.inner(self)
 
     def sup_norm(self):

--- a/src/pymordemos/neural_networks.py
+++ b/src/pymordemos/neural_networks.py
@@ -89,8 +89,8 @@ def neural_networks_demo(args):
 
         speedups.append(time_fom / time_red)
 
-    absolute_errors = (U - U_red).l2_norm()
-    relative_errors = (U - U_red).l2_norm() / U.l2_norm()
+    absolute_errors = (U - U_red).norm()
+    relative_errors = (U - U_red).norm() / U.norm()
 
     if args['--vis']:
         fom.visualize((U, U_red),

--- a/src/pymordemos/neural_networks_fenics.py
+++ b/src/pymordemos/neural_networks_fenics.py
@@ -125,8 +125,8 @@ def neural_networks_demo(args):
 
         speedups.append(time_fom / time_red)
 
-    absolute_errors = (U - U_red).l2_norm()
-    relative_errors = (U - U_red).l2_norm() / U.l2_norm()
+    absolute_errors = (U - U_red).norm()
+    relative_errors = (U - U_red).norm() / U.norm()
 
     print(f'Average absolute error: {np.average(absolute_errors)}')
     print(f'Average relative error: {np.average(relative_errors)}')

--- a/src/pymortests/algorithms/basic.py
+++ b/src/pymortests/algorithms/basic.py
@@ -27,25 +27,24 @@ import pymortests.strategies as pyst
 
 @pyst.given_vector_arrays(count=2,
                           tolerances=hyst.sampled_from([(1e-5, 1e-8), (1e-10, 1e-12), (0., 1e-8), (1e-5, 1e-8)]),
-                          norms=hyst.sampled_from([('sup', np.inf), ('l2', 2)]))
-def test_almost_equal(vector_arrays, tolerances, norms):
+                          sup_norm=hyst.booleans())
+def test_almost_equal(vector_arrays, tolerances, sup_norm):
     v1, v2 = vector_arrays
     rtol, atol = tolerances
-    n, o = norms
     try:
         dv1 = v1.to_numpy()
         dv2 = v2.to_numpy()
     except NotImplementedError:
         dv1 = dv2 = None
     for ind1, ind2 in valid_inds_of_same_length(v1, v2):
-        r = almost_equal(v1[ind1], v2[ind2], norm=n, rtol=rtol, atol=atol)
+        r = almost_equal(v1[ind1], v2[ind2], sup_norm=sup_norm, rtol=rtol, atol=atol)
         assert isinstance(r, np.ndarray)
         assert r.shape == (v1.len_ind(ind1),)
         if dv1 is not None:
             if dv2.shape[1] == 0:
                 continue
-            assert np.all(r == (np.linalg.norm(indexed(dv1, ind1) - indexed(dv2, ind2), ord=o, axis=1)
-                                <= atol + rtol * np.linalg.norm(indexed(dv2, ind2), ord=o, axis=1)))
+            assert np.all(r == (np.linalg.norm(indexed(dv1, ind1) - indexed(dv2, ind2), ord=np.inf if sup_norm else None, axis=1)
+                                <= atol + rtol * np.linalg.norm(indexed(dv2, ind2), ord=np.inf if sup_norm else None, axis=1)))
 
 
 def test_almost_equal_product(operator_with_arrays_and_products):
@@ -56,30 +55,22 @@ def test_almost_equal_product(operator_with_arrays_and_products):
     v2.append(v1[:len(v1) // 2])
     for ind1, ind2 in valid_inds_of_same_length(v1, v2):
         for rtol, atol in ((1e-5, 1e-8), (1e-10, 1e-12), (0., 1e-8), (1e-5, 1e-8)):
-            norm = induced_norm(product)
-
-            r = almost_equal(v1[ind1], v2[ind2], norm=norm)
-            assert isinstance(r, np.ndarray)
-            assert r.shape == (v1.len_ind(ind1),)
-            assert np.all(r == (norm(v1[ind1] - v2[ind2])
-                                <= atol + rtol * norm(v2[ind2])))
 
             r = almost_equal(v1[ind1], v2[ind2], product=product)
             assert isinstance(r, np.ndarray)
             assert r.shape == (v1.len_ind(ind1),)
-            assert np.all(r == (norm(v1[ind1] - v2[ind2])
-                                <= atol + rtol * norm(v2[ind2])))
+            assert np.all(r == ((v1[ind1] - v2[ind2]).norm(product)
+                                <= atol + rtol * (v2[ind2]).norm(product)))
 
 
 @pyst.given_vector_arrays(count=1, index_strategy=pyst.pairs_same_length,
                           tolerances=hyst.sampled_from([(1e-5, 1e-8), (1e-10, 1e-12), (0., 1e-8), (1e-5, 1e-8), (1e-12, 0.)]),
-                          norm=hyst.sampled_from(['sup', 'l2']))
+                          sup_norm=hyst.booleans())
 @settings(print_blob=True)
-def test_almost_equal_self(vectors_and_indices, tolerances, norm):
+def test_almost_equal_self(vectors_and_indices, tolerances, sup_norm):
     v, (ind,_) = vectors_and_indices
     rtol, atol = tolerances
-    n = norm
-    r = almost_equal(v[ind], v[ind], norm=n)
+    r = almost_equal(v[ind], v[ind], sup_norm=sup_norm)
     assert isinstance(r, np.ndarray)
     assert r.shape == (v.len_ind(ind),)
     assert np.all(r)
@@ -87,54 +78,46 @@ def test_almost_equal_self(vectors_and_indices, tolerances, norm):
     # the first assumption here is a direct translation of the old loop abort
     assume(v.len_ind(ind) > 0 and np.max(v[ind].sup_norm() > 0))
     # the second one accounts for old input missing very-near zero data
-    if norm == 'l2':
-        norm = lambda U: U.norm()
-    else:
+    if sup_norm:
         norm = lambda U: U.sup_norm()
+    else:
+        norm = lambda U: U.norm()
     tol_min = np.min(np.abs(tolerances))
     v_n_min = np.min(norm(v[ind]))
     assume(v_n_min > tol_min)
 
     c = v.copy()
     c.scal(atol * (1 - 1e-10) / (np.max(norm(v[ind]))))
-    assert np.all(almost_equal(c[ind], c.zeros(v.len_ind(ind)), atol=atol, rtol=rtol, norm=n))
+    assert np.all(almost_equal(c[ind], c.zeros(v.len_ind(ind)), atol=atol, rtol=rtol, sup_norm=sup_norm))
 
     if atol > 0:
         c = v.copy()
         c.scal(2. * atol / (np.max(norm(v[ind]))))
-        assert not np.all(almost_equal(c[ind], c.zeros(v.len_ind(ind)), atol=atol, rtol=rtol, norm=n))
+        assert not np.all(almost_equal(c[ind], c.zeros(v.len_ind(ind)), atol=atol, rtol=rtol, sup_norm=sup_norm))
 
     c = v.copy()
     c.scal(1. + rtol * 0.9)
-    assert np.all(almost_equal(c[ind], v[ind], atol=atol, rtol=rtol, norm=n))
+    assert np.all(almost_equal(c[ind], v[ind], atol=atol, rtol=rtol, sup_norm=sup_norm))
 
     if rtol > 0:
         c = v.copy()
         c.scal(2. + rtol * 1.1)
-        assert not np.all(almost_equal(c[ind], v[ind], atol=atol, rtol=rtol, norm=n))
+        assert not np.all(almost_equal(c[ind], v[ind], atol=atol, rtol=rtol, sup_norm=sup_norm))
 
     c = v.copy()
     c.scal(1. + atol * 0.9 / np.max(norm(v[ind])))
-    assert np.all(almost_equal(c[ind], v[ind], atol=atol, rtol=rtol, norm=n))
+    assert np.all(almost_equal(c[ind], v[ind], atol=atol, rtol=rtol, sup_norm=sup_norm))
 
     if atol > 0 or rtol > 0:
         c = v.copy()
         c.scal(1 + rtol * 1.1 + atol * 1.1 / np.max(norm(v[ind])))
-        assert not np.all(almost_equal(c[ind], v[ind], atol=atol, rtol=rtol, norm=n))
+        assert not np.all(almost_equal(c[ind], v[ind], atol=atol, rtol=rtol, sup_norm=sup_norm))
 
 
 def test_almost_equal_self_product(operator_with_arrays_and_products):
     _, _, v, _, product, _ = operator_with_arrays_and_products
-    norm = induced_norm(product)
     for ind in valid_inds(v):
         for rtol, atol in ((1e-5, 1e-8), (1e-10, 1e-12), (0., 1e-8), (1e-5, 1e-8), (1e-12, 0.)):
-            r = almost_equal(v[ind], v[ind], norm=norm)
-            assert isinstance(r, np.ndarray)
-            assert r.shape == (v.len_ind(ind),)
-            assert np.all(r)
-            if v.len_ind(ind) == 0 or np.max(v[ind].sup_norm() == 0):
-                continue
-
             r = almost_equal(v[ind], v[ind], product=product)
             assert isinstance(r, np.ndarray)
             assert r.shape == (v.len_ind(ind),)
@@ -143,36 +126,30 @@ def test_almost_equal_self_product(operator_with_arrays_and_products):
                 continue
 
             c = v.copy()
-            c.scal(atol * (1 - 1e-10) / (np.max(norm(v[ind]))))
-            assert np.all(almost_equal(c[ind], c.zeros(v.len_ind(ind)), atol=atol, rtol=rtol, norm=norm))
+            c.scal(atol * (1 - 1e-10) / (np.max((v[ind]).norm(product))))
             assert np.all(almost_equal(c[ind], c.zeros(v.len_ind(ind)), atol=atol, rtol=rtol, product=product))
 
             if atol > 0:
                 c = v.copy()
-                c.scal(2. * atol / (np.max(norm(v[ind]))))
-                assert not np.all(almost_equal(c[ind], c.zeros(v.len_ind(ind)), atol=atol, rtol=rtol, norm=norm))
+                c.scal(2. * atol / (np.max((v[ind]).norm(product))))
                 assert not np.all(almost_equal(c[ind], c.zeros(v.len_ind(ind)), atol=atol, rtol=rtol, product=product))
 
             c = v.copy()
             c.scal(1. + rtol * 0.9)
-            assert np.all(almost_equal(c[ind], v[ind], atol=atol, rtol=rtol, norm=norm))
             assert np.all(almost_equal(c[ind], v[ind], atol=atol, rtol=rtol, product=product))
 
             if rtol > 0:
                 c = v.copy()
                 c.scal(2. + rtol * 1.1)
-                assert not np.all(almost_equal(c[ind], v[ind], atol=atol, rtol=rtol, norm=norm))
                 assert not np.all(almost_equal(c[ind], v[ind], atol=atol, rtol=rtol, product=product))
 
             c = v.copy()
-            c.scal(1. + atol * 0.9 / np.max(np.max(norm(v[ind]))))
-            assert np.all(almost_equal(c[ind], v[ind], atol=atol, rtol=rtol, norm=norm))
+            c.scal(1. + atol * 0.9 / np.max(np.max((v[ind]).norm(product))))
             assert np.all(almost_equal(c[ind], v[ind], atol=atol, rtol=rtol, product=product))
 
             if atol > 0 or rtol > 0:
                 c = v.copy()
-                c.scal(1 + rtol * 1.1 + atol * 1.1 / np.max(np.max(norm(v[ind]))))
-                assert not np.all(almost_equal(c[ind], v[ind], atol=atol, rtol=rtol, norm=norm))
+                c.scal(1 + rtol * 1.1 + atol * 1.1 / np.max(np.max((v[ind]).norm(product))))
                 assert not np.all(almost_equal(c[ind], v[ind], atol=atol, rtol=rtol, product=product))
 
 
@@ -180,10 +157,10 @@ def test_almost_equal_self_product(operator_with_arrays_and_products):
 def test_almost_equal_incompatible(vector_arrays):
     v1, v2 = vector_arrays
     for ind1, ind2 in valid_inds_of_same_length(v1, v2):
-        for n in ['sup', 'l2']:
+        for sup_norm in (False, True):
             c1, c2 = v1.copy(), v2.copy()
             with pytest.raises(Exception):
-                almost_equal(c1[ind1], c2[ind2], norm=n)
+                almost_equal(c1[ind1], c2[ind2], sup_norm=sup_norm)
 
 
 @given(pyst.base_vector_arrays(count=2))

--- a/src/pymortests/algorithms/basic.py
+++ b/src/pymortests/algorithms/basic.py
@@ -87,17 +87,21 @@ def test_almost_equal_self(vectors_and_indices, tolerances, norm):
     # the first assumption here is a direct translation of the old loop abort
     assume(v.len_ind(ind) > 0 and np.max(v[ind].sup_norm() > 0))
     # the second one accounts for old input missing very-near zero data
+    if norm == 'l2':
+        norm = lambda U: U.norm()
+    else:
+        norm = lambda U: U.sup_norm()
     tol_min = np.min(np.abs(tolerances))
-    v_n_min = np.min(getattr(v[ind], n + '_norm')())
+    v_n_min = np.min(norm(v[ind]))
     assume(v_n_min > tol_min)
 
     c = v.copy()
-    c.scal(atol * (1 - 1e-10) / (np.max(getattr(v[ind], n + '_norm')())))
+    c.scal(atol * (1 - 1e-10) / (np.max(norm(v[ind]))))
     assert np.all(almost_equal(c[ind], c.zeros(v.len_ind(ind)), atol=atol, rtol=rtol, norm=n))
 
     if atol > 0:
         c = v.copy()
-        c.scal(2. * atol / (np.max(getattr(v[ind], n + '_norm')())))
+        c.scal(2. * atol / (np.max(norm(v[ind]))))
         assert not np.all(almost_equal(c[ind], c.zeros(v.len_ind(ind)), atol=atol, rtol=rtol, norm=n))
 
     c = v.copy()
@@ -110,12 +114,12 @@ def test_almost_equal_self(vectors_and_indices, tolerances, norm):
         assert not np.all(almost_equal(c[ind], v[ind], atol=atol, rtol=rtol, norm=n))
 
     c = v.copy()
-    c.scal(1. + atol * 0.9 / np.max(getattr(v[ind], n + '_norm')()))
+    c.scal(1. + atol * 0.9 / np.max(norm(v[ind])))
     assert np.all(almost_equal(c[ind], v[ind], atol=atol, rtol=rtol, norm=n))
 
     if atol > 0 or rtol > 0:
         c = v.copy()
-        c.scal(1 + rtol * 1.1 + atol * 1.1 / np.max(getattr(v[ind], n + '_norm')()))
+        c.scal(1 + rtol * 1.1 + atol * 1.1 / np.max(norm(v[ind])))
         assert not np.all(almost_equal(c[ind], v[ind], atol=atol, rtol=rtol, norm=n))
 
 

--- a/src/pymortests/algorithms/eigs.py
+++ b/src/pymortests/algorithms/eigs.py
@@ -23,4 +23,4 @@ def test_eigs(n, k, which):
     Aop = NumpyMatrixOperator(A)
     ew, ev = eigs(Aop, k=k, which=which)
 
-    assert np.sum((Aop.apply(ev) - ev * ew).l2_norm()) < 1e-4
+    assert np.sum((Aop.apply(ev) - ev * ew).norm()) < 1e-4

--- a/src/pymortests/solver.py
+++ b/src/pymortests/solver.py
@@ -50,18 +50,18 @@ def test_generic_solvers(generic_solver):
     op = GenericOperator(generic_solver)
     rhs = op.range.make_array(np.ones(10))
     solution = op.apply_inverse(rhs)
-    assert ((op.apply(solution) - rhs).l2_norm() / rhs.l2_norm())[0] < 1e-8
+    assert ((op.apply(solution) - rhs).norm() / rhs.norm())[0] < 1e-8
 
 
 def test_numpy_dense_solvers():
     op = NumpyMatrixOperator(np.eye(10) * np.arange(1, 11))
     rhs = op.range.make_array(np.ones(10))
     solution = op.apply_inverse(rhs)
-    assert ((op.apply(solution) - rhs).l2_norm() / rhs.l2_norm())[0] < 1e-8
+    assert ((op.apply(solution) - rhs).norm() / rhs.norm())[0] < 1e-8
 
 
 def test_numpy_sparse_solvers(numpy_sparse_solver):
     op = NumpyMatrixOperator(diags([np.arange(1., 11.)], [0]), solver_options=numpy_sparse_solver)
     rhs = op.range.make_array(np.ones(10))
     solution = op.apply_inverse(rhs)
-    assert ((op.apply(solution) - rhs).l2_norm() / rhs.l2_norm())[0] < 1e-8
+    assert ((op.apply(solution) - rhs).norm() / rhs.norm())[0] < 1e-8

--- a/src/pymortests/vectorarray.py
+++ b/src/pymortests/vectorarray.py
@@ -83,7 +83,7 @@ def test_zeros(vector_array):
         assert len(v) == c
         if min(v.dim, c) > 0:
             assert max(v.sup_norm()) == 0
-            assert max(v.l2_norm()) == 0
+            assert max(v.norm()) == 0
         try:
             assert v.to_numpy().shape == (c, v.dim)
             assert np.allclose(v.to_numpy(), np.zeros((c, v.dim)))
@@ -101,7 +101,7 @@ def test_ones(vector_array):
         assert len(v) == c
         if min(v.dim, c) > 0:
             assert np.allclose(v.sup_norm(), np.ones(c))
-            assert np.allclose(v.l2_norm(), np.full(c, np.sqrt(v.dim)))
+            assert np.allclose(v.norm(), np.full(c, np.sqrt(v.dim)))
         try:
             assert v.to_numpy().shape == (c, v.dim)
             assert np.allclose(v.to_numpy(), np.ones((c, v.dim)))
@@ -120,7 +120,7 @@ def test_full(vector_array):
             assert len(v) == c
             if min(v.dim, c) > 0:
                 assert np.allclose(v.sup_norm(), np.full(c, abs(val)))
-                assert np.allclose(v.l2_norm(), np.full(c, np.sqrt(val**2 * v.dim)))
+                assert np.allclose(v.norm(), np.full(c, np.sqrt(val**2 * v.dim)))
             try:
                 assert v.to_numpy().shape == (c, v.dim)
                 assert np.allclose(v.to_numpy(), np.full((c, v.dim), val))
@@ -285,9 +285,9 @@ def test_copy_repeated_index(vector_array):
         except NotImplementedError:
             pass
         c[0].scal(2.)
-        assume(c[0].l2_norm() != np.inf)
+        assume(c[0].norm() != np.inf)
         assert almost_equal(c[1], v[ind[0]])
-        assert float_cmp(c[0].l2_norm(), 2 * v[ind[0]].l2_norm())
+        assert float_cmp(c[0].norm(), 2 * v[ind[0]].norm())
         try:
             assert indexed(v.to_numpy(), ind).shape == c.to_numpy().shape
         except NotImplementedError:
@@ -380,7 +380,7 @@ def test_scla(vectors_and_indices):
         c[ind].scal(x)
         assert np.all(almost_equal(c[ind_complement_], v[ind_complement_]))
         assert np.allclose(c[ind].sup_norm(), v[ind].sup_norm() * abs(x))
-        assert np.allclose(c[ind].l2_norm(), v[ind].l2_norm() * abs(x))
+        assert np.allclose(c[ind].norm(), v[ind].norm() * abs(x))
         try:
             y = v.to_numpy(True)
             if isinstance(x, np.ndarray) and not isinstance(ind, Number):
@@ -418,7 +418,7 @@ def test_axpy(vector_arrays, random):
             assert np.all(almost_equal(c1[ind1_complement], v1[ind1_complement]))
             assert np.all(almost_equal(c2, v2))
             assert np.all(c1[ind1].sup_norm() <= v1[ind1].sup_norm() + abs(a) * v2[ind2].sup_norm() * (1. + 1e-10))
-            assert np.all(c1[ind1].l2_norm() <= (v1[ind1].l2_norm() + abs(a) * v2[ind2].l2_norm()) * (1. + 1e-10))
+            assert np.all(c1[ind1].norm() <= (v1[ind1].norm() + abs(a) * v2[ind2].norm()) * (1. + 1e-10))
             try:
                 x = v1.to_numpy(True).astype(complex)  # ensure that inplace addition works
                 if isinstance(ind1, Number):
@@ -470,7 +470,7 @@ def test_axpy_one_x(vector_arrays, random):
             assert np.all(almost_equal(c1[ind1_complement], v1[ind1_complement]))
             assert np.all(almost_equal(c2, v2))
             assert np.all(c1[ind1].sup_norm() <= v1[ind1].sup_norm() + abs(a) * v2[ind2].sup_norm() * (1. + 1e-10))
-            assert np.all(c1[ind1].l2_norm() <= (v1[ind1].l2_norm() + abs(a) * v2[ind2].l2_norm()) * (1. + 1e-10))
+            assert np.all(c1[ind1].norm() <= (v1[ind1].norm() + abs(a) * v2[ind2].norm()) * (1. + 1e-10))
             try:
                 x = v1.to_numpy(True).astype(complex)  # ensure that inplace addition works
                 if isinstance(ind1, Number):
@@ -553,7 +553,7 @@ def test_pairwise_inner(vector_arrays):
         assert r.shape == (v1.len_ind(ind1),)
         r2 = v2[ind2].pairwise_inner(v1[ind1])
         assert np.allclose, (r, r2)
-        assert np.all(r <= v1[ind1].l2_norm() * v2[ind2].l2_norm() * (1. + 1e-10))
+        assert np.all(r <= v1[ind1].norm() * v2[ind2].norm() * (1. + 1e-10))
         try:
             assert np.allclose(r, np.sum(indexed(v1.to_numpy(), ind1).conj() * indexed(v2.to_numpy(), ind2), axis=1))
         except NotImplementedError:
@@ -568,14 +568,14 @@ def test_pairwise_inner_self(vectors_and_indices):
     assert r.shape == (v.len_ind(ind1),)
     r2 = v[ind2].pairwise_inner(v[ind1])
     assert np.allclose(r, r2.T.conj())
-    assert np.all(r <= v[ind1].l2_norm() * v[ind2].l2_norm() * (1. + 1e-10))
+    assert np.all(r <= v[ind1].norm() * v[ind2].norm() * (1. + 1e-10))
     try:
             assert np.allclose(r, np.sum(indexed(v.to_numpy(), ind1).conj() * indexed(v.to_numpy(), ind2), axis=1))
     except NotImplementedError:
         pass
     ind = ind1
     r = v[ind].pairwise_inner(v[ind])
-    assert np.allclose(r, v[ind].l2_norm() ** 2)
+    assert np.allclose(r, v[ind].norm() ** 2)
 
 
 @settings(deadline=None, print_blob=True)
@@ -593,7 +593,7 @@ def test_inner(vectors_and_indices):
     assert r.shape == (v1.len_ind(ind1), v2.len_ind(ind2))
     r2 = v2[ind2].inner(v1[ind1])
     assert np.allclose(r, r2.T.conj())
-    assert np.all(r <= v1[ind1].l2_norm()[:, np.newaxis] * v2[ind2].l2_norm()[np.newaxis, :] * (1. + 1e-10))
+    assert np.all(r <= v1[ind1].norm()[:, np.newaxis] * v2[ind2].norm()[np.newaxis, :] * (1. + 1e-10))
     try:
         assert np.allclose(r, indexed(v1.to_numpy(), ind1).conj().dot(indexed(v2.to_numpy(), ind2).T))
     except NotImplementedError:
@@ -619,7 +619,7 @@ def test_inner_self(vectors_and_indices):
     assert r.shape == (v.len_ind(ind1), v.len_ind(ind2))
     r2 = v[ind2].inner(v[ind1])
     assert np.allclose(r, r2.T.conj())
-    assert np.all(r <= v[ind1].l2_norm()[:, np.newaxis] * v[ind2].l2_norm()[np.newaxis, :] * (1. + 1e-10))
+    assert np.all(r <= v[ind1].norm()[:, np.newaxis] * v[ind2].norm()[np.newaxis, :] * (1. + 1e-10))
     try:
             assert np.allclose(r, indexed(v.to_numpy(), ind1).conj().dot(indexed(v.to_numpy(), ind2).T))
     except NotImplementedError:
@@ -674,10 +674,10 @@ def test_lincomb_wrong_coefficients(vectors_and_indices, random):
 
 
 @pyst.given_vector_arrays(index_strategy=pyst.valid_indices)
-def test_l2_norm(vectors_and_indices):
+def test_norm(vectors_and_indices):
     v, ind = vectors_and_indices
     c = v.copy()
-    norm = c[ind].l2_norm()
+    norm = c[ind].norm()
     assert isinstance(norm, np.ndarray)
     assert norm.shape == (v.len_ind(ind),)
     assert np.all(norm >= 0)
@@ -688,18 +688,18 @@ def test_l2_norm(vectors_and_indices):
     except NotImplementedError:
         pass
     c.scal(4.)
-    assert np.allclose(c[ind].l2_norm(), norm * 4)
+    assert np.allclose(c[ind].norm(), norm * 4)
     c.scal(-4.)
-    assert np.allclose(c[ind].l2_norm(), norm * 16)
+    assert np.allclose(c[ind].norm(), norm * 16)
     c.scal(0.)
-    assert np.allclose(c[ind].l2_norm(), 0)
+    assert np.allclose(c[ind].norm(), 0)
 
 
 @pyst.given_vector_arrays(index_strategy=pyst.valid_indices)
-def test_l2_norm2(vectors_and_indices):
+def test_norm2(vectors_and_indices):
     v, ind = vectors_and_indices
     c = v.copy()
-    norm = c[ind].l2_norm2()
+    norm = c[ind].norm2()
     assert isinstance(norm, np.ndarray)
     assert norm.shape == (v.len_ind(ind),)
     assert np.all(norm >= 0)
@@ -710,11 +710,11 @@ def test_l2_norm2(vectors_and_indices):
     except NotImplementedError:
         pass
     c.scal(4.)
-    assert np.allclose(c[ind].l2_norm2(), norm * 16)
+    assert np.allclose(c[ind].norm2(), norm * 16)
     c.scal(-4.)
-    assert np.allclose(c[ind].l2_norm2(), norm * 256)
+    assert np.allclose(c[ind].norm2(), norm * 256)
     c.scal(0.)
-    assert np.allclose(c[ind].l2_norm2(), 0)
+    assert np.allclose(c[ind].norm2(), 0)
 
 
 @pyst.given_vector_arrays(index_strategy=pyst.valid_indices)


### PR DESCRIPTION
Following #1066, the implementations of `VectorArray.l2_norm`, `VectorArray.l2_norm2` are moved to private `_norm`, `_norm2` methods. `l2_norm` and `l2_norm2` are deprecated so that there is only one method to compute the Euclidean norm of a `VectorArray`. What that means (the Euclidean norm of the `dofs` of the array) is clarified in the docstring.

Moreover, `almost_equal` has been simplified by replacing the (unused) `norm` parameter by the `sup_norm` parameter.