### PR TITLE
fix parse(mu) for a mu that is a Mu

### DIFF
--- a/.ci/gitlab/ci.yml
+++ b/.ci/gitlab/ci.yml
@@ -862,7 +862,8 @@ docs:
     dependencies: ["docs build 3 7", "binder base image"]
     before_script:
         - apk --update add make python3 bash
-        - pip3 install jinja2 pathlib jupyter-repo2docker six
+        # chardet is a workaround for https://github.com/jupyterhub/repo2docker/issues/1063
+        - pip3 install jinja2 pathlib jupyter-repo2docker six chardet
     script:
         - ${CI_PROJECT_DIR}/.ci/gitlab/deploy_docs.bash
     rules:

--- a/.ci/gitlab/template.ci.py
+++ b/.ci/gitlab/template.ci.py
@@ -375,7 +375,8 @@ docs:
     dependencies: ["docs build 3 7", "binder base image"]
     before_script:
         - apk --update add make python3 bash
-        - pip3 install jinja2 pathlib jupyter-repo2docker six
+        # chardet is a workaround for https://github.com/jupyterhub/repo2docker/issues/1063
+        - pip3 install jinja2 pathlib jupyter-repo2docker six chardet
     script:
         - ${CI_PROJECT_DIR}/.ci/gitlab/deploy_docs.bash
     rules:

--- a/src/pymor/parameters/base.py
+++ b/src/pymor/parameters/base.py
@@ -126,7 +126,7 @@ class Parameters(SortedFrozenDict):
             return Mu({})
 
         elif isinstance(mu, Mu):
-            mu == self or fail(self.why_incompatible(mu))
+            mu.parameters == self or fail(self.why_incompatible(mu))
             set(mu) == set(self) or fail(f'additional parameters {set(mu) - set(self)}')
             return mu
 


### PR DESCRIPTION
Otherwise `parameters.parse(mu)` fails, if `isinstance(mu, Mu)`. Was I really the first one to stumble upon this?