### PR TITLE
intermittent MPI CI failure workaround

### DIFF
--- a/.ci/gitlab/test_mpi.bash
+++ b/.ci/gitlab/test_mpi.bash
@@ -3,7 +3,7 @@
 THIS_DIR="$(cd "$(dirname ${BASH_SOURCE[0]})" ; pwd -P )"
 source ${THIS_DIR}/common_test_setup.bash
 
-xvfb-run -a mpirun -n 2 coverage run --rcfile=setup.cfg --parallel-mode src/pymortests/mpi_run_demo_tests.py
+xvfb-run -a mpirun --mca btl self,vader -n 2 coverage run --rcfile=setup.cfg --parallel-mode src/pymortests/mpi_run_demo_tests.py
 coverage combine
 # the test_thermalblock_ipython results in '(builtin)' missing which we "--ignore-errors"
 coverage xml --ignore-errors

--- a/.ci/gitlab/test_mpi.bash
+++ b/.ci/gitlab/test_mpi.bash
@@ -3,7 +3,14 @@
 THIS_DIR="$(cd "$(dirname ${BASH_SOURCE[0]})" ; pwd -P )"
 source ${THIS_DIR}/common_test_setup.bash
 
-xvfb-run -a mpirun --mca btl self,vader -n 2 coverage run --rcfile=setup.cfg --parallel-mode src/pymortests/mpi_run_demo_tests.py
+# as a workaround intermittent MPI finalize errors which we
+# cannot seem to directly affect, we save the intermediate
+# pytest exit code in a file and check that afterwards
+# while ignoring the mpirun result itself
+xvfb-run -a mpirun --mca btl self,vader -n 2 coverage run --rcfile=setup.cfg \
+  --parallel-mode src/pymortests/mpi_run_demo_tests.py || true
+[[ "$(cat pytest.mpirun.success)" == "True" ]] || exit 127
+
 coverage combine
 # the test_thermalblock_ipython results in '(builtin)' missing which we "--ignore-errors"
 coverage xml --ignore-errors

--- a/src/pymortests/mpi_run_demo_tests.py
+++ b/src/pymortests/mpi_run_demo_tests.py
@@ -4,8 +4,18 @@
 
 if __name__ == '__main__':
     from pymor.tools import mpi
-    import runpy
+    import pytest
+    import os
+    from pathlib import Path
 
+    this_dir = Path(__file__).resolve().parent
+    pymor_root_dir = (this_dir / '..' / '..').resolve()
+
+    result_file_fn = pymor_root_dir / 'pytest.mpirun.success'
+    try:
+        os.unlink(result_file_fn)
+    except FileNotFoundError:
+        pass
     # ensure that FEniCS visualization does nothing on all MPI ranks
     def monkey_plot():
         def nop(*args, **kwargs):
@@ -31,4 +41,7 @@ if __name__ == '__main__':
 
     mpi.call(monkey_plot)
 
-    runpy.run_module('pymortests.demos', init_globals=None, run_name='__main__', alter_sys=True)
+    demo = str(pymor_root_dir / 'src' / 'pymortests' / 'demos.py')
+    success = pytest.main(['-svx', '-k', 'test_demo', demo]) == pytest.ExitCode.OK
+    with open(result_file_fn, 'wt') as result_file:
+        result_file.write(f'{success}')


### PR DESCRIPTION
This workaround treats the result of pytest as the success/fail trigger for the pipeline
not the exit code of the mpirun script.

The background here are intermittent failures were one rank does not call `MPI_Finalize` 
before exiting. While I made it configurable for pyMOR to tell mpi4py to do that
or not on module de-init, mpirun still sometimes errors out with "unclean"
process exits. These are never reproducable (locally or on pipeline re-run), not limited to 
python versions, nor have any other descernible pattern. Which is why I propose this workaround. 

This PR also forces the mpi runtime to use the in memory transport which
should stop the "slow transport fallback" message from popping up in logs.
