### PR TITLE
Allow to change aspect ratios of matplotlib plots

### DIFF
--- a/src/pymor/discretizers/builtin/gui/jupyter/matplotlib.py
+++ b/src/pymor/discretizers/builtin/gui/jupyter/matplotlib.py
@@ -10,7 +10,7 @@ from ipywidgets import HTML, HBox, widgets, Layout
 import matplotlib.pyplot as plt
 
 from pymor.core.config import config
-from pymor.discretizers.builtin.gui.matplotlib import MatplotlibPatchAxes, Matplotlib1DAxes, figsize
+from pymor.discretizers.builtin.gui.matplotlib import MatplotlibPatchAxes, Matplotlib1DAxes
 from pymor.vectorarrays.interface import VectorArray
 
 
@@ -47,20 +47,9 @@ class MPLPlotBase:
 
         do_animation = not separate_axes and len(U[0]) > 1
 
-        # Setting the aspect ratio in figure() only works by specifying absolute values for figsize, which we calculate
-        # using figsize (matplotlib.figure.figaspect does not do exactly what we want). To ensure a correct aspect
-        # ratio in the respective axes created by base classes, we also need to provide a correct bounding_box.
-        if bounding_box is None:
-            bounding_box = grid.bounding_box()
-        figure_kwargs = {}
-        if grid.dim == 2:
-            assert len(bounding_box) == 2 and all(len(b) == 2 for b in bounding_box)
-            aspect_ratio = (bounding_box[1][1] - bounding_box[0][1]) / (bounding_box[1][0] - bounding_box[0][0])
-            figure_kwargs['figsize'] = figsize(aspect_ratio)
-
         if separate_plots:
             for i, (vmin, vmax, u) in enumerate(zip(self.vmins, self.vmaxs, U)):
-                figure = plt.figure(self.fig_ids[i], **figure_kwargs)
+                figure = plt.figure(self.fig_ids[i])
                 sync_timer = sync_timer or figure.canvas.new_timer()
                 if grid.dim == 2:
                     plot = MatplotlibPatchAxes(U=u, figure=figure, sync_timer=sync_timer, grid=grid, vmin=vmin, vmax=vmax,
@@ -74,7 +63,7 @@ class MPLPlotBase:
                 self.plots.append(plot)
                     # plt.tight_layout()
         else:
-            figure = plt.figure(self.fig_ids[0], **figure_kwargs)
+            figure = plt.figure(self.fig_ids[0])
             sync_timer = sync_timer or figure.canvas.new_timer()
             if grid.dim == 2:
                 plot = MatplotlibPatchAxes(U=U, figure=figure, sync_timer=sync_timer, grid=grid, vmin=self.vmins,

--- a/src/pymor/discretizers/builtin/gui/matplotlib.py
+++ b/src/pymor/discretizers/builtin/gui/matplotlib.py
@@ -17,16 +17,6 @@ from pymor.discretizers.builtin.grids.constructions import flatten_grid
 from pymor.discretizers.builtin.grids.referenceelements import triangle, square
 
 
-def figsize(height_over_width):
-    # figaspect increases the width, but we want to adjust the height
-    from matplotlib.figure import figaspect
-    w, h = figaspect(height_over_width)
-    from matplotlib import rcParams
-    reference_width = rcParams["figure.figsize"][0]
-    scaling = reference_width/w
-    return reference_width, h*scaling
-
-
 class MatplotlibAxesBase:
 
     def __init__(self, figure, sync_timer, grid, U=None, vmin=None, vmax=None, codim=2, separate_axes=False, columns=2,
@@ -41,10 +31,11 @@ class MatplotlibAxesBase:
             if len(U) == 1:
                 columns = 1 # otherwise we get a sep axes object with 0 data
             rows = int(np.ceil(len(U) / columns))
-            self.ax = figure.subplots(rows, columns, squeeze=False, figsize=figsize(aspect_ratio)).flatten()
+            self.ax = figure.subplots(rows, columns, squeeze=False).flatten()
         else:
             self.ax = (figure.gca(),)
-            self.ax[0].set_aspect(aspect_ratio)
+        for ax in self.ax:
+            ax.set_aspect(aspect_ratio)
         self.figure = figure
         self.codim = codim
         self.grid = grid

--- a/src/pymor/discretizers/builtin/gui/matplotlib.py
+++ b/src/pymor/discretizers/builtin/gui/matplotlib.py
@@ -41,6 +41,7 @@ class MatplotlibAxesBase:
         self.grid = grid
         self.separate_axes = separate_axes
         self.count = len(U) if separate_axes or isinstance(U, tuple) else 1
+        self.aspect_ratio = aspect_ratio
 
         self._plot_init()
 
@@ -109,7 +110,12 @@ class MatplotlibPatchAxes(MatplotlibAxesBase):
                                  facecolors=np.zeros(len(self.subentities)),
                                  vmin=self.vmin, vmax=self.vmax, shading='flat')
         if self.colorbar:
-            self.figure.colorbar(self.p, ax=self.ax[0])
+            # thin plots look ugly with a huge colorbar on the right
+            if self.aspect_ratio < 0.75:
+                orientation = 'horizontal'
+            else:
+                orientation = 'vertical'
+            self.figure.colorbar(self.p, ax=self.ax[0], orientation=orientation)
 
     def set(self, U, vmin=None, vmax=None):
         self.vmin = self.vmin if vmin is None else vmin


### PR DESCRIPTION
Following up on #1171, I tried to get away without specifying the absolute figure size, cause that is never a good idea. I found a way to only scale the axes which works well in my example. I also place the colorbar horizontally, if the grid is thin, cause it looks really ugly otherwise. This is of course a serious design decision...