### PR TITLE
Enable `solve` and `output` for `LTIModel`

### DIFF
--- a/docs/source/tutorial_lti_systems.md
+++ b/docs/source/tutorial_lti_systems.md
@@ -161,10 +161,10 @@ With this done, we can compute the output for some given input and plot it.
 ```{code-cell}
 Y = fom.output(input='[sin(t[0]), sin(2 * t[0])]')
 fig, ax = plt.subplots()
-ax.plot(np.linspace(0, fom.T, fom.time_stepper.nt + 1), Y)
-ax.set_xlabel('$t$')
-ax.set_ylabel('$y(t)$')
-_ = ax.set_title('Output')
+for i, y in enumerate(Y.T):
+  ax.plot(np.linspace(0, fom.T, fom.time_stepper.nt + 1), y, label=f'$y_{i+1}(t)$')
+_ = ax.set(xlabel='$t$', ylabel='$y(t)$', title='Output')
+_ = ax.legend()
 ```
 
 ## Transfer function evaluation

--- a/docs/source/tutorial_lti_systems.md
+++ b/docs/source/tutorial_lti_systems.md
@@ -159,7 +159,7 @@ fom = fom.with_(T=10, time_stepper=ImplicitEulerTimeStepper(100))
 With this done, we can compute the output for some given input and plot it.
 
 ```{code-cell}
-Y = fom.output(input='[sin(t), sin(2 * t)]')
+Y = fom.output(input='[sin(t[0]), sin(2 * t[0])]')
 fig, ax = plt.subplots()
 ax.plot(np.linspace(0, fom.T, fom.time_stepper.nt + 1), Y)
 ax.set_xlabel('$t$')

--- a/docs/source/tutorial_lti_systems.md
+++ b/docs/source/tutorial_lti_systems.md
@@ -63,6 +63,7 @@ Discrete-time LTI systems can be constructed by passing positive values for the
 `sampling_time` to any constructor of an {{LTIModel}}.
 
 :::
+
 ## Building a model
 
 We consider the following one-dimensional heat equation over {math}`(0, 1)` with

--- a/docs/source/tutorial_lti_systems.md
+++ b/docs/source/tutorial_lti_systems.md
@@ -159,7 +159,7 @@ fom = fom.with_(T=10, time_stepper=ImplicitEulerTimeStepper(100))
 With this done, we can compute the output for some given input and plot it.
 
 ```{code-cell}
-Y = fom.output(input='[sin(t[0]), sin(2 * t[0])]')
+Y = fom.output(input='[sin(t), sin(2*t)]')
 fig, ax = plt.subplots()
 ax.plot(np.linspace(0, fom.T, fom.time_stepper.nt + 1), Y)
 ax.set_xlabel('$t$')

--- a/docs/source/tutorial_lti_systems.md
+++ b/docs/source/tutorial_lti_systems.md
@@ -159,8 +159,7 @@ fom = fom.with_(T=10, time_stepper=ImplicitEulerTimeStepper(100))
 With this done, we can compute the output for some given input and plot it.
 
 ```{code-cell}
-u = lambda t: np.array([[np.sin(t)], [np.sin(2 * t)]])
-Y = fom.output(input=u)
+Y = fom.output(input='[sin(t), sin(2 * t)]')
 fig, ax = plt.subplots()
 ax.plot(np.linspace(0, fom.T, fom.time_stepper.nt + 1), Y)
 ax.set_xlabel('$t$')

--- a/docs/source/tutorial_lti_systems.md
+++ b/docs/source/tutorial_lti_systems.md
@@ -142,6 +142,32 @@ print(fom)
 which gives the dimensions of the underlying system more directly,
 together with some of its properties.
 
+## Time-domain simulation
+
+The `solve` and `output` methods can be used to respectively compute the
+solution and output trajectories.
+For this, it is necessary to set the final time and the time-stepper.
+This could have been done in the `from_matrices` call.
+Instead of creating a new model using `from_matrices`,
+we can redefine `fom` using its `with_` method.
+
+```{code-cell}
+from pymor.algorithms.timestepping import ImplicitEulerTimeStepper
+fom = fom.with_(T=10, time_stepper=ImplicitEulerTimeStepper(100))
+```
+
+With this done, we can compute the output for some given input and plot it.
+
+```{code-cell}
+u = lambda t: np.array([[np.sin(t)], [np.sin(2 * t)]])
+Y = fom.output(input=u)
+fig, ax = plt.subplots()
+ax.plot(np.linspace(0, fom.T, fom.time_stepper.nt + 1), Y)
+ax.set_xlabel('$t$')
+ax.set_ylabel('$y(t)$')
+_ = ax.set_title('Output')
+```
+
 ## Transfer function evaluation
 
 The transfer function {math}`H` is the function such that

--- a/docs/source/tutorial_lti_systems.md
+++ b/docs/source/tutorial_lti_systems.md
@@ -220,8 +220,8 @@ In words, if the input is a pure exponential,
 the frequency is preserved in the output,
 the amplitude is multiplied by the amplitude of the transfer function, and
 the phase is shifted by the argument of the transfer function.
-In particular, if the input is sinusiodal, i.e., {math}`\xi = 0`,
-then the output is also sinusiodal.
+In particular, if the input is sinusoidal, i.e., {math}`\xi = 0`,
+then the output is also sinusoidal.
 
 It is of interest to plot the transfer function over the imaginary axis to
 visualize how the LTI system responds to each frequency in the input.

--- a/docs/source/tutorial_lti_systems.md
+++ b/docs/source/tutorial_lti_systems.md
@@ -159,7 +159,7 @@ fom = fom.with_(T=10, time_stepper=ImplicitEulerTimeStepper(100))
 With this done, we can compute the output for some given input and plot it.
 
 ```{code-cell}
-Y = fom.output(input='[sin(t), sin(2*t)]')
+Y = fom.output(input='[sin(t[0]), sin(2 * t[0])]')
 fig, ax = plt.subplots()
 ax.plot(np.linspace(0, fom.T, fom.time_stepper.nt + 1), Y)
 ax.set_xlabel('$t$')

--- a/src/pymor/algorithms/timestepping.py
+++ b/src/pymor/algorithms/timestepping.py
@@ -180,7 +180,7 @@ def implicit_euler(A, F, M, U0, t0, t1, nt, mu=None, num_values=None, solver_opt
     assert U0 in A.source
     assert len(U0) == 1
 
-    R = A.source.empty(reserve=nt+1)
+    R = A.source.empty(reserve=num_values)
     R.append(U0)
 
     options = (A.solver_options if solver_options == 'operator' else
@@ -293,7 +293,7 @@ def implicit_midpoint_rule(A, F, M, U0, t0, t1, nt, mu=None, num_values=None, so
     assert U0 in A.source
     assert len(U0) == 1
 
-    R = A.source.empty(reserve=nt+1)
+    R = A.source.empty(reserve=num_values)
     R.append(U0)
 
     if solver_options == 'operator':

--- a/src/pymor/algorithms/timestepping.py
+++ b/src/pymor/algorithms/timestepping.py
@@ -140,8 +140,7 @@ class ImplicitMidpointTimeStepper(TimeStepper):
     def __init__(self, nt, solver_options='operator'):
         self.__auto_init(locals())
 
-    def solve(self, initial_time, end_time, initial_data, operator, rhs=None, mass=None, mu=None,
-              num_values=None):
+    def solve(self, initial_time, end_time, initial_data, operator, rhs=None, mass=None, mu=None, num_values=None):
         if not operator.linear:
             raise NotImplementedError
         return implicit_midpoint_rule(operator, rhs, mass, initial_data, initial_time, end_time,

--- a/src/pymor/algorithms/timestepping.py
+++ b/src/pymor/algorithms/timestepping.py
@@ -120,7 +120,7 @@ class ExplicitEulerTimeStepper(TimeStepper):
 
 
 class ImplicitMidpointTimeStepper(TimeStepper):
-    """Implict midpoint rule time-stepper. Symplectic integrator + preserves quadratic invariants.
+    """Implicit midpoint rule time-stepper. Symplectic integrator + preserves quadratic invariants.
 
     Solves equations of the form ::
 

--- a/src/pymor/algorithms/timestepping.py
+++ b/src/pymor/algorithms/timestepping.py
@@ -147,6 +147,21 @@ class ImplicitMidpointTimeStepper(TimeStepper):
                                       self.nt, mu, num_values, solver_options=self.solver_options)
 
 
+class DiscreteTimeStepper(TimeStepper):
+    """Discrete time-stepper.
+
+    Solves equations of the form ::
+
+        M(mu) * u_k+1 + A(u_k, mu, k) = F(mu, k).
+    """
+
+    def __init__(self):
+        pass
+
+    def solve(self, initial_time, end_time, initial_data, operator, rhs=None, mass=None, mu=None, num_values=None):
+        return discrete(operator, rhs, mass, initial_data, initial_time, end_time, mu, num_values)
+
+
 def implicit_euler(A, F, M, U0, t0, t1, nt, mu=None, num_values=None, solver_options='operator'):
     assert isinstance(A, Operator)
     assert isinstance(F, (type(None), Operator, VectorArray))
@@ -322,6 +337,60 @@ def implicit_midpoint_rule(A, F, M, U0, t0, t1, nt, mu=None, num_values=None, so
             rhs += dt_F
         U = M_dt_A_impl.apply_inverse(rhs, mu=mu)
         while t - t0 + (min(dt, DT) * 0.5) >= len(R) * DT:
+            R.append(U)
+
+    return R
+
+
+def discrete(A, F, M, U0, k0, k1, mu=None, num_values=None):
+    assert isinstance(A, Operator)
+    assert isinstance(F, (type(None), Operator, VectorArray))
+    assert isinstance(M, (type(None), Operator))
+    assert A.source == A.range
+    nt = k1 - k0
+    num_values = num_values or nt + 1
+    dt = 1
+    DT = nt / (num_values - 1)
+
+    if F is None:
+        F_time_dep = False
+    elif isinstance(F, Operator):
+        assert F.source.dim == 1
+        assert F.range == A.range
+        F_time_dep = _depends_on_time(F, mu)
+        if not F_time_dep:
+            Fk = F.as_vector(mu)
+    else:
+        assert len(F) == 1
+        assert F in A.range
+        F_time_dep = False
+        Fk = F
+
+    if M is None:
+        from pymor.operators.constructions import IdentityOperator
+        M = IdentityOperator(A.source)
+
+    assert A.source == M.source == M.range
+    assert U0 in A.source
+    assert len(U0) == 1
+
+    R = A.source.empty(reserve=num_values)
+    R.append(U0)
+
+    if not _depends_on_time(M, mu):
+        M = M.assemble(mu)
+
+    U = U0.copy()
+
+    for k in range(k0, k0 + nt):
+        mu = mu.with_(t=k)
+        rhs = -A.apply(U, mu=mu)
+        if F_time_dep:
+            Fk = F.as_vector(mu)
+        if F:
+            rhs += Fk
+        U = M.apply_inverse(rhs, mu=mu, initial_guess=U)
+        while k - k0 + 1 + (min(dt, DT) * 0.5) >= len(R) * DT:
             R.append(U)
 
     return R

--- a/src/pymor/analyticalproblems/expressions.py
+++ b/src/pymor/analyticalproblems/expressions.py
@@ -444,13 +444,13 @@ class Neg(Expression):
         self.shape = operand.shape
 
     def numpy_expr(self):
-        return f'(- {self.operand.numpy_expr()})'
+        return f'(-{self.operand.numpy_expr()})'
 
     def fenics_expr(self, params):
         return np.vectorize(lambda x: -x)(self.operand.fenics_expr(params))
 
     def __str__(self):
-        return f'(- {self.operand})'
+        return f'(-{self.operand})'
 
 
 class Indexed(Expression):

--- a/src/pymor/analyticalproblems/functions.py
+++ b/src/pymor/analyticalproblems/functions.py
@@ -306,7 +306,7 @@ class ExpressionFunction(GenericFunction):
                  getattr(self, '_name', None)))
 
     def __str__(self):
-        return f'{{{self.variable} -> {self.expression}}}'
+        return f'{self.name}: {self.variable} -> {self.expression}'
 
 
 class LincombFunction(Function):

--- a/src/pymor/analyticalproblems/functions.py
+++ b/src/pymor/analyticalproblems/functions.py
@@ -306,7 +306,7 @@ class ExpressionFunction(GenericFunction):
                  getattr(self, '_name', None)))
 
     def __str__(self):
-        return f'{{x -> {self.expression}}}'
+        return f'{{{self.variable} -> {self.expression}}}'
 
 
 class LincombFunction(Function):

--- a/src/pymor/models/basic.py
+++ b/src/pymor/models/basic.py
@@ -82,7 +82,7 @@ class StationaryModel(Model):
             f'    class: {self.__class__.__name__}\n'
             f'    {"linear" if self.linear else "non-linear"}\n'
             f'    solution_space:  {self.solution_space}\n'
-            f'    dim_output:      {self.dim_output}\n'
+            f'    dim_output:      {self.dim_output}'
         )
 
     def _compute_solution(self, mu=None, **kwargs):
@@ -318,7 +318,7 @@ class InstationaryModel(Model):
             f'    T: {self.T}\n'
             f'    solution_space:  {self.solution_space}\n'
             f'    dim_input:       {self.dim_input}\n'
-            f'    dim_output:      {self.dim_output}\n'
+            f'    dim_output:      {self.dim_output}'
         )
 
     def with_time_stepper(self, **kwargs):

--- a/src/pymor/models/basic.py
+++ b/src/pymor/models/basic.py
@@ -340,13 +340,13 @@ class InstationaryModel(Model):
         This method interprets the given model as an |LTIModel|
         in the following way::
 
-            - self.operator        -> A
+            -self.operator         -> A
             self.rhs               -> B
             self.output_functional -> C
             None                   -> D
             self.mass              -> E
         """
-        A = - self.operator
+        A = -self.operator
         B = self.rhs
         C = self.output_functional
         E = self.mass

--- a/src/pymor/models/interface.py
+++ b/src/pymor/models/interface.py
@@ -254,7 +254,7 @@ class Model(CacheableObject, ParametricObject):
             If `True`, return the output estimate as a |NumPy array|,
             where each component corresponds to the respective component
             of the :attr:`output_functional`.
-            Otherwise, return the euclidian norm of all components.
+            Otherwise, return the Euclidean norm of all components.
         kwargs
             Additional keyword arguments to customize how the error estimate is
             computed or to select additional data to be returned.
@@ -315,14 +315,14 @@ class Model(CacheableObject, ParametricObject):
             If `True`, return the output estimate as a |NumPy array|,
             where each component corresponds to the respective component
             of the :attr:`output_functional`.
-            Otherwise, return the euclidian norm of all components.
+            Otherwise, return the Euclidean norm of all components.
         mu
             |Parameter values| for which to compute the values.
         input
             The model input. Either a |NumPy array| of shape `(self.dim_input,)`,
             a |Function| with `dim_domain == 1` and `shape_range == (self.dim_input,)`
-            mapping time to input, or a `str` expression whith `t` as variable that
-            can be used to instatiate an |ExpressionFunction| of this type.
+            mapping time to input, or a `str` expression with `t` as variable that
+            can be used to instantiate an |ExpressionFunction| of this type.
             Can be `None` if `self.dim_input == 0`.
         kwargs
             Further keyword arguments to select further quantities that should
@@ -440,8 +440,8 @@ class Model(CacheableObject, ParametricObject):
         input
             The model input. Either a |NumPy array| of shape `(self.dim_input,)`,
             a |Function| with `dim_domain == 1` and `shape_range == (self.dim_input,)`
-            mapping time to input, or a `str` expression whith `t` as variable that
-            can be used to instatiate an |ExpressionFunction| of this type.
+            mapping time to input, or a `str` expression with `t` as variable that
+            can be used to instantiate an |ExpressionFunction| of this type.
             Can be `None` if `self.dim_input == 0`.
         return_error_estimate
             If `True`, also return an error estimate for the computed solution.
@@ -479,8 +479,8 @@ class Model(CacheableObject, ParametricObject):
         input
             The model input. Either a |NumPy array| of shape `(self.dim_input,)`,
             a |Function| with `dim_domain == 1` and `shape_range == (self.dim_input,)`
-            mapping time to input, or a `str` expression whith `t` as variable that
-            can be used to instatiate an |ExpressionFunction| of this type.
+            mapping time to input, or a `str` expression with `t` as variable that
+            can be used to instantiate an |ExpressionFunction| of this type.
             Can be `None` if `self.dim_input == 0`.
         return_error_estimate
             If `True`, also return an error estimate for the computed output.
@@ -488,7 +488,7 @@ class Model(CacheableObject, ParametricObject):
             If `True`, return the output estimate as a |NumPy array|,
             where each component corresponds to the respective component
             of the :attr:`output_functional`.
-            Otherwise, return the euclidian norm of all components.
+            Otherwise, return the Euclidean norm of all components.
         kwargs
             Additional keyword arguments passed to :meth:`compute` that
             might affect how the solution is computed.
@@ -529,8 +529,8 @@ class Model(CacheableObject, ParametricObject):
         input
             The model input. Either a |NumPy array| of shape `(self.dim_input,)`,
             a |Function| with `dim_domain == 1` and `shape_range == (self.dim_input,)`
-            mapping time to input, or a `str` expression whith `t` as variable that
-            can be used to instatiate an |ExpressionFunction| of this type.
+            mapping time to input, or a `str` expression with `t` as variable that
+            can be used to instantiate an |ExpressionFunction| of this type.
             Can be `None` if `self.dim_input == 0`.
 
         Returns
@@ -555,8 +555,8 @@ class Model(CacheableObject, ParametricObject):
         input
             The model input. Either a |NumPy array| of shape `(self.dim_input,)`,
             a |Function| with `dim_domain == 1` and `shape_range == (self.dim_input,)`
-            mapping time to input, or a `str` expression whith `t` as variable that
-            can be used to instatiate an |ExpressionFunction| of this type.
+            mapping time to input, or a `str` expression with `t` as variable that
+            can be used to instantiate an |ExpressionFunction| of this type.
             Can be `None` if `self.dim_input == 0`.
         return_array
             if `True`, return the output gradient as a |NumPy array|.
@@ -594,8 +594,8 @@ class Model(CacheableObject, ParametricObject):
         input
             The model input. Either a |NumPy array| of shape `(self.dim_input,)`,
             a |Function| with `dim_domain == 1` and `shape_range == (self.dim_input,)`
-            mapping time to input, or a `str` expression whith `t` as variable that
-            can be used to instatiate an |ExpressionFunction| of this type.
+            mapping time to input, or a `str` expression with `t` as variable that
+            can be used to instantiate an |ExpressionFunction| of this type.
             Can be `None` if `self.dim_input == 0`.
         kwargs
             Additional keyword arguments passed to :meth:`compute` that
@@ -631,14 +631,14 @@ class Model(CacheableObject, ParametricObject):
         input
             The model input. Either a |NumPy array| of shape `(self.dim_input,)`,
             a |Function| with `dim_domain == 1` and `shape_range == (self.dim_input,)`
-            mapping time to input, or a `str` expression whith `t` as variable that
-            can be used to instatiate an |ExpressionFunction| of this type.
+            mapping time to input, or a `str` expression with `t` as variable that
+            can be used to instantiate an |ExpressionFunction| of this type.
             Can be `None` if `self.dim_input == 0`.
         return_vector
             If `True`, return the output estimate as a |NumPy array|,
             where each component corresponds to the respective component
             of the :attr:`output_functional`.
-            Otherwise, return the euclidian norm of all components.
+            Otherwise, return the Euclidean norm of all components.
         kwargs
             Additional keyword arguments passed to :meth:`compute` that
             might affect how the error estimate (or the output) is computed.

--- a/src/pymor/models/interface.py
+++ b/src/pymor/models/interface.py
@@ -278,7 +278,7 @@ class Model(CacheableObject, ParametricObject):
                 *, mu=None, input=None, **kwargs):
         """Compute the solution of the model and associated quantities.
 
-        This methods computes the output of the model, its internal state,
+        This method computes the output of the model, its internal state,
         and various associated quantities for given |parameter values| `mu`.
 
         .. note::

--- a/src/pymor/models/interface.py
+++ b/src/pymor/models/interface.py
@@ -278,9 +278,8 @@ class Model(CacheableObject, ParametricObject):
                 *, mu=None, input=None, **kwargs):
         """Compute the solution of the model and associated quantities.
 
-        This methods computes the output of the model it's internal state
-        and various associated quantities for given |parameter values|
-        `mu`.
+        This methods computes the output of the model, its internal state,
+        and various associated quantities for given |parameter values| `mu`.
 
         .. note::
 

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -656,7 +656,10 @@ class LTIModel(Model):
             E = IdentityOperator(BlockVectorSpace([self.solution_space, other.solution_space]))
         else:
             E = BlockDiagonalOperator([self.E, other.E])
-        initial_data = BlockColumnOperator([self.initial_data, other.initial_data])
+        if self.T is not None and other.T is not None:
+            initial_data = BlockColumnOperator([self.initial_data, other.initial_data])
+        else:
+            initial_data = None
         return self.with_(A=A, B=B, C=C, D=D, E=E, initial_data=initial_data)
 
     def __sub__(self, other):
@@ -681,7 +684,10 @@ class LTIModel(Model):
         C = BlockRowOperator([self.C, self.D @ other.C])
         D = self.D @ other.D
         E = BlockDiagonalOperator([self.E, other.E])
-        initial_data = BlockColumnOperator([self.initial_data, other.initial_data])
+        if self.T is not None and other.T is not None:
+            initial_data = BlockColumnOperator([self.initial_data, other.initial_data])
+        else:
+            initial_data = None
         return self.with_(A=A, B=B, C=C, D=D, E=E, initial_data=initial_data)
 
     @cached

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -2595,18 +2595,25 @@ class LinearDelayModel(Model):
     def __init__(self, A, Ad, tau, B, C, D=None, E=None, sampling_time=0,
                  error_estimator=None, visualizer=None, name=None):
 
-        assert A.linear and A.source == A.range
+        assert A.linear
+        assert A.source == A.range
         assert isinstance(Ad, tuple) and len(Ad) > 0
         assert all(Ai.linear and Ai.source == Ai.range == A.source for Ai in Ad)
         assert isinstance(tau, tuple) and len(tau) == len(Ad) and all(taui > 0 for taui in tau)
-        assert B.linear and B.range == A.source
-        assert C.linear and C.source == A.range
+        assert B.linear
+        assert B.range == A.source
+        assert C.linear
+        assert C.source == A.range
 
         D = D or ZeroOperator(C.range, B.source)
-        assert D.linear and D.source == B.source and D.range == C.range
+        assert D.linear
+        assert D.source == B.source
+        assert D.range == C.range
 
         E = E or IdentityOperator(A.source)
-        assert E.linear and E.source == E.range == A.source
+        assert E.linear
+        assert E.source == E.range
+        assert E.source == A.source
 
         sampling_time = float(sampling_time)
         assert sampling_time >= 0

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -2765,9 +2765,9 @@ class LinearDelayModel(Model):
 
         if isinstance(other, LTIModel):
             if isinstance(self.E, IdentityOperator) and isinstance(other.E, IdentityOperator):
-                E = IdentityOperator(BlockVectorSpace([self.solution_space, other.solution_space]))
+                E = IdentityOperator(BlockVectorSpace([other.solution_space, self.solution_space]))
             else:
-                E = BlockDiagonalOperator([self.E, other.E])
+                E = BlockDiagonalOperator([other.E, self.E])
             A = BlockOperator([[other.A, other.B @ self.C],
                                [None, self.A]])
             Ad = tuple(BlockDiagonalOperator([ZeroOperator(other.solution_space, other.solution_space), op])

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -22,9 +22,9 @@ from pymor.models.transfer_function import FactorizedTransferFunction
 from pymor.models.transforms import BilinearTransformation, MoebiusTransformation
 from pymor.operators.block import (BlockOperator, BlockRowOperator, BlockColumnOperator, BlockDiagonalOperator,
                                    SecondOrderModelOperator)
-from pymor.operators.constructions import (IdentityOperator, InverseOperator, LincombOperator, LowRankOperator,
-                                           VectorOperator, ZeroOperator)
-from pymor.operators.numpy import NumpyGenericOperator, NumpyMatrixOperator
+from pymor.operators.constructions import (IdentityOperator, InverseOperator, LincombOperator, LinearInputOperator,
+                                           LowRankOperator, VectorOperator, ZeroOperator)
+from pymor.operators.numpy import NumpyMatrixOperator
 from pymor.parameters.base import Parameters, Mu
 from pymor.vectorarrays.block import BlockVectorSpace
 from pymor.vectorarrays.interface import VectorArray
@@ -610,13 +610,7 @@ class LTIModel(Model):
         # solution computation
         mu = mu.with_(t=0)
         X0 = self.initial_data.as_range_array(mu)
-        input_op = NumpyGenericOperator(
-            lambda U, mu: U * mu['input'],
-            dim_range=self.dim_input,
-            parameters={'input': self.dim_input},
-            linear=True,
-        )
-        rhs = self.B @ input_op
+        rhs = LinearInputOperator(self.B)
         X = self.time_stepper.solve(
             operator=-self.A,
             rhs=rhs,

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -221,7 +221,8 @@ class LTIModel(Model):
         return string
 
     @classmethod
-    def from_matrices(cls, A, B, C, D=None, E=None, sampling_time=0, presets=None,
+    def from_matrices(cls, A, B, C, D=None, E=None, sampling_time=0,
+                      T=None, initial_data=None, time_stepper=None, num_values=None, presets=None,
                       state_id='STATE', solver_options=None, error_estimator=None,
                       visualizer=None, name=None):
         """Create |LTIModel| from matrices.
@@ -241,6 +242,17 @@ class LTIModel(Model):
         sampling_time
             `0` if the system is continuous-time, otherwise a positive number that denotes the
             sampling time (in seconds).
+        T
+            The final time T.
+        initial_data
+            The initial data `x_0` as a |NumPy array|. If `None`, it is assumed
+            to be zero.
+        time_stepper
+            The :class:`time-stepper <pymor.algorithms.timestepping.TimeStepper>`
+            to be used by :meth:`~pymor.models.interface.Model.solve`.
+        num_values
+            The number of returned vectors of the solution trajectory. If `None`, each
+            intermediate vector that is calculated is returned.
         presets
             A `dict` of preset attributes or `None`.
             See :meth:`~pymor.models.iosys.LTIModel.__init__`.
@@ -268,8 +280,9 @@ class LTIModel(Model):
         assert isinstance(A, (np.ndarray, sps.spmatrix))
         assert isinstance(B, (np.ndarray, sps.spmatrix))
         assert isinstance(C, (np.ndarray, sps.spmatrix))
-        assert D is None or isinstance(D, (np.ndarray, sps.spmatrix))
-        assert E is None or isinstance(E, (np.ndarray, sps.spmatrix))
+        assert isinstance(D, (np.ndarray, sps.spmatrix, type(None)))
+        assert isinstance(E, (np.ndarray, sps.spmatrix, type(None)))
+        assert isinstance(initial_data, (np.ndarray, type(None)))
 
         A = NumpyMatrixOperator(A, source_id=state_id, range_id=state_id)
         B = NumpyMatrixOperator(B, range_id=state_id)
@@ -278,10 +291,12 @@ class LTIModel(Model):
             D = NumpyMatrixOperator(D)
         if E is not None:
             E = NumpyMatrixOperator(E, source_id=state_id, range_id=state_id)
+        if initial_data is not None:
+            initial_data = A.source.from_numpy(initial_data)
 
-        return cls(A, B, C, D, E, sampling_time=sampling_time, presets=presets,
-                   solver_options=solver_options, error_estimator=error_estimator, visualizer=visualizer,
-                   name=name)
+        return cls(A, B, C, D, E, sampling_time=sampling_time, T=T, initial_data=initial_data,
+                   time_stepper=time_stepper, num_values=num_values, presets=presets,
+                   solver_options=solver_options, error_estimator=error_estimator, visualizer=visualizer, name=name)
 
     def to_matrices(self):
         """Return operators as matrices.
@@ -307,9 +322,9 @@ class LTIModel(Model):
         return A, B, C, D, E
 
     @classmethod
-    def from_files(cls, A_file, B_file, C_file, D_file=None, E_file=None, sampling_time=0, presets=None,
-                   state_id='STATE', solver_options=None, error_estimator=None, visualizer=None,
-                   name=None):
+    def from_files(cls, A_file, B_file, C_file, D_file=None, E_file=None, sampling_time=0,
+                   T=None, initial_data_file=None, time_stepper=None, num_values=None, presets=None,
+                   state_id='STATE', solver_options=None, error_estimator=None, visualizer=None, name=None):
         """Create |LTIModel| from matrices stored in separate files.
 
         Parameters
@@ -327,6 +342,17 @@ class LTIModel(Model):
         sampling_time
             `0` if the system is continuous-time, otherwise a positive number that denotes the
             sampling time (in seconds).
+        T
+            The final time T.
+        initial_data_file
+            `None` or the name of the file (with extension) containing the
+            initial data.
+        time_stepper
+            The :class:`time-stepper <pymor.algorithms.timestepping.TimeStepper>`
+            to be used by :meth:`~pymor.models.interface.Model.solve`.
+        num_values
+            The number of returned vectors of the solution trajectory. If `None`, each
+            intermediate vector that is calculated is returned.
         presets
             A `dict` of preset attributes or `None`.
             See :meth:`~pymor.models.iosys.LTIModel.__init__`.
@@ -358,10 +384,12 @@ class LTIModel(Model):
         C = load_matrix(C_file)
         D = load_matrix(D_file) if D_file is not None else None
         E = load_matrix(E_file) if E_file is not None else None
+        initial_data = load_matrix(initial_data_file) if initial_data_file is not None else None
 
-        return cls.from_matrices(A, B, C, D, E, sampling_time=sampling_time, presets=presets,
-                                 state_id=state_id, solver_options=solver_options,
-                                 error_estimator=error_estimator, visualizer=visualizer, name=name)
+        return cls.from_matrices(A, B, C, D, E, sampling_time=sampling_time, T=T, initial_data=initial_data,
+                                 time_stepper=time_stepper, num_values=num_values, presets=presets, state_id=state_id,
+                                 solver_options=solver_options, error_estimator=error_estimator, visualizer=visualizer,
+                                 name=name)
 
     def to_files(self, A_file, B_file, C_file, D_file=None, E_file=None):
         """Write operators to files as matrices.
@@ -394,9 +422,8 @@ class LTIModel(Model):
             save_matrix(file, mat)
 
     @classmethod
-    def from_mat_file(cls, file_name, sampling_time=0, presets=None,
-                      state_id='STATE', solver_options=None, error_estimator=None,
-                      visualizer=None, name=None):
+    def from_mat_file(cls, file_name, sampling_time=0, T=None, time_stepper=None, num_values=None, presets=None,
+                      state_id='STATE', solver_options=None, error_estimator=None, visualizer=None, name=None):
         """Create |LTIModel| from matrices stored in a .mat file.
 
         Supports the format used in the `SLICOT benchmark collection
@@ -410,6 +437,14 @@ class LTIModel(Model):
         sampling_time
             `0` if the system is continuous-time, otherwise a positive number that denotes the
             sampling time (in seconds).
+        T
+            The final time T.
+        time_stepper
+            The :class:`time-stepper <pymor.algorithms.timestepping.TimeStepper>`
+            to be used by :meth:`~pymor.models.interface.Model.solve`.
+        num_values
+            The number of returned vectors of the solution trajectory. If `None`, each
+            intermediate vector that is calculated is returned.
         presets
             A `dict` of preset attributes or `None`.
             See :meth:`~pymor.models.iosys.LTIModel.__init__`.
@@ -453,9 +488,10 @@ class LTIModel(Model):
             if mat is not None and np.issubdtype(mat.dtype, np.integer):
                 matrices[i] = mat.astype(np.float_)
 
-        return cls.from_matrices(*matrices, sampling_time=sampling_time, presets=presets,
-                                 state_id=state_id, solver_options=solver_options,
-                                 error_estimator=error_estimator, visualizer=visualizer, name=name)
+        return cls.from_matrices(*matrices, sampling_time=sampling_time, T=T, time_stepper=time_stepper,
+                                 num_values=num_values, presets=presets, state_id=state_id,
+                                 solver_options=solver_options, error_estimator=error_estimator, visualizer=visualizer,
+                                 name=name)
 
     def to_mat_file(self, file_name):
         """Save operators as matrices to .mat file.
@@ -475,9 +511,8 @@ class LTIModel(Model):
         spio.savemat(file_name, mat_dict)
 
     @classmethod
-    def from_abcde_files(cls, files_basename, sampling_time=0, presets=None,
-                         state_id='STATE', solver_options=None, error_estimator=None,
-                         visualizer=None, name=None):
+    def from_abcde_files(cls, files_basename, sampling_time=0, T=None, time_stepper=None, num_values=None, presets=None,
+                         state_id='STATE', solver_options=None, error_estimator=None, visualizer=None, name=None):
         """Create |LTIModel| from matrices stored in .[ABCDE] files.
 
         Parameters
@@ -487,6 +522,14 @@ class LTIModel(Model):
         sampling_time
             `0` if the system is continuous-time, otherwise a positive number that denotes the
             sampling time (in seconds).
+        T
+            The final time T.
+        time_stepper
+            The :class:`time-stepper <pymor.algorithms.timestepping.TimeStepper>`
+            to be used by :meth:`~pymor.models.interface.Model.solve`.
+        num_values
+            The number of returned vectors of the solution trajectory. If `None`, each
+            intermediate vector that is calculated is returned.
         presets
             A `dict` of preset attributes or `None`.
             See :meth:`~pymor.models.iosys.LTIModel.__init__`.
@@ -520,9 +563,10 @@ class LTIModel(Model):
         D = load_matrix(files_basename + '.D') if os.path.isfile(files_basename + '.D') else None
         E = load_matrix(files_basename + '.E') if os.path.isfile(files_basename + '.E') else None
 
-        return cls.from_matrices(A, B, C, D, E, sampling_time=sampling_time, presets=presets,
-                                 state_id=state_id, solver_options=solver_options,
-                                 error_estimator=error_estimator, visualizer=visualizer, name=name)
+        return cls.from_matrices(A, B, C, D, E, sampling_time=sampling_time, T=T, time_stepper=time_stepper,
+                                 num_values=num_values, presets=presets, state_id=state_id,
+                                 solver_options=solver_options, error_estimator=error_estimator, visualizer=visualizer,
+                                 name=name)
 
     def to_abcde_files(self, files_basename):
         """Save operators as matrices to .[ABCDE] files in Matrix Market format.

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -596,7 +596,8 @@ class LTIModel(Model):
             E = IdentityOperator(BlockVectorSpace([self.solution_space, other.solution_space]))
         else:
             E = BlockDiagonalOperator([self.E, other.E])
-        return self.with_(A=A, B=B, C=C, D=D, E=E)
+        initial_data = BlockColumnOperator([self.initial_data, other.initial_data])
+        return self.with_(A=A, B=B, C=C, D=D, E=E, initial_data=initial_data)
 
     def __sub__(self, other):
         """Subtract an |LTIModel|."""
@@ -620,7 +621,8 @@ class LTIModel(Model):
         C = BlockRowOperator([self.C, self.D @ other.C])
         D = self.D @ other.D
         E = BlockDiagonalOperator([self.E, other.E])
-        return self.with_(A=A, B=B, C=C, D=D, E=E)
+        initial_data = BlockColumnOperator([self.initial_data, other.initial_data])
+        return self.with_(A=A, B=B, C=C, D=D, E=E, initial_data=initial_data)
 
     @cached
     def _poles(self, mu=None):

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -22,10 +22,11 @@ from pymor.models.transforms import BilinearTransformation, MoebiusTransformatio
 from pymor.operators.block import (BlockOperator, BlockRowOperator, BlockColumnOperator, BlockDiagonalOperator,
                                    SecondOrderModelOperator)
 from pymor.operators.constructions import (IdentityOperator, InverseOperator, LincombOperator, LowRankOperator,
-                                           ZeroOperator)
-from pymor.operators.numpy import NumpyMatrixOperator
+                                           VectorOperator, ZeroOperator)
+from pymor.operators.numpy import NumpyGenericOperator, NumpyMatrixOperator
 from pymor.parameters.base import Parameters, Mu
 from pymor.vectorarrays.block import BlockVectorSpace
+from pymor.vectorarrays.interface import VectorArray
 
 
 @defaults('value')
@@ -71,6 +72,21 @@ class LTIModel(Model):
     sampling_time
         `0` if the system is continuous-time, otherwise a positive number that denotes the
         sampling time (in seconds).
+    T
+        The final time T.
+    initial_data
+        The initial data `x_0`. Either a |VectorArray| of length 1 or
+        (for the |Parameter|-dependent case) a vector-like |Operator|
+        (i.e. a linear |Operator| with `source.dim == 1`) which
+        applied to `NumpyVectorArray(np.array([1]))` will yield the
+        initial data for given |parameter values|. If `None`, it is
+        assumed to be zero.
+    time_stepper
+        The :class:`time-stepper <pymor.algorithms.timestepping.TimeStepper>`
+        to be used by :meth:`~pymor.models.interface.Model.solve`.
+    num_values
+        The number of returned vectors of the solution trajectory. If `None`, each
+        intermediate vector that is calculated is returned.
     presets
         A `dict` of preset attributes or `None`. The dict must only contain keys that correspond to
         attributes of |LTIModel| such as `poles`, `c_lrcf`, `o_lrcf`, `c_dense`, `o_dense`, `hsv`,
@@ -123,7 +139,8 @@ class LTIModel(Model):
 
     cache_region = 'memory'
 
-    def __init__(self, A, B, C, D=None, E=None, sampling_time=0, presets=None,
+    def __init__(self, A, B, C, D=None, E=None, sampling_time=0,
+                 T=None, initial_data=None, time_stepper=None, num_values=None, presets=None,
                  solver_options=None, ast_pole_data=None,
                  error_estimator=None, visualizer=None, name=None):
 
@@ -146,6 +163,15 @@ class LTIModel(Model):
 
         sampling_time = float(sampling_time)
         assert sampling_time >= 0
+
+        if initial_data is None:
+            initial_data = A.source.zeros(1)
+        if isinstance(initial_data, VectorArray):
+            assert initial_data in A.source
+            assert len(initial_data) == 1
+            initial_data = VectorOperator(initial_data, name='initial_data')
+        assert initial_data.source.is_scalar
+        assert initial_data.range == A.source
 
         assert presets is None or presets.keys() <= {'poles', 'c_lrcf', 'o_lrcf', 'c_dense', 'o_dense', 'hsv',
                                                      'h2_norm', 'hinf_norm', 'l2_norm', 'linf_norm', 'fpeak'}
@@ -516,6 +542,42 @@ class LTIModel(Model):
             _mmwrite(Path(files_basename + '.D'), D)
         if E is not None:
             _mmwrite(Path(files_basename + '.E'), E)
+
+    _compute_allowed_kwargs = frozenset({'input'})
+
+    def _compute(self, solution=False, output=False, solution_d_mu=False, output_d_mu=False,
+                 solution_error_estimate=False, output_error_estimate=False,
+                 output_d_mu_return_array=False, mu=None, input=None, **kwargs):
+        if not solution and not output:
+            return {}
+
+        # solution computation
+        mu = mu.with_(t=0.)
+        X0 = self.initial_data.as_range_array(mu)
+        if input is None:
+            rhs = None
+        else:
+            input_op = NumpyGenericOperator(lambda U, mu: U @ input(mu['t'][0]).T,
+                                            dim_range=self.dim_input,
+                                            parameters={'t': 1},
+                                            linear=True)
+            rhs = self.B @ input_op
+        X = self.time_stepper.solve(operator=-self.A,
+                                    rhs=rhs,
+                                    initial_data=X0,
+                                    mass=None if isinstance(self.E, IdentityOperator) else self.E,
+                                    initial_time=0, end_time=self.T, mu=mu, num_values=self.num_values)
+        data = {'solution': X}
+
+        # output computation
+        if output:
+            Cx = self.C.apply(X, mu=mu).to_numpy()
+            if input is None or isinstance(self.D, ZeroOperator):
+                data['output'] = Cx
+            else:
+                raise NotImplementedError
+
+        return data
 
     def __add__(self, other):
         """Add an |LTIModel|."""

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -184,6 +184,11 @@ class LTIModel(Model):
                 if time_stepper is None:
                     time_stepper = DiscreteTimeStepper()
                 assert isinstance(time_stepper, DiscreteTimeStepper)
+        else:
+            if initial_data is not None:
+                raise ValueError('Initial data is given but T is not.')
+            if time_stepper is not None:
+                raise ValueError('Time-stepper is given but T is not.')
 
         assert presets is None or presets.keys() <= {'poles', 'c_lrcf', 'o_lrcf', 'c_dense', 'o_dense', 'hsv',
                                                      'h2_norm', 'hinf_norm', 'l2_norm', 'linf_norm', 'fpeak'}

--- a/src/pymor/models/transfer_function.py
+++ b/src/pymor/models/transfer_function.py
@@ -67,9 +67,9 @@ class TransferFunction(CacheableObject, ParametricObject):
             f'    number of outputs: {self.dim_output}\n'
         )
         if self.sampling_time == 0:
-            string += '    continuous-time\n'
+            string += '    continuous-time'
         else:
-            string += f'    {f"discrete-time (sampling_time={self.sampling_time:.2e}s)"}\n'
+            string += f'    {f"discrete-time (sampling_time={self.sampling_time:.2e}s)"}'
         return string
 
     @cached

--- a/src/pymor/operators/constructions.py
+++ b/src/pymor/operators/constructions.py
@@ -1430,3 +1430,27 @@ class NumpyConversionOperator(Operator):
     def apply_inverse_adjoint(self, U, mu=None, initial_guess=None, least_squares=False):
         assert U in self.source
         return self.range.from_numpy(U.to_numpy())
+
+
+class LinearInputOperator(Operator):
+    """Operator representing the product B(mu)*input(t).
+
+    Parameters
+    ----------
+    B
+        The input |Operator|.
+    """
+
+    linear = True
+
+    def __init__(self, B):
+        self.B = B
+        self.source = NumpyVectorSpace(1)
+        self.range = B.range
+        self.parameters_own = {'input': B.source.dim}
+
+    def apply(self, U, mu=None):
+        return self.B.as_range_array(mu).lincomb(U.to_numpy() * mu['input'])
+
+    def as_range_array(self, mu=None):
+        return self.B.as_range_array(mu).lincomb(mu['input'])

--- a/src/pymor/operators/numpy.py
+++ b/src/pymor/operators/numpy.py
@@ -395,7 +395,7 @@ class NumpyMatrixOperator(NumpyMatrixBasedOperator):
                                    solver_options=solver_options)
 
     def __getstate__(self):
-        if hasattr(self.matrix, 'factorization'):  # remove unplicklable SuperLU factorization
+        if hasattr(self.matrix, 'factorization'):  # remove unpicklable SuperLU factorization
             del self.matrix.factorization
         return self.__dict__
 

--- a/src/pymor/parameters/base.py
+++ b/src/pymor/parameters/base.py
@@ -171,7 +171,7 @@ class Parameters(SortedFrozenDict):
                 return v
             elif isinstance(v, (str, Function)):
                 if isinstance(v, str):
-                    v = ExpressionFunction(v, dim_domain=1, variable='t')
+                    v = ExpressionFunction(v.replace('t', 't[0]'), dim_domain=1, variable='t')
                 v.dim_domain == 1 or fail(f'wrong domain dimension of parameter function {k}')
                 len(v.shape_range) == 1 or fail(f'wrong shape_range of parameter function {k}')
                 v.shape_range[0] == self[k] or fail(f'wrong range dimension of prameter function {k}')

--- a/src/pymor/parameters/base.py
+++ b/src/pymor/parameters/base.py
@@ -171,7 +171,7 @@ class Parameters(SortedFrozenDict):
                 return v
             elif isinstance(v, (str, Function)):
                 if isinstance(v, str):
-                    v = ExpressionFunction(v.replace('t', 't[0]'), dim_domain=1, variable='t')
+                    v = ExpressionFunction(v, dim_domain=1, variable='t')
                 v.dim_domain == 1 or fail(f'wrong domain dimension of parameter function {k}')
                 len(v.shape_range) == 1 or fail(f'wrong shape_range of parameter function {k}')
                 v.shape_range[0] == self[k] or fail(f'wrong range dimension of prameter function {k}')

--- a/src/pymor/parameters/base.py
+++ b/src/pymor/parameters/base.py
@@ -101,9 +101,6 @@ class Parameters(SortedFrozenDict):
         values `[2, 3]`. Further, each parameter value can be given as a
         vector-valued |Function| with `dim_domain == 1` to specify time-dependent
         values. A `str` is converted to an appropriate |ExpressionFunction|.
-        Note that |ExpressionFunctions| are functions of the variable `x`, so you
-        have to write `x` instead of `t` for the time parameter in the string
-        expression.
 
         Parameters
         ----------


### PR DESCRIPTION
This PR is similar to #1054 but is limited to `solve` and `output`. I would be for adding impulse response and step response once #1305 is merged, as I believe that it would be expected that they avoid computing the whole solution trajectory first (the same could be said for `output`, but at least it is consistent with `InstationaryModel`).

I opened this as a draft PR since there are a few issues worth discussing before merging:

1. For now, `solve` and `output` expect the input as a callable (via the `input` keyword argument). Since caching doesn't support callables as parameters, I had to implement `_compute` to avoid caching. Is this fine, or do we want a way to enable caching? One option would be using `ExpressionParameterFunctionals`, but, comparatively, defining a lambda function is much simpler and requires no extra imports.
2. The output of an `LTIModel` can depend not only on the solution but also on the input (if `D` is nonzero). To evaluate the input, the time discretization needs to be known. In principle, it is possible to compute the time points, but it seems a bit nontrivial since time-steppers use both `nt` and `num_values`. Is it actually easy to compute time points, or would it be better for the time-stepper to return it?
3. ~~I made some changes to `docs/source/getting_started.rst` such that `make docs` doesn't fail because of logging messages. Did others observe the same issue? Should this be extracted into a different PR?~~ (this is no longer relevant with myst-nb)

Closes #531.