### PR TITLE
[ci] adjust for new debian release

### DIFF
--- a/.ci/gitlab/install_checks/debian_buster/check.bash
+++ b/.ci/gitlab/install_checks/debian_buster/check.bash
@@ -4,7 +4,7 @@ set -eu
 cp ${CI_PROJECT_DIR}/.ci/gitlab/install_checks/ci.pip.conf /etc/pip.conf
 
 # first section should ideally only needs minimal setup for out extension modules to compile
-apt update
+apt-get --allow-releaseinfo-change update
 apt install -y gcc python3-dev
 pip3 install -U pip
 pip install ${CI_PROJECT_DIR}[full]
@@ -12,3 +12,4 @@ pip install ${CI_PROJECT_DIR}[full]
 # second section gets additional setup for slycot, mpi4py etc
 apt install -y libopenblas-dev gfortran libopenmpi-dev gcc cmake make
 pip install -r ${CI_PROJECT_DIR}/requirements-optional.txt
+


### PR DESCRIPTION
apt will now error out b/c the suite value changed.
Buster is now oldstable
