### PR TITLE
fix "oldest" CI job

### DIFF
--- a/.ci/gitlab/test_oldest.bash
+++ b/.ci/gitlab/test_oldest.bash
@@ -3,6 +3,14 @@
 THIS_DIR="$(cd "$(dirname ${BASH_SOURCE[0]})" ; pwd -P )"
 source ${THIS_DIR}/common_test_setup.bash
 
+# _downgrade_ packages to what's avail in the oldest mirror
+sudo pip uninstall -y -r requirements-optional.txt
+sudo pip uninstall -y -r requirements-ci.txt
+sudo pip uninstall -y -r requirements.txt
+sudo pip install -U --use-feature=2020-resolver -r requirements.txt
+sudo pip install -U --use-feature=2020-resolver -r requirements-ci.txt
+sudo pip install -U --use-feature=2020-resolver -r requirements-optional.txt
+
 # we've changed numpy versions, recompile cyx
 find src/pymor/ -name _*.c | xargs rm -f
 find src/pymor/ -name _*.so | xargs rm -f


### PR DESCRIPTION
While documenting the CI setup in the other PR I discovered
that the "oldest" job actually no longer uses the packages
from the "oldest" pypi mirror. This PR makes sure of that
by removing all installed packages and installing again
from the "oldest" mirror. 
