### PR TITLE
[docs] add logo to documentation, adjust colors and fix minor bugs

### DIFF
--- a/docs/source/_static/pymor.css
+++ b/docs/source/_static/pymor.css
@@ -52,3 +52,8 @@
 .md-search__input::placeholder {
     color: #f5f5f5 !important;
 }
+
+.p-Collapse-header {
+    padding: calc(var(--jp-widgets-container-padding) * 1 / 5) var(--jp-widgets-container-padding) !important;
+    font-size: .7rem !important;
+}

--- a/docs/source/_static/pymor.css
+++ b/docs/source/_static/pymor.css
@@ -10,7 +10,11 @@
 }
 
 .output.text_html {
-    display: inline-block;
+    display: inline;
+}
+
+.output.text_html div:last-child {
+    float: none !important;
 }
 
 .md-header {

--- a/docs/source/_static/pymor.css
+++ b/docs/source/_static/pymor.css
@@ -12,3 +12,43 @@
 .cell_output {
     display: inline-block;
 }
+
+.md-header {
+    background-color: #3155a0 !important;
+    color: white !important;
+}
+
+@media only screen and (max-width:76.1875em) {
+    .md-nav--primary .md-nav__title--site {
+        background-color: #3155a0 !important;
+    }
+}
+
+.md-tabs {
+    background-color: white !important;
+    color: rgba(0,0,0,.87) !important;
+}
+
+.md-typeset a {
+    color: #3155a0 !important;
+}
+
+.md-nav__link--active, .md-nav__link:active {
+    color: #3155a0 !important;
+}
+
+.md-typeset a:hover {
+    color: #469ecc !important;
+}
+
+.md-nav__item a:hover {
+    color: #469ecc !important;
+}
+
+.md-search__input {
+    background-color: #242e60 !important;
+}
+
+.md-search__input::placeholder {
+    color: #f5f5f5 !important;
+}

--- a/docs/source/_static/pymor.css
+++ b/docs/source/_static/pymor.css
@@ -9,7 +9,7 @@
     overflow:hidden;
 }
 
-.cell_output {
+.output.text_html {
     display: inline-block;
 }
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -161,10 +161,9 @@ html_theme_options = {
     'html_minify': on_gitlab_ci,
     'css_minify': on_gitlab_ci,
     'nav_title': 'pyMOR Documentation',
-    'logo_icon': '&#xe869',
     'globaltoc_depth': 5,
-    'theme_color': '58c9f5',
-    'color_primary': 'light-blue',
+    'theme_color': 'indigo',
+    'color_primary': 'indigo',
     'color_accent': 'blue',
     'version_dropdown': True,
     'version_json': '/versions.json'
@@ -175,7 +174,7 @@ html_title = "%s v%s Manual" % (project, version)
 
 # The name of an image file (within the static path) to place at the top of
 # the sidebar.
-#html_logo = 'scipyshiny_small.png'
+html_logo = '../../logo/pymor_logo_white.svg'
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -160,7 +160,7 @@ html_theme_options = {
     'base_url': 'https://gh-docs.pymor.org/',
     'html_minify': on_gitlab_ci,
     'css_minify': on_gitlab_ci,
-    'nav_title': 'pyMOR Documentation',
+    'nav_title': 'Documentation',
     'globaltoc_depth': 5,
     'theme_color': 'indigo',
     'color_primary': 'indigo',


### PR DESCRIPTION
This PR adds our new logo to the documentation and changes the colors such that they match the colors in the logo. The main color is chosen to be the same as on the webpage.

Unfortunately, it is not possible to set `color_primary` to some hex value, but one can only select certain values from a predefined list (the reason is that some other colors, for instance the font colors, are adjusted according to the value of `color_primary`). I selected `indigo` as `color_primary` since that seemed to be the closest possible choice to the main colors of our logo.

This is the result:
![image](https://user-images.githubusercontent.com/28065234/92357823-c8ca4700-f0e8-11ea-8e50-59234b92cfd1.png)

![image](https://user-images.githubusercontent.com/28065234/92357843-cf58be80-f0e8-11ea-9b7a-ed6c8063742a.png)