### PR TITLE
Let Model outputs be NumPy arrays

### DIFF
--- a/notebooks/delay.ipynb
+++ b/notebooks/delay.ipynb
@@ -121,7 +121,7 @@
     "sigma = np.logspace(0, 1, r)\n",
     "sigma = np.concatenate((1j * sigma, -1j * sigma))\n",
     "b = td_lti.input_space.ones(2 * r)\n",
-    "c = td_lti.output_space.ones(2 * r)\n",
+    "c = td_lti.D.range.ones(2 * r)\n",
     "\n",
     "rom = interp.reduce(sigma, b, c)\n",
     "err_rom = td_lti - rom"

--- a/notebooks/delay.ipynb
+++ b/notebooks/delay.ipynb
@@ -120,7 +120,7 @@
     "r = 3\n",
     "sigma = np.logspace(0, 1, r)\n",
     "sigma = np.concatenate((1j * sigma, -1j * sigma))\n",
-    "b = td_lti.input_space.ones(2 * r)\n",
+    "b = td_lti.D.source.ones(2 * r)\n",
     "c = td_lti.D.range.ones(2 * r)\n",
     "\n",
     "rom = interp.reduce(sigma, b, c)\n",

--- a/notebooks/delay.ipynb
+++ b/notebooks/delay.ipynb
@@ -120,8 +120,8 @@
     "r = 3\n",
     "sigma = np.logspace(0, 1, r)\n",
     "sigma = np.concatenate((1j * sigma, -1j * sigma))\n",
-    "b = td_lti.D.source.ones(2 * r)\n",
-    "c = td_lti.D.range.ones(2 * r)\n",
+    "b = np.ones((2*r, td_lti.input_dim))\n",
+    "c = np.ones((2*r, td_lti.output_dim))\n",
     "\n",
     "rom = interp.reduce(sigma, b, c)\n",
     "err_rom = td_lti - rom"

--- a/notebooks/delay.ipynb
+++ b/notebooks/delay.ipynb
@@ -120,8 +120,8 @@
     "r = 3\n",
     "sigma = np.logspace(0, 1, r)\n",
     "sigma = np.concatenate((1j * sigma, -1j * sigma))\n",
-    "b = np.ones((2*r, td_lti.input_dim))\n",
-    "c = np.ones((2*r, td_lti.output_dim))\n",
+    "b = np.ones((2*r, td_lti.dim_input))\n",
+    "c = np.ones((2*r, td_lti.dim_output))\n",
     "\n",
     "rom = interp.reduce(sigma, b, c)\n",
     "err_rom = td_lti - rom"

--- a/notebooks/heat.ipynb
+++ b/notebooks/heat.ipynb
@@ -763,7 +763,7 @@
     "    else:\n",
     "        return np.array([[complex(sy_dtf.subs(sy_s, s))]])\n",
     "\n",
-    "tf = TransferFunction(lti.input_dim, lti.output_dim, H, dH)\n",
+    "tf = TransferFunction(lti.dim_input, lti.dim_output, H, dH)\n",
     "print(tf)"
    ]
   },

--- a/notebooks/heat.ipynb
+++ b/notebooks/heat.ipynb
@@ -763,7 +763,7 @@
     "    else:\n",
     "        return np.array([[complex(sy_dtf.subs(sy_s, s))]])\n",
     "\n",
-    "tf = TransferFunction(lti.input_space, lti.output_dim, H, dH)\n",
+    "tf = TransferFunction(lti.input_dim, lti.output_dim, H, dH)\n",
     "print(tf)"
    ]
   },

--- a/notebooks/heat.ipynb
+++ b/notebooks/heat.ipynb
@@ -763,7 +763,7 @@
     "    else:\n",
     "        return np.array([[complex(sy_dtf.subs(sy_s, s))]])\n",
     "\n",
-    "tf = TransferFunction(lti.input_space, lti.output_space, H, dH)\n",
+    "tf = TransferFunction(lti.input_space, lti.output_dim, H, dH)\n",
     "print(tf)"
    ]
   },

--- a/notebooks/parametric_delay.ipynb
+++ b/notebooks/parametric_delay.ipynb
@@ -51,7 +51,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fom = TransferFunction(NumpyVectorSpace(1), NumpyVectorSpace(1),\n",
+    "fom = TransferFunction(1, 1,\n",
     "                       H, dH,\n",
     "                       parameters={'tau': 1})"
    ]

--- a/notebooks/parametric_heat.ipynb
+++ b/notebooks/parametric_heat.ipynb
@@ -120,8 +120,8 @@
    "outputs": [],
    "source": [
     "print(f'order of the model = {lti.order}')\n",
-    "print(f'number of inputs   = {lti.input_dim}')\n",
-    "print(f'number of outputs  = {lti.output_dim}')"
+    "print(f'number of inputs   = {lti.dim_input}')\n",
+    "print(f'number of outputs  = {lti.dim_output}')"
    ]
   },
   {

--- a/notebooks/parametric_string.ipynb
+++ b/notebooks/parametric_string.ipynb
@@ -111,8 +111,8 @@
    "outputs": [],
    "source": [
     "print(f'order of the model = {so_sys.order}')\n",
-    "print(f'number of inputs   = {so_sys.input_dim}')\n",
-    "print(f'number of outputs  = {so_sys.output_dim}')"
+    "print(f'number of inputs   = {so_sys.dim_input}')\n",
+    "print(f'number of outputs  = {so_sys.dim_output}')"
    ]
   },
   {

--- a/src/pymor/models/basic.py
+++ b/src/pymor/models/basic.py
@@ -70,7 +70,7 @@ class StationaryModel(Model):
         self.solution_space = operator.source
         self.linear = operator.linear and (output_functional is None or output_functional.linear)
         if output_functional is not None:
-            self.output_dim = output_functional.range.dim
+            self.dim_output = output_functional.range.dim
 
     def __str__(self):
         return (
@@ -78,7 +78,7 @@ class StationaryModel(Model):
             f'    class: {self.__class__.__name__}\n'
             f'    {"linear" if self.linear else "non-linear"}\n'
             f'    solution_space:  {self.solution_space}\n'
-            f'    output_dim:      {self.output_dim}\n'
+            f'    dim_output:      {self.dim_output}\n'
         )
 
     def _compute_solution(self, mu=None, **kwargs):
@@ -169,7 +169,7 @@ class InstationaryModel(Model):
         self.solution_space = operator.source
         self.linear = operator.linear and (output_functional is None or output_functional.linear)
         if output_functional is not None:
-            self.output_dim = output_functional.range.dim
+            self.dim_output = output_functional.range.dim
 
     def __str__(self):
         return (
@@ -178,7 +178,7 @@ class InstationaryModel(Model):
             f'    {"linear" if self.linear else "non-linear"}\n'
             f'    T: {self.T}\n'
             f'    solution_space:  {self.solution_space}\n'
-            f'    output_dim:      {self.output_dim}\n'
+            f'    dim_output:      {self.dim_output}\n'
         )
 
     def with_time_stepper(self, **kwargs):

--- a/src/pymor/models/basic.py
+++ b/src/pymor/models/basic.py
@@ -70,7 +70,7 @@ class StationaryModel(Model):
         self.solution_space = operator.source
         self.linear = operator.linear and (output_functional is None or output_functional.linear)
         if output_functional is not None:
-            self.output_space = output_functional.range
+            self.output_dim = output_functional.range.dim
 
     def __str__(self):
         return (
@@ -78,7 +78,7 @@ class StationaryModel(Model):
             f'    class: {self.__class__.__name__}\n'
             f'    {"linear" if self.linear else "non-linear"}\n'
             f'    solution_space:  {self.solution_space}\n'
-            f'    output_space:    {self.output_space}\n'
+            f'    output_dim:      {self.output_dim}\n'
         )
 
     def _compute_solution(self, mu=None, **kwargs):
@@ -168,6 +168,8 @@ class InstationaryModel(Model):
         self.__auto_init(locals())
         self.solution_space = operator.source
         self.linear = operator.linear and (output_functional is None or output_functional.linear)
+        if output_functional is not None:
+            self.output_dim = output_functional.range.dim
 
     def __str__(self):
         return (
@@ -176,7 +178,7 @@ class InstationaryModel(Model):
             f'    {"linear" if self.linear else "non-linear"}\n'
             f'    T: {self.T}\n'
             f'    solution_space:  {self.solution_space}\n'
-            f'    output_space:    {self.output_space}\n'
+            f'    output_dim:      {self.output_dim}\n'
         )
 
     def with_time_stepper(self, **kwargs):

--- a/src/pymor/models/interface.py
+++ b/src/pymor/models/interface.py
@@ -331,9 +331,9 @@ class Model(CacheableObject, ParametricObject):
 
         Returns
         -------
-        The computed model output as a 2D |NumPy array| with dimension
-        :attr:`output_dim` in axis 1. (For stationary problems, axis 0 has
-        dimension 1. For time-dependent problems, the dimension of axis 0 
+        The computed model output as a 2D |NumPy array|. The dimension
+        of axis 1 is :attr:`output_dim`. (For stationary problems, axis 0 has
+        dimension 1. For time-dependent problems, the dimension of axis 0
         depends on the number of time steps.)
         When `return_error_estimate` is `True`, the estimate is returned as
         second value.

--- a/src/pymor/models/interface.py
+++ b/src/pymor/models/interface.py
@@ -24,7 +24,7 @@ class Model(CacheableObject, ParametricObject):
     ----------
     solution_space
         |VectorSpace| of the solution |VectorArrays| returned by :meth:`solve`.
-    output_dim
+    dim_output
         Dimension of the model output returned by :meth:`output`. 0 if the
         model has no output.
     linear
@@ -34,7 +34,7 @@ class Model(CacheableObject, ParametricObject):
     """
 
     solution_space = None
-    output_dim = 0
+    dim_output = 0
     linear = False
     products = FrozenDict()
 
@@ -332,7 +332,7 @@ class Model(CacheableObject, ParametricObject):
         Returns
         -------
         The computed model output as a 2D |NumPy array|. The dimension
-        of axis 1 is :attr:`output_dim`. (For stationary problems, axis 0 has
+        of axis 1 is :attr:`dim_output`. (For stationary problems, axis 0 has
         dimension 1. For time-dependent problems, the dimension of axis 0
         depends on the number of time steps.)
         When `return_error_estimate` is `True`, the estimate is returned as

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -17,6 +17,7 @@ from pymor.operators.block import (BlockOperator, BlockRowOperator, BlockColumnO
 from pymor.operators.constructions import IdentityOperator, LincombOperator, ZeroOperator
 from pymor.operators.numpy import NumpyMatrixOperator
 from pymor.parameters.base import Mu
+from pymor.tools.deprecated import Deprecated
 from pymor.vectorarrays.block import BlockVectorSpace
 
 
@@ -36,6 +37,16 @@ class InputOutputModel(Model):
         assert cont_time in (True, False)
         super().__init__(error_estimator=error_estimator, visualizer=visualizer, name=name)
         self.__auto_init(locals())
+
+    @property
+    @Deprecated('dim_input')
+    def input_dim(self):
+        return self.dim_input
+
+    @property
+    @Deprecated('dim_output')
+    def output_dim(self):
+        return self.dim_output
 
     def eval_tf(self, s, mu=None):
         """Evaluate the transfer function."""

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -1893,7 +1893,7 @@ class LinearDelayModel(InputStateOutputModel):
         E = E or IdentityOperator(A.source)
         assert E.linear and E.source == E.range == A.source
 
-        super().__init__(B.source, A.source, C.range, cont_time=cont_time,
+        super().__init__(B.source.dim, A.source, C.range.dim, cont_time=cont_time,
                          error_estimator=error_estimator, visualizer=visualizer, name=name)
 
         self.__auto_init(locals())

--- a/src/pymor/models/neural_network.py
+++ b/src/pymor/models/neural_network.py
@@ -63,7 +63,7 @@ if config.HAVE_TORCH:
             self.__auto_init(locals())
             self.solution_space = NumpyVectorSpace(neural_network.output_dimension)
             if output_functional is not None:
-                self.output_space = output_functional.range
+                self.output_dim = output_functional.range.dim
 
         def _compute_solution(self, mu=None, **kwargs):
 
@@ -130,7 +130,7 @@ if config.HAVE_TORCH:
             self.__auto_init(locals())
             self.solution_space = NumpyVectorSpace(neural_network.output_dimension)
             if output_functional is not None:
-                self.output_space = output_functional.range
+                self.output_dim = output_functional.range.dim
 
         def _compute_solution(self, mu=None, **kwargs):
 

--- a/src/pymor/models/neural_network.py
+++ b/src/pymor/models/neural_network.py
@@ -63,7 +63,7 @@ if config.HAVE_TORCH:
             self.__auto_init(locals())
             self.solution_space = NumpyVectorSpace(neural_network.output_dimension)
             if output_functional is not None:
-                self.output_dim = output_functional.range.dim
+                self.dim_output = output_functional.range.dim
 
         def _compute_solution(self, mu=None, **kwargs):
 
@@ -130,7 +130,7 @@ if config.HAVE_TORCH:
             self.__auto_init(locals())
             self.solution_space = NumpyVectorSpace(neural_network.output_dimension)
             if output_functional is not None:
-                self.output_dim = output_functional.range.dim
+                self.dim_output = output_functional.range.dim
 
         def _compute_solution(self, mu=None, **kwargs):
 

--- a/src/pymor/reductors/bt.py
+++ b/src/pymor/reductors/bt.py
@@ -204,10 +204,10 @@ class BRBTReductor(GenericBTReductor):
         options = self.solver_options
 
         cf = solve_pos_ricc_lrcf(A, E, B.as_range_array(), C.as_source_array(),
-                                 R=self.gamma**2 * np.eye(self.fom.output_dim) if self.gamma != 1 else None,
+                                 R=self.gamma**2 * np.eye(self.fom.dim_output) if self.gamma != 1 else None,
                                  trans=False, options=options)
         of = solve_pos_ricc_lrcf(A, E, B.as_range_array(), C.as_source_array(),
-                                 R=self.gamma**2 * np.eye(self.fom.input_dim) if self.gamma != 1 else None,
+                                 R=self.gamma**2 * np.eye(self.fom.dim_input) if self.gamma != 1 else None,
                                  trans=True, options=options)
         return cf, of
 

--- a/src/pymor/reductors/h2.py
+++ b/src/pymor/reductors/h2.py
@@ -210,8 +210,8 @@ class IRKAReductor(GenericIRKAReductor):
             - dict with `'sigma'`, `'b'`, `'c'` as keys mapping to
               initial interpolation points (a 1D |NumPy array|), right
               tangential directions (|NumPy array| of shape
-              `(len(sigma), fom.D.dim_input)`), and left tangential directions
-              (|NumPy array| of shape `(len(sigma), fom.D.dim_input)`),
+              `(len(sigma), fom.dim_input)`), and left tangential directions
+              (|NumPy array| of shape `(len(sigma), fom.dim_input)`),
             - initial reduced-order model (|LTIModel|).
 
             If the order of reduced model is given, initial
@@ -323,8 +323,8 @@ class OneSidedIRKAReductor(GenericIRKAReductor):
             - dict with `'sigma'`, `'b'`, `'c'` as keys mapping to
               initial interpolation points (a 1D |NumPy array|), right
               tangential directions (|NumPy array| of shape
-              `(len(sigma), fom.D.dim_input)`), and left tangential directions
-              (|NumPy array| of shape `(len(sigma), fom.D.dim_input)`),
+              `(len(sigma), fom.dim_input)`), and left tangential directions
+              (|NumPy array| of shape `(len(sigma), fom.dim_input)`),
             - initial reduced-order model (|LTIModel|).
 
             If the order of reduced model is given, initial
@@ -456,8 +456,8 @@ class TSIAReductor(GenericIRKAReductor):
             - dict with `'sigma'`, `'b'`, `'c'` as keys mapping to
               initial interpolation points (a 1D |NumPy array|), right
               tangential directions (|NumPy array| of shape
-              `(len(sigma), fom.D.dim_input)`), and left tangential directions
-              (|NumPy array| of shape `(len(sigma), fom.D.dim_input)`),
+              `(len(sigma), fom.dim_input)`), and left tangential directions
+              (|NumPy array| of shape `(len(sigma), fom.dim_input)`),
             - initial reduced-order model (|LTIModel|).
 
             If the order of reduced model is given, initial
@@ -572,8 +572,8 @@ class TFIRKAReductor(GenericIRKAReductor):
             - dict with `'sigma'`, `'b'`, `'c'` as keys mapping to
               initial interpolation points (a 1D |NumPy array|), right
               tangential directions (|NumPy array| of shape
-              `(len(sigma), fom.D.dim_input)`), and left tangential directions
-              (|NumPy array| of shape `(len(sigma), fom.D.dim_input)`),
+              `(len(sigma), fom.dim_input)`), and left tangential directions
+              (|NumPy array| of shape `(len(sigma), fom.dim_input)`),
             - initial reduced-order model (|LTIModel|).
 
             If the order of reduced model is given, initial

--- a/src/pymor/reductors/h2.py
+++ b/src/pymor/reductors/h2.py
@@ -67,16 +67,16 @@ class GenericIRKAReductor(BasicObject):
             assert ('sigma', 'b', 'c') in rom0_params
             assert isinstance(rom0_params['sigma'], np.ndarray)
             assert rom0_params['sigma'].ndim == 1
-            assert rom0_params['b'] in self.fom.D.source
-            assert rom0_params['c'] in self.fom.D.range
-            assert len(rom0_params['sigma']) == len(rom0_params['b'])
-            assert len(rom0_params['sigma']) == len(rom0_params['c'])
+            assert rom0_params['b'].shape[1] == self.fom.input_dim
+            assert rom0_params['c'].shape[1] == self.fom.output_dim
+            assert len(rom0_params['sigma']) == rom0_params['b'].shape[0]
+            assert len(rom0_params['sigma']) == rom0_params['c'].shape[0]
         elif isinstance(rom0_params, LTIModel):
             assert rom0_params.order > 0
             if hasattr(self.fom, 'order'):  # self.fom can be a TransferFunction
                 assert rom0_params < self.fom.order
-            assert rom0_params.D.source == self.fom.D.source
-            assert rom0_params.D.range == self.fom.D.range
+            assert rom0_params.input_dim == self.fom.input_dim
+            assert rom0_params.output_dim == self.fom.output_dim
         else:
             raise ValueError(f'rom0_params is of wrong type ({type(rom0_params)}).')
 
@@ -89,12 +89,12 @@ class GenericIRKAReductor(BasicObject):
 
     def _order_to_sigma_b_c(self, r):
         sigma = np.logspace(-1, 1, r)
-        b = (NumpyVectorSpace(self.fom.input_dim).ones(r)
+        b = (np.ones((r, 1))
              if self.fom.input_dim == 1
-             else NumpyVectorSpace(self.fom.input_dim).random(r, distribution='normal', seed=0))
-        c = (NumpyVectorSpace(self.fom.output_dim).ones(r)
+             else np.random.RandomState(0).normal(size=(r, self.fom.input_dim)))
+        c = (np.ones((r, 1))
              if self.fom.output_dim == 1
-             else NumpyVectorSpace(self.fom.output_dim).random(r, distribution='normal', seed=0))
+             else np.random.RandomState(0).normal(size=(r, self.fom.output_dim)))
         return sigma, b, c
 
     @staticmethod
@@ -209,10 +209,9 @@ class IRKAReductor(GenericIRKAReductor):
             - initial interpolation points (a 1D |NumPy array|),
             - dict with `'sigma'`, `'b'`, `'c'` as keys mapping to
               initial interpolation points (a 1D |NumPy array|), right
-              tangential directions (|VectorArray| from
-              `fom.D.source`), and left tangential directions
-              (|VectorArray| from `fom.D.range`), all of the same
-              length (the order of the reduced model),
+              tangential directions (|NumPy array| of shape
+              `(len(sigma), fom.D.input_dim)`), and left tangential directions
+              (|NumPy array| of shape `(len(sigma), fom.D.input_dim)`),
             - initial reduced-order model (|LTIModel|).
 
             If the order of reduced model is given, initial
@@ -323,10 +322,9 @@ class OneSidedIRKAReductor(GenericIRKAReductor):
             - initial interpolation points (a 1D |NumPy array|),
             - dict with `'sigma'`, `'b'`, `'c'` as keys mapping to
               initial interpolation points (a 1D |NumPy array|), right
-              tangential directions (|VectorArray| from
-              `fom.D.source`), and left tangential directions
-              (|VectorArray| from `fom.D.range`), all of the same
-              length (the order of the reduced model),
+              tangential directions (|NumPy array| of shape
+              `(len(sigma), fom.D.input_dim)`), and left tangential directions
+              (|NumPy array| of shape `(len(sigma), fom.D.input_dim)`),
             - initial reduced-order model (|LTIModel|).
 
             If the order of reduced model is given, initial
@@ -405,13 +403,13 @@ class OneSidedIRKAReductor(GenericIRKAReductor):
             else self.fom
         )
         if self.version == 'V':
-            self.V = tangential_rational_krylov(fom.A, fom.E, fom.B, b, sigma,
+            self.V = tangential_rational_krylov(fom.A, fom.E, fom.B, fom.B.source.from_numpy(b), sigma,
                                                 orth=False)
             gram_schmidt(self.V, atol=0, rtol=0,
                          product=None if projection == 'orth' else fom.E,
                          copy=False)
         else:
-            self.V = tangential_rational_krylov(fom.A, fom.E, fom.C, c, sigma, trans=True,
+            self.V = tangential_rational_krylov(fom.A, fom.E, fom.C, fom.C.range.from_numpy(c), sigma, trans=True,
                                                 orth=False)
             gram_schmidt(self.V, atol=0, rtol=0,
                          product=None if projection == 'orth' else fom.E,
@@ -457,10 +455,9 @@ class TSIAReductor(GenericIRKAReductor):
             - initial interpolation points (a 1D |NumPy array|),
             - dict with `'sigma'`, `'b'`, `'c'` as keys mapping to
               initial interpolation points (a 1D |NumPy array|), right
-              tangential directions (|VectorArray| from
-              `fom.D.source`), and left tangential directions
-              (|VectorArray| from `fom.D.range`), all of the same
-              length (the order of the reduced model),
+              tangential directions (|NumPy array| of shape
+              `(len(sigma), fom.D.input_dim)`), and left tangential directions
+              (|NumPy array| of shape `(len(sigma), fom.D.input_dim)`),
             - initial reduced-order model (|LTIModel|).
 
             If the order of reduced model is given, initial
@@ -574,10 +571,9 @@ class TFIRKAReductor(GenericIRKAReductor):
             - initial interpolation points (a 1D |NumPy array|),
             - dict with `'sigma'`, `'b'`, `'c'` as keys mapping to
               initial interpolation points (a 1D |NumPy array|), right
-              tangential directions (|VectorArray| from
-              `fom.D.source`), and left tangential directions
-              (|VectorArray| from `fom.D.range`), all of the same
-              length (the order of the reduced model),
+              tangential directions (|NumPy array| of shape
+              `(len(sigma), fom.D.input_dim)`), and left tangential directions
+              (|NumPy array| of shape `(len(sigma), fom.D.input_dim)`),
             - initial reduced-order model (|LTIModel|).
 
             If the order of reduced model is given, initial
@@ -658,9 +654,9 @@ def _lti_to_poles_b_c(rom):
     poles
         1D |NumPy array| of poles.
     b
-        |VectorArray| from `rom.B.source`.
+        |NumPy array| of shape `(len(poles), rom.input_dim)`.
     c
-        |VectorArray| from `rom.C.range`.
+        |NumPy array| of shape `(len(poles), rom.output_dim)`.
     """
     A = to_matrix(rom.A, format='dense')
     B = to_matrix(rom.B, format='dense')
@@ -672,8 +668,8 @@ def _lti_to_poles_b_c(rom):
         E = to_matrix(rom.E, format='dense')
         poles, X = spla.eig(A, E)
         EX = E @ X
-    b = rom.B.source.from_numpy(spla.solve(EX, B))
-    c = rom.C.range.from_numpy((C @ X).T)
+    b = spla.solve(EX, B)
+    c = (C @ X).T
     return poles, b, c
 
 
@@ -694,9 +690,9 @@ def _poles_b_c_to_lti(poles, b, c):
     poles
         Sequence of poles.
     b
-        |VectorArray| of right residue rank-1 factors.
+        |NumPy array| of shape `(len(poles), rom.input_dim)`.
     c
-        |VectorArray| of left residue rank-1 factors.
+        |NumPy array| of shape `(len(poles), rom.output_dim)`.
 
     Returns
     -------
@@ -706,14 +702,14 @@ def _poles_b_c_to_lti(poles, b, c):
     for i, pole in enumerate(poles):
         if pole.imag == 0:
             A.append(pole.real)
-            B.append(b[i].to_numpy().real)
-            C.append(c[i].to_numpy().real.T)
+            B.append(b[i].real)
+            C.append(c[i].real.T)
         elif pole.imag > 0:
             A.append([[pole.real, pole.imag],
                       [-pole.imag, pole.real]])
-            bi = b[i].to_numpy()
+            bi = b[i]
             B.append(np.vstack([2 * bi.real, -2 * bi.imag]))
-            ci = c[i].to_numpy()
+            ci = c[i]
             C.append(np.hstack([ci.real.T, ci.imag.T]))
     A = spla.block_diag(*A)
     B = np.vstack(B)

--- a/src/pymor/reductors/h2.py
+++ b/src/pymor/reductors/h2.py
@@ -67,16 +67,16 @@ class GenericIRKAReductor(BasicObject):
             assert ('sigma', 'b', 'c') in rom0_params
             assert isinstance(rom0_params['sigma'], np.ndarray)
             assert rom0_params['sigma'].ndim == 1
-            assert rom0_params['b'].shape[1] == self.fom.input_dim
-            assert rom0_params['c'].shape[1] == self.fom.output_dim
+            assert rom0_params['b'].shape[1] == self.fom.dim_input
+            assert rom0_params['c'].shape[1] == self.fom.dim_output
             assert len(rom0_params['sigma']) == rom0_params['b'].shape[0]
             assert len(rom0_params['sigma']) == rom0_params['c'].shape[0]
         elif isinstance(rom0_params, LTIModel):
             assert rom0_params.order > 0
             if hasattr(self.fom, 'order'):  # self.fom can be a TransferFunction
                 assert rom0_params < self.fom.order
-            assert rom0_params.input_dim == self.fom.input_dim
-            assert rom0_params.output_dim == self.fom.output_dim
+            assert rom0_params.dim_input == self.fom.dim_input
+            assert rom0_params.dim_output == self.fom.dim_output
         else:
             raise ValueError(f'rom0_params is of wrong type ({type(rom0_params)}).')
 
@@ -90,11 +90,11 @@ class GenericIRKAReductor(BasicObject):
     def _order_to_sigma_b_c(self, r):
         sigma = np.logspace(-1, 1, r)
         b = (np.ones((r, 1))
-             if self.fom.input_dim == 1
-             else np.random.RandomState(0).normal(size=(r, self.fom.input_dim)))
+             if self.fom.dim_input == 1
+             else np.random.RandomState(0).normal(size=(r, self.fom.dim_input)))
         c = (np.ones((r, 1))
-             if self.fom.output_dim == 1
-             else np.random.RandomState(0).normal(size=(r, self.fom.output_dim)))
+             if self.fom.dim_output == 1
+             else np.random.RandomState(0).normal(size=(r, self.fom.dim_output)))
         return sigma, b, c
 
     @staticmethod
@@ -210,8 +210,8 @@ class IRKAReductor(GenericIRKAReductor):
             - dict with `'sigma'`, `'b'`, `'c'` as keys mapping to
               initial interpolation points (a 1D |NumPy array|), right
               tangential directions (|NumPy array| of shape
-              `(len(sigma), fom.D.input_dim)`), and left tangential directions
-              (|NumPy array| of shape `(len(sigma), fom.D.input_dim)`),
+              `(len(sigma), fom.D.dim_input)`), and left tangential directions
+              (|NumPy array| of shape `(len(sigma), fom.D.dim_input)`),
             - initial reduced-order model (|LTIModel|).
 
             If the order of reduced model is given, initial
@@ -265,7 +265,7 @@ class IRKAReductor(GenericIRKAReductor):
         self._check_common_args(tol, maxit, num_prev, conv_crit)
         assert projection in ('orth', 'biorth', 'arnoldi')
         if projection == 'arnoldi':
-            assert self.fom.input_dim == self.fom.output_dim == 1
+            assert self.fom.dim_input == self.fom.dim_output == 1
 
         self.logger.info('Starting IRKA')
         self._conv_data = (num_prev + 1) * [None]
@@ -323,8 +323,8 @@ class OneSidedIRKAReductor(GenericIRKAReductor):
             - dict with `'sigma'`, `'b'`, `'c'` as keys mapping to
               initial interpolation points (a 1D |NumPy array|), right
               tangential directions (|NumPy array| of shape
-              `(len(sigma), fom.D.input_dim)`), and left tangential directions
-              (|NumPy array| of shape `(len(sigma), fom.D.input_dim)`),
+              `(len(sigma), fom.D.dim_input)`), and left tangential directions
+              (|NumPy array| of shape `(len(sigma), fom.D.dim_input)`),
             - initial reduced-order model (|LTIModel|).
 
             If the order of reduced model is given, initial
@@ -456,8 +456,8 @@ class TSIAReductor(GenericIRKAReductor):
             - dict with `'sigma'`, `'b'`, `'c'` as keys mapping to
               initial interpolation points (a 1D |NumPy array|), right
               tangential directions (|NumPy array| of shape
-              `(len(sigma), fom.D.input_dim)`), and left tangential directions
-              (|NumPy array| of shape `(len(sigma), fom.D.input_dim)`),
+              `(len(sigma), fom.D.dim_input)`), and left tangential directions
+              (|NumPy array| of shape `(len(sigma), fom.D.dim_input)`),
             - initial reduced-order model (|LTIModel|).
 
             If the order of reduced model is given, initial
@@ -572,8 +572,8 @@ class TFIRKAReductor(GenericIRKAReductor):
             - dict with `'sigma'`, `'b'`, `'c'` as keys mapping to
               initial interpolation points (a 1D |NumPy array|), right
               tangential directions (|NumPy array| of shape
-              `(len(sigma), fom.D.input_dim)`), and left tangential directions
-              (|NumPy array| of shape `(len(sigma), fom.D.input_dim)`),
+              `(len(sigma), fom.D.dim_input)`), and left tangential directions
+              (|NumPy array| of shape `(len(sigma), fom.D.dim_input)`),
             - initial reduced-order model (|LTIModel|).
 
             If the order of reduced model is given, initial
@@ -654,9 +654,9 @@ def _lti_to_poles_b_c(rom):
     poles
         1D |NumPy array| of poles.
     b
-        |NumPy array| of shape `(len(poles), rom.input_dim)`.
+        |NumPy array| of shape `(len(poles), rom.dim_input)`.
     c
-        |NumPy array| of shape `(len(poles), rom.output_dim)`.
+        |NumPy array| of shape `(len(poles), rom.dim_output)`.
     """
     A = to_matrix(rom.A, format='dense')
     B = to_matrix(rom.B, format='dense')
@@ -690,9 +690,9 @@ def _poles_b_c_to_lti(poles, b, c):
     poles
         Sequence of poles.
     b
-        |NumPy array| of shape `(len(poles), rom.input_dim)`.
+        |NumPy array| of shape `(len(poles), rom.dim_input)`.
     c
-        |NumPy array| of shape `(len(poles), rom.output_dim)`.
+        |NumPy array| of shape `(len(poles), rom.dim_output)`.
 
     Returns
     -------

--- a/src/pymor/reductors/h2.py
+++ b/src/pymor/reductors/h2.py
@@ -703,14 +703,12 @@ def _poles_b_c_to_lti(poles, b, c):
         if pole.imag == 0:
             A.append(pole.real)
             B.append(b[i].real)
-            C.append(c[i].real.T)
+            C.append(c[i].real[:, np.newaxis])
         elif pole.imag > 0:
             A.append([[pole.real, pole.imag],
                       [-pole.imag, pole.real]])
-            bi = b[i]
-            B.append(np.vstack([2 * bi.real, -2 * bi.imag]))
-            ci = c[i]
-            C.append(np.hstack([ci.real.T, ci.imag.T]))
+            B.append(np.vstack([2 * b[i].real, -2 * b[i].imag]))
+            C.append(np.hstack([c[i].real[:, np.newaxis], c[i].imag[:, np.newaxis]]))
     A = spla.block_diag(*A)
     B = np.vstack(B)
     C = np.hstack(C)

--- a/src/pymor/reductors/h2.py
+++ b/src/pymor/reductors/h2.py
@@ -19,6 +19,7 @@ from pymor.operators.constructions import IdentityOperator
 from pymor.parameters.base import Mu
 from pymor.reductors.basic import LTIPGReductor
 from pymor.reductors.interpolation import LTIBHIReductor, TFBHIReductor
+from pymor.vectorarrays.numpy import NumpyVectorSpace
 
 
 class GenericIRKAReductor(BasicObject):
@@ -67,7 +68,7 @@ class GenericIRKAReductor(BasicObject):
             assert isinstance(rom0_params['sigma'], np.ndarray)
             assert rom0_params['sigma'].ndim == 1
             assert rom0_params['b'] in self.fom.input_space
-            assert rom0_params['c'] in self.fom.output_space
+            assert rom0_params['c'] in self.fom.D.range
             assert len(rom0_params['sigma']) == len(rom0_params['b'])
             assert len(rom0_params['sigma']) == len(rom0_params['c'])
         elif isinstance(rom0_params, LTIModel):
@@ -75,7 +76,7 @@ class GenericIRKAReductor(BasicObject):
             if hasattr(self.fom, 'order'):  # self.fom can be a TransferFunction
                 assert rom0_params < self.fom.order
             assert rom0_params.input_space == self.fom.input_space
-            assert rom0_params.output_space == self.fom.output_space
+            assert rom0_params.D.range == self.fom.D.range
         else:
             raise ValueError(f'rom0_params is of wrong type ({type(rom0_params)}).')
 
@@ -91,9 +92,9 @@ class GenericIRKAReductor(BasicObject):
         b = (self.fom.input_space.ones(r)
              if self.fom.input_dim == 1
              else self.fom.input_space.random(r, distribution='normal', seed=0))
-        c = (self.fom.output_space.ones(r)
+        c = (NumpyVectorSpace(self.fom.output_dim).ones(r)
              if self.fom.output_dim == 1
-             else self.fom.output_space.random(r, distribution='normal', seed=0))
+             else NumpyVectorSpace(self.fom.output_dim).random(r, distribution='normal', seed=0))
         return sigma, b, c
 
     @staticmethod
@@ -210,7 +211,7 @@ class IRKAReductor(GenericIRKAReductor):
               initial interpolation points (a 1D |NumPy array|), right
               tangential directions (|VectorArray| from
               `fom.input_space`), and left tangential directions
-              (|VectorArray| from `fom.output_space`), all of the same
+              (|VectorArray| from `fom.D.range`), all of the same
               length (the order of the reduced model),
             - initial reduced-order model (|LTIModel|).
 
@@ -324,7 +325,7 @@ class OneSidedIRKAReductor(GenericIRKAReductor):
               initial interpolation points (a 1D |NumPy array|), right
               tangential directions (|VectorArray| from
               `fom.input_space`), and left tangential directions
-              (|VectorArray| from `fom.output_space`), all of the same
+              (|VectorArray| from `fom.D.range`), all of the same
               length (the order of the reduced model),
             - initial reduced-order model (|LTIModel|).
 
@@ -458,7 +459,7 @@ class TSIAReductor(GenericIRKAReductor):
               initial interpolation points (a 1D |NumPy array|), right
               tangential directions (|VectorArray| from
               `fom.input_space`), and left tangential directions
-              (|VectorArray| from `fom.output_space`), all of the same
+              (|VectorArray| from `fom.D.range`), all of the same
               length (the order of the reduced model),
             - initial reduced-order model (|LTIModel|).
 
@@ -575,7 +576,7 @@ class TFIRKAReductor(GenericIRKAReductor):
               initial interpolation points (a 1D |NumPy array|), right
               tangential directions (|VectorArray| from
               `fom.input_space`), and left tangential directions
-              (|VectorArray| from `fom.output_space`), all of the same
+              (|VectorArray| from `fom.D.range`), all of the same
               length (the order of the reduced model),
             - initial reduced-order model (|LTIModel|).
 

--- a/src/pymor/reductors/h2.py
+++ b/src/pymor/reductors/h2.py
@@ -66,6 +66,8 @@ class GenericIRKAReductor(BasicObject):
         elif isinstance(rom0_params, dict):
             assert ('sigma', 'b', 'c') in rom0_params
             assert isinstance(rom0_params['sigma'], np.ndarray)
+            assert isinstance(rom0_params['b'], np.ndarray)
+            assert isinstance(rom0_params['c'], np.ndarray)
             assert rom0_params['sigma'].ndim == 1
             assert rom0_params['b'].shape[1] == self.fom.dim_input
             assert rom0_params['c'].shape[1] == self.fom.dim_output
@@ -654,9 +656,9 @@ def _lti_to_poles_b_c(rom):
     poles
         1D |NumPy array| of poles.
     b
-        |NumPy array| of shape `(len(poles), rom.dim_input)`.
+        |NumPy array| of shape `(rom.order, rom.dim_input)`.
     c
-        |NumPy array| of shape `(len(poles), rom.dim_output)`.
+        |NumPy array| of shape `(rom.order, rom.dim_output)`.
     """
     A = to_matrix(rom.A, format='dense')
     B = to_matrix(rom.B, format='dense')
@@ -690,9 +692,9 @@ def _poles_b_c_to_lti(poles, b, c):
     poles
         Sequence of poles.
     b
-        |NumPy array| of shape `(len(poles), rom.dim_input)`.
+        |NumPy array| of shape `(rom.order, rom.dim_input)`.
     c
-        |NumPy array| of shape `(len(poles), rom.dim_output)`.
+        |NumPy array| of shape `(rom.order, rom.dim_output)`.
 
     Returns
     -------

--- a/src/pymor/reductors/h2.py
+++ b/src/pymor/reductors/h2.py
@@ -67,7 +67,7 @@ class GenericIRKAReductor(BasicObject):
             assert ('sigma', 'b', 'c') in rom0_params
             assert isinstance(rom0_params['sigma'], np.ndarray)
             assert rom0_params['sigma'].ndim == 1
-            assert rom0_params['b'] in self.fom.input_space
+            assert rom0_params['b'] in self.fom.D.source
             assert rom0_params['c'] in self.fom.D.range
             assert len(rom0_params['sigma']) == len(rom0_params['b'])
             assert len(rom0_params['sigma']) == len(rom0_params['c'])
@@ -75,7 +75,7 @@ class GenericIRKAReductor(BasicObject):
             assert rom0_params.order > 0
             if hasattr(self.fom, 'order'):  # self.fom can be a TransferFunction
                 assert rom0_params < self.fom.order
-            assert rom0_params.input_space == self.fom.input_space
+            assert rom0_params.D.source == self.fom.D.source
             assert rom0_params.D.range == self.fom.D.range
         else:
             raise ValueError(f'rom0_params is of wrong type ({type(rom0_params)}).')
@@ -89,9 +89,9 @@ class GenericIRKAReductor(BasicObject):
 
     def _order_to_sigma_b_c(self, r):
         sigma = np.logspace(-1, 1, r)
-        b = (self.fom.input_space.ones(r)
+        b = (NumpyVectorSpace(self.fom.input_dim).ones(r)
              if self.fom.input_dim == 1
-             else self.fom.input_space.random(r, distribution='normal', seed=0))
+             else NumpyVectorSpace(self.fom.input_dim).random(r, distribution='normal', seed=0))
         c = (NumpyVectorSpace(self.fom.output_dim).ones(r)
              if self.fom.output_dim == 1
              else NumpyVectorSpace(self.fom.output_dim).random(r, distribution='normal', seed=0))
@@ -210,7 +210,7 @@ class IRKAReductor(GenericIRKAReductor):
             - dict with `'sigma'`, `'b'`, `'c'` as keys mapping to
               initial interpolation points (a 1D |NumPy array|), right
               tangential directions (|VectorArray| from
-              `fom.input_space`), and left tangential directions
+              `fom.D.source`), and left tangential directions
               (|VectorArray| from `fom.D.range`), all of the same
               length (the order of the reduced model),
             - initial reduced-order model (|LTIModel|).
@@ -324,7 +324,7 @@ class OneSidedIRKAReductor(GenericIRKAReductor):
             - dict with `'sigma'`, `'b'`, `'c'` as keys mapping to
               initial interpolation points (a 1D |NumPy array|), right
               tangential directions (|VectorArray| from
-              `fom.input_space`), and left tangential directions
+              `fom.D.source`), and left tangential directions
               (|VectorArray| from `fom.D.range`), all of the same
               length (the order of the reduced model),
             - initial reduced-order model (|LTIModel|).
@@ -458,7 +458,7 @@ class TSIAReductor(GenericIRKAReductor):
             - dict with `'sigma'`, `'b'`, `'c'` as keys mapping to
               initial interpolation points (a 1D |NumPy array|), right
               tangential directions (|VectorArray| from
-              `fom.input_space`), and left tangential directions
+              `fom.D.source`), and left tangential directions
               (|VectorArray| from `fom.D.range`), all of the same
               length (the order of the reduced model),
             - initial reduced-order model (|LTIModel|).
@@ -575,7 +575,7 @@ class TFIRKAReductor(GenericIRKAReductor):
             - dict with `'sigma'`, `'b'`, `'c'` as keys mapping to
               initial interpolation points (a 1D |NumPy array|), right
               tangential directions (|VectorArray| from
-              `fom.input_space`), and left tangential directions
+              `fom.D.source`), and left tangential directions
               (|VectorArray| from `fom.D.range`), all of the same
               length (the order of the reduced model),
             - initial reduced-order model (|LTIModel|).

--- a/src/pymor/reductors/interpolation.py
+++ b/src/pymor/reductors/interpolation.py
@@ -88,7 +88,7 @@ class GenericBHIReductor(BasicObject):
             length `r`.
         b
             Right tangential directions, |VectorArray| of length `r`
-            from `self.fom.input_space`.
+            from `self.fom.D.source`.
         c
             Left tangential directions, |VectorArray| of length `r` from
             `self.fom.D.range`.
@@ -106,12 +106,12 @@ class GenericBHIReductor(BasicObject):
             Reduced-order model.
         """
         r = len(sigma)
-        assert b in self.fom.input_space and len(b) == r
+        assert b in self.fom.D.source and len(b) == r
         assert c in self.fom.D.range and len(c) == r
         assert projection in ('orth', 'biorth')
 
         # rescale tangential directions (to avoid overflow or underflow)
-        b = b * (1 / b.norm()) if b.dim > 1 else self.fom.input_space.ones(r)
+        b = b * (1 / b.norm()) if b.dim > 1 else self.fom.D.source.ones(r)
         c = c * (1 / c.norm()) if c.dim > 1 else self.fom.D.range.ones(r)
 
         # compute projection matrices
@@ -201,7 +201,7 @@ class LTIBHIReductor(GenericBHIReductor):
             length `r`.
         b
             Right tangential directions, |VectorArray| of length `r`
-            from `self.fom.input_space`.
+            from `self.fom.D.source`.
         c
             Left tangential directions, |VectorArray| of length `r` from
             `self.fom.D.range`.
@@ -359,7 +359,7 @@ class TFBHIReductor(BasicObject):
             length `r`.
         b
             Right tangential directions, |VectorArray| from
-            `fom.input_space` of length `r`.
+            `fom.D.source` of length `r`.
         c
             Left tangential directions, |VectorArray| from
             `fom.D.range` of length `r`.
@@ -371,11 +371,11 @@ class TFBHIReductor(BasicObject):
             function of `fom`.
         """
         r = len(sigma)
-        assert b in self.fom.input_space and len(b) == r
+        assert b.dim == self.fom.input_dim and len(b) == r
         assert c.dim == self.fom.output_dim and len(c) == r
 
         # rescale tangential directions (to avoid overflow or underflow)
-        b = b * (1 / b.norm()) if b.dim > 1 else self.fom.input_space.ones(r)
+        b = b * (1 / b.norm()) if b.dim > 1 else NumpyVectorSpace(self.fom.input_dim).ones(r)
         c = c * (1 / c.norm()) if c.dim > 1 else NumpyVectorSpace(self.fom.output_dim).ones(r)
 
         b = b.to_numpy()

--- a/src/pymor/reductors/interpolation.py
+++ b/src/pymor/reductors/interpolation.py
@@ -88,10 +88,10 @@ class GenericBHIReductor(BasicObject):
             length `r`.
         b
             Right tangential directions, |NumPy array| of shape
-            `(r, fom.input_dim)`.
+            `(r, fom.dim_input)`.
         c
             Left tangential directions, |NumPy array| of shape
-            `(r, fom.output_dim)`.
+            `(r, fom.dim_output)`.
         projection
             Projection method:
 
@@ -106,8 +106,8 @@ class GenericBHIReductor(BasicObject):
             Reduced-order model.
         """
         r = len(sigma)
-        assert b.shape == (r, self.fom.input_dim)
-        assert c.shape == (r, self.fom.output_dim)
+        assert b.shape == (r, self.fom.dim_input)
+        assert c.shape == (r, self.fom.dim_output)
         assert projection in ('orth', 'biorth')
 
         # rescale tangential directions (to avoid overflow or underflow)
@@ -203,10 +203,10 @@ class LTIBHIReductor(GenericBHIReductor):
             length `r`.
         b
             Right tangential directions, |NumPy array| of shape
-            `(r, fom.input_dim)`.
+            `(r, fom.dim_input)`.
         c
             Left tangential directions, |NumPy array| of shape
-            `(r, fom.output_dim)`.
+            `(r, fom.dim_output)`.
         projection
             Projection method:
 
@@ -226,10 +226,10 @@ class LTIBHIReductor(GenericBHIReductor):
         if projection != 'arnoldi':
             return super().reduce(sigma, b, c, projection=projection)
 
-        assert self.fom.input_dim == 1 and self.fom.output_dim == 1
+        assert self.fom.dim_input == 1 and self.fom.dim_output == 1
         r = len(sigma)
-        assert b.shape == (r, self.fom.input_dim)
-        assert c.shape == (r, self.fom.output_dim)
+        assert b.shape == (r, self.fom.dim_input)
+        assert c.shape == (r, self.fom.dim_output)
 
         # compute projection matrices
         self.V = rational_arnoldi(self.fom.A, self.fom.E, self.fom.B, sigma)
@@ -361,10 +361,10 @@ class TFBHIReductor(BasicObject):
             length `r`.
         b
             Right tangential directions, |NumPy array| of shape
-            `(r, fom.input_dim)`.
+            `(r, fom.dim_input)`.
         c
             Left tangential directions, |NumPy array| of shape
-            `(r, fom.output_dim)`.
+            `(r, fom.dim_output)`.
 
         Returns
         -------
@@ -373,8 +373,8 @@ class TFBHIReductor(BasicObject):
             function of `fom`.
         """
         r = len(sigma)
-        assert b.shape == (r, self.fom.input_dim)
-        assert c.shape == (r, self.fom.output_dim)
+        assert b.shape == (r, self.fom.dim_input)
+        assert c.shape == (r, self.fom.dim_output)
 
         # rescale tangential directions (to avoid overflow or underflow)
         b = b * (1 / np.linalg.norm(b)) if b.shape[1] > 1 else np.ones((r, 1))
@@ -383,8 +383,8 @@ class TFBHIReductor(BasicObject):
         # matrices of the interpolatory LTI system
         Er = np.empty((r, r), dtype=np.complex_)
         Ar = np.empty((r, r), dtype=np.complex_)
-        Br = np.empty((r, self.fom.input_dim), dtype=np.complex_)
-        Cr = np.empty((self.fom.output_dim, r), dtype=np.complex_)
+        Br = np.empty((r, self.fom.dim_input), dtype=np.complex_)
+        Cr = np.empty((self.fom.dim_output, r), dtype=np.complex_)
 
         Hs = [self.fom.eval_tf(s, mu=self.mu) for s in sigma]
         dHs = [self.fom.eval_dtf(s, mu=self.mu) for s in sigma]

--- a/src/pymor/reductors/interpolation.py
+++ b/src/pymor/reductors/interpolation.py
@@ -12,6 +12,7 @@ from pymor.operators.constructions import LincombOperator
 from pymor.parameters.base import Mu
 from pymor.reductors.basic import (ProjectionBasedReductor, LTIPGReductor, SOLTIPGReductor,
                                    DelayLTIPGReductor)
+from pymor.vectorarrays.numpy import NumpyVectorSpace
 
 
 class GenericBHIReductor(BasicObject):
@@ -90,7 +91,7 @@ class GenericBHIReductor(BasicObject):
             from `self.fom.input_space`.
         c
             Left tangential directions, |VectorArray| of length `r` from
-            `self.fom.output_space`.
+            `self.fom.D.range`.
         projection
             Projection method:
 
@@ -106,12 +107,12 @@ class GenericBHIReductor(BasicObject):
         """
         r = len(sigma)
         assert b in self.fom.input_space and len(b) == r
-        assert c in self.fom.output_space and len(c) == r
+        assert c in self.fom.D.range and len(c) == r
         assert projection in ('orth', 'biorth')
 
         # rescale tangential directions (to avoid overflow or underflow)
         b = b * (1 / b.norm()) if b.dim > 1 else self.fom.input_space.ones(r)
-        c = c * (1 / c.norm()) if c.dim > 1 else self.fom.output_space.ones(r)
+        c = c * (1 / c.norm()) if c.dim > 1 else self.fom.D.range.ones(r)
 
         # compute projection matrices
         self.V = self.fom.solution_space.empty(reserve=r)
@@ -203,7 +204,7 @@ class LTIBHIReductor(GenericBHIReductor):
             from `self.fom.input_space`.
         c
             Left tangential directions, |VectorArray| of length `r` from
-            `self.fom.output_space`.
+            `self.fom.D.range`.
         projection
             Projection method:
 
@@ -361,7 +362,7 @@ class TFBHIReductor(BasicObject):
             `fom.input_space` of length `r`.
         c
             Left tangential directions, |VectorArray| from
-            `fom.output_space` of length `r`.
+            `fom.D.range` of length `r`.
 
         Returns
         -------
@@ -371,11 +372,11 @@ class TFBHIReductor(BasicObject):
         """
         r = len(sigma)
         assert b in self.fom.input_space and len(b) == r
-        assert c in self.fom.output_space and len(c) == r
+        assert c.dim == self.fom.output_dim and len(c) == r
 
         # rescale tangential directions (to avoid overflow or underflow)
         b = b * (1 / b.norm()) if b.dim > 1 else self.fom.input_space.ones(r)
-        c = c * (1 / c.norm()) if c.dim > 1 else self.fom.output_space.ones(r)
+        c = c * (1 / c.norm()) if c.dim > 1 else NumpyVectorSpace(self.fom.output_dim).ones(r)
 
         b = b.to_numpy()
         c = c.to_numpy()

--- a/src/pymor/reductors/sor_irka.py
+++ b/src/pymor/reductors/sor_irka.py
@@ -41,7 +41,7 @@ class SORIRKAReductor(GenericIRKAReductor):
               initial interpolation points (a 1D |NumPy array|), right
               tangential directions (|VectorArray| from
               `fom.input_space`), and left tangential directions
-              (|VectorArray| from `fom.output_space`), all of the same
+              (|VectorArray| from `fom.D.range`), all of the same
               length (the order of the reduced model),
             - initial reduced-order model (|LTIModel|).
 

--- a/src/pymor/reductors/sor_irka.py
+++ b/src/pymor/reductors/sor_irka.py
@@ -40,7 +40,7 @@ class SORIRKAReductor(GenericIRKAReductor):
             - dict with `'sigma'`, `'b'`, `'c'` as keys mapping to
               initial interpolation points (a 1D |NumPy array|), right
               tangential directions (|VectorArray| from
-              `fom.input_space`), and left tangential directions
+              `fom.D.source`), and left tangential directions
               (|VectorArray| from `fom.D.range`), all of the same
               length (the order of the reduced model),
             - initial reduced-order model (|LTIModel|).

--- a/src/pymordemos/delay.py
+++ b/src/pymordemos/delay.py
@@ -77,8 +77,8 @@ if __name__ == '__main__':
 
     # match steady state (add interpolation point at 0)
     sigma_ss = list(sigma_list[-1]) + [0]
-    b_ss = np.ones((r+1, tf.input_dim))
-    c_ss = np.ones((r+1, tf.output_dim))
+    b_ss = np.ones((r+1, tf.dim_input))
+    c_ss = np.ones((r+1, tf.dim_output))
     interp_reductor = TFBHIReductor(tf)
     rom_ss = interp_reductor.reduce(sigma_ss, b_ss, c_ss)
 

--- a/src/pymordemos/delay.py
+++ b/src/pymordemos/delay.py
@@ -26,7 +26,7 @@ if __name__ == '__main__':
     def dH(s):
         return np.array([[-(tau * s + tau + 1) * np.exp(-s) / (tau * s + 1) ** 2]])
 
-    tf = TransferFunction(NumpyVectorSpace(1), 1, H, dH)
+    tf = TransferFunction(1, 1, H, dH)
 
     r = 10
     tf_irka_reductor = TFIRKAReductor(tf)
@@ -78,7 +78,7 @@ if __name__ == '__main__':
 
     # match steady state (add interpolation point at 0)
     sigma_ss = list(sigma_list[-1]) + [0]
-    b_ss = tf.input_space.ones(r + 1)
+    b_ss = NumpyVectorSpace(tf.input_dim).ones(r + 1)
     c_ss = NumpyVectorSpace(tf.output_dim).ones(r + 1)
     interp_reductor = TFBHIReductor(tf)
     rom_ss = interp_reductor.reduce(sigma_ss, b_ss, c_ss)

--- a/src/pymordemos/delay.py
+++ b/src/pymordemos/delay.py
@@ -15,7 +15,6 @@ import matplotlib.pyplot as plt
 from pymor.models.iosys import TransferFunction
 from pymor.reductors.interpolation import TFBHIReductor
 from pymor.reductors.h2 import TFIRKAReductor
-from pymor.vectorarrays.numpy import NumpyVectorSpace
 
 if __name__ == '__main__':
     tau = 0.1
@@ -78,8 +77,8 @@ if __name__ == '__main__':
 
     # match steady state (add interpolation point at 0)
     sigma_ss = list(sigma_list[-1]) + [0]
-    b_ss = NumpyVectorSpace(tf.input_dim).ones(r + 1)
-    c_ss = NumpyVectorSpace(tf.output_dim).ones(r + 1)
+    b_ss = np.ones((r+1, tf.input_dim))
+    c_ss = np.ones((r+1, tf.output_dim))
     interp_reductor = TFBHIReductor(tf)
     rom_ss = interp_reductor.reduce(sigma_ss, b_ss, c_ss)
 

--- a/src/pymordemos/delay.py
+++ b/src/pymordemos/delay.py
@@ -26,7 +26,7 @@ if __name__ == '__main__':
     def dH(s):
         return np.array([[-(tau * s + tau + 1) * np.exp(-s) / (tau * s + 1) ** 2]])
 
-    tf = TransferFunction(NumpyVectorSpace(1), NumpyVectorSpace(1), H, dH)
+    tf = TransferFunction(NumpyVectorSpace(1), 1, H, dH)
 
     r = 10
     tf_irka_reductor = TFIRKAReductor(tf)
@@ -79,7 +79,7 @@ if __name__ == '__main__':
     # match steady state (add interpolation point at 0)
     sigma_ss = list(sigma_list[-1]) + [0]
     b_ss = tf.input_space.ones(r + 1)
-    c_ss = tf.output_space.ones(r + 1)
+    c_ss = NumpyVectorSpace(tf.output_dim).ones(r + 1)
     interp_reductor = TFBHIReductor(tf)
     rom_ss = interp_reductor.reduce(sigma_ss, b_ss, c_ss)
 

--- a/src/pymordemos/heat.py
+++ b/src/pymordemos/heat.py
@@ -53,8 +53,8 @@ if __name__ == '__main__':
     lti = fom.to_lti()
 
     print(f'order of the model = {lti.order}')
-    print(f'number of inputs   = {lti.input_dim}')
-    print(f'number of outputs  = {lti.output_dim}')
+    print(f'number of inputs   = {lti.dim_input}')
+    print(f'number of outputs  = {lti.dim_output}')
 
     # System poles
     poles = lti.poles()

--- a/src/pymordemos/string_equation.py
+++ b/src/pymordemos/string_equation.py
@@ -45,8 +45,8 @@ if __name__ == '__main__':
     so_sys = SecondOrderModel.from_matrices(M, E, K, B, Cp)
 
     print(f'order of the model = {so_sys.order}')
-    print(f'number of inputs   = {so_sys.input_dim}')
-    print(f'number of outputs  = {so_sys.output_dim}')
+    print(f'number of inputs   = {so_sys.dim_input}')
+    print(f'number of outputs  = {so_sys.dim_output}')
 
     poles = so_sys.poles()
     fig, ax = plt.subplots()


### PR DESCRIPTION
As discussed, outputs of Models are made NumPy arrays instead of VectorArrays to facilitate interfaces with pyMOR Models from user code / external code. 

**Edit:**
~I chose `output_dim` over `dim_output` to be consistent with the choice in `models.iosys` and also because I think it sounds nicer. However, this is somewhat inconsistent with the rest of pyMOR where 'dim_***' is used.~

The dimension of the output is given by `dim_output` attribute. `output_dim` of `IntputOutputModel` has been renamed accordingly. Its `input_dim` attribute has been renamed to `dim_input`. The old names are deprecated.

In addition, `input_space` and `output_space` have been removed from `InputOutputModel` and the `b` and `c` arrays of tangential directions for the interpolatory reductors have been made numpy arrays instead of `VectorArrays`.