### PR TITLE
Various Improvements to the HAPOD algorithm

### DIFF
--- a/src/pymor/algorithms/hapod.py
+++ b/src/pymor/algorithms/hapod.py
@@ -188,7 +188,7 @@ def hapod(tree, snapshots, local_eps, product=None, pod_method=default_pod_metho
     return result
 
 
-def inc_hapod(steps, snapshots, eps, omega, product=None, executor=None, eval_snapshots_in_executor=False):
+def inc_hapod(steps, snapshots, eps, omega, product=None):
     """Incremental Hierarchical Approximate POD.
 
     This computes the incremental HAPOD from :cite:`HLR18`.
@@ -208,11 +208,6 @@ def inc_hapod(steps, snapshots, eps, omega, product=None, executor=None, eval_sn
         approximation quality.
     product
         Inner product |Operator| w.r.t. which to compute the POD.
-    executor
-        If not `None`, a :class:`concurrent.futures.Executor` object to use
-        for parallelization.
-    eval_snapshots_in_executor
-        If `True` also parallelize the evaluation of the snapshot map.
 
     Returns
     -------
@@ -237,9 +232,7 @@ def inc_hapod(steps, snapshots, eps, omega, product=None, executor=None, eval_sn
     result = hapod(tree,
                    get_snapshots,
                    std_local_eps(tree, eps, omega, False),
-                   product=product,
-                   executor=executor,
-                   eval_snapshots_in_executor=eval_snapshots_in_executor)
+                   product=product)
     assert last_step == steps - 1
     return result
 
@@ -286,7 +279,7 @@ def dist_hapod(num_slices, snapshots, eps, omega, product=None, executor=None, e
                  eval_snapshots_in_executor=eval_snapshots_in_executor)
 
 
-def inc_vectorarray_hapod(steps, U, eps, omega, product=None, executor=None):
+def inc_vectorarray_hapod(steps, U, eps, omega, product=None):
     """Incremental Hierarchical Approximate POD.
 
     This computes the incremental HAPOD from :cite:`HLR18` for a given |VectorArray|.
@@ -304,9 +297,6 @@ def inc_vectorarray_hapod(steps, U, eps, omega, product=None, executor=None):
         approximation quality.
     product
         Inner product |Operator| w.r.t. which to compute the POD.
-    executor
-        If not `None`, a :class:`concurrent.futures.Executor` object to use
-        for parallelization.
 
     Returns
     -------
@@ -325,7 +315,7 @@ def inc_vectorarray_hapod(steps, U, eps, omega, product=None, executor=None):
             yield U[slice: slice+chunk_size]
 
     return inc_hapod(len(slices), snapshots(),
-                     eps, omega, product=product, executor=executor)
+                     eps, omega, product=product)
 
 
 def dist_vectorarray_hapod(num_slices, U, eps, omega, product=None, executor=None):

--- a/src/pymor/algorithms/hapod.py
+++ b/src/pymor/algorithms/hapod.py
@@ -196,10 +196,11 @@ def inc_hapod(steps, snapshots, eps, omega, product=None, executor=None, eval_sn
     Parameters
     ----------
     steps
-        The number of incremental POD updates.
+        The number of incremental POD updates. Has to agree with the lenght
+        of `snapshots`.
     snapshots
-        A mapping `snapshots(step)` returning for each incremental POD
-        step the associated snapshot vectors.
+        An iterable returning for each incremental POD step the associated
+        snapshot vectors.
     eps
         Desired l2-mean approximation error.
     omega
@@ -223,12 +224,24 @@ def inc_hapod(steps, snapshots, eps, omega, product=None, executor=None, eval_sn
         The total number of input snapshot vectors.
     """
     tree = IncHAPODTree(steps)
-    return hapod(tree,
-                 lambda node: snapshots(-node - 1),
-                 std_local_eps(tree, eps, omega, False),
-                 product=product,
-                 executor=executor,
-                 eval_snapshots_in_executor=eval_snapshots_in_executor)
+    last_step = -1
+    snapshots = iter(snapshots)
+
+    def get_snapshots(node):
+        nonlocal last_step
+        step = -node - 1
+        assert step == last_step + 1
+        last_step += 1
+        return next(snapshots)
+
+    result = hapod(tree,
+                   get_snapshots,
+                   std_local_eps(tree, eps, omega, False),
+                   product=product,
+                   executor=executor,
+                   eval_snapshots_in_executor=eval_snapshots_in_executor)
+    assert last_step == steps - 1
+    return result
 
 
 def dist_hapod(num_slices, snapshots, eps, omega, product=None, executor=None, eval_snapshots_in_executor=False):
@@ -294,8 +307,6 @@ def inc_vectorarray_hapod(steps, U, eps, omega, product=None, executor=None):
     executor
         If not `None`, a :class:`concurrent.futures.Executor` object to use
         for parallelization.
-    eval_snapshots_in_executor
-        If `True` also parallelize the evaluation of the snapshot map.
 
     Returns
     -------
@@ -308,8 +319,12 @@ def inc_vectorarray_hapod(steps, U, eps, omega, product=None, executor=None):
     """
     chunk_size = ceil(len(U) / steps)
     slices = range(0, len(U), chunk_size)
-    return inc_hapod(len(slices),
-                     lambda i: U[slices[i]: slices[i]+chunk_size],
+
+    def snapshots():
+        for slice in slices:
+            yield U[slice: slice+chunk_size]
+
+    return inc_hapod(len(slices), snapshots(),
                      eps, omega, product=product, executor=executor)
 
 


### PR DESCRIPTION
- `hapod` launches now its own asyncio event loop in order to avoid conflicts with already running event loops (e.g. when running form juypter).
- Non-leaf child nodes are always processed before leaf nodes, in order to ensure the right execution order for incremental POD computations.
- `inc_hapod` now accepts arbitrary iterables for the snapshot data.

In particular, now the following code works:

```python
from pymor.analyticalproblems.thermalblock import thermal_block_problem
from pymor.discretizers.builtin.fv import discretize_stationary_fv

fom, _ = discretize_stationary_fv(thermal_block_problem())

def snapshot_generator():
    for mu in fom.parameters.space((0.1, 1)).sample_randomly(10):
        yield fom.solve(mu=mu)

from pymor.algorithms.hapod import inc_hapod

inc_hapod(10, snapshot_generator(), 1e-4, 0.9)
```

Fixes #1310.