### PR TITLE
Time dependent parameter values

### DIFF
--- a/src/pymor/algorithms/timestepping.py
+++ b/src/pymor/algorithms/timestepping.py
@@ -131,7 +131,7 @@ def implicit_euler(A, F, M, U0, t0, t1, nt, mu=None, num_values=None, solver_opt
     elif isinstance(F, Operator):
         assert F.source.dim == 1
         assert F.range == A.range
-        F_time_dep = F.parametric and 't' in F.parameters
+        F_time_dep = depends_on_time(F, mu)
         if not F_time_dep:
             dt_F = F.as_vector(mu) * dt
     else:
@@ -156,7 +156,7 @@ def implicit_euler(A, F, M, U0, t0, t1, nt, mu=None, num_values=None, solver_opt
                M.solver_options if solver_options == 'mass' else
                solver_options)
     M_dt_A = (M + A * dt).with_(solver_options=options)
-    if not M_dt_A.parametric or 't' not in M_dt_A.parameters:
+    if not depends_on_time(M_dt_A, mu):
         M_dt_A = M_dt_A.assemble(mu)
 
     t = t0
@@ -186,7 +186,7 @@ def explicit_euler(A, F, U0, t0, t1, nt, mu=None, num_values=None):
     if isinstance(F, Operator):
         assert F.source.dim == 1
         assert F.range == A.range
-        F_time_dep = F.parametric and 't' in F.parameters
+        F_time_dep = depends_on_time(F, mu)
         if not F_time_dep:
             F_ass = F.as_vector(mu)
     elif isinstance(F, VectorArray):
@@ -198,7 +198,7 @@ def explicit_euler(A, F, U0, t0, t1, nt, mu=None, num_values=None):
     assert len(U0) == 1
     assert U0 in A.source
 
-    A_time_dep = A.parametric and 't' in A.parameters
+    A_time_dep = depends_on_time(A, mu)
     if not A_time_dep:
         A = A.assemble(mu)
 
@@ -228,3 +228,9 @@ def explicit_euler(A, F, U0, t0, t1, nt, mu=None, num_values=None):
                 R.append(U)
 
     return R
+
+
+def depends_on_time(obj, mu):
+    if not mu:
+        return False
+    return 't' in obj.parameters or any(mu.is_time_dependent(k) for k in obj.parameters)

--- a/src/pymor/algorithms/timestepping.py
+++ b/src/pymor/algorithms/timestepping.py
@@ -131,7 +131,7 @@ def implicit_euler(A, F, M, U0, t0, t1, nt, mu=None, num_values=None, solver_opt
     elif isinstance(F, Operator):
         assert F.source.dim == 1
         assert F.range == A.range
-        F_time_dep = depends_on_time(F, mu)
+        F_time_dep = _depends_on_time(F, mu)
         if not F_time_dep:
             dt_F = F.as_vector(mu) * dt
     else:
@@ -156,7 +156,7 @@ def implicit_euler(A, F, M, U0, t0, t1, nt, mu=None, num_values=None, solver_opt
                M.solver_options if solver_options == 'mass' else
                solver_options)
     M_dt_A = (M + A * dt).with_(solver_options=options)
-    if not depends_on_time(M_dt_A, mu):
+    if not _depends_on_time(M_dt_A, mu):
         M_dt_A = M_dt_A.assemble(mu)
 
     t = t0
@@ -186,7 +186,7 @@ def explicit_euler(A, F, U0, t0, t1, nt, mu=None, num_values=None):
     if isinstance(F, Operator):
         assert F.source.dim == 1
         assert F.range == A.range
-        F_time_dep = depends_on_time(F, mu)
+        F_time_dep = _depends_on_time(F, mu)
         if not F_time_dep:
             F_ass = F.as_vector(mu)
     elif isinstance(F, VectorArray):
@@ -198,7 +198,7 @@ def explicit_euler(A, F, U0, t0, t1, nt, mu=None, num_values=None):
     assert len(U0) == 1
     assert U0 in A.source
 
-    A_time_dep = depends_on_time(A, mu)
+    A_time_dep = _depends_on_time(A, mu)
     if not A_time_dep:
         A = A.assemble(mu)
 
@@ -230,7 +230,7 @@ def explicit_euler(A, F, U0, t0, t1, nt, mu=None, num_values=None):
     return R
 
 
-def depends_on_time(obj, mu):
+def _depends_on_time(obj, mu):
     if not mu:
         return False
     return 't' in obj.parameters or any(mu.is_time_dependent(k) for k in obj.parameters)

--- a/src/pymor/analyticalproblems/functions.py
+++ b/src/pymor/analyticalproblems/functions.py
@@ -265,6 +265,9 @@ class ExpressionFunction(GenericFunction):
                 (self.expression, self.dim_domain, self.shape_range, self.parameters, self.values,
                  getattr(self, '_name', None)))
 
+    def __str__(self):
+        return f'{{x -> {self.expression}}}'
+
 
 class LincombFunction(Function):
     """A |Function| representing a linear combination of |Functions|.

--- a/src/pymor/core/cache.py
+++ b/src/pymor/core/cache.py
@@ -81,7 +81,7 @@ from pymor.core.defaults import defaults, defaults_changes
 from pymor.core.exceptions import CacheKeyGenerationError
 from pymor.core.logger import getLogger
 from pymor.core.pickle import dumps
-from pymor.parameters.base import Mu, Parameters
+from pymor.parameters.base import Mu
 
 
 @atexit.register
@@ -385,13 +385,13 @@ def build_cache_key(obj):
             if obj.dtype == object:
                 raise CacheKeyGenerationError('Cannot generate cache key for provided arguments')
             return obj
+        elif t is Mu:
+            return transform_obj(obj._raw_values)
         elif t in (list, tuple):
             return tuple(transform_obj(o) for o in obj)
         elif t in (set, frozenset):
             return tuple(transform_obj(o) for o in sorted(obj))
-        elif t in (Mu, Parameters):
-            return tuple((transform_obj(k), transform_obj(v)) for k, v in obj.items())
-        elif t in (dict, Mu, Parameters):
+        elif t is dict:
             return tuple((transform_obj(k), transform_obj(v)) for k, v in sorted(obj.items()))
         elif isinstance(obj, Number):
             # handle numpy number objects

--- a/src/pymor/parameters/base.py
+++ b/src/pymor/parameters/base.py
@@ -117,7 +117,7 @@ class Parameters(SortedFrozenDict):
         ValueError
             Is raised if `mu` cannot be interpreted as |parameter values| for the
             given |Parameters|.
-      """
+        """
 
         from pymor.analyticalproblems.functions import Function, ExpressionFunction
 

--- a/src/pymor/parameters/base.py
+++ b/src/pymor/parameters/base.py
@@ -32,6 +32,8 @@ class Parameters(SortedFrozenDict):
     specifying the dimension (number of scalar components) of the parameter.
     """
 
+    __slots__ = ()
+
     def _post_init(self):
         assert all(type(k) is str and type(v) is int and 0 <= v
                    for k, v in self.items())

--- a/src/pymor/parameters/base.py
+++ b/src/pymor/parameters/base.py
@@ -102,6 +102,9 @@ class Parameters(SortedFrozenDict):
         values `[2, 3]`. Further, each parameter value can be given as a
         vector-valued |Function| with `dim_domain == 1` to specify time-dependent
         values. A `str` is converted to an appropriate |ExpressionFunction|.
+        Note that |ExpressionFunctions| are functions of the variable `x`, so you
+        have to write `x` instead of `t` for the time parameter in the string
+        expression.
 
         Parameters
         ----------

--- a/src/pymor/parameters/base.py
+++ b/src/pymor/parameters/base.py
@@ -310,10 +310,28 @@ class Mu(FrozenDict):
         return mu
 
     def is_time_dependent(self, param):
+        """Check whether the values for a given parameter depend on time.
+
+        This is the case when the value for `self[param]` was given by a |Function|
+        instead of a constant array.
+        """
         from pymor.analyticalproblems.functions import Function
         return isinstance(self._raw_values[param], Function)
 
     def get_time_dependent_value(self, param):
+        """Return time-dependent |Function| for given parameter.
+
+        Parameters
+        ----------
+        param
+            The parameter for which to return the time-dependent values.
+
+        Returns
+        -------
+        If `param` depends on time, this corresponding |Function| (and not its
+        evaluation at the current time) is returned. If `param` is not given
+        by a |Function|, a |ConstantFunction| is returned.
+        """
         from pymor.analyticalproblems.functions import Function
         value = self._raw_values[param]
         if not isinstance(value, Function):

--- a/src/pymor/parameters/base.py
+++ b/src/pymor/parameters/base.py
@@ -267,7 +267,7 @@ class Mu(FrozenDict):
     ----------
     Anything that dict accepts for the construction of a dictionary.
     Values are automatically converted to one-dimensional |NumPy arrays|,
-    except for |Functions| which are interpreted as time dependent parameter
+    except for |Functions| which are interpreted as time-dependent parameter
     values. Unless the Python interpreter runs with the `-O` flag,
     the arrays are made immutable.
 

--- a/src/pymor/parameters/base.py
+++ b/src/pymor/parameters/base.py
@@ -243,16 +243,9 @@ class Parameters(SortedFrozenDict):
                    for k, v in other.items())
         return Parameters({k: v for k, v in self.items() if k not in other})
 
-    def __le__(self, mu):
-        """Check if |parameter values| are compatible with the given |Parameters|.
-
-        Each of the parameter must be contained in  `mu` and the dimensions have to match,
-        i.e. ::
-
-            mu[parameter].size == self[parameter]
-        """
-        if isinstance(mu, Parameters):
-            return all(mu.get(k) == v for k, v in self.items())
+    def __le__(self, params):
+        if isinstance(params, Parameters):
+            return all(params.get(k) == v for k, v in self.items())
         else:
             return NotImplemented
 

--- a/src/pymor/parameters/base.py
+++ b/src/pymor/parameters/base.py
@@ -363,7 +363,7 @@ class Mu(FrozenDict):
     def __str__(self):
         def format_value(k, v):
             if self.is_time_dependent(k):
-                return f'{self._raw_values[k]}({self.get("t", 0)})={format_array(v)}'
+                return f'{self._raw_values[k]}({self.get("t", 0)}) = {format_array(v)}'
             else:
                 return format_array(v)
 

--- a/src/pymor/parameters/base.py
+++ b/src/pymor/parameters/base.py
@@ -361,8 +361,13 @@ class Mu(FrozenDict):
         return self.keys() == mu.keys() and all(np.array_equal(v, mu[k]) for k, v in self.items())
 
     def __str__(self):
-        return '{' + ', '.join(f'{k}{"(t)" if self.is_time_dependent(k) else ""}: {format_array(v)}'
-                               for k, v in self.items()) + '}'
+        def format_value(k, v):
+            if self.is_time_dependent(k):
+                return f'{self._raw_values[k]}({self.get("t", 0)})={format_array(v)}'
+            else:
+                return format_array(v)
+
+        return '{' + ', '.join(f'{k}: {format_value(k, v)}' for k, v in self.items()) + '}'
 
     def __repr__(self):
         return f'Mu({dict(sorted(self._raw_values.items()))})'

--- a/src/pymor/parameters/base.py
+++ b/src/pymor/parameters/base.py
@@ -365,7 +365,10 @@ class Mu(FrozenDict):
 
     def to_numpy(self):
         """All parameter values as a NumPy array, ordered alphabetically."""
-        return np.hstack([v for k, v in self.items()])
+        if len(self) == 0:
+            return np.array([])
+        else:
+            return np.hstack([v for k, v in self.items()])
 
     def copy(self):
         return self

--- a/src/pymor/parameters/base.py
+++ b/src/pymor/parameters/base.py
@@ -37,6 +37,7 @@ class Parameters(SortedFrozenDict):
     def _post_init(self):
         assert all(type(k) is str and type(v) is int and 0 <= v
                    for k, v in self.items())
+        assert self.get('t', 1) == 1, 'time parameter must have length 1'
 
     @classmethod
     def of(cls, *args):
@@ -128,7 +129,7 @@ class Parameters(SortedFrozenDict):
             raise ValueError(f'{mu_str} is incompatible with Parameters {self} ({msg})')
 
         if not self:
-            mu is None or mu == {} or fail('must be None or empty dict')
+            mu is None or len(mu) == 0 or fail('must be None or empty dict')
             return Mu({})
 
         if isinstance(mu, Mu):
@@ -289,12 +290,14 @@ class Mu(FrozenDict):
                 # each time a Mu is created (which would make instantiation of simple Mus without
                 # time dependency significantly more expensive).
                 from pymor.analyticalproblems.functions import Function
+                assert k != 't'
                 assert isinstance(v, Function) and v.dim_domain == 1 and len(v.shape_range) == 1 and \
                     v.shape_range[0] > 0
                 vv = v(raw_values.get('t', 0))
             else:
                 vv = np.array(v, copy=False, ndmin=1)
                 assert vv.ndim == 1
+                assert k != 't' or len(vv) == 1
             assert not vv.setflags(write=False)
             values_for_t[k] = vv
 

--- a/src/pymor/tools/frozendict.py
+++ b/src/pymor/tools/frozendict.py
@@ -9,6 +9,8 @@
 class FrozenDict(dict):
     """An immutable dictionary."""
 
+    __slots__ = ()
+
     @property
     def _blocked_attribute(self):
         raise AttributeError(f'A {type(self).__name__} cannot be modified.')
@@ -38,6 +40,8 @@ class FrozenDict(dict):
 
 class SortedFrozenDict(FrozenDict):
     """A sorted immutable dictionary."""
+
+    __slots__ = ()
 
     def __new__(cls, *args, **kwargs):
         new = dict.__new__(cls)

--- a/src/pymortests/fixtures/parameter.py
+++ b/src/pymortests/fixtures/parameter.py
@@ -7,7 +7,7 @@ import numpy as np
 from pymor.parameters.base import Mu
 
 
-def parameters_of_type(parameters, seed):
+def mu_of_type(parameters, seed):
     np.random.seed(seed)
     while True:
         if parameters is None:

--- a/src/pymortests/function.py
+++ b/src/pymortests/function.py
@@ -8,7 +8,7 @@ import pytest
 from pymor.analyticalproblems.functions import ConstantFunction, GenericFunction
 from pymor.core.pickle import dumps, loads
 from pymortests.fixtures.function import function_argument
-from pymortests.fixtures.parameter import parameters_of_type
+from pymortests.fixtures.parameter import mu_of_type
 from pymortests.pickling import assert_picklable, assert_picklable_without_dumps_function
 
 
@@ -28,7 +28,7 @@ np.testing.assert_allclose = monkey_allclose
 
 def test_evaluate(function):
     f = function
-    mus = parameters_of_type(f.parameters, 4711)
+    mus = mu_of_type(f.parameters, 4711)
     for count in [0, 1, 5, (0, 1), (2, 2, 2)]:
         arg = function_argument(f, count, 454)
         result = f.evaluate(arg, next(mus))
@@ -73,7 +73,7 @@ def test_pickle_without_dumps_function(picklable_function):
 def test_pickle_by_evaluation(function):
     f = function
     f2 = loads(dumps(f))
-    mus = parameters_of_type(f.parameters, 47)
+    mus = mu_of_type(f.parameters, 47)
     for arg in function_argument(f, 10, 42):
         mu = next(mus)
         assert np.all(f.evaluate(arg, mu) == f2.evaluate(arg, mu))

--- a/src/pymortests/parameters.py
+++ b/src/pymortests/parameters.py
@@ -2,10 +2,14 @@
 # Copyright 2013-2021 pyMOR developers and contributors. All rights reserved.
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
+import numpy as np
+import pytest
+from hypothesis import given
+
+from pymor.analyticalproblems.functions import ConstantFunction
 from pymor.parameters.base import Parameters, Mu
 from pymortests.base import runmodule
-
-import pytest
+import pymortests.strategies as pyst
 
 
 num_samples = 100
@@ -40,6 +44,60 @@ def test_parse_parameter():
     mu_as_list = [1, 2, 3]
     mu_as_parameter_and_back = list(parameters.parse(mu_as_list).to_numpy())
     assert mu_as_list == mu_as_parameter_and_back
+
+
+@given(pyst.mus)
+def test_mu_parameters(mu):
+    params = mu.parameters
+    assert isinstance(params, Parameters)
+    assert mu.keys() == params.keys()
+    assert params.is_compatible(mu)
+
+
+@given(pyst.mus)
+def test_mu_values(mu):
+    assert all(isinstance(v, np.ndarray) for v in mu.values())
+    assert all(v.ndim == 1 for v in mu.values())
+    assert all(len(v) > 0 for v in mu.values())
+
+
+@given(pyst.mus)
+def test_mu_time_dependent(mu):
+    for param in mu:
+        func = mu.get_time_dependent_value(param)
+        if mu.is_time_dependent(param):
+            assert np.all(mu[param] == func(mu.get('t', 0)))
+        else:
+            assert isinstance(func, ConstantFunction)
+            assert np.all(mu[param] == func.value)
+
+
+@given(pyst.mus)
+def test_mu_with_changed_time(mu):
+    mu2 = mu.with_(t=42)
+    for param in mu:
+        if param == 't':
+            assert mu2['t'].item() == 42
+            continue
+        func = mu.get_time_dependent_value(param)
+        if mu.is_time_dependent(param):
+            assert np.all(mu2[param] == func(42))
+        else:
+            assert np.all(mu[param] == mu2[param])
+
+
+@given(pyst.mus)
+def test_mu_to_numpy(mu):
+    mu_array = mu.to_numpy()
+    mu2 = mu.parameters.parse(mu_array)
+    assert mu == mu2
+
+
+def test_mu_t_wrong_value():
+    with pytest.raises(Exception):
+        Mu(t=ConstantFunction(np.array([3])))
+    with pytest.raises(Exception):
+        Mu(t=np.array([1, 2]))
 
 
 if __name__ == "__main__":

--- a/src/pymortests/strategies.py
+++ b/src/pymortests/strategies.py
@@ -9,7 +9,9 @@ from hypothesis.extra import numpy as hynp
 import numpy as np
 from scipy.stats._multivariate import random_correlation_gen
 
+from pymor.analyticalproblems.functions import Function, ExpressionFunction, ConstantFunction
 from pymor.core.config import config
+from pymor.parameters.base import Mu
 from pymor.vectorarrays.list import NumpyListVectorSpace
 from pymor.vectorarrays.block import BlockVectorSpace
 from pymor.vectorarrays.numpy import NumpyVectorSpace
@@ -473,3 +475,17 @@ def base_vector_arrays(draw, count=1, dtype=None, max_dim=100):
 def equal_tuples(draw, strategy, count):
     val = draw(strategy)
     return draw(hyst.tuples(*[hyst.just(val) for _ in range(count)]))
+
+
+# stick to a few representative examples to avoid only seeing degenerate cases
+# in the selected examples
+mus = hyst.dictionaries(
+    keys=hyst.sampled_from(['t', 'foo', 'bar']),
+    values=hyst.sampled_from([
+        np.array([1.]),
+        np.array([1., 32., 3]),
+        ExpressionFunction('x+1', 1, (1,)),
+        ExpressionFunction('[1., 0] * x + [0, 1.] * x**2', 1, (2,)),
+        ConstantFunction(np.array([1., 2, 3]))
+    ])
+).filter(lambda mu: 't' not in mu or (not isinstance(mu['t'], Function) and len(mu['t']) == 1)).map(Mu)


### PR DESCRIPTION
This PR introduces support for time-dependent parameter values:

- `Mu` can be instantiated with values which are a `Function` with `dim_domain == 1` and `len(shape_range) == 1`.
- If the value for parameter `k` is such a `Function`, `mu[k]` will be given by the function evaluated at `mu[t]`.
- If `t` has no value in `mu` the value `0` is used instead.
- One can check whether a parameter value depends on time (and will change in `mu.with_(t=new_value)`) using the new `is_time_dependent` method.
- The time dependent function can be recovered using `mu.get_time_dependent_value`, which will return a `ConstantFunction` for values that do not depend on time.
- `Parameters.parse` has been extended accordingly. Instead of a `Function`, also a `str` can be provided, which is then converted to an `ExpressionFunction`.

Due to efficiency reasons when creating, say, a million of `Mu` instances, only the entire vector of values for a given parameter may be given by a `Function`, not individual entries in the vector. However, I plan to allow this for `Parameters.parse` sometime in the future after #1277 has been merged.