### PR TITLE
Fix almost_less for negative numbers

### DIFF
--- a/src/pymor/tools/floatcmp.py
+++ b/src/pymor/tools/floatcmp.py
@@ -68,28 +68,20 @@ def bounded(lower, upper, x, rtol=None, atol=None):
 
 
 @defaults('rtol', 'atol')
-def compare_with_tolerance(x, y, comparison_op, rtol=1e-14, atol=1e-14):
-    """'One-sided' Comparison x and y component-wise with given comparison op.
+def almost_less(x, y, rtol=1e-14, atol=1e-14):
+    """Component-wise check if x <= y up to a given tolerance.
 
-    For scalars we define almost equality as ::
+    For scalars the check is given by  ::
 
-       compare_with_tolerance(x,y) <=> op(x - y, atol + y*rtol)
+       almost_less(x, y) <=> (x - y  <= atol + |y| * rtol)
 
     Parameters
     ----------
     x, y
         |NumPy arrays| to be compared. Have to be broadcastable to the same shape.
-    comparison_op
-        binary operator object, see |operator| module.
     rtol
         The relative tolerance.
     atol
         The absolute tolerance.
     """
-    if comparison_op is operator.eq:
-        warnings.warn('Use float_cmp for float equality tests')
-    return comparison_op(x-y, atol + y * rtol)
-
-
-def almost_less(x, y, rtol=None, atol=None):
-    return compare_with_tolerance(x, y, operator.le, rtol, atol)
+    return x - y <= atol + np.abs(y) * rtol

--- a/src/pymortests/tools.py
+++ b/src/pymortests/tools.py
@@ -113,6 +113,7 @@ def test_compare_with_tolerance():
         op = operator.le
         assert almost_less(0., 1, rtol, atol), msg
         assert almost_less(-1., -0., rtol, atol), msg
+        assert almost_less(-1, -0.9, rtol, atol), msg
         assert compare_with_tolerance(0., 1, op, rtol, atol), msg
         assert compare_with_tolerance(-1., -0., op, rtol, atol), msg
         assert compare_with_tolerance(-1., 1., op, rtol, atol), msg

--- a/src/pymortests/tools.py
+++ b/src/pymortests/tools.py
@@ -2,7 +2,6 @@
 # Copyright 2013-2021 pyMOR developers and contributors. All rights reserved.
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
-import operator
 from math import sin, pi, exp, factorial
 import numpy as np
 import os
@@ -19,7 +18,7 @@ from pymortests.fixtures.grid import hy_rect_or_tria_grid
 from pymor.discretizers.builtin.grids.vtkio import write_vtk
 from pymor.discretizers.builtin.quadratures import GaussQuadratures
 from pymor.tools.deprecated import Deprecated
-from pymor.tools.floatcmp import float_cmp, float_cmp_all, compare_with_tolerance, almost_less
+from pymor.tools.floatcmp import float_cmp, float_cmp_all, almost_less
 from pymor.vectorarrays.numpy import NumpyVectorSpace
 from pymor.tools import timing, formatsrc
 
@@ -105,30 +104,19 @@ def test_float_cmp():
             assert not float_cmp(-inf, inf, rtol, atol), msg
 
 
-def test_compare_with_tolerance():
+def test_almost_less():
     tol_range = [0.0, 1e-8, 1]
     inf = float('inf')
     for (rtol, atol) in itertools.product(tol_range, tol_range):
         msg = f'rtol: {rtol} | atol {atol}'
-        op = operator.le
         assert almost_less(0., 1, rtol, atol), msg
         assert almost_less(-1., -0., rtol, atol), msg
         assert almost_less(-1, -0.9, rtol, atol), msg
-        assert compare_with_tolerance(0., 1, op, rtol, atol), msg
-        assert compare_with_tolerance(-1., -0., op, rtol, atol), msg
-        assert compare_with_tolerance(-1., 1., op, rtol, atol), msg
-        assert compare_with_tolerance(0., atol, op, rtol, atol), msg
-        assert (rtol == 0.0 and not compare_with_tolerance(0., inf, op, rtol, atol), msg) or \
-               compare_with_tolerance(0., inf, op, rtol, atol), msg
-        op = operator.ge
-        assert compare_with_tolerance(1., 0., op, rtol, atol), msg
-        assert compare_with_tolerance(-0., -1., op, rtol, atol), msg
-        assert compare_with_tolerance(1., -1., op, rtol, atol), msg
-        assert compare_with_tolerance(atol, 0, op, rtol, atol), msg
-        assert not compare_with_tolerance(-inf, 0., op, rtol, atol), msg
-
-    with pytest.warns(Warning, match='Use float_cmp'):
-        compare_with_tolerance(0.0, 0.0, operator.eq)
+        assert almost_less(0., 1, rtol, atol), msg
+        assert almost_less(-1., 1., rtol, atol), msg
+        assert almost_less(atol, 0., rtol, atol), msg
+        assert (rtol == 0.0 and not almost_less(0., inf, rtol, atol), msg) or \
+               almost_less(0., inf, rtol, atol), msg
 
 
 @given(hy_rect_or_tria_grid)


### PR DESCRIPTION
This PR fixes `pymor.tools.floatcmp.almost_less` for negative numbers by taking the absolute value of `y`. It also removes `compare_with_tolerance` in favor of directly implementing `almost_less`.