### PR TITLE
Bugfix in get_ast_spectrum

### DIFF
--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -1253,8 +1253,8 @@ class LTIModel(InputStateOutputModel):
             ast_ews = ew[ast_idx]
             idx = ast_ews.argsort()
 
-            ast_lev = self.A.source.from_numpy(lev[:, idx][:, ast_idx][:, 0, :].T)
-            ast_rev = self.A.range.from_numpy(rev[:, idx][:, ast_idx][:, 0, :].T)
+            ast_lev = self.A.source.from_numpy(lev[:, ast_idx][:, 0, :][:, idx].T)
+            ast_rev = self.A.range.from_numpy(rev[:, ast_idx][:, 0, :][:, idx].T)
 
             return ast_lev, ast_ews[idx], ast_rev
 

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -1200,6 +1200,10 @@ class LTIModel(InputStateOutputModel):
         rev
             |VectorArray| of right eigenvectors.
         """
+        if not isinstance(mu, Mu):
+            mu = self.parameters.parse(mu)
+        assert self.parameters.assert_compatible(mu)
+
         A, B, C, D, E = (op.assemble(mu=mu) for op in [self.A, self.B, self.C, self.D, self.E])
 
         if ast_pole_data is not None:


### PR DESCRIPTION
The parameter passed to the `LTIModel.get_ast_spectrum` method is now parsed. Also, a bug w.r.t. indexing is fixed.