### PR TITLE
Make changing number of POD modes for POD-greedy less error prone

### DIFF
--- a/src/pymor/algorithms/greedy.py
+++ b/src/pymor/algorithms/greedy.py
@@ -248,8 +248,11 @@ class RBSurrogate(WeakGreedySurrogate):
             U = self.fom.solve(mu)
         with self.logger.block('Extending basis with solution snapshot ...'):
             extension_params = self.extension_params
-            if len(U) > 1 and extension_params is None:
-                extension_params = {'method': 'pod'}
+            if len(U) > 1:
+                if extension_params is None:
+                    extension_params = {'method': 'pod'}
+                else:
+                    extension_params.setdefault('method', 'pod')
             self.reductor.extend_basis(U, copy_U=False, **(extension_params or {}))
             if not self.use_error_estimator:
                 self.remote_reductor = self.pool.push(self.reductor)


### PR DESCRIPTION
Currently, specifying `extension_params={'pod_modes': 5}` for `rb_greedy` causes `gram_schmidt` to be chosen as extension algorithm instead of POD. This PR changes the behavior to always use POD for solution snapshots with more than one vector unless another `extension_method` is explicitly specified.