### PR TITLE
Prevent corruption of memory cache

### DIFF
--- a/.github/workflows/enforce-labels.yml
+++ b/.github/workflows/enforce-labels.yml
@@ -7,7 +7,7 @@ jobs:
   enforce-label:
     runs-on: ubuntu-latest
     steps:
-    - uses: yogevbd/enforce-label-action@2.1.0
+    - uses: yogevbd/enforce-label-action@2.2.1
       with:
         REQUIRED_LABELS_ANY: "pr:change,pr:deprecation,pr:fix,pr:new-feature,pr:removal"
         REQUIRED_LABELS_ANY_DESCRIPTION: "Select at least one label with a 'pr:' prefix for this pull request" 

--- a/src/pymor/core/cache.py
+++ b/src/pymor/core/cache.py
@@ -63,6 +63,7 @@ A cache region can be emptied using :meth:`CacheRegion.clear`. The function
 
 import atexit
 from collections import OrderedDict
+from copy import deepcopy
 import functools
 import getpass
 import hashlib
@@ -150,10 +151,7 @@ class MemoryRegion(CacheRegion):
         if value is self.NO_VALUE:
             return False, None
         else:
-            from pymor.vectorarrays.interface import VectorArray
-            if isinstance(value, VectorArray):
-                value = value.copy()
-            return True, value
+            return True, deepcopy(value)
 
     def set(self, key, value):
         if key in self._cache:
@@ -161,11 +159,7 @@ class MemoryRegion(CacheRegion):
             return
         if len(self._cache) == self.max_keys:
             self._cache.popitem(last=False)
-
-        import numpy as np
-        if isinstance(value, np.ndarray):
-            value.setflags(write=False)
-        self._cache[key] = value
+        self._cache[key] = deepcopy(value)
 
     def clear(self):
         self._cache = OrderedDict()

--- a/src/pymortests/cache.py
+++ b/src/pymortests/cache.py
@@ -7,7 +7,11 @@ import os
 from uuid import uuid4
 from datetime import datetime, timedelta
 
+import numpy as np
+
 from pymor.core import cache
+from pymor.models.basic import StationaryModel
+from pymor.operators.numpy import NumpyMatrixOperator
 from pymortests.base import runmodule
 
 
@@ -84,6 +88,22 @@ def test_region_api():
             # second set is ignored
             backend.set('mykey', 2)
             assert backend.get('mykey') == (True, 1)
+
+
+def test_memory_region_safety():
+
+    op = NumpyMatrixOperator(np.eye(1))
+    rhs = op.range.make_array(np.array([1]))
+    m = StationaryModel(op, rhs)
+    m.enable_caching('memory')
+
+    U = m.solve()
+    del U[:]
+    U = m.solve()
+    assert len(U) == 1
+    del U[:]
+    U = m.solve()
+    assert len(U) == 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR changes the behavior of `MemoryRegion` to always make a `deepcopy` of any values stored in the cache and to only return deep copies of the values contained in the cache. While this may increase the memory footprint and somewhat hurt performance, it seems like the only way to make using `MemoryRegion` really safe. The practical impact of the increased memory usage should be quite small, IMHO.

Note that the current provisions of returning copies of `VectorArrays` and making NumPy arrays immutable had no effect since all values stored in the cache are actually 2-tuples.

See #1133 for a non-obvious real world example of `MemoryRegion` being corrupted.