### PR TITLE
Let sample_randomly return a Mu instance in case count=None

### DIFF
--- a/docs/source/tutorial_basis_generation.rst
+++ b/docs/source/tutorial_basis_generation.rst
@@ -249,7 +249,7 @@ the best-approximation error in `trivial_basis` for some test vector
 
 .. jupyter-execute::
 
-    V = fom.solve(parameter_space.sample_randomly(1)[0])
+    V = fom.solve(parameter_space.sample_randomly())
 
 The matrix :math:`G` of all inner products between vectors in `trivial_basis`
 is a so called `Gramian matrix <https://en.wikipedia.org/wiki/Gramian_matrix>`_.

--- a/docs/source/tutorial_mor_with_anns.rst
+++ b/docs/source/tutorial_mor_with_anns.rst
@@ -193,7 +193,7 @@ the full problem and the reduced model and visualize the result:
 
 .. jupyter-execute::
 
-    mu = parameter_space.sample_randomly(1)[0]
+    mu = parameter_space.sample_randomly()
 
     U = fom.solve(mu)
     U_red = rom.solve(mu)

--- a/src/pymor/parameters/base.py
+++ b/src/pymor/parameters/base.py
@@ -480,7 +480,9 @@ class ParameterSpace(ParametricObject):
         Parameters
         ----------
         count
-            `None` or number of random samples (see below).
+            If `None`, a single dict `mu` of |parameter values| is returned.
+            Otherwise, the number of random samples to generate and return as
+            a list of |parameter values| dicts.
         random_state
             :class:`~numpy.random.RandomState` to use for sampling.
             If `None`, a new random state is generated using `seed`
@@ -491,19 +493,14 @@ class ParameterSpace(ParametricObject):
 
         Returns
         -------
-        If `count` is `None`, an inexhaustible iterator returning random
-        |parameter value| dicts.
-        Otherwise a list of `count` random |parameter value| dicts.
+        The sampled |parameter values|.
         """
         assert not random_state or seed is None
         random_state = get_random_state(random_state, seed)
         get_param = lambda: Mu(((k, random_state.uniform(self.ranges[k][0], self.ranges[k][1], size))
                                for k, size in self.parameters.items()))
         if count is None:
-            def param_generator():
-                while True:
-                    yield get_param()
-            return param_generator()
+            return get_param()
         else:
             return [get_param() for _ in range(count)]
 

--- a/src/pymortests/parameters.py
+++ b/src/pymortests/parameters.py
@@ -2,7 +2,7 @@
 # Copyright 2013-2020 pyMOR developers and contributors. All rights reserved.
 # License: BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
 
-from pymor.parameters.base import Parameters
+from pymor.parameters.base import Parameters, Mu
 from pymortests.base import runmodule
 
 import pytest
@@ -28,6 +28,11 @@ def test_randomly(space):
     assert len(values) == num_samples
     for value in values:
         assert space.contains(value)
+
+
+def test_randomly_without_count(space):
+    mu = space.sample_randomly()
+    assert isinstance(mu, Mu)
 
 
 def test_parse_parameter():


### PR DESCRIPTION
The current behavior of `ParameterSpace.sample_randomly` with `count=None` is to return an inexhaustible iterator. A feature, which was probably never used. This PR changes the behavior to return a single `Mu` instance instead. Thus, one can write:

```python
m.solve(parameter_space.sample_randomly())
```

instead of

```python
m.solve(parameter_space.sample_randomly(1)[0])
```

I think this new behavior is very useful for interactive use.