### PR TITLE
Add PGFPlots output for builtin discretizations via tikzplotlib

### DIFF
--- a/dependencies.py
+++ b/dependencies.py
@@ -47,7 +47,8 @@ install_suggests = {'ipython>=5.0': 'an enhanced interactive python shell',
                     'nbresuse': 'resource usage indicator for notebooks',
                     'torch;python_version<"3.9"': 'PyTorch open source machine learning framework',
                     'jupyter_contrib_nbextensions': 'modular collection of jupyter extensions',
-                    'pillow': 'image library used for bitmap data functions'}
+                    'pillow': 'image library used for bitmap data functions',
+                    'tikzplotlib': 'create PGFPlots figures for builtin discretizations',}
 doc_requires = ['sphinx>=1.7', 'jupyter_sphinx', 'matplotlib', _PYSIDE, 'ipyparallel>=6.2.5', 'python-slugify',
                 'ipywidgets', 'sphinx-qt-documentation', 'bash_kernel', 'sphinx-material'] + install_requires
 ci_requires = [_PYTEST, 'pytest-cov', 'pytest-xdist', 'check-manifest', 'nbconvert', 'pytest-parallel', 

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -43,6 +43,7 @@ sphinx-material
 sphinx-qt-documentation
 sphinx>=1.7
 sympy
+tikzplotlib
 torch;python_version<"3.9"
 typer
 wheel

--- a/src/pymor/core/config.py
+++ b/src/pymor/core/config.py
@@ -116,6 +116,7 @@ _PACKAGES = {
     'SCIPY_LSMR': lambda: hasattr(import_module('scipy.sparse.linalg'), 'lsmr'),
     'SLYCOT': lambda: _get_slycot_version(),
     'SPHINX': lambda: import_module('sphinx').__version__,
+    'TIKZPLOTLIB': lambda: import_module('tikzplotlib').__version__,
     'TORCH': lambda: import_module('torch').__version__,
     'TYPER': lambda: import_module('typer').__version__,
 }

--- a/src/pymor/discretizers/builtin/grids/tikzio.py
+++ b/src/pymor/discretizers/builtin/grids/tikzio.py
@@ -1,0 +1,70 @@
+# This file is part of the pyMOR project (http://www.pymor.org).
+# Copyright 2013-2020 pyMOR developers and contributors. All rights reserved.
+# License: BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+
+import numpy as np
+
+from pymor.core.config import config
+from pymor.discretizers.builtin.grids.rect import RectGrid
+
+
+def write_tikz(grid, data, filename, codim=2, colorbar=True):
+    """Output grid-associated data as a PGFPlots figure.
+
+    Parameters
+    ----------
+    grid
+        Must be a |RectGrid| at the moment.
+    data
+        |VectorArray| with either cell (ie one datapoint per codim 0 entity)
+        or vertex (ie one datapoint per codim 2 entity) data in each array element.
+    filename
+        Name of main output file.
+    codim
+        The codimension associated with the data.
+    colorbar
+        If `True` include a colorbar in the plot.
+    """
+    if not config.HAVE_MATPLOTLIB:
+        raise ImportError('matplotlib missing')
+    if not config.HAVE_TIKZPLOTLIB:
+        raise ImportError('tikzplotlib missing')
+    if not isinstance(grid, RectGrid):
+        raise NotImplementedError
+    if grid.identify_bottom_top or grid.identify_left_right:
+        raise NotImplementedError
+    if codim not in (0, 2):
+        raise NotImplementedError
+
+    if len(data) == 0:
+        raise ValueError('Nothing to visualize')
+    assert (codim == 0 and data.dim == grid.size(0)) or \
+           (codim == 2 and data.dim == grid.size(2))
+
+    from matplotlib import pyplot as plt
+    import tikzplotlib
+
+    X = np.linspace(grid.domain[0][0], grid.domain[1][0], grid.num_intervals[0] + 1)
+    Y = np.linspace(grid.domain[0][1], grid.domain[1][1], grid.num_intervals[1] + 1)
+
+    def write_one_figure(filename, data):
+        fig = plt.figure()
+        if codim == 0:
+            data = data.to_numpy().reshape((grid.num_intervals[1], grid.num_intervals[0]))
+            plt.pcolormesh(X, Y, data, shading='flat', figure=fig)
+        elif codim == 2:
+            data = data.to_numpy().reshape((grid.num_intervals[1] + 1, grid.num_intervals[0] + 1))
+            plt.pcolormesh(X, Y, data, shading='gouraud', figure=fig)
+        else:
+            assert False
+        if colorbar:
+            plt.colorbar()
+        tikzplotlib.save(filename, override_externals=True)
+        plt.close(fig)
+
+    if len(data) == 1:
+        write_one_figure(filename, data)
+    else:
+        filename_base = filename[:-4] if filename.endswith('.tex') else filename
+        for i, d in enumerate(data):
+            write_one_figure(f'{filename_base}_{i:03}.tex', d)

--- a/src/pymor/discretizers/builtin/gui/visualizers.py
+++ b/src/pymor/discretizers/builtin/gui/visualizers.py
@@ -83,7 +83,9 @@ class PatchVisualizer(ImmutableObject):
                 and all(len(u) == len(U[0]) for u in U))
         if filename:
             use_tikz = filename.endswith('.tex')
-            if not isinstance(U, tuple):
+            if not isinstance(U, tuple) or len(U) == 1:
+                if isinstance(U, tuple):
+                    U = U[0]
                 if use_tikz:
                     write_tikz(self.grid, U, filename, codim=self.codim, **kwargs)
                 else:

--- a/src/pymor/discretizers/builtin/gui/visualizers.py
+++ b/src/pymor/discretizers/builtin/gui/visualizers.py
@@ -7,6 +7,7 @@ from pymor.core.base import ImmutableObject
 from pymor.core.config import is_jupyter
 from pymor.discretizers.builtin.grids.oned import OnedGrid
 from pymor.discretizers.builtin.grids.referenceelements import triangle, square
+from pymor.discretizers.builtin.grids.tikzio import write_tikz
 from pymor.discretizers.builtin.grids.vtkio import write_vtk
 from pymor.vectorarrays.interface import VectorArray
 
@@ -39,7 +40,8 @@ class PatchVisualizer(ImmutableObject):
         self.__auto_init(locals())
 
     def visualize(self, U, m, title=None, legend=None, separate_colorbars=False,
-                  rescale_colorbars=False, block=None, filename=None, columns=2):
+                  rescale_colorbars=False, block=None, filename=None, columns=2,
+                  **kwargs):
         """Visualize the provided data.
 
         Parameters
@@ -66,33 +68,45 @@ class PatchVisualizer(ImmutableObject):
         filename
             If specified, write the data to a VTK-file using
             :func:`~pymor.discretizers.builtin.grids.vtkio.write_vtk` instead of displaying it.
+            If `filename` ends with `'.tex'`, use
+            :func:`~pymor.discretizers.builtin.grids.tikzio.write_tikz` to create a PGFPlots
+            figure instead.
         columns
             The number of columns in the visualizer GUI in case multiple plots are displayed
             at the same time.
+        kwargs
+            Additional visualization options, depending on the backend.
         """
         assert isinstance(U, VectorArray) \
             or (isinstance(U, tuple)
                 and all(isinstance(u, VectorArray) for u in U)
                 and all(len(u) == len(U[0]) for u in U))
         if filename:
+            use_tikz = filename.endswith('.tex')
             if not isinstance(U, tuple):
-                write_vtk(self.grid, U, filename, codim=self.codim)
+                if use_tikz:
+                    write_tikz(self.grid, U, filename, codim=self.codim, **kwargs)
+                else:
+                    write_vtk(self.grid, U, filename, codim=self.codim, **kwargs)
             else:
                 for i, u in enumerate(U):
-                    write_vtk(self.grid, u, f'{filename}-{i}', codim=self.codim)
+                    if use_tikz:
+                        write_tikz(self.grid, u, f'{filename[:-4]}-{i}.tex', codim=self.codim, **kwargs)
+                    else:
+                        write_vtk(self.grid, u, f'{filename}-{i}', codim=self.codim, **kwargs)
         else:
             if self.backend == 'jupyter':
                 from pymor.discretizers.builtin.gui.jupyter import get_visualizer
                 return get_visualizer()(self.grid, U, bounding_box=self.bounding_box, codim=self.codim, title=title,
                                         legend=legend, separate_colorbars=separate_colorbars,
-                                        rescale_colorbars=rescale_colorbars, columns=columns)
+                                        rescale_colorbars=rescale_colorbars, columns=columns, **kwargs)
             else:
                 block = self.block if block is None else block
                 from pymor.discretizers.builtin.gui.qt import visualize_patch
                 return visualize_patch(self.grid, U, bounding_box=self.bounding_box, codim=self.codim, title=title,
                                        legend=legend, separate_colorbars=separate_colorbars,
                                        rescale_colorbars=rescale_colorbars, backend=self.backend, block=block,
-                                       columns=columns)
+                                       columns=columns, **kwargs)
 
 
 class OnedVisualizer(ImmutableObject):


### PR DESCRIPTION
Currently supports only `RectGrid`. (Unstructured) triangular grids seems to require hacking tikzplotlib as all triangles get converted to corresponding tikz directives, which is not feasible even for relatively small grids.