### PR TITLE
Fix bug in apply_inverse for LincombOperators

### DIFF
--- a/.ci/gitlab/deploy_docs.bash
+++ b/.ci/gitlab/deploy_docs.bash
@@ -29,11 +29,13 @@ cd ${REPO_DIR}
 git config user.name "pyMOR Bot"
 git config user.email "gitlab-ci@pymor.org"
 git add ${TARGET_DIR}
-git commit -m "Updated docs for ${CI_COMMIT_REF_NAME}"
+(git diff --quiet && git diff --staged --quiet) || \
+  git commit -m "Updated docs for ${CI_COMMIT_REF_NAME}"
 
 ${PYMOR_ROOT}/.ci/gitlab/docs_makeindex.py ${REPO_DIR}
 git add list.html
-git commit -m "Updated index for ${CI_COMMIT_REF_NAME}" || echo "nothing to add"
+(git diff --quiet && git diff --staged --quiet) || \
+  git commit -m "Updated index for ${CI_COMMIT_REF_NAME}"
 
 git push || (git pull --rebase && git push )
 
@@ -54,7 +56,8 @@ done
 git add ${TARGET_DIR}/*ipynb
 git add ${REPO_DIR}/.binder/
 
-git commit -am "Binder setup for ${CI_COMMIT_REF_NAME}"
+(git diff --quiet && git diff --staged --quiet) || \
+  git commit -am "Binder setup for ${CI_COMMIT_REF_NAME}"
 
 # makes sure the binder infra is usable
 repo2docker --user-id 2000 --user-name juno --no-run --debug .

--- a/src/pymor/operators/constructions.py
+++ b/src/pymor/operators/constructions.py
@@ -178,21 +178,23 @@ class LincombOperator(Operator):
 
     def apply_inverse(self, V, mu=None, initial_guess=None, least_squares=False):
         if len(self.operators) == 1:
-            if self.coefficients[0] == 0.:
+            coeff = self.evaluate_coefficients(mu)[0]
+            if not coeff:
                 if least_squares:
                     return self.source.zeros(len(V))
                 else:
                     raise InversionError
             else:
                 U = self.operators[0].apply_inverse(V, mu=mu, initial_guess=initial_guess, least_squares=least_squares)
-                U *= (1. / self.coefficients[0])
+                U *= (1. / coeff)
                 return U
         else:
             return super().apply_inverse(V, mu=mu, initial_guess=initial_guess, least_squares=least_squares)
 
     def apply_inverse_adjoint(self, U, mu=None, initial_guess=None, least_squares=False):
         if len(self.operators) == 1:
-            if self.coefficients[0] == 0.:
+            coeff = self.evaluate_coefficients(mu)[0]
+            if not coeff:
                 if least_squares:
                     return self.range.zeros(len(U))
                 else:
@@ -200,7 +202,7 @@ class LincombOperator(Operator):
             else:
                 V = self.operators[0].apply_inverse_adjoint(U, mu=mu,
                                                             initial_guess=initial_guess, least_squares=least_squares)
-                V *= (1. / self.coefficients[0])
+                V *= (1. / coeff)
                 return V
         else:
             return super().apply_inverse_adjoint(U, mu=mu, initial_guess=initial_guess, least_squares=least_squares)

--- a/src/pymortests/operators.py
+++ b/src/pymortests/operators.py
@@ -131,10 +131,13 @@ def test_identity_lincomb():
     identity = IdentityOperator(space)
     ones = space.ones()
     idid = (identity + identity)
+    idid_ = ExpressionParameterFunctional('2', {}) * identity
     assert almost_equal(ones * 2, idid.apply(ones))
     assert almost_equal(ones * 2, idid.apply_adjoint(ones))
     assert almost_equal(ones * 0.5, idid.apply_inverse(ones))
     assert almost_equal(ones * 0.5, idid.apply_inverse_adjoint(ones))
+    assert almost_equal(ones * 0.5, idid_.apply_inverse(ones))
+    assert almost_equal(ones * 0.5, idid_.apply_inverse_adjoint(ones))
 
 
 def test_identity_numpy_lincomb():


### PR DESCRIPTION
I have found a small bug in `apply_inverse` and `apply_inverse_adjoint` in `LincombOperator`. 

The first commit of this PR tweaks a simple test which should go through but doesn't, the second fixes the bug.