### PR TITLE
add compute() to Model

### DIFF
--- a/docs/source/tutorial_projection.rst
+++ b/docs/source/tutorial_projection.rst
@@ -96,10 +96,10 @@ outputs or error estimates. Next, we take a look at the implemenation of
     print_source(fom.compute)
 
 What we see is a default implementation from :class:`~pymor.models.interface.Model` that
-takes care of :mod:`caching <pymor.core.cache>` and :mod:`logging <pymor.core.logger>`,
-but defers the actual computations to further private methods. Implementors can directly implement
-:meth:`~pymor.models.interface.Model._compute` to compute multiple return values
-at once in an optimized way. Our given model, however, just implements 
+takes care of checking the input |parameter values| `mu`, :mod:`caching <pymor.core.cache>` and
+:mod:`logging <pymor.core.logger>`, but defers the actual computations to further private methods.
+Implementors can directly implement :meth:`~pymor.models.interface.Model._compute` to compute
+multiple return values at once in an optimized way. Our given model, however, just implements 
 :meth:`~pymor.models.interface.Model._compute_solution` where we can find the
 actual code:
 

--- a/docs/source/tutorial_projection.rst
+++ b/docs/source/tutorial_projection.rst
@@ -78,7 +78,7 @@ Solving the Model
 Now that we have our FOM and a reduced space :math:`V_N` spanned by `basis`, we can project
 the |Model|. However, before doing so, we need to understand how actually
 solving the FOM works. Let's take a look at what
-:meth:`~pymor.models.interface.Model.solve` actually does:
+:meth:`~pymor.models.interface.Model.solve` does:
 
 .. jupyter-execute::
 
@@ -86,19 +86,26 @@ solving the FOM works. Let's take a look at what
     print_source(fom.solve)
 
 This does not look too interesting. Actually, :meth:`~pymor.models.interface.Model.solve`
-is just a thin wrapper around the `_solve` method, which performs the actual
-computations. All that :meth:`~pymor.models.interface.Model.solve` does is
-checking the input |parameter values| `mu` and :mod:`caching <pymor.core.cache>`
-the results. So let's take a look at `_solve`:
+is just a convenience method around :meth:`~pymor.models.interface.Model.compute` which
+handles the actual computation of the solution and various other associated values like
+outputs or error estimates. Next, we take a look at the implemenation of
+:meth:`~pymor.models.interface.Model.compute`: 
 
 .. jupyter-execute::
 
-    print_source(fom._solve)
+    print_source(fom.compute)
 
-There is some code related to logging and the computation of an output functional.
-The interesting line is::
+What we see is a default implementation from :class:`~pymor.models.interface.Model` that
+takes care of :mod:`caching <pymor.core.cache>` and :mod:`logging <pymor.core.logger>`,
+but defers the actual computations to further private methods. Implementors can directly implement
+:meth:`~pymor.models.interface.Model._compute` to compute multiple return values
+at once in an optimized way. Our given model, however, just implements 
+:meth:`~pymor.models.interface.Model._compute_solution` where we can find the
+actual code:
 
-    U = self.operator.apply_inverse(self.rhs.as_range_array(mu), mu=mu)
+.. jupyter-execute::
+
+    print_source(fom._compute_solution)
 
 What does this mean? If we look at the type of `fom`,
 

--- a/docs/source/tutorial_projection.rst
+++ b/docs/source/tutorial_projection.rst
@@ -167,12 +167,13 @@ Let's try solving the model on our own:
 
 That did not work too well! In pyMOR, all parametric objects expect the
 `mu` argument to be an instance of the :class:`~pymor.parameters.base.Mu`
-class. :meth:`~pymor.models.interface.Model.solve` is an exception: for
-convenience, it accepts as a `mu` argument anything that can be converted
+class. :meth:`~pymor.models.interface.Model.compute` and related methods
+like :meth:`~pymor.models.interface.Model.solve` are an exception: for
+convenience, they accept as a `mu` argument anything that can be converted
 to a :class:`~pymor.parameters.base.Mu` instance using the
 :meth:`~pymor.parameters.base.Parameters.parse` method of the
 :class:`~pymor.parameters.base.Parameters` class. In fact, if you look
-back at the implementation of :meth:`~pymor.models.interface.Model.solve`,
+back at the implementation of :meth:`~pymor.models.interface.Model.compute`,
 you see the explicit call to :meth:`~pymor.parameters.base.Parameters.parse`.
 We try again:
 

--- a/src/pymor/algorithms/error.py
+++ b/src/pymor/algorithms/error.py
@@ -333,9 +333,10 @@ def _compute_errors(mu, fom, reductor, error_estimator, error_norms, condition, 
 
     for i_N, N in enumerate(basis_sizes):
         rom = reductor.reduce(dims={k: N for k in reductor.bases})
-        u = rom.solve(mu)
+        result = rom.compute(solution=True, solution_error_estimate=error_estimator, mu=mu)
+        u = result['solution']
         if error_estimator:
-            e = rom.estimate_error(u, mu)
+            e = result['solution_error_estimate']
             e = e[0] if hasattr(e, '__len__') else e
             error_estimates[i_N] = e
         if fom and reductor:

--- a/src/pymor/algorithms/greedy.py
+++ b/src/pymor/algorithms/greedy.py
@@ -268,7 +268,7 @@ def _rb_surrogate_evaluate(rom=None, fom=None, reductor=None, mus=None, error_no
             return -1., None
 
     if fom is None:
-        errors = [rom.estimate_error(rom.solve(mu), mu) for mu in mus]
+        errors = [rom.estimate_error(mu) for mu in mus]
     elif error_norm is not None:
         errors = [error_norm(fom.solve(mu) - reductor.reconstruct(rom.solve(mu))) for mu in mus]
     else:

--- a/src/pymor/models/interface.py
+++ b/src/pymor/models/interface.py
@@ -66,12 +66,12 @@ class Model(CacheableObject, ParametricObject):
     def _compute_solution_error_estimate(self, solution, mu=None, **kwargs):
         if self.error_estimator is None:
             raise ValueError('Model has no error estimator')
-        return self.error_estimator.estimate_error(solution, mu, self)
+        return self.error_estimator.estimate_error(solution, mu, self, **kwargs)
 
     def _compute_output_error_estimate(self, solution, mu=None, **kwargs):
         if self.error_estimator is None:
             raise ValueError('Model has no error estimator')
-        return self.error_estimator.estimate_output_error(solution, mu, self)
+        return self.error_estimator.estimate_output_error(solution, mu, self, **kwargs)
 
     _compute_allowed_kwargs = frozenset()
 

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -45,9 +45,6 @@ class InputOutputModel(Model):
     def output_dim(self):
         return self.output_space.dim
 
-    def _solve(self, mu=None):
-        raise NotImplementedError
-
     def eval_tf(self, s, mu=None):
         """Evaluate the transfer function."""
         raise NotImplementedError

--- a/src/pymor/models/mpi.py
+++ b/src/pymor/models/mpi.py
@@ -36,9 +36,9 @@ class MPIModel:
         self.parameters_internal = m.parameters_internal
         self.visualizer = MPIVisualizer(obj_id)
 
-    def _solve(self, mu=None):
+    def _compute_solution(self, mu=None, **kwargs):
         return self.solution_space.make_array(
-            mpi.call(mpi.method_call_manage, self.obj_id, 'solve', mu=mu)
+            mpi.call(mpi.method_call_manage, self.obj_id, '_compute_solution', mu=mu, **kwargs)
         )
 
     def visualize(self, U, **kwargs):

--- a/src/pymor/models/neural_network.py
+++ b/src/pymor/models/neural_network.py
@@ -62,9 +62,7 @@ if config.HAVE_TORCH:
             if output_functional is not None:
                 self.output_space = output_functional.range
 
-        def _solve(self, mu=None, return_output=False):
-            if not self.logging_disabled:
-                self.logger.info(f'Solving {self.name} for {mu} ...')
+        def _compute_solution(self, mu=None, **kwargs):
 
             # convert the parameter `mu` into a form that is usable in PyTorch
             converted_input = torch.from_numpy(mu.to_numpy()).double()
@@ -73,13 +71,7 @@ if config.HAVE_TORCH:
             # convert plain numpy array to element of the actual solution space
             U = self.solution_space.make_array(U)
 
-            if return_output:
-                if self.output_functional is None:
-                    raise ValueError('Model has no output')
-                return U, self.output_functional.apply(U, mu=mu)
-            else:
-                return U
-
+            return U
 
     class FullyConnectedNN(nn.Module, BasicObject):
         """Class for neural networks with fully connected layers.

--- a/src/pymordemos/analyze_pickle.py
+++ b/src/pymordemos/analyze_pickle.py
@@ -72,10 +72,10 @@ def analyze_pickle_histogram(args):
 
     if hasattr(rom, 'estimate'):
         ests = []
-        for u, mu in zip(us, mus):
+        for mu in mus:
             print(f'Estimating error for {mu} ... ', end='')
             sys.stdout.flush()
-            ests.append(rom.estimate_error(u, mu=mu))
+            ests.append(rom.estimate_error(mu))
             print('done')
 
     if args['--detailed']:
@@ -212,10 +212,10 @@ def analyze_pickle_convergence(args):
         if hasattr(rom, 'estimate'):
             ests = []
             start = time.time()
-            for u, mu in zip(us, mus):
+            for mu in mus:
                 # print('e', end='')
                 # sys.stdout.flush()
-                ests.append(rom.estimate_error(u, mu=mu))
+                ests.append(rom.estimate_error(mu))
             ESTS.append(max(ests))
             T_ESTS.append((time.time() - start) * 1000. / len(mus))
 


### PR DESCRIPTION
With this PR, `Model` gets a new `compute` method which realizes the computation of the model's solution and of derived quantities such as outputs or error estimates.

- `solve`, `output` and `estimate_error` are implemented by calling `compute` with appropriate arguments.

- By relying on a central method, we can avoid having to pass computed values from the outside, e.g. the solution to `estimate_error`. (Note that it might depend on the `Model` which values have to be passed.) 

- `compute` returns a dict of all computed values. `solve`, etc. remain as convenience methods.

- `compute` can be easily extended to return further quantities of interest. E.g. an optional `stages` argument might indicate to return intermediate Newton stages as an additional item of the return value.

- `Model.compute` has a default implementation which relays individual computational tasks to dedicated `_compute_solution`, `_compute_output`, etc. methods which allow to more easily customize `compute` when subclassing. Before these methods are called `_compute` is called in which, e.g., simultaneous solution and output computation can be realized. For values that already have been computed, the respective `_compute_...` methods will then be skipped.

- The signature of `compute` should stay stable for the foreseeable future. The base class implementation may change in the future.

- I decided to keep automatic caching of the solution in the default implementation of `compute`. In particular, for models using `_compute_solution`, a call to `m.output(mu)` will not trigger an additional solution of the model, when `m.solve(mu)` has been called before for the same `mu` and caching is enabled.

- The `solve_d_mu` and `output_d_mu` methods from #1110 will also make use of `compute`.

See discussion in #1095.

Documentation still needs to be updated.

@pymor/pymor-devs, @HenKlei, @TiKeil, while not much has changed internally, this PR will significantly affect the user expercience. Please take a close look.