### PR TITLE
[docs.sphinx] also show private members in the documenation

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -245,7 +245,7 @@ coverage_c_path = []
 coverage_c_regexes = {}
 coverage_ignore_c_items = {}
 
-# autodoc_default_flags = ['members', 'undoc-members', 'show-inheritance']
+autodoc_default_flags = ['members', 'private_members', 'undoc-members', 'show-inheritance']
 
 # PyQt5 inventory is only used internally, actual link targets PySide2
 intersphinx_mapping = {'python': ('https://docs.python.org/3', None),


### PR DESCRIPTION
I noticed that the documentation does not include private methods such as `_compute_*` methods in `Model`. In #1110, I need the documentation for a private method, and I currently get an error because the citation is not visible. 

So, should we merge this and show all private members? 

Alternatively, there apparently also exists a way to manually include private methods in the documentation with 
e.g.
```
.. document private functions
.. automethod:: _compute_output_dmu
```
This could also be an option. What do you think @pymor/all 