### PR TITLE
Several EI improvements

### DIFF
--- a/docs/source/bibliography.bib
+++ b/docs/source/bibliography.bib
@@ -35,6 +35,18 @@
   publisher={Springer}
 }
 
+@article{BMNP04,
+  title = {An `empirical Interpolation' Method: Application to Efficient Reduced-Basis Discretization of Partial Differential Equations},
+  author = {Barrault, Maxime and Maday, Yvon and Nguyen, Ngoc Cuong and Patera, Anthony T.},
+  year = {2004},
+  volume = {339},
+  pages = {667--672},
+  issn = {1631-073X},
+  doi = {10.1016/j.crma.2004.08.006},
+  journal = {Comptes Rendus Mathematique. Academie des Sciences. Paris},
+  number = {9},
+}
+
 @Article{BG09,
   author =       {Beattie, C.~A. and Gugercin, S.},
   title =        {Interpolatory Projection Methods for Structure-preserving

--- a/src/pymor/algorithms/ei.py
+++ b/src/pymor/algorithms/ei.py
@@ -113,7 +113,7 @@ def ei_greedy(U, error_norm=None, atol=None, rtol=None, max_interpolation_dofs=N
     while True:
         if max_interpolation_dofs is not None and len(interpolation_dofs) >= max_interpolation_dofs:
             logger.info('Maximum number of interpolation DOFs reached. Stopping extension loop.')
-            logger.info(f'Final maximum interpolation error with'
+            logger.info(f'Final maximum interpolation error with '
                         f'{len(interpolation_dofs)} interpolation DOFs: {max_err}')
             break
 

--- a/src/pymor/algorithms/ei.py
+++ b/src/pymor/algorithms/ei.py
@@ -76,6 +76,8 @@ def ei_greedy(U, error_norm=None, atol=None, rtol=None, max_interpolation_dofs=N
                                     be near zero).
             :coefficients:          |NumPy array| of coefficients such that `collateral_basis`
                                     is given by `U.lincomb(coefficients)`.
+            :interpolation_matrix:  The interpolation matrix, i.e., the evaluation of
+                                    `collateral_basis` at `interpolation_dofs`.
     """
     if pool:  # dispatch to parallel implemenation
         assert isinstance(U, (VectorArray, RemoteObject))
@@ -162,9 +164,10 @@ def ei_greedy(U, error_norm=None, atol=None, rtol=None, max_interpolation_dofs=N
         inv_interpolation_matrix = np.linalg.inv(interpolation_matrix)
         collateral_basis = collateral_basis.lincomb(inv_interpolation_matrix.T)
         coefficients = inv_interpolation_matrix.T @ coefficients
+        interpolation_matrix = np.eye(len(collateral_basis))
 
     data = {'errors': max_errs, 'triangularity_errors': triangularity_errs,
-            'coefficients': coefficients}
+            'coefficients': coefficients, 'interpolation_matrix': interpolation_matrix}
 
     return interpolation_dofs, collateral_basis, data
 
@@ -446,9 +449,10 @@ def _parallel_ei_greedy(U, pool, error_norm=None, atol=None, rtol=None, max_inte
         inv_interpolation_matrix = np.linalg.inv(interpolation_matrix)
         collateral_basis = collateral_basis.lincomb(inv_interpolation_matrix.T)
         coefficients = inv_interpolation_matrix.T @ coefficients
+        interpolation_matrix = np.eye(len(collateral_basis))
 
     data = {'errors': max_errs, 'triangularity_errors': triangularity_errs,
-            'coefficients': coefficients}
+            'coefficients': coefficients, 'interpolation_matrix': interpolation_matrix}
 
     return interpolation_dofs, collateral_basis, data
 

--- a/src/pymor/algorithms/ei.py
+++ b/src/pymor/algorithms/ei.py
@@ -385,7 +385,7 @@ def interpolate_function(function, parameter_sample, evaluation_points,
     function
         The function to interpolate.
     parameter_sample
-        A list of |Parameters| for which `function` is evaluate to generate the
+        A list of |Parameters| for which `function` is evaluated to generate the
         training data.
     evaluation_points
         |NumPy array| of coordinates at which `function` should be evaluated to

--- a/src/pymor/analyticalproblems/functions.py
+++ b/src/pymor/analyticalproblems/functions.py
@@ -5,9 +5,10 @@
 from numbers import Number
 
 import numpy as np
+from scipy.linalg import solve, solve_triangular
 
 from pymor.core.base import abstractmethod
-from pymor.parameters.base import ParametricObject
+from pymor.parameters.base import ParametricObject, Mu
 from pymor.parameters.functionals import ParameterFunctional, ExpressionParameterFunctional
 
 
@@ -380,3 +381,130 @@ class BitmapFunction(Function):
              * ((self.range[1] - self.range[0]) / 255.)
              + self.range[0])
         return F
+
+
+class EmpiricalInterpolatedFunction(LincombFunction):
+    """Empirically interpolated |Function|.
+
+    Instantiated by :func:`~pymor.algorithm.ei.interpolate_function`.
+
+    Parameters
+    ----------
+    function
+        The |Function| to interpolate.
+    interpolation_points
+        |NumPy array| containing the coordinates at which the function
+        is interpolated. Typically `X[dofs]` where `X` is the array of
+        evaluation points used for snapshot data generation and `dofs`
+        is returned by :func:`~pymor.algorithm.ei.ei_greedy`.
+    interpolation_matrix
+        The interpolation matrix corresponding to the selected interpolation
+        basis vectors and `interpolation_points` as returned by
+        :func:`pymor.algorithms.ei.ei_greedy`.
+    triangular
+        Whether or not `interpolation_matrix` is lower triangular with unit
+        diagonal.
+    snapshot_mus
+        List of |parameter values| for which the snapshot data for
+        :func:`pymor.algorithms.ei.ei_greedy` has been computed.
+    snapshot_coefficients
+        Matrix of linear coefficients s.t. the i-th interpolation basis vector
+        is given by a linear combination of the functions corresponding to
+        `snapshot_mus` with the i-th row of `snapshot_coefficients` as
+        coefficients. Returned by :func:`~pymor.algorithm.ei.ei_greedy` as
+        `data['coefficients']`.
+    evaluation_points
+        Optional |NumPy array| of coordinates at which the function has been
+        evaluated to obtain the snapshot data. If the same evaluation points
+        are used to evaluate :class:`EmpiricalInterpolatedFunction`, then
+        re-evaluation of the snapshot data at the evaluation points can be
+        avoided, when this argument is specified together with `basis_evaluations`.
+    basis_evaluations
+        Optional |Numpy array| of evaluations of the interpolation basis at
+        `evaluation_points`. Corresponds to the `basis` return value of
+        :func:`~pymor.algorithms.ei.ei_greedy`.
+    """
+
+    def __init__(self, function, interpolation_points, interpolation_matrix, triangular,
+                 snapshot_mus, snapshot_coefficients,
+                 evaluation_points=None, basis_evaluations=None,
+                 name=None):
+
+        assert isinstance(function, Function)
+        if len(function.shape_range) > 0:
+            raise NotImplementedError
+        assert isinstance(interpolation_points, np.ndarray) and interpolation_points.ndim == 2 and \
+            interpolation_points.shape[1] == function.dim_domain
+        assert isinstance(interpolation_matrix, np.ndarray) and \
+            interpolation_matrix.shape == (len(interpolation_points),) * 2
+        assert all(isinstance(mu, Mu) for mu in snapshot_mus)
+        assert isinstance(snapshot_coefficients, np.ndarray) and \
+            snapshot_coefficients.shape == (len(interpolation_points), len(snapshot_mus))
+        assert (evaluation_points is None) == (basis_evaluations is None)
+        assert evaluation_points is None or isinstance(evaluation_points, np.ndarray) and \
+            evaluation_points.ndim == 2 and evaluation_points.shape[1] == function.dim_domain
+        assert basis_evaluations is None or isinstance(basis_evaluations, np.ndarray) and \
+            basis_evaluations.shape == (len(interpolation_points), len(evaluation_points)) + function.shape_range
+
+        self.__auto_init(locals())
+        functions = [EmpiricalInterpolatedFunctionBasisFunction(self, i) for i in range(len(interpolation_points))]
+        coefficients = [EmpiricalInterpolatedFunctionFunctional(self, i) for i in range(len(interpolation_points))]
+        super().__init__(functions, coefficients)
+        self._last_evaluation_points, self._last_basis_evaluations = evaluation_points, basis_evaluations
+        if self._last_evaluation_points is not None:
+            self._last_evaluation_points.flags.writeable = False
+            self._last_basis_evaluations.flags.writeable = False
+        self._last_mu = None
+
+    def _update_coefficients(self, mu):
+        if mu is not self._last_mu:
+            assert self.parameters.assert_compatible(mu)
+            self._last_mu = mu
+            fx = self.function.evaluate(self.interpolation_points, mu=mu)
+            if self.triangular:
+                self._last_interpolation_coefficients = solve_triangular(
+                    self.interpolation_matrix, fx, lower=True, unit_diagonal=True
+                )
+            else:
+                self._last_interpolation_coefficients = solve(self.interpolation_matrix, fx)
+
+    def _update_evaluation_points(self, x):
+        if self._last_evaluation_points is not None and np.all(x == self._last_evaluation_points):
+            return
+        if self._last_evaluation_points is not None:
+            self.logger.info('Evaluating function snapshots for new evaluation points.')
+        x.flags.writeable = False
+        self._last_evaluation_points = x
+        snapshot_evaluations = np.array([self.function.evaluate(x, mu=mu) for mu in self.snapshot_mus])
+        self._last_basis_evaluations = self.snapshot_coefficients @ snapshot_evaluations.T
+
+    def evaluate(self, x, mu=None):
+        self._update_evaluation_points(x)
+        basis_evaluations = self._last_basis_evaluations
+        interpolation_coefficients = self._evaluate_coefficients(mu)
+        return basis_evaluations.T @ interpolation_coefficients
+
+
+class EmpiricalInterpolatedFunctionFunctional(ParameterFunctional):
+
+    def __init__(self, interpolated_function, index):
+        self.__auto_init(locals())
+        # we explicitly have to set the parameters since interpolation_points isn't initialized yet
+        self.parameters = interpolated_function.function.parameters
+
+    def evaluate(self, mu=None):
+        self.interpolated_function._update_coefficients(mu)
+        return self.interpolated_function._last_interpolation_coefficients[self.index]
+
+
+class EmpiricalInterpolatedFunctionBasisFunction(Function):
+
+    def __init__(self, interpolated_function, index):
+        self.__auto_init(locals())
+        self.dim_domain = interpolated_function.function.dim_domain
+        self.shape_range = interpolated_function.function.shape_range
+        self.parameters = {}
+
+    def evaluate(self, x, mu=None):
+        self.interpolated_function._update_evaluation_points(x)
+        return self.interpolated_function._last_basis_evaluations[self.index].copy()

--- a/src/pymor/basic.py
+++ b/src/pymor/basic.py
@@ -11,7 +11,7 @@ to have the most important parts of pyMOR directly available.
 # flake8: noqa
 
 from pymor.algorithms.basic import almost_equal, relative_error, project_array
-from pymor.algorithms.ei import interpolate_operators, ei_greedy, deim
+from pymor.algorithms.ei import interpolate_operators, interpolate_function, ei_greedy, deim
 from pymor.algorithms.error import reduction_error_analysis
 from pymor.algorithms.gram_schmidt import gram_schmidt, gram_schmidt_biorth
 from pymor.algorithms.greedy import rb_greedy

--- a/src/pymor/discretizers/builtin/grids/oned.py
+++ b/src/pymor/discretizers/builtin/grids/oned.py
@@ -71,7 +71,7 @@ class OnedGrid(GridWithOrthogonalCenters):
     def orthogonal_centers(self):
         return self.centers(0)
 
-    def visualize(self, U, codim=2, **kwargs):
+    def visualize(self, U, codim=1, **kwargs):
         """Visualize scalar data associated to the grid as a patch plot.
 
         Parameters
@@ -82,7 +82,7 @@ class OnedGrid(GridWithOrthogonalCenters):
             |Numpy arrays| can be provided, in which case a subplot is created for
             each entry of the tuple. The lengths of all arrays have to agree.
         codim
-            The codimension of the entities the data in `U` is attached to (either 0 or 2).
+            The codimension of the entities the data in `U` is attached to (either 0 or 1).
         kwargs
             See :func:`~pymor.discretizers.builtin.gui.visualizers.OnedVisualizer.visualize`
         """

--- a/src/pymordemos/function_ei.py
+++ b/src/pymordemos/function_ei.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python
+# This file is part of the pyMOR project (https://www.pymor.org).
+# Copyright 2013-2021 pyMOR developers and contributors. All rights reserved.
+# License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
+
+import sys
+
+import numpy as np
+from typer import Argument, Option, run
+
+from pymor.algorithms.greedy import rb_greedy
+from pymor.algorithms.ei import interpolate_function
+from pymor.algorithms.error import reduction_error_analysis
+from pymor.analyticalproblems.domaindescriptions import RectDomain
+from pymor.analyticalproblems.elliptic import StationaryProblem
+from pymor.analyticalproblems.functions import ConstantFunction, ExpressionFunction
+from pymor.discretizers.builtin import discretize_stationary_cg
+from pymor.parameters.functionals import ExpressionParameterFunctional
+from pymor.reductors.coercive import CoerciveRBReductor
+
+
+def main(
+    ei_snapshots: int = Argument(..., help='Number of snapshots for empirical interpolation.'),
+    ei_size: int = Argument(..., help='Number of interpolation DOFs.'),
+    snapshots: int = Argument(..., help='Number of snapshots for basis generation.'),
+    rb_size: int = Argument(..., help='Size of the reduced basis.'),
+    grid: int = Option(100, help='Use grid with 4*NI*NI elements'),
+    plot_ei_err: bool = Option(False, help='Plot empirical interpolation error.'),
+    plot_solutions: bool = Option(False, help='Plot some example solutions.'),
+    test: int = Option(10, help='Number of snapshots to use for stochastic error estimation.'),
+):
+    """Reduction of a problem without parameter separability using empirical interpolation."""
+    problem = StationaryProblem(
+        domain=RectDomain(),
+
+        diffusion=ExpressionFunction('(x[...,1] > 0.5) * x[...,0]**exponent[0] + 0.1', 2,
+                                     parameters={'exponent': 1}),
+
+        rhs=ConstantFunction(1., 2),
+
+        parameter_ranges=(1, 10)
+    )
+
+    print('Discretize ...')
+    fom, data = discretize_stationary_cg(problem, diameter=1. / grid)
+
+    print(data['grid'])
+    print(f'The parameters are {fom.parameters}')
+
+    if plot_solutions:
+        print('Showing some solutions')
+        Us = ()
+        legend = ()
+        for mu in problem.parameter_space.sample_uniformly(4):
+            print(f"Solving for exponent = {mu['exponent']} ... ")
+            sys.stdout.flush()
+            Us = Us + (fom.solve(mu),)
+            legend = legend + (f"exponent: {mu['exponent']}",)
+        fom.visualize(Us, legend=legend, title='Detailed Solutions', block=True)
+
+    diffusion_ei, ei_data = interpolate_function(
+        problem.diffusion,
+        parameter_sample=problem.parameter_space.sample_uniformly(ei_snapshots),
+        evaluation_points=data['grid'].centers(0),
+        max_interpolation_dofs=ei_size
+    )
+
+    problem_ei = problem.with_(diffusion=diffusion_ei)
+    fom_ei, _ = discretize_stationary_cg(problem_ei, diameter=1. / grid)
+
+    if plot_ei_err:
+        print('Showing some EI errors')
+        ERRs = ()
+        legend = ()
+        for mu in problem.parameter_space.sample_randomly(2):
+            print(f"Solving for exponent = \n{mu['exponent']} ... ")
+            sys.stdout.flush()
+            U = fom.solve(mu)
+            U_EI = fom_ei.solve(mu)
+            ERR = U - U_EI
+            ERRs = ERRs + (ERR,)
+            legend = legend + (f"exponent: {mu['exponent']}",)
+            print(f'Error: {np.max(fom.l2_norm(ERR))}')
+        fom.visualize(ERRs, legend=legend, title='EI Errors', separate_colorbars=True)
+
+    print('RB generation ...')
+
+    coercivity_estimator = ExpressionParameterFunctional('1.', fom.parameters)
+    reductor = CoerciveRBReductor(fom_ei, product=fom.h1_0_semi_product, coercivity_estimator=coercivity_estimator,
+                                  check_orthonormality=False)
+
+    greedy_data = rb_greedy(fom_ei, reductor, problem.parameter_space.sample_uniformly(snapshots),
+                            max_extensions=rb_size)
+    rom = greedy_data['rom']
+
+    results = reduction_error_analysis(rom, fom=fom, reductor=reductor, error_estimator=True,
+                                       error_norms=[fom.h1_0_semi_norm], condition=True,
+                                       test_mus=problem.parameter_space.sample_randomly(test),
+                                       plot=True)
+    print(results['summary'])
+    import matplotlib.pyplot
+    matplotlib.pyplot.show()
+
+    mumax = results['max_error_mus'][0, -1]
+    U = fom.solve(mumax)
+    U_RB = reductor.reconstruct(rom.solve(mumax))
+    fom.visualize((U, U_RB, U - U_RB), legend=('Detailed Solution', 'Reduced Solution', 'Error'),
+                  separate_colorbars=True, block=True)
+
+
+if __name__ == '__main__':
+    run(main)

--- a/src/pymortests/demos.py
+++ b/src/pymortests/demos.py
@@ -124,6 +124,10 @@ FENICS_NONLINEAR_ARGS = (
     ('fenics_nonlinear', [3, 5, 1]),
 )
 
+FUNCTION_EI_ARGS = (
+    ('function_ei', ['--grid=10', 3, 2, 3, 2]),
+)
+
 DEMO_ARGS = (
     DISCRETIZATION_ARGS
     + THERMALBLOCK_ARGS
@@ -135,6 +139,7 @@ DEMO_ARGS = (
     + SYS_MOR_ARGS
     + HAPOD_ARGS
     + FENICS_NONLINEAR_ARGS
+    + FUNCTION_EI_ARGS
 )
 DEMO_ARGS = [(f'pymordemos.{a}', b) for (a, b) in DEMO_ARGS]
 


### PR DESCRIPTION
- `ei_greedy` improvements:
    - The `nodal_basis` option allows to compute a nodal interpolation basis.
    - The interpolation matrix is now returned in the data dictionary.
    - The `coefficients` array of `data` contains the coefficients of the computed basis w.r.t. the input data vectors.
    - `error_norm` can be set to `'sup'` to use `sup_norm` for the error as it makes sense for the interpolation of functions.
- The new `interpolate_function` uses `ei_greedy` (and the new `coefficients` return value) to build an `EmpiricalInterpolatedFunction` from an arbitrary pyMOR `Function`.
- The new `function_ei` demo demonstrates the new functionality.