### PR TITLE
Allow caching in MPI wrapped models

### DIFF
--- a/src/pymor/core/cache.py
+++ b/src/pymor/core/cache.py
@@ -186,7 +186,14 @@ class DiskRegion(CacheRegion):
         if has_key:
             getLogger('pymor.core.cache.DiskRegion').warning('Key already present in cache region, ignoring.')
             return
-        self._cache.set(key, value)
+        try:
+            self._cache.set(key, value)
+        except NotImplementedError:
+            if isinstance(value, tuple):
+                getLogger('pymor.core.cache.DiskRegion').warning(
+                    ('Disk-based caching of {} is not supported.').format(type(value[0])))
+        except TypeError as te:
+            getLogger('pymor.core.cache.DiskRegion').warning(('Disk-based caching ignored: {}.').format(te))
 
     def clear(self):
         self._cache.clear()

--- a/src/pymor/models/mpi.py
+++ b/src/pymor/models/mpi.py
@@ -139,7 +139,6 @@ def mpi_wrap_model(local_models, mpi_spaces=('STATE',), use_with=True, with_appl
         if m.visualizer:
             wrapped_attributes['visualizer'] = MPIVisualizer(local_models)
         m = m.with_(**wrapped_attributes)
-        m.disable_caching()
         return m
     else:
 

--- a/src/pymor/vectorarrays/mpi.py
+++ b/src/pymor/vectorarrays/mpi.py
@@ -102,6 +102,9 @@ class MPIVectorArray(VectorArray):
     def __del__(self):
         mpi.call(mpi.remove_object, self.obj_id)
 
+    def __getstate__(self):
+        raise NotImplementedError
+
     @property
     def real(self):
         real_id = mpi.call(_MPIVectorArray_real, self.obj_id)


### PR DESCRIPTION
This pr implements the suggestion of #1328.

I've decided for the second approach to prevent accidental enabling of disk based caching.
It is, for example, currently possible to create an MPI wrapped `LTIModel` with enabled caching by calling `to_lti()` on an MPI wrapped `InstationaryModel` with disabled caching.