### PR TITLE
Keep consistent defaults with multiple processes

### DIFF
--- a/src/pymor/__init__.py
+++ b/src/pymor/__init__.py
@@ -89,6 +89,7 @@ if mpi.parallel and mpi.event_loop_settings()['auto_launch']:
                 mpi.quit()
     else:
         print(f'Rank {mpi.rank}: MPI parallel run detected. Launching event loop ...')
-        mpi.event_loop()
+    mpi.launch_event_loop()
+    if not mpi.rank0:
         import sys
         sys.exit(0)

--- a/src/pymor/core/defaults.py
+++ b/src/pymor/core/defaults.py
@@ -368,6 +368,12 @@ def load_defaults_from_file(filename='./pymor_defaults.py'):
         raise KeyError(f'Error loading defaults from file. Key {e} does not correspond to a default')
 
 
+def _set_defaults(defaults):
+    from pymor.tools import mpi
+    if not mpi.rank0:
+        set_defaults(defaults)
+
+
 def set_defaults(defaults):
     """Set |default| values.
 
@@ -382,6 +388,9 @@ def set_defaults(defaults):
         Dictionary of default values. Keys are the full paths of the default
         values (see :func:`defaults`).
     """
+    from pymor.tools import mpi
+    if mpi._event_loop and mpi.rank0:
+        mpi.call(_set_defaults, defaults)
     try:
         _default_container.update(defaults, type='user')
     except KeyError as e:

--- a/src/pymor/core/defaults.py
+++ b/src/pymor/core/defaults.py
@@ -397,6 +397,33 @@ def set_defaults(defaults):
         raise KeyError(f'Error setting defaults. Key {e} does not correspond to a default')
 
 
+def get_defaults(user=True, file=True, code=True):
+    """Get |default| values.
+
+    Returns all |default| values as a dict. The parameters can be set to filter by type.
+
+    Parameters
+    ----------
+    user
+        If `True`, returned dict contains defaults that have been set by the user
+        with :func:`set_defaults`.
+    file
+        If `True`, returned dict contains defaults that have been loaded from file.
+    code
+        If `True`, returned dict contains unmodified default values.
+    """
+    defaults = {}
+    for k in _default_container.keys():
+        v, t = _default_container.get(k)
+        if t == 'user' and user:
+            defaults[k] = v
+        if t == 'file' and file:
+            defaults[k] = v
+        if t == 'code' and code:
+            defaults[k] = v
+    return defaults
+
+
 def defaults_changes():
     """Returns the number of changes made to to pyMOR's global |defaults|.
 
@@ -415,12 +442,3 @@ def defaults_changes():
         worker.
     """
     return _default_container.changes
-
-
-def user_defaults():
-    defaults = {}
-    for k in sorted(_default_container.keys()):
-        v, t = _default_container.get(k)
-        if t == 'user':
-            defaults[k] = v
-    return defaults

--- a/src/pymor/core/defaults.py
+++ b/src/pymor/core/defaults.py
@@ -415,3 +415,12 @@ def defaults_changes():
         worker.
     """
     return _default_container.changes
+
+
+def user_defaults():
+    defaults = {}
+    for k in sorted(_default_container.keys()):
+        v, t = _default_container.get(k)
+        if t == 'user':
+            defaults[k] = v
+    return defaults

--- a/src/pymor/core/defaults.py
+++ b/src/pymor/core/defaults.py
@@ -389,7 +389,7 @@ def set_defaults(defaults):
         values (see :func:`defaults`).
     """
     from pymor.tools import mpi
-    if mpi._event_loop and mpi.rank0:
+    if mpi._event_loop_running and mpi.rank0:
         mpi.call(_set_defaults, defaults)
     try:
         _default_container.update(defaults, type='user')

--- a/src/pymor/parallel/ipython.py
+++ b/src/pymor/parallel/ipython.py
@@ -175,8 +175,8 @@ class IPythonPool(WorkerPoolBase):
         self.view.apply(_remove_object, remote_id)
 
     def _update_defaults(self):
-        self._apply(defaults.set_defaults, defaults.user_defaults())
         self._updated_defaults = defaults.defaults_changes()
+        self._apply(defaults.set_defaults, defaults.get_defaults(user=True, file=True, code=False))
 
 
 class RemoteId(int):

--- a/src/pymor/parallel/ipython.py
+++ b/src/pymor/parallel/ipython.py
@@ -160,13 +160,19 @@ class IPythonPool(WorkerPoolBase):
         return remote_id
 
     def _apply(self, function, *args, **kwargs):
+        if defaults.defaults_changes() > self._updated_defaults:
+            self._update_defaults()
         return self.view.apply_sync(_worker_call_function, function, False, args, kwargs)
 
     def _apply_only(self, function, worker, *args, **kwargs):
+        if defaults.defaults_changes() > self._updated_defaults:
+            self._update_defaults()
         view = self.client[int(worker)]
         return view.apply_sync(_worker_call_function, function, False, args, kwargs)
 
     def _map(self, function, chunks, **kwargs):
+        if defaults.defaults_changes() > self._updated_defaults:
+            self._update_defaults()
         result = self.view.map_sync(_worker_call_function,
                                     *zip(*((function, True, a, kwargs) for a in zip(*chunks))))
         return list(chain(*result))

--- a/src/pymor/tools/mpi.py
+++ b/src/pymor/tools/mpi.py
@@ -101,7 +101,7 @@ def launch_event_loop():
     if rank0:
         from pymor.core import defaults
         if defaults.defaults_changes() > 0:
-            call(defaults.set_defaults, defaults.user_defaults())
+            call(defaults.set_defaults, defaults.get_defaults(user=True, file=True, code=False))
         _event_loop = True
     else:
         event_loop()

--- a/src/pymor/tools/mpi.py
+++ b/src/pymor/tools/mpi.py
@@ -77,7 +77,7 @@ parallel = (size > 1)
 
 _managed_objects = {}
 _object_counter = 0
-_event_loop = False
+_event_loop_running = False
 
 
 ################################################################################
@@ -97,12 +97,12 @@ def event_loop_settings(auto_launch=True):
 
 
 def launch_event_loop():
-    global _event_loop
+    global _event_loop_running
     if rank0:
         from pymor.core import defaults
         if defaults.defaults_changes() > 0:
             call(defaults.set_defaults, defaults.get_defaults(user=True, file=True, code=False))
-        _event_loop = True
+        _event_loop_running = True
     else:
         event_loop()
 
@@ -162,10 +162,10 @@ def quit():
     This will cause :func:`event_loop` to terminate on all
     MPI ranks.
     """
-    global finished, _event_loop
+    global finished, _event_loop_running
     comm.bcast(('QUIT', None, None))
     finished = True
-    _event_loop = False
+    _event_loop_running = False
 
 
 ################################################################################

--- a/src/pymor/tools/mpi.py
+++ b/src/pymor/tools/mpi.py
@@ -77,6 +77,7 @@ parallel = (size > 1)
 
 _managed_objects = {}
 _object_counter = 0
+_event_loop = False
 
 
 ################################################################################
@@ -93,6 +94,14 @@ def event_loop_settings(auto_launch=True):
         all MPI ranks (except 0) when pyMOR is imported.
     """
     return {'auto_launch': auto_launch}
+
+
+def launch_event_loop():
+    global _event_loop
+    if rank0:
+        _event_loop = True
+    else:
+        event_loop()
 
 
 def event_loop():
@@ -150,9 +159,10 @@ def quit():
     This will cause :func:`event_loop` to terminate on all
     MPI ranks.
     """
-    global finished
+    global finished, _event_loop
     comm.bcast(('QUIT', None, None))
     finished = True
+    _event_loop = False
 
 
 ################################################################################
@@ -286,6 +296,7 @@ def remove_object(obj_id):
 
 if __name__ == '__main__':
     assert config.HAVE_MPI
+    launch_event_loop()
     if rank0:
         if len(sys.argv) >= 2:
             filename = sys.argv[1]
@@ -300,5 +311,3 @@ if __name__ == '__main__':
             except ImportError:
                 import code
                 code.interact()
-    else:
-        event_loop()

--- a/src/pymor/tools/mpi.py
+++ b/src/pymor/tools/mpi.py
@@ -99,6 +99,9 @@ def event_loop_settings(auto_launch=True):
 def launch_event_loop():
     global _event_loop
     if rank0:
+        from pymor.core import defaults
+        if defaults.defaults_changes() > 0:
+            call(defaults.set_defaults, defaults.user_defaults())
         _event_loop = True
     else:
         event_loop()


### PR DESCRIPTION
This pr synchronizes defaults according to the instructions in #1329.

I have never used anything of the `pymor.parallel` package before, so someone should take a closer look at this part. Especially because I am assuming that 'job scheduling' refers to `_push_object`. Maybe there are cases where it is necessary to check the defaults in `_apply`/ `_apply_only` too?
Kept all commits to make the code review easier. But as they all perform just small changes, you might want to squash merge them.