### PR TITLE
Fix `make docs` printing `rules`, edit `tools.formatsrc` and `rule.__repr__`

### DIFF
--- a/docs/source/tutorial_projection.rst
+++ b/docs/source/tutorial_projection.rst
@@ -560,7 +560,7 @@ be the first matching rule. We can take a look at it:
 
 .. jupyter-execute::
 
-    ProjectRules.rules[8]
+    print_source(ProjectRules.rules[8].action)
 
 The implementation of the action for |LincombOperators| uses the
 :meth:`~pymor.algorithms.rules.RuleTable.replace_children` method of |RuleTable|,
@@ -585,7 +585,7 @@ will apply:
 
 .. jupyter-execute::
 
-    ProjectRules.rules[3]
+    print_source(ProjectRules.rules[3].action)
 
 This action has special cases for all possible combinations of given or not-given
 :attr:`~pymor.operators.interface.Operator.range` and :attr:`~pymor.operators.interface.Operator.source`

--- a/docs/source/tutorial_projection.rst
+++ b/docs/source/tutorial_projection.rst
@@ -560,7 +560,7 @@ be the first matching rule. We can take a look at it:
 
 .. jupyter-execute::
 
-    print_source(ProjectRules.rules[8].action)
+    ProjectRules.rules[8]
 
 The implementation of the action for |LincombOperators| uses the
 :meth:`~pymor.algorithms.rules.RuleTable.replace_children` method of |RuleTable|,
@@ -585,7 +585,7 @@ will apply:
 
 .. jupyter-execute::
 
-    print_source(ProjectRules.rules[3].action)
+    ProjectRules.rules[3]
 
 This action has special cases for all possible combinations of given or not-given
 :attr:`~pymor.operators.interface.Operator.range` and :attr:`~pymor.operators.interface.Operator.source`

--- a/src/pymor/algorithms/rules.py
+++ b/src/pymor/algorithms/rules.py
@@ -56,6 +56,11 @@ class rule:
     condition_description = None
     condition_type = None
 
+    def _ipython_display_(self):
+        from inspect import getsource
+        from IPython.display import Code, display
+        display(Code(getsource(self.action), language='python'))
+
     @property
     def action_description(self):
         return self.action.__doc__ or self.action.__name__[len('action_'):]

--- a/src/pymor/algorithms/rules.py
+++ b/src/pymor/algorithms/rules.py
@@ -61,6 +61,17 @@ class rule:
         from IPython.display import Code, display
         display(Code(getsource(self.action), language='python'))
 
+    def __repr__(self):
+        from inspect import getsource
+        source = getsource(self.action)
+        try:
+            from pygments import highlight
+            from pygments.lexers import PythonLexer
+            from pygments.formatters import Terminal256Formatter
+            return highlight(source, PythonLexer(), Terminal256Formatter())
+        except ImportError:
+            return source
+
     @property
     def action_description(self):
         return self.action.__doc__ or self.action.__name__[len('action_'):]

--- a/src/pymor/algorithms/rules.py
+++ b/src/pymor/algorithms/rules.py
@@ -56,10 +56,6 @@ class rule:
     condition_description = None
     condition_type = None
 
-    def __repr__(self):
-        from pymor.tools.formatsrc import source_repr
-        return source_repr(self.action)
-
     @property
     def action_description(self):
         return self.action.__doc__ or self.action.__name__[len('action_'):]

--- a/src/pymor/algorithms/rules.py
+++ b/src/pymor/algorithms/rules.py
@@ -9,6 +9,7 @@ from weakref import WeakValueDictionary
 from pymor.core.base import BasicObject, UberMeta, abstractmethod, classinstancemethod
 from pymor.core.exceptions import NoMatchingRuleError, RuleNotMatchingError
 from pymor.operators.interface import Operator
+from pymor.tools.formatsrc import format_source, print_source
 from pymor.tools.table import format_table
 
 
@@ -57,20 +58,10 @@ class rule:
     condition_type = None
 
     def _ipython_display_(self):
-        from inspect import getsource
-        from IPython.display import Code, display
-        display(Code(getsource(self.action), language='python'))
+        print_source(self.action)
 
     def __repr__(self):
-        from inspect import getsource
-        source = getsource(self.action)
-        try:
-            from pygments import highlight
-            from pygments.lexers import PythonLexer
-            from pygments.formatters import Terminal256Formatter
-            return highlight(source, PythonLexer(), Terminal256Formatter())
-        except ImportError:
-            return source
+        return format_source(self.action)
 
     @property
     def action_description(self):

--- a/src/pymor/tools/formatsrc.py
+++ b/src/pymor/tools/formatsrc.py
@@ -8,6 +8,19 @@ from pymor.core.config import is_jupyter
 
 
 def format_source(obj):
+    """Format source code of an object.
+
+    Parameters
+    ----------
+    obj
+        The object of which to format the source code.
+
+    Returns
+    -------
+    source
+        The source code as a `Code` widget in case a Jupyter notebook is used or as a string
+        otherwise.
+    """
     source = getsource(obj)
 
     if is_jupyter():
@@ -24,6 +37,13 @@ def format_source(obj):
 
 
 def print_source(obj):
+    """Print source code of an object.
+
+    Parameters
+    ----------
+    obj
+        The object of which to print the source code.
+    """
     source = format_source(obj)
     if is_jupyter():
         from IPython.display import display

--- a/src/pymor/tools/formatsrc.py
+++ b/src/pymor/tools/formatsrc.py
@@ -18,22 +18,19 @@ def format_source(obj):
     Returns
     -------
     source
-        The source code as a `Code` widget in case a Jupyter notebook is used or as a string
-        otherwise.
+        The source code as a string, possibly highlighted when used in a
+        terminal.
     """
     source = getsource(obj)
-
     if is_jupyter():
-        from IPython.display import Code
-        return Code(source, language='python')
-    else:
-        try:
-            from pygments import highlight
-            from pygments.lexers import PythonLexer
-            from pygments.formatters import Terminal256Formatter
-            return highlight(source, PythonLexer(), Terminal256Formatter())
-        except ImportError:
-            return source
+        return source
+    try:
+        from pygments import highlight
+        from pygments.lexers import PythonLexer
+        from pygments.formatters import Terminal256Formatter
+        return highlight(source, PythonLexer(), Terminal256Formatter())
+    except ImportError:
+        return source
 
 
 def print_source(obj):
@@ -46,7 +43,7 @@ def print_source(obj):
     """
     source = format_source(obj)
     if is_jupyter():
-        from IPython.display import display
-        display(source)
+        from IPython.display import Code, display
+        display(Code(source, language='python'))
     else:
         print(source)

--- a/src/pymor/tools/formatsrc.py
+++ b/src/pymor/tools/formatsrc.py
@@ -30,13 +30,3 @@ def print_source(obj):
         display(source)
     else:
         print(source)
-
-
-def source_repr(obj):
-    source = format_source(obj)
-    if is_jupyter():
-        from IPython.display import display
-        display(source)
-        return ''
-    else:
-        return source

--- a/src/pymortests/tools.py
+++ b/src/pymortests/tools.py
@@ -11,7 +11,7 @@ import itertools
 from hypothesis import given
 
 from pymor.core.logger import getLogger
-from pymor.tools.formatsrc import print_source, source_repr
+from pymor.tools.formatsrc import print_source
 from pymor.tools.io import SafeTemporaryFileName
 from pymortests.base import runmodule
 from pymortests.fixtures.grid import hy_rect_or_tria_grid
@@ -187,7 +187,6 @@ def test_formatsrc():
     obj = formatsrc.format_source
     formatsrc.format_source(obj)
     print_source(obj)
-    source_repr(obj)
 
 
 def test_formatsrc_nopygments(monkeypatch):


### PR DESCRIPTION
Fixes #1189.

I find `rule.__repr__` showing source code and potentially not just returning a string a bit strange, so I removed it. I'm open to other ideas.

Edit: This PR:

- edits methods in `tools.formatsrc`, removes `source_repr`
- edits `rule.__repr__` to only return `str`
- adds `rule._ipython_display_`