### PR TITLE
[operators/block] skip ZeroOperators in apply and apply_adjoint

### DIFF
--- a/src/pymor/operators/block.py
+++ b/src/pymor/operators/block.py
@@ -65,7 +65,10 @@ class BlockOperatorBase(Operator):
 
         V_blocks = [None for i in range(self.num_range_blocks)]
         for (i, j), op in np.ndenumerate(self.blocks):
-            Vi = op.apply(U.block(j) if self.blocked_source else U, mu=mu)
+            if isinstance(op, ZeroOperator):
+                Vi = op.range.zeros()
+            else:
+                Vi = op.apply(U.block(j) if self.blocked_source else U, mu=mu)
             if V_blocks[i] is None:
                 V_blocks[i] = Vi
             else:
@@ -78,7 +81,10 @@ class BlockOperatorBase(Operator):
 
         U_blocks = [None for j in range(self.num_source_blocks)]
         for (i, j), op in np.ndenumerate(self.blocks):
-            Uj = op.apply_adjoint(V.block(i) if self.blocked_range else V, mu=mu)
+            if isinstance(op, ZeroOperator):
+                Uj = op.source.zeros()
+            else:
+                Uj = op.apply_adjoint(V.block(i) if self.blocked_range else V, mu=mu)
             if U_blocks[j] is None:
                 U_blocks[j] = Uj
             else:

--- a/src/pymor/operators/block.py
+++ b/src/pymor/operators/block.py
@@ -66,7 +66,7 @@ class BlockOperatorBase(Operator):
         V_blocks = [None for i in range(self.num_range_blocks)]
         for (i, j), op in np.ndenumerate(self.blocks):
             if isinstance(op, ZeroOperator):
-                Vi = op.range.zeros()
+                Vi = op.range.zeros(len(U))
             else:
                 Vi = op.apply(U.block(j) if self.blocked_source else U, mu=mu)
             if V_blocks[i] is None:
@@ -82,7 +82,7 @@ class BlockOperatorBase(Operator):
         U_blocks = [None for j in range(self.num_source_blocks)]
         for (i, j), op in np.ndenumerate(self.blocks):
             if isinstance(op, ZeroOperator):
-                Uj = op.source.zeros()
+                Uj = op.source.zeros(len(V))
             else:
                 Uj = op.apply_adjoint(V.block(i) if self.blocked_range else V, mu=mu)
             if U_blocks[j] is None:


### PR DESCRIPTION
When initailizing a `BlockOperator`, `None` objects in `blocks` are automatically converted to `ZeroOperators`. For a case when a `BlockOperator` has a very sparse structure, this can end in `apply` and `apply_adjoint` computing `op.apply` for many `ZeroOperators`. This PR adds an if statement to neglect all `ZeroOperators` which gave significant speed up in my use case.

Other methods apart from `apply` and `apply_adjoint` in `BlockOperator` may also suffer from this issue, but as far as my investigations showed, the performance is still good enough.