### PR TITLE
Workaround for MPI hangs in CI

### DIFF
--- a/.ci/gitlab/ci.yml
+++ b/.ci/gitlab/ci.yml
@@ -184,6 +184,9 @@ mpi 3 7:
     - when: on_success
     variables:
         COVERAGE_FILE: coverage_mpi__3.7
+    retry:
+        max: 2
+        when: always
     services:
     image: zivgitlab.wwu.io/pymor/docker/pymor/testing_py3.7:54d3d2850cb70905dcf5a212edcc511728096742
     script:
@@ -204,6 +207,9 @@ mpi 3 8:
     - when: on_success
     variables:
         COVERAGE_FILE: coverage_mpi__3.8
+    retry:
+        max: 2
+        when: always
     services:
     image: zivgitlab.wwu.io/pymor/docker/pymor/testing_py3.8:54d3d2850cb70905dcf5a212edcc511728096742
     script:
@@ -224,6 +230,9 @@ mpi 3 9:
     - when: on_success
     variables:
         COVERAGE_FILE: coverage_mpi__3.9
+    retry:
+        max: 2
+        when: always
     services:
     image: zivgitlab.wwu.io/pymor/docker/pymor/testing_py3.9:54d3d2850cb70905dcf5a212edcc511728096742
     script:

--- a/.ci/gitlab/template.ci.py
+++ b/.ci/gitlab/template.ci.py
@@ -191,6 +191,11 @@ ci setup:
     {{ never_on_schedule_rule() }}
     variables:
         COVERAGE_FILE: coverage_{{script}}__{{py}}
+    {%- if script == "mpi" %}
+    retry:
+        max: 2
+        when: always
+    {%- endif %}
     services:
     {%- if script == "oldest" %}
         - name: {{registry}}/pymor/pypi-mirror_oldest_py{{py}}:{{pypi_mirror_tag}}

--- a/.ci/gitlab/test_mpi.bash
+++ b/.ci/gitlab/test_mpi.bash
@@ -7,7 +7,7 @@ source ${THIS_DIR}/common_test_setup.bash
 # cannot seem to directly affect, we save the intermediate
 # pytest exit code in a file and check that afterwards
 # while ignoring the mpirun result itself
-xvfb-run -a mpirun --mca btl self,vader -n 2 coverage run --rcfile=setup.cfg \
+xvfb-run -a mpirun --timeout 1200 --mca btl self,vader -n 2 coverage run --rcfile=setup.cfg \
   --parallel-mode src/pymortests/mpi_run_demo_tests.py || true
 [[ "$(cat pytest.mpirun.success)" == "True" ]] || exit 127
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,6 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
+exclude: .ci/gitlab/ci.yml
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.2.0


### PR DESCRIPTION
Since I was unable to find the actual
cause for the MPI processes to sometimes hang on gitlab
those jobs are now restarted automatically.
For the next person to look into this:
 - if a hang happens, it will happen never happen in the first demo to use mpi
 - Doesn't matter if it's auto-mpi pools for algorithms or MPI-wrapped models
 - Doesn't matter if in-memory or tcp transport is used
 - Output verbosity, probably due to changing timing of calls between processes,
   seems to affect frequency of hangs
 - Restarting the event loop, and clearing remote objects between demos, produced
   crashes, but might be worth looking into again
 - making mpirun produce stack traces on job timeout fails with input/output 
   errors in pstack (after symlinking pstack to gstack)


