### PR TITLE
Improve shift selection in `lradi`

### DIFF
--- a/src/pymor/algorithms/lradi.py
+++ b/src/pymor/algorithms/lradi.py
@@ -2,17 +2,17 @@
 # Copyright 2013-2021 pyMOR developers and contributors. All rights reserved.
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
-import scipy.linalg as spla
 import numpy as np
+import scipy.linalg as spla
 
 from pymor.algorithms.genericsolvers import _parse_options
 from pymor.algorithms.gram_schmidt import gram_schmidt
 from pymor.algorithms.lyapunov import _solve_lyap_lrcf_check_args
-from pymor.vectorarrays.constructions import cat_arrays
 from pymor.core.defaults import defaults
 from pymor.core.logger import getLogger
 from pymor.operators.constructions import IdentityOperator
 from pymor.tools.random import get_random_state
+from pymor.vectorarrays.constructions import cat_arrays
 
 
 @defaults('lradi_tol', 'lradi_maxiter', 'lradi_shifts', 'projection_shifts_init_maxiter',

--- a/src/pymor/algorithms/lradi.py
+++ b/src/pymor/algorithms/lradi.py
@@ -95,7 +95,7 @@ def solve_lyap_lrcf(A, E, B, trans=False, options=None):
     if E is None:
         E = IdentityOperator(A.source)
 
-    Z = A.source.empty(reserve=len(B) * options['maxiter'])
+    Z = A.source.empty()
     W = B.copy()
 
     j = 0

--- a/src/pymor/algorithms/lradi.py
+++ b/src/pymor/algorithms/lradi.py
@@ -145,9 +145,11 @@ def solve_lyap_lrcf(A, E, B, trans=False, options=None):
 
 
 def projection_shifts_init(A, E, B, shift_options):
-    """Find starting shift parameters for low-rank ADI iteration using
-    Galerkin projection on spaces spanned by LR-ADI iterates.
+    """Find starting projection shifts.
 
+    Uses Galerkin projection on the space spanned by the right-hand side if
+    it produces stable shifts.
+    Otherwise, uses a randomly generated subspace.
     See :cite:`PK16`, pp. 92-95.
 
     Parameters
@@ -180,9 +182,9 @@ def projection_shifts_init(A, E, B, shift_options):
 
 
 def projection_shifts(A, E, V, prev_shifts):
-    """Find further shift parameters for low-rank ADI iteration using
-    Galerkin projection on spaces spanned by LR-ADI iterates.
+    """Find further projection shifts.
 
+    Uses Galerkin projection on spaces spanned by LR-ADI iterates.
     See :cite:`PK16`, pp. 92-95.
 
     Parameters

--- a/src/pymor/algorithms/lradi.py
+++ b/src/pymor/algorithms/lradi.py
@@ -209,17 +209,12 @@ def projection_shifts(A, E, V, prev_shifts):
     else:
         Q = gram_schmidt(V, atol=0, rtol=0)
 
-    Ap = A.apply2(Q, Q)
-    Ep = E.apply2(Q, Q)
-
-    shifts = spla.eigvals(Ap, Ep)
-    shifts.imag[abs(shifts.imag) < np.finfo(float).eps] = 0
-    shifts = shifts[np.real(shifts) < 0]
+    shifts = spla.eigvals(A.apply2(Q, Q), E.apply2(Q, Q))
+    shifts = shifts[shifts.real < 0]
+    shifts = shifts[shifts.imag >= 0]
     if shifts.size == 0:
         return prev_shifts
     else:
-        if np.any(shifts.imag != 0):
-            shifts = shifts[np.abs(shifts).argsort()]
-        else:
-            shifts.sort()
+        shifts.imag[-shifts.imag / shifts.real < 1e-12] = 0
+        shifts = shifts[np.abs(shifts).argsort()]
         return shifts

--- a/src/pymor/algorithms/lradi.py
+++ b/src/pymor/algorithms/lradi.py
@@ -90,7 +90,7 @@ def solve_lyap_lrcf(A, E, B, trans=False, options=None):
         init_shifts = projection_shifts_init
         iteration_shifts = projection_shifts
     else:
-        raise ValueError('Unknown lradi shift strategy.')
+        raise ValueError('Unknown low-rank ADI shift strategy.')
 
     if E is None:
         E = IdentityOperator(A.source)

--- a/src/pymor/algorithms/lradi.py
+++ b/src/pymor/algorithms/lradi.py
@@ -16,12 +16,13 @@ from pymor.vectorarrays.constructions import cat_arrays
 
 
 @defaults('lradi_tol', 'lradi_maxiter', 'lradi_shifts', 'projection_shifts_init_maxiter',
-          'projection_shifts_init_seed')
+          'projection_shifts_init_seed', 'projection_shifts_subspace_columns')
 def lyap_lrcf_solver_options(lradi_tol=1e-10,
                              lradi_maxiter=500,
                              lradi_shifts='projection_shifts',
                              projection_shifts_init_maxiter=20,
-                             projection_shifts_init_seed=None):
+                             projection_shifts_init_seed=None,
+                             projection_shifts_subspace_columns=6):
     """Return available Lyapunov solvers with default options.
 
     Parameters
@@ -36,6 +37,8 @@ def lyap_lrcf_solver_options(lradi_tol=1e-10,
         See :func:`projection_shifts_init`.
     projection_shifts_init_seed
         See :func:`projection_shifts_init`.
+    projection_shifts_subspace_columns
+        See :func:`projection_shifts`.
 
     Returns
     -------
@@ -48,7 +51,8 @@ def lyap_lrcf_solver_options(lradi_tol=1e-10,
                       'shift_options':
                       {'projection_shifts': {'type': 'projection_shifts',
                                              'init_maxiter': projection_shifts_init_maxiter,
-                                             'init_seed': projection_shifts_init_seed}}}}
+                                             'init_seed': projection_shifts_init_seed,
+                                             'subspace_columns': projection_shifts_subspace_columns}}}}
 
 
 def solve_lyap_lrcf(A, E, B, trans=False, options=None):
@@ -134,7 +138,7 @@ def solve_lyap_lrcf(A, E, B, trans=False, options=None):
         res = np.linalg.norm(W.gramian(), ord=2)
         logger.info(f'Relative residual at step {j}: {res/init_res:.5e}')
         if j_shift >= shifts.size:
-            shifts = iteration_shifts(A, E, V, shifts)
+            shifts = iteration_shifts(A, E, V, Z, shifts, shift_options)
             j_shift = 0
 
     if res > Btol:
@@ -181,7 +185,7 @@ def projection_shifts_init(A, E, B, shift_options):
     raise RuntimeError('Could not generate initial shifts for low-rank ADI iteration.')
 
 
-def projection_shifts(A, E, V, prev_shifts):
+def projection_shifts(A, E, V, Z, prev_shifts, shift_options):
     """Find further projection shifts.
 
     Uses Galerkin projection on spaces spanned by LR-ADI iterates.
@@ -195,19 +199,27 @@ def projection_shifts(A, E, V, prev_shifts):
         The |Operator| E from the corresponding Lyapunov equation.
     V
         A |VectorArray| representing the currently computed iterate.
+    Z
+        A |VectorArray| representing the current approximate solution.
     prev_shifts
         A |NumPy array| containing the set of all previously used shift
         parameters.
+    shift_options
+        The shift options to use (see :func:`lyap_lrcf_solver_options`).
 
     Returns
     -------
     shifts
         A |NumPy array| containing a set of stable shift parameters.
     """
-    if prev_shifts[-1].imag != 0:
-        Q = gram_schmidt(cat_arrays([V.real, V.imag]), atol=0, rtol=0)
+    if shift_options['subspace_columns'] == 1:
+        if prev_shifts[-1].imag != 0:
+            Q = gram_schmidt(cat_arrays([V.real, V.imag]), atol=0, rtol=0)
+        else:
+            Q = gram_schmidt(V, atol=0, rtol=0)
     else:
-        Q = gram_schmidt(V, atol=0, rtol=0)
+        num_columns = shift_options['subspace_columns'] * len(V)
+        Q = gram_schmidt(Z[-num_columns:], atol=0, rtol=0)
 
     shifts = spla.eigvals(A.apply2(Q, Q), E.apply2(Q, Q))
     shifts = shifts[shifts.real < 0]

--- a/src/pymor/bindings/pymess.py
+++ b/src/pymor/bindings/pymess.py
@@ -33,7 +33,7 @@ if config.HAVE_PYMESS:
                              adi_shifts_b0=None,
                              adi_shifts_l0=16,
                              adi_shifts_p=None,
-                             adi_shifts_paratype=pymess.MESS_LRCFADI_PARA_ADAPTIVE_V):
+                             adi_shifts_paratype=pymess.MESS_LRCFADI_PARA_ADAPTIVE_Z):
         """Return available adi solver options with default values for the pymess backend.
 
         Parameters

--- a/src/pymortests/lyapunov.py
+++ b/src/pymortests/lyapunov.py
@@ -118,7 +118,8 @@ def test_lrcf(n, m, with_E, trans, lyap_solver):
     Bva = Aop.source.from_numpy(B.T if not trans else B)
 
     Zva = solve_lyap_lrcf(Aop, Eop, Bva, trans=trans, options=lyap_solver)
-    assert len(Zva) <= n
+    if lyap_solver != 'pymess_lradi':
+        assert len(Zva) <= n
 
     Z = Zva.to_numpy().T
     assert relative_residual(A, E, B, Z @ Z.T, trans=trans) < 1e-10

--- a/src/pymortests/lyapunov.py
+++ b/src/pymortests/lyapunov.py
@@ -3,24 +3,21 @@
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
 import os
+from itertools import chain, product
 
 import numpy as np
+import pytest
 import scipy.linalg as spla
 import scipy.sparse as sps
 
-from pymor.algorithms.lyapunov import solve_lyap_lrcf, solve_lyap_dense
+from pymor.algorithms.lyapunov import solve_lyap_dense, solve_lyap_lrcf
 from pymor.core.config import config
 from pymor.operators.numpy import NumpyMatrixOperator
 
-import pytest
-
-
-n_list = [100, 200]
+n_list_small = [10, 20]
+n_list_big = [300]
 m_list = [1, 2]
 lyap_lrcf_solver_list = [
-    'scipy',
-    'slycot_bartels-stewart',
-    'pymess_glyap',
     'pymess_lradi',
     'lradi',
 ]
@@ -95,19 +92,19 @@ def _check_availability(lyap_solver):
         pytest.skip('pymess not available')
 
 
-@pytest.mark.parametrize('n', n_list)
 @pytest.mark.parametrize('m', m_list)
 @pytest.mark.parametrize('with_E', [False, True])
 @pytest.mark.parametrize('trans', [False, True])
-@pytest.mark.parametrize('lyap_solver', lyap_lrcf_solver_list)
+@pytest.mark.parametrize('n,lyap_solver', chain(product(n_list_small, lyap_dense_solver_list),
+                                                product(n_list_big, lyap_lrcf_solver_list)))
 def test_lrcf(n, m, with_E, trans, lyap_solver):
     _check_availability(lyap_solver)
 
     if not with_E:
-        A = conv_diff_1d_fd(n, 1, 1)
+        A = conv_diff_1d_fd(n, 1, 0.1)
         E = None
     else:
-        A, E = conv_diff_1d_fem(n, 1, 1)
+        A, E = conv_diff_1d_fem(n, 1, 0.1)
     np.random.seed(0)
     B = np.random.randn(n, m)
     if trans:
@@ -118,14 +115,13 @@ def test_lrcf(n, m, with_E, trans, lyap_solver):
     Bva = Aop.source.from_numpy(B.T if not trans else B)
 
     Zva = solve_lyap_lrcf(Aop, Eop, Bva, trans=trans, options=lyap_solver)
-    if lyap_solver != 'pymess_lradi':
-        assert len(Zva) <= n
+    assert len(Zva) <= n
 
     Z = Zva.to_numpy().T
     assert relative_residual(A, E, B, Z @ Z.T, trans=trans) < 1e-10
 
 
-@pytest.mark.parametrize('n', n_list)
+@pytest.mark.parametrize('n', n_list_small)
 @pytest.mark.parametrize('m', m_list)
 @pytest.mark.parametrize('with_E', [False, True])
 @pytest.mark.parametrize('trans', [False, True])

--- a/src/pymortests/riccati.py
+++ b/src/pymortests/riccati.py
@@ -2,19 +2,18 @@
 # Copyright 2013-2021 pyMOR developers and contributors. All rights reserved.
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
+from itertools import chain, product
+
 import numpy as np
+import pytest
 import scipy.linalg as spla
 
-from pymor.algorithms.riccati import solve_ricc_lrcf, solve_pos_ricc_lrcf
+from pymor.algorithms.riccati import solve_pos_ricc_lrcf, solve_ricc_lrcf
 from pymor.operators.numpy import NumpyMatrixOperator
-
-from itertools import chain, product
-import pytest
-from .lyapunov import fro_norm, conv_diff_1d_fd, conv_diff_1d_fem, _check_availability
-
+from pymortests.lyapunov import _check_availability, conv_diff_1d_fd, conv_diff_1d_fem, fro_norm
 
 n_list_small = [10, 20]
-n_list_big = [200, 300]
+n_list_big = [250]
 m_list = [1, 2]
 p_list = [1, 2]
 ricc_lrcf_solver_list_small = [
@@ -93,8 +92,7 @@ def test_ricc_lrcf(n, m, p, with_E, with_R, trans, solver):
     except NotImplementedError:
         return
 
-    if solver != 'pymess_lrnm':
-        assert len(Zva) <= n
+    assert len(Zva) <= n
 
     Z = Zva.to_numpy().T
     assert relative_residual(A, E, B, C, R, Z, trans) < 1e-8

--- a/src/pymortests/riccati.py
+++ b/src/pymortests/riccati.py
@@ -93,7 +93,8 @@ def test_ricc_lrcf(n, m, p, with_E, with_R, trans, solver):
     except NotImplementedError:
         return
 
-    assert len(Zva) <= n
+    if solver != 'pymess_lrnm':
+        assert len(Zva) <= n
 
     Z = Zva.to_numpy().T
     assert relative_residual(A, E, B, C, R, Z, trans) < 1e-8


### PR DESCRIPTION
This PR:
- adds `subspace_columns` option to `lradi`,
- changes the corresponding default option for `pymess`, and
- makes other edits in `lradi` (one bigger change is how much memory is reserved for the low-rank factor; I'm not sure if it's better to reserve a lot and clear a lot or just not reserve anything, so I went for the simpler option).

This was motivated by the Gramian computation for the [Penzl's FOM model](https://morwiki.mpi-magdeburg.mpg.de/morwiki/index.php/FOM). Here is the code:

```python
import numpy as np
import scipy.sparse as sps

from pymor.core.defaults import set_defaults
from pymor.models.iosys import LTIModel

set_defaults({
    'pymor.algorithms.lyapunov.solve_lyap_lrcf.default_sparse_solver_backend': 'lradi',
    # 'pymor.algorithms.lradi.lyap_lrcf_solver_options.projection_shifts_subspace_columns': 1,
})

A1 = np.array([[-1, 100], [-100, -1]])
A2 = np.array([[-1, 200], [-200, -1]])
A3 = np.array([[-1, 400], [-400, -1]])
A4 = sps.diags(np.arange(-1, -1001, -1))
A = sps.block_diag((A1, A2, A3, A4), format='csc')
B = np.ones((1006, 1))
B[:6] = 10
C = B.T

fom = LTIModel.from_matrices(A, B, C)

fom.gramian('c_lrcf')
```

Wtih the changes here, `lradi` goes from stopping at 500 iterations to converging in 74.