### PR TITLE
Add `FenicsMatrixOperator._real_apply_inverse_adjoint_one_vector`

### DIFF
--- a/src/pymor/bindings/fenics.py
+++ b/src/pymor/bindings/fenics.py
@@ -194,6 +194,21 @@ if config.HAVE_FENICS:
             _apply_inverse(self.matrix, r.impl, v.impl, options)
             return r
 
+        def _real_apply_inverse_adjoint_one_vector(self, u, mu=None, initial_guess=None,
+                                                   least_squares=False, prepare_data=None):
+            if least_squares:
+                raise NotImplementedError
+            r = (self.range.real_zero_vector() if initial_guess is None else
+                 initial_guess.copy(deep=True))
+            options = self.solver_options.get('inverse') if self.solver_options else None
+            if not hasattr(self, '_matrix_transpose'):
+                self._matrix_transpose = self.matrix.copy()
+                mat = df.as_backend_type(self.matrix).mat()
+                mat_tr = df.as_backend_type(self._matrix_transpose).mat()
+                mat.transpose(mat_tr)
+            _apply_inverse(self._matrix_transpose, r.impl, u.impl, options)
+            return r
+
         def _assemble_lincomb(self, operators, coefficients, identity_shift=0., solver_options=None, name=None):
             if not all(isinstance(op, FenicsMatrixOperator) for op in operators):
                 return None

--- a/src/pymor/bindings/fenics.py
+++ b/src/pymor/bindings/fenics.py
@@ -200,7 +200,7 @@ if config.HAVE_FENICS:
                 raise NotImplementedError
             r = (self.range.real_zero_vector() if initial_guess is None else
                  initial_guess.copy(deep=True))
-            options = self.solver_options.get('inverse') if self.solver_options else None
+            options = self.solver_options.get('inverse_adjoint') if self.solver_options else None
             if not hasattr(self, '_matrix_transpose'):
                 self._matrix_transpose = self.matrix.copy()
                 mat = df.as_backend_type(self.matrix).mat()

--- a/src/pymor/bindings/fenics.py
+++ b/src/pymor/bindings/fenics.py
@@ -201,13 +201,20 @@ if config.HAVE_FENICS:
             r = (self.range.real_zero_vector() if initial_guess is None else
                  initial_guess.copy(deep=True))
             options = self.solver_options.get('inverse_adjoint') if self.solver_options else None
-            if not hasattr(self, '_matrix_transpose'):
-                self._matrix_transpose = self.matrix.copy()
-                mat = df.as_backend_type(self.matrix).mat()
-                mat_tr = df.as_backend_type(self._matrix_transpose).mat()
-                mat.transpose(mat_tr)
-            _apply_inverse(self._matrix_transpose, r.impl, u.impl, options)
-            return r
+            try:
+                # since dolfin does not have "apply_inverse_adjoint", we try transposing the matrix
+                if not hasattr(self, '_matrix_transpose'):
+                    self._matrix_transpose = self.matrix.copy()
+                    mat = df.as_backend_type(self.matrix).mat()
+                    mat_tr = df.as_backend_type(self._matrix_transpose).mat()
+                    mat.transpose(mat_tr)
+                _apply_inverse(self._matrix_transpose, r.impl, u.impl, options)
+                return r
+            except Exception as e:
+                self.logger.info(f'Was not able to transpose the FEniCS matrix ({e}).')
+                super()._real_apply_inverse_adjoint_one_vector(u, mu=mu, initial_guess=initial_guess,
+                                                               least_squares=least_squares,
+                                                               prepare_data=prepare_data)
 
         def _assemble_lincomb(self, operators, coefficients, identity_shift=0., solver_options=None, name=None):
             if not all(isinstance(op, FenicsMatrixOperator) for op in operators):

--- a/src/pymortests/fixtures/operator.py
+++ b/src/pymortests/fixtures/operator.py
@@ -489,6 +489,24 @@ unpicklable_misc_operator_with_arrays_and_products_generators = \
 
 
 if config.HAVE_FENICS:
+    def fenics_matrix_operator_factory():
+        import dolfin as df
+        from pymor.bindings.fenics import FenicsMatrixOperator
+
+        mesh = df.UnitSquareMesh(10, 10)
+        V = df.FunctionSpace(mesh, "CG", 2)
+
+        u = df.TrialFunction(V)
+        v = df.TestFunction(V)
+        c = df.Constant([1, 1])
+
+        op = FenicsMatrixOperator(
+            df.assemble(u * v * df.dx + df.inner(c, df.grad(u)) * v * df.dx),
+            V, V)
+
+        prod = FenicsMatrixOperator(df.assemble(u*v*df.dx), V, V)
+        return op, None, op.source.random(), op.range.random(), prod, prod
+
     def fenics_nonlinear_operator_factory():
         import dolfin as df
         from pymor.bindings.fenics import FenicsVectorSpace, FenicsOperator, FenicsMatrixOperator
@@ -520,11 +538,15 @@ if config.HAVE_FENICS:
         prod = FenicsMatrixOperator(df.assemble(u*v*df.dx), V, V)
         return op, op.parameters.parse(42), op.source.random(), op.range.random(), prod, prod
 
-    fenics_with_arrays_and_products_generators = [lambda: fenics_nonlinear_operator_factory()]
-    fenics_with_arrays_generators = [lambda: fenics_nonlinear_operator_factory()[:4]]
-
+    fenics_with_arrays_and_products_generators = [
+        lambda: fenics_matrix_operator_factory(),
+        lambda: fenics_nonlinear_operator_factory(),
+    ]
+    fenics_with_arrays_generators = [
+        lambda: fenics_matrix_operator_factory()[:4],
+        lambda: fenics_nonlinear_operator_factory()[:4],
+    ]
 else:
-
     fenics_with_arrays_and_products_generators = []
     fenics_with_arrays_generators = []
 

--- a/src/pymortests/operators.py
+++ b/src/pymortests/operators.py
@@ -348,7 +348,7 @@ def test_restricted(operator_with_arrays):
             return
         op_U = rop.range.make_array(op.apply(U, mu=mu).dofs(dofs))
         rop_U = rop.apply(rop.source.make_array(U.dofs(source_dofs)), mu=mu)
-        assert_all_almost_equal(op_U, rop_U)
+        assert_all_almost_equal(op_U, rop_U, rtol=1e-13)
 
 
 def test_restricted_jacobian(operator_with_arrays):
@@ -369,7 +369,7 @@ def test_restricted_jacobian(operator_with_arrays):
         rop_U = rop.jacobian(r_apply_to, mu=mu).apply(r_apply_to)
         assert len(rop_U) == len(op_U)
         assert len(r_apply_to) == len(apply_to)
-        assert_all_almost_equal(op_U, rop_U)
+        assert_all_almost_equal(op_U, rop_U, rtol=1e-13)
 
 
 def test_InverseOperator(operator_with_arrays):


### PR DESCRIPTION
This PR makes `FenicsMatrixOperator.apply_inverse_adjoint` not use pyMOR's `lgmres` by working with the underlying `PETScMatrix`.