### PR TITLE
Some improvements to WebGL visualizations

### DIFF
--- a/src/pymor/discretizers/builtin/gui/jupyter/__init__.py
+++ b/src/pymor/discretizers/builtin/gui/jupyter/__init__.py
@@ -18,7 +18,9 @@ from pymor.core.config import config
 
 
 @defaults('backend')
-def get_visualizer(backend='MPL'):
+def get_visualizer(backend='py3js'):
+    if backend not in ('py3js', 'MPL'):
+        raise ValueError
     if backend == 'py3js' and config.HAVE_PYTHREEJS:
         from pymor.discretizers.builtin.gui.jupyter.threejs import visualize_py3js
         return visualize_py3js


### PR DESCRIPTION
- Use `Label`s from ipywidgets to render colorbar.
- Fix the behavior of `rescale_colorbars`.
- Some minor layout improvements.

In addition, the threejs backend is made the default jupyter visualization backend as already advertised in the release notes of 2020.1.

Fixes #1289.