### PR TITLE
Various Improvements to the HAPOD algorithm (v2)

### DIFF
--- a/src/pymor/algorithms/hapod.py
+++ b/src/pymor/algorithms/hapod.py
@@ -27,7 +27,10 @@ class Node:
 
     @property
     def depth(self):
-        return 1 + max(c.depth for c in self.children) if self.children else 1
+        max_level = 0
+        for _, level in self.traverse(True):
+            max_level = max(max_level, level)
+        return max_level + 1
 
     @property
     def is_leaf(self):
@@ -36,6 +39,56 @@ class Node:
     @property
     def is_root(self):
         return not self.parent
+
+    def traverse(self, return_level=False):
+        current_node = self
+        last_child = None
+        level = 0
+        while True:
+            if last_child is None:
+                if return_level:
+                    yield current_node, level
+                else:
+                    yield current_node
+            if current_node.children:
+                if last_child is None:
+                    current_node = current_node.children[0]
+                    level += 1
+                    continue
+                else:
+                    last_child_pos = current_node.children.index(last_child)
+                    if last_child_pos + 1 < len(current_node.children):
+                        current_node = current_node.children[last_child_pos+1]
+                        last_child = None
+                        level += 1
+                        continue
+            if not current_node.parent:
+                return
+            last_child = current_node
+            current_node = current_node.parent
+            level -= 1
+
+    def __str__(self):
+        lines = []
+        for node, level in self.traverse(True):
+            line = ''
+            if node.parent:
+                p = node.parent
+                while p.parent:
+                    if p.parent.children.index(p) + 1 == len(p.parent.children):
+                        line = '  ' + line
+                    else:
+                        line = '| ' + line
+                    p = p.parent
+                line += '+-o'
+            else:
+                line += 'o'
+            if node.tag is not None:
+                line += f' {node.tag}'
+            if node.after:
+                line += f' (after {",".join(str(a) for a in node.after)})'
+            lines.append(line)
+        return '\n'.join(lines)
 
 
 def inc_hapod_tree(steps):

--- a/src/pymor/algorithms/hapod.py
+++ b/src/pymor/algorithms/hapod.py
@@ -172,7 +172,7 @@ def hapod(tree, snapshots, local_eps, product=None, pod_method=default_pod_metho
     return result
 
 
-def inc_hapod(steps, snapshots, eps, omega, product=None, executor=None, eval_snapshots_in_executor=False):
+def inc_hapod(steps, snapshots, eps, omega, product=None, executor=None):
     """Incremental Hierarchical Approximate POD.
 
     This computes the incremental HAPOD from :cite:`HLR18`.
@@ -194,9 +194,7 @@ def inc_hapod(steps, snapshots, eps, omega, product=None, executor=None, eval_sn
         Inner product |Operator| w.r.t. which to compute the POD.
     executor
         If not `None`, a :class:`concurrent.futures.Executor` object to use
-        for parallelization.
-    eval_snapshots_in_executor
-        If `True` also parallelize the evaluation of the snapshot map.
+        to compute new snapshot vectors and POD updates in parallel.
 
     Returns
     -------
@@ -223,7 +221,7 @@ def inc_hapod(steps, snapshots, eps, omega, product=None, executor=None, eval_sn
                    std_local_eps(tree, eps, omega, False),
                    product=product,
                    executor=executor,
-                   eval_snapshots_in_executor=eval_snapshots_in_executor)
+                   eval_snapshots_in_executor=True)
     assert last_step == steps - 1
     return result
 
@@ -270,7 +268,7 @@ def dist_hapod(num_slices, snapshots, eps, omega, product=None, executor=None, e
                  eval_snapshots_in_executor=eval_snapshots_in_executor)
 
 
-def inc_vectorarray_hapod(steps, U, eps, omega, product=None, executor=None):
+def inc_vectorarray_hapod(steps, U, eps, omega, product=None):
     """Incremental Hierarchical Approximate POD.
 
     This computes the incremental HAPOD from :cite:`HLR18` for a given |VectorArray|.
@@ -288,9 +286,6 @@ def inc_vectorarray_hapod(steps, U, eps, omega, product=None, executor=None):
         approximation quality.
     product
         Inner product |Operator| w.r.t. which to compute the POD.
-    executor
-        If not `None`, a :class:`concurrent.futures.Executor` object to use
-        for parallelization.
 
     Returns
     -------
@@ -309,7 +304,7 @@ def inc_vectorarray_hapod(steps, U, eps, omega, product=None, executor=None):
             yield U[slice: slice+chunk_size]
 
     return inc_hapod(len(slices), snapshots(),
-                     eps, omega, product=product, executor=executor)
+                     eps, omega, product=product)
 
 
 def dist_vectorarray_hapod(num_slices, U, eps, omega, product=None, executor=None):

--- a/src/pymor/algorithms/hapod.py
+++ b/src/pymor/algorithms/hapod.py
@@ -93,8 +93,8 @@ class Node:
 def inc_hapod_tree(steps):
     tree = node = Node()
     for step in range(steps)[::-1]:
-        # add leaf node for a new snapshot and set local_eps to 0 to prevent computing a POD
-        node.add_child(step, after=(step-1,) if step > 0 else None)
+        # add leaf node for a new snapshot
+        node.add_child(tag=step, after=(step-1,) if step > 0 else None)
         if step > 0:
             # add node for the previous POD step
             node = node.add_child()

--- a/src/pymordemos/hapod.py
+++ b/src/pymordemos/hapod.py
@@ -21,6 +21,7 @@ def main(
     dist: int = Argument(..., help='Number of slices for distributed HAPOD.'),
     inc: int = Argument(..., help='Number of steps for incremental HAPOD.'),
 
+    arity: int = Option(None, help='Arity of distributed HAPOD tree'),
     grid: int = Option(60, help='Use grid with (2*NI)*NI elements.'),
     nt: int = Option(100, help='Number of time steps.'),
     omega: float = Option(0.9, help='Parameter omega from HAPOD algorithm.'),
@@ -47,7 +48,7 @@ def main(
     pod_time = time.perf_counter() - tic
 
     tic = time.perf_counter()
-    dist_modes = dist_vectorarray_hapod(dist, U, tol, omega, product=m.l2_product, executor=executor)[0]
+    dist_modes = dist_vectorarray_hapod(dist, U, tol, omega, arity=arity, product=m.l2_product, executor=executor)[0]
     dist_time = time.perf_counter() - tic
 
     tic = time.perf_counter()

--- a/src/pymortests/demos.py
+++ b/src/pymortests/demos.py
@@ -116,7 +116,7 @@ SYS_MOR_ARGS = (
 HAPOD_ARGS = (
     ('hapod', ['--snap=3', 1e-2, 10, 100]),
     ('hapod', ['--snap=3', '--threads=2', 1e-2, 10, 100]),
-    ('hapod', ['--snap=3', '--procs=2', 1e-2, 10, 100]),
+    ('hapod', ['--snap=3', '--procs=2', '--arity=2', 1e-2, 10, 100]),
 )
 
 FENICS_NONLINEAR_ARGS = (


### PR DESCRIPTION
- `hapod` launches now its own asyncio event loop in order to avoid conflicts with already running event loops (e.g. when running form juypter).
- It is now possible to explicitly specify that a node has to be processed after certain other nodes. In particular, this can be used to ensure the right execution order for incremental POD computations.
- HAPOD trees are now created dynamically, which should significantly simplify specifying own tree topologies.
- `dist_hapod` now has an `arity` argument, which allows to control the number of intermediate POD levels.
- `inc_hapod` now accepts arbitrary iterables for the snapshot data.

In particular, now the following code works:

```python
from pymor.analyticalproblems.thermalblock import thermal_block_problem
from pymor.discretizers.builtin.fv import discretize_stationary_fv

fom, _ = discretize_stationary_fv(thermal_block_problem())

def snapshot_generator():
    for mu in fom.parameters.space((0.1, 1)).sample_randomly(10):
        yield fom.solve(mu=mu)

from pymor.algorithms.hapod import inc_hapod

inc_hapod(10, snapshot_generator(), 1e-4, 0.9)
```

Fixes #1310.

This supersedes #1319 where an explicit rule on the execution order is specified. However, that approach is less flexible and does not allow to compute incremental POD updates an new snapshot vectors in parallel as this approach does.