### PR TITLE
[ci] move more jobs onto autoscaled machines

### DIFF
--- a/.ci/gitlab/ci.yml
+++ b/.ci/gitlab/ci.yml
@@ -17,6 +17,8 @@ stages:
             - runner_system_failure
             - stuck_or_timeout_failure
             - api_failure
+    tags:
+      - autoscaling
     rules:
         - if: $CI_COMMIT_REF_NAME =~ /^staging.*/
           when: never
@@ -29,7 +31,8 @@ stages:
 .pytest:
     extends: .test_base
     tags:
-      - long execution time
+      - long execution time 
+      - autoscaling
     environment:
         name: unsafe
     stage: test
@@ -74,6 +77,7 @@ stages:
 .docker-in-docker:
     tags:
       - docker-in-docker
+      - autoscaling
     extends: .test_base
     timeout: 45 minutes
     retry:

--- a/.ci/gitlab/template.ci.py
+++ b/.ci/gitlab/template.ci.py
@@ -19,6 +19,8 @@ stages:
             - runner_system_failure
             - stuck_or_timeout_failure
             - api_failure
+    tags:
+      - autoscaling
     rules:
         - if: $CI_COMMIT_REF_NAME =~ /^staging.*/
           when: never
@@ -31,7 +33,8 @@ stages:
 .pytest:
     extends: .test_base
     tags:
-      - long execution time
+      - long execution time 
+      - autoscaling
     environment:
         name: unsafe
     stage: test
@@ -76,6 +79,7 @@ stages:
 .docker-in-docker:
     tags:
       - docker-in-docker
+      - autoscaling
     extends: .test_base
     timeout: 45 minutes
     retry:


### PR DESCRIPTION
Since our dedicated build box has intermittent docker daemon connection
problems this PR moves most of the jobs to the openstack
autoscaled machines exclusively
