### PR TITLE
adds a CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,19 @@
+# YAML 1.2
+---
+authors: 
+  -
+    family-names: Milk
+    given-names: "René"
+    orcid: "https://orcid.org/0000-0002-9548-2238"
+  -
+    family-names: Rave
+    given-names: Stephan
+    orcid: "https://orcid.org/0000-0003-0439-7212"
+  -
+    family-names: Schindler
+    given-names: Felix
+cff-version: "1.1.0"
+doi: "10.1137/15M1026614"
+message: "If you use this software, please cite it using these metadata."
+title: "pyMOR -- Generic Algorithms and Interfaces for Model Order Reduction"
+...

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -21,6 +21,7 @@ include .env
 
 include MANIFEST.in
 include README.rst
+include CITATION.cff
 # this file and entry needs to be removed upon completion of issue #540
 include src/pymor/tools/LICENSE-MIT
 


### PR DESCRIPTION
so we get a nice GitHub widget for it:

<blockquote class="twitter-tweet"><p lang="en" dir="ltr">We’ve just added built-in citation support to GitHub so researchers and scientists can more easily receive acknowledgments for their contributions to software.<br><br>Just push a CITATION.cff file and we’ll add a handy widget to the repo sidebar for you.<br><br>Enjoy! 🎉 <a href="https://t.co/L85MS5pY2Y">pic.twitter.com/L85MS5pY2Y</a></p>&mdash; Nat Friedman (@natfriedman) <a href="https://twitter.com/natfriedman/status/1420122675813441540?ref_src=twsrc%5Etfw">July 27, 2021</a></blockquote> 