### PR TITLE
[docs] remove cell_input borders

### DIFF
--- a/docs/source/_static/pymor.css
+++ b/docs/source/_static/pymor.css
@@ -1,3 +1,9 @@
+.cell_input {
+  border: 0px #ccc solid !important;
+  border-left-color: green !important;
+  border-left-width: medium !important;
+}
+
 .md-typeset .md-typeset__table{
     display:block;
     /* background-color: red; */


### PR DESCRIPTION
Removes the input cell's grey border in tutorials. 