### PR TITLE
Use complex vector handling of wrapped object in MPIVectorArray

### DIFF
--- a/src/pymor/vectorarrays/mpi.py
+++ b/src/pymor/vectorarrays/mpi.py
@@ -102,6 +102,20 @@ class MPIVectorArray(VectorArray):
     def __del__(self):
         mpi.call(mpi.remove_object, self.obj_id)
 
+    @property
+    def real(self):
+        real_id = mpi.call(_MPIVectorArray_real, self.obj_id)
+        return MPIVectorArray(real_id, self.space)
+
+    @property
+    def imag(self):
+        imag_id = mpi.call(_MPIVectorArray_imag, self.obj_id)
+        return MPIVectorArray(imag_id, self.space)
+
+    def conj(self):
+        conj_id = mpi.call(_MPIVectorArray_conj, self.obj_id)
+        return MPIVectorArray(conj_id, self.space)
+
 
 class MPIVectorSpace(VectorSpace):
     """|VectorSpace| of :class:`MPIVectorArrays <MPIVectorArray>`.
@@ -210,6 +224,18 @@ def _MPIVectorArray_axpy(obj_id, alpha, x_obj_id):
     obj = mpi.get_object(obj_id)
     x = mpi.get_object(x_obj_id)
     obj.axpy(alpha, x)
+
+
+def _MPIVectorArray_real(obj_id):
+    return mpi.manage_object(mpi.get_object(obj_id).real)
+
+
+def _MPIVectorArray_imag(obj_id):
+    return mpi.manage_object(mpi.get_object(obj_id).imag)
+
+
+def _MPIVectorArray_conj(obj_id):
+    return mpi.manage_object(mpi.get_object(obj_id).conj())
 
 
 class MPIVectorArrayNoComm(MPIVectorArray):

--- a/src/pymor/vectorarrays/mpi.py
+++ b/src/pymor/vectorarrays/mpi.py
@@ -105,16 +105,15 @@ class MPIVectorArray(VectorArray):
     @property
     def real(self):
         real_id = mpi.call(_MPIVectorArray_real, self.obj_id)
-        return MPIVectorArray(real_id, self.space)
+        return type(self)(real_id, self.space)
 
     @property
     def imag(self):
         imag_id = mpi.call(_MPIVectorArray_imag, self.obj_id)
-        return MPIVectorArray(imag_id, self.space)
+        return type(self)(imag_id, self.space)
 
     def conj(self):
-        conj_id = mpi.call(_MPIVectorArray_conj, self.obj_id)
-        return MPIVectorArray(conj_id, self.space)
+        return type(self)(mpi.call(mpi.method_call_manage, self.obj_id, 'conj'), self.space)
 
 
 class MPIVectorSpace(VectorSpace):
@@ -232,10 +231,6 @@ def _MPIVectorArray_real(obj_id):
 
 def _MPIVectorArray_imag(obj_id):
     return mpi.manage_object(mpi.get_object(obj_id).imag)
-
-
-def _MPIVectorArray_conj(obj_id):
-    return mpi.manage_object(mpi.get_object(obj_id).conj())
 
 
 class MPIVectorArrayNoComm(MPIVectorArray):


### PR DESCRIPTION
Currently, calling `real`, `imag` or `conj()` on an MPIVectorArray accesses the methods of vectorarrays.interface that don't implement what they are pretending to.
With this change, the corresponding methods of the wrapped object are executed.

It breaks lradi when executed with mpi.
