### PR TITLE
Add methods to `models.iosys` for exporting matrices

### DIFF
--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -611,15 +611,16 @@ class LTIModel(InputStateOutputModel):
         files_basename
             The basename of files containing the operators.
         """
+        from pathlib import Path
         from pymor.tools.io import _mmwrite
         A, B, C, D, E = self.to_matrices()
-        _mmwrite(files_basename + '.A', A)
-        _mmwrite(files_basename + '.B', B)
-        _mmwrite(files_basename + '.C', C)
+        _mmwrite(Path(files_basename + '.A'), A)
+        _mmwrite(Path(files_basename + '.B'), B)
+        _mmwrite(Path(files_basename + '.C'), C)
         if D is not None:
-            _mmwrite(files_basename + '.D', D)
+            _mmwrite(Path(files_basename + '.D'), D)
         if E is not None:
-            _mmwrite(files_basename + '.E', E)
+            _mmwrite(Path(files_basename + '.E'), E)
 
     def __add__(self, other):
         """Add an |LTIModel|."""

--- a/src/pymor/tools/io.py
+++ b/src/pymor/tools/io.py
@@ -135,7 +135,7 @@ def _get_file_extension(path):
     if suffix_count and len(path.suffixes[-1]) == 4:
         extension = path.suffixes[-1].lower()
     elif path.suffixes[-1].lower() == '.gz' and suffix_count >= 2 and len(path.suffixes[-2]) == 4:
-        extension = '.'.join(path.suffixes[-2:]).lower()
+        extension = ''.join(path.suffixes[-2:]).lower()
     else:
         extension = ''
     return extension

--- a/src/pymor/tools/io.py
+++ b/src/pymor/tools/io.py
@@ -15,7 +15,7 @@ from scipy.sparse import issparse
 from pymor.core.logger import getLogger
 
 
-def _loadmat(path, key):
+def _loadmat(path, key=None):
     try:
         data = loadmat(path, mat_dtype=True)
     except Exception as e:
@@ -37,7 +37,7 @@ def _loadmat(path, key):
         return data[0]
 
 
-def _savemat(path, matrix, key):
+def _savemat(path, matrix, key=None):
     if key is None:
         raise IOError('"key" must be specified for MATLAB file')
     try:
@@ -46,7 +46,7 @@ def _savemat(path, matrix, key):
         raise IOError(e)
 
 
-def _mmread(path, key):
+def _mmread(path, key=None):
     if key:
         raise IOError('Cannot specify "key" for Matrix Market file')
     try:
@@ -58,7 +58,7 @@ def _mmread(path, key):
         raise IOError(e)
 
 
-def _mmwrite(path, matrix, key):
+def _mmwrite(path, matrix, key=None):
     if key:
         raise IOError('Cannot specify "key" for Matrix Market file')
     try:
@@ -69,7 +69,7 @@ def _mmwrite(path, matrix, key):
         raise IOError(e)
 
 
-def _load(path, key):
+def _load(path, key=None):
     try:
         data = np.load(path)
     except Exception as e:
@@ -93,7 +93,7 @@ def _load(path, key):
     return matrix
 
 
-def _save(path, matrix, key):
+def _save(path, matrix, key=None):
     if key:
         raise IOError('Cannot specify "key" for NPY file')
     try:
@@ -102,7 +102,7 @@ def _save(path, matrix, key):
         raise IOError(e)
 
 
-def _savez(path, matrix, key):
+def _savez(path, matrix, key=None):
     try:
         if key is None:
             np.savez(path, matrix)
@@ -112,7 +112,7 @@ def _savez(path, matrix, key):
         raise IOError(e)
 
 
-def _loadtxt(path, key):
+def _loadtxt(path, key=None):
     if key:
         raise IOError('Cannot specify "key" for TXT file')
     try:
@@ -121,7 +121,7 @@ def _loadtxt(path, key):
         raise IOError(e)
 
 
-def _savetxt(path, matrix, key):
+def _savetxt(path, matrix, key=None):
     if key:
         raise IOError('Cannot specify "key" for TXT file')
     try:
@@ -141,7 +141,7 @@ def _get_file_extension(path):
     return extension
 
 
-def load_matrix(path, key):
+def load_matrix(path, key=None):
     """Load matrix from file.
 
     Parameters
@@ -194,7 +194,7 @@ def load_matrix(path, key):
     raise IOError(f'Could not load file {path} (key = {key})')
 
 
-def save_matrix(path, matrix, key):
+def save_matrix(path, matrix, key=None):
     """Save matrix to file.
 
     Parameters

--- a/src/pymor/tools/io.py
+++ b/src/pymor/tools/io.py
@@ -7,19 +7,15 @@ import shutil
 import tempfile
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Optional, Union
 
 import numpy as np
-from numpy.typing import ArrayLike
 from scipy.io import loadmat, mmread, mmwrite, savemat
-from scipy.sparse import issparse, spmatrix
+from scipy.sparse import issparse
 
 from pymor.core.logger import getLogger
 
-MatrixType = Union[ArrayLike, spmatrix]
 
-
-def _loadmat(path: Path, key: Optional[str] = None) -> MatrixType:
+def _loadmat(path, key):
     try:
         data = loadmat(path, mat_dtype=True)
     except Exception as e:
@@ -41,7 +37,7 @@ def _loadmat(path: Path, key: Optional[str] = None) -> MatrixType:
         return data[0]
 
 
-def _savemat(path: Path, matrix: MatrixType, key: Optional[str] = None) -> None:
+def _savemat(path, matrix, key):
     if key is None:
         raise IOError('"key" must be specified for MATLAB file')
     try:
@@ -50,7 +46,7 @@ def _savemat(path: Path, matrix: MatrixType, key: Optional[str] = None) -> None:
         raise IOError(e)
 
 
-def _mmread(path: Path, key: Optional[str] = None) -> MatrixType:
+def _mmread(path, key):
     if key:
         raise IOError('Cannot specify "key" for Matrix Market file')
     try:
@@ -62,7 +58,7 @@ def _mmread(path: Path, key: Optional[str] = None) -> MatrixType:
         raise IOError(e)
 
 
-def _mmwrite(path: Path, matrix: MatrixType, key: Optional[str] = None) -> None:
+def _mmwrite(path, matrix, key):
     if key:
         raise IOError('Cannot specify "key" for Matrix Market file')
     try:
@@ -73,7 +69,7 @@ def _mmwrite(path: Path, matrix: MatrixType, key: Optional[str] = None) -> None:
         raise IOError(e)
 
 
-def _load(path: Path, key: Optional[str] = None) -> MatrixType:
+def _load(path, key):
     try:
         data = np.load(path)
     except Exception as e:
@@ -97,7 +93,7 @@ def _load(path: Path, key: Optional[str] = None) -> MatrixType:
     return matrix
 
 
-def _save(path: Path, matrix: MatrixType, key: Optional[str] = None) -> None:
+def _save(path, matrix, key):
     if key:
         raise IOError('Cannot specify "key" for NPY file')
     try:
@@ -106,7 +102,7 @@ def _save(path: Path, matrix: MatrixType, key: Optional[str] = None) -> None:
         raise IOError(e)
 
 
-def _savez(path: Path, matrix: MatrixType, key: Optional[str] = None) -> None:
+def _savez(path, matrix, key):
     try:
         if key is None:
             np.savez(path, matrix)
@@ -116,7 +112,7 @@ def _savez(path: Path, matrix: MatrixType, key: Optional[str] = None) -> None:
         raise IOError(e)
 
 
-def _loadtxt(path: Path, key: Optional[str] = None) -> MatrixType:
+def _loadtxt(path, key):
     if key:
         raise IOError('Cannot specify "key" for TXT file')
     try:
@@ -125,7 +121,7 @@ def _loadtxt(path: Path, key: Optional[str] = None) -> MatrixType:
         raise IOError(e)
 
 
-def _savetxt(path: Path, matrix: MatrixType, key: Optional[str] = None) -> None:
+def _savetxt(path, matrix, key):
     if key:
         raise IOError('Cannot specify "key" for TXT file')
     try:
@@ -134,7 +130,7 @@ def _savetxt(path: Path, matrix: MatrixType, key: Optional[str] = None) -> None:
         raise IOError(e)
 
 
-def _get_file_extension(path: Path) -> str:
+def _get_file_extension(path):
     suffix_count = len(path.suffixes)
     if suffix_count and len(path.suffixes[-1]) == 4:
         extension = path.suffixes[-1].lower()
@@ -145,13 +141,13 @@ def _get_file_extension(path: Path) -> str:
     return extension
 
 
-def load_matrix(path: Union[str, Path], key: Optional[str] = None) -> Union[ArrayLike, spmatrix]:
+def load_matrix(path, key):
     """Load matrix from file.
 
     Parameters
     ----------
     path
-        Path to the file.
+        Path to the file (`str` or `pathlib.Path`).
     key
         Key of the matrix (only for NPY, NPZ, and MATLAB files).
 
@@ -198,13 +194,13 @@ def load_matrix(path: Union[str, Path], key: Optional[str] = None) -> Union[Arra
     raise IOError(f'Could not load file {path} (key = {key})')
 
 
-def save_matrix(path: Union[str, Path], matrix: Union[ArrayLike, spmatrix], key: Optional[str] = None) -> None:
+def save_matrix(path, matrix, key):
     """Save matrix to file.
 
     Parameters
     ----------
     path
-        Path to the file.
+        Path to the file (`str` or `pathlib.Path`).
     matrix
         Matrix to save.
     key

--- a/src/pymor/tools/io.py
+++ b/src/pymor/tools/io.py
@@ -62,7 +62,12 @@ def _mmwrite(path, matrix, key=None):
     if key:
         raise IOError('Cannot specify "key" for Matrix Market file')
     try:
-        with open(path, 'wb') as f:
+        if path.suffix != '.gz':
+            open_file = open
+        else:
+            import gzip
+            open_file = gzip.open
+        with open_file(path, 'wb') as f:
             # when mmwrite is given a string, it will append '.mtx'
             mmwrite(f, matrix)
     except Exception as e:

--- a/src/pymortests/iosys_save_load.py
+++ b/src/pymortests/iosys_save_load.py
@@ -1,0 +1,99 @@
+# This file is part of the pyMOR project (https://www.pymor.org).
+# Copyright 2013-2021 pyMOR developers and contributors. All rights reserved.
+# License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
+
+import os
+import tempfile
+
+import numpy as np
+import pytest
+import scipy.sparse as sps
+
+from pymor.models.iosys import LTIModel, SecondOrderModel
+
+
+def _build_matrices_lti(with_D, with_E):
+    A = sps.csc_matrix([[1, 2], [3, 4]])
+    B = np.array([[1], [2]])
+    C = np.array([[1, 2]])
+    D = np.array([[1]]) if with_D else None
+    E = np.array([[5, 6], [7, 8]]) if with_E else None
+    return A, B, C, D, E
+
+
+def _test_matrices_lti(A, B, C, D, E,
+                       A2, B2, C2, D2, E2,
+                       with_D, with_E):
+    assert np.allclose(A.toarray(), A2.toarray())
+    assert np.allclose(B, B2)
+    assert np.allclose(C, C2)
+    if with_D:
+        assert np.allclose(D, D2)
+    else:
+        assert D2 is None
+    if with_E:
+        assert np.allclose(E, E2)
+    else:
+        assert E2 is None
+
+
+@pytest.mark.parametrize('with_D', [False, True])
+@pytest.mark.parametrize('with_E', [False, True])
+def test_matrices_lti(with_D, with_E):
+    matrices = _build_matrices_lti(with_D, with_E)
+
+    lti = LTIModel.from_matrices(*matrices)
+    matrices2 = lti.to_matrices()
+
+    _test_matrices_lti(*matrices, *matrices2, with_D, with_E)
+
+
+@pytest.mark.parametrize('with_D', [False, True])
+@pytest.mark.parametrize('with_E', [False, True])
+def test_files_lti(with_D, with_E):
+    matrices = _build_matrices_lti(with_D, with_E)
+
+    lti = LTIModel.from_matrices(*matrices)
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        files = (
+            os.path.join(tmpdirname, 'A.mtx'),
+            os.path.join(tmpdirname, 'B.mtx'),
+            os.path.join(tmpdirname, 'C.mtx'),
+            os.path.join(tmpdirname, 'D.mtx') if with_D else None,
+            os.path.join(tmpdirname, 'E.mtx') if with_E else None,
+        )
+        lti.to_files(*files)
+        lti2 = LTIModel.from_files(*files)
+    matrices2 = lti2.to_matrices()
+
+    _test_matrices_lti(*matrices, *matrices2, with_D, with_E)
+
+
+@pytest.mark.parametrize('with_D', [False, True])
+@pytest.mark.parametrize('with_E', [False, True])
+def test_mat_file_lti(with_D, with_E):
+    matrices = _build_matrices_lti(with_D, with_E)
+
+    lti = LTIModel.from_matrices(*matrices)
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        file_name = os.path.join(tmpdirname, 'lti')
+        lti.to_mat_file(file_name)
+        lti2 = LTIModel.from_mat_file(file_name)
+    matrices2 = lti2.to_matrices()
+
+    _test_matrices_lti(*matrices, *matrices2, with_D, with_E)
+
+
+@pytest.mark.parametrize('with_D', [False, True])
+@pytest.mark.parametrize('with_E', [False, True])
+def test_abcde_files(with_D, with_E):
+    matrices = _build_matrices_lti(with_D, with_E)
+
+    lti = LTIModel.from_matrices(*matrices)
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        files_basename = os.path.join(tmpdirname, 'lti')
+        lti.to_abcde_files(files_basename)
+        lti2 = LTIModel.from_abcde_files(files_basename)
+    matrices2 = lti2.to_matrices()
+
+    _test_matrices_lti(*matrices, *matrices2, with_D, with_E)

--- a/src/pymortests/tools.py
+++ b/src/pymortests/tools.py
@@ -198,6 +198,25 @@ def test_load_matrix(loadable_matrices):
             load_matrix(m)
 
 
+@pytest.mark.parametrize('ext', ['.mat', '.mtx', '.mtz.gz', '.npy', '.npz', '.txt'])
+def test_save_load_matrix(ext):
+    import filecmp
+    from pymor.tools.io import load_matrix, save_matrix
+    A = np.eye(2)
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        path = os.path.join(tmpdirname, 'matrix' + ext)
+        key = None
+        if ext == '.mat':
+            key = 'A'
+        save_matrix(path, A, key)
+        B = load_matrix(path, key)
+        assert np.all(A == B)
+        path2 = os.path.join(tmpdirname, 'matrix2' + ext)
+        save_matrix(path2, A, key)
+        if ext != '.mtz.gz':
+            assert filecmp.cmp(path, path2)
+
+
 def test_cwd_ctx_manager():
     original_cwd = os.getcwd()
     target = tempfile.gettempdir()

--- a/src/pymortests/tools.py
+++ b/src/pymortests/tools.py
@@ -2,25 +2,26 @@
 # Copyright 2013-2021 pyMOR developers and contributors. All rights reserved.
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
-from math import sin, pi, exp, factorial
-import numpy as np
-import os
-import pytest
 import itertools
+import os
 import tempfile
+from math import exp, factorial, pi, sin
+
+import numpy as np
+import pytest
 from hypothesis import given
 
 from pymor.core.logger import getLogger
-from pymor.tools.formatsrc import print_source
-from pymor.tools.io import SafeTemporaryFileName, change_to_directory
-from pymortests.base import runmodule
-from pymortests.fixtures.grid import hy_rect_or_tria_grid
 from pymor.discretizers.builtin.grids.vtkio import write_vtk
 from pymor.discretizers.builtin.quadratures import GaussQuadratures
+from pymor.tools import formatsrc, timing
 from pymor.tools.deprecated import Deprecated
-from pymor.tools.floatcmp import float_cmp, float_cmp_all, almost_less
+from pymor.tools.floatcmp import almost_less, float_cmp, float_cmp_all
+from pymor.tools.formatsrc import print_source
+from pymor.tools.io import SafeTemporaryFileName, change_to_directory
 from pymor.vectorarrays.numpy import NumpyVectorSpace
-from pymor.tools import timing, formatsrc
+from pymortests.base import runmodule
+from pymortests.fixtures.grid import hy_rect_or_tria_grid
 
 logger = getLogger('pymortests.tools')
 


### PR DESCRIPTION
This PR adds `to_*` methods to `LTIModel` and `SecondOrderModel`, tests for `from_*` and `to_*` methods, and output methods to `tools.io`. The tests should cover most of what is not covered by #1300 in `models.iosys`. I'm not sure how the CI will react to creating temporary files; I guess we'll see.