### PR TITLE
Small bug fix in models.interface

### DIFF
--- a/src/pymor/models/interface.py
+++ b/src/pymor/models/interface.py
@@ -104,7 +104,7 @@ class Model(CacheableObject, ParametricObject):
         must contain the key `'output'`.
         """
         if not getattr(self, 'output_functional', None):
-            return np.zeros(len(solution), 0)
+            return np.zeros((len(solution), 0))
         else:
             return self.output_functional.apply(solution, mu=mu).to_numpy()
 


### PR DESCRIPTION
While working on https://github.com/pymor/pymor/pull/1282#discussion_r622018563, I stumbled across this small bug, where `dtype` was set to `0` in `np.zeros`. This call happens in the case of a missing `output_functional` when `compute` is called with `output=True`.