### PR TITLE
Simplify SecondOrderModel-related operators

### DIFF
--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -1379,7 +1379,7 @@ class SecondOrderModel(InputStateOutputModel):
         lti
             |LTIModel| equivalent to the second-order model.
         """
-        return LTIModel(A=SecondOrderModelOperator(self.E, self.K),
+        return LTIModel(A=SecondOrderModelOperator(0, 1, -self.E, -self.K),
                         B=BlockColumnOperator([ZeroOperator(self.B.range, self.B.source), self.B]),
                         C=BlockRowOperator([self.Cp, self.Cv]),
                         D=self.D,


### PR DESCRIPTION
After I found another issue with `assemble_lincomb` and `RecursionError`, this time with multiplying `SecondOrderModelOperator` by `-1`, I concluded it might be best to remove `ShiftedSecondOrderModelOperator` and generalize `SecondOrderModelOperator`. In particular, with this PR, `SecondOrderModelOperator` represents 2x2 block operators of the form `[[a * I, b * I], [B, A]]`.