### PR TITLE
Remove mailing list mentions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,9 +21,6 @@ Therefore the recommended way to send us your code is to create a
 [fork](https://guides.github.com/activities/forking/) of pyMOR
 on GitHub (if you do not have one already) and push your commits into a branch 
 containing the code and create a pull request for it.
-Alternatively, you may send patches to our
-[mailinglist](http://listserv.uni-muenster.de/mailman/listinfo/pymor-dev)
-that have been created using `git format-patch`.
 
 Once we have received your code, it will be reviewed and
 discussed with you by pyMOR's 
@@ -33,7 +30,8 @@ main repository. We may also make suggestions how to modify
 or improve your code to make it better fit into the project.
 
 Of course, were are happy to help you prepare contributions to pyMOR.
-Feel free to [ask](http://listserv.uni-muenster.de/mailman/listinfo/pymor-dev)
+Feel free to
+[ask](https://github.com/pymor/pymor/discussions?discussions_q=category%3AQ%26A)
 for help at any time.
 
 

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -21,7 +21,7 @@
  1. [ ] update researchgate https://www.researchgate.net/project/pyMOR-Model-Order-Reduction-with-Python
         (check formatting after submit!)
  1. [ ] Submit release to NA-digest: http://icl.utk.edu/na-digest/websubmit.html
- 1. [ ] Send release announcement to pymor-dev
+ 1. [ ] Announce release in [GitHub discussions](https://github.com/pymor/pymor/discussions)
  1. [ ] add a new section in https://github.com/pymor/docker/blob/master/docs/releases/Dockerfile
  1. [ ] all developers check if (stale) branches can be pruned
  1. [ ] Remove deprecated features in master

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -276,5 +276,5 @@ growing set of :doc:`tutorials`, which focus on specific aspects of pyMOR.
 
 Should you have any problems regarding pyMOR, questions or
 `feature requests <https://github.com/pymor/pymor/issues>`_, do not hesitate
-to contact us at our
-`mailing list <http://listserv.uni-muenster.de/mailman/listinfo/pymor-dev>`_!
+to contact us via
+`GitHub discussions <https://github.com/pymor/pymor/discussions>`_!

--- a/setup.py
+++ b/setup.py
@@ -153,7 +153,7 @@ def setup_package():
         name='pymor',
         version=versioneer.get_version(),
         author='pyMOR developers',
-        author_email='pymor-dev@listserv.uni-muenster.de',
+        author_email='main.developers@pymor.org',
         maintainer='Rene Fritze',
         maintainer_email='rene.fritze@wwu.de',
         package_dir={'': 'src'},


### PR DESCRIPTION
I just found that there are still some mentions of the now non-existent pymor-dev mailing list. I removed some, but there is still one in `setup.py`. @renefritze, any idea what to do about the `author_email` field in `setup.py`?