### PR TITLE
Add vectorarray cow test

### DIFF
--- a/src/pymortests/vectorarray.py
+++ b/src/pymortests/vectorarray.py
@@ -277,7 +277,7 @@ def test_COW(vectors_and_indices):
             c = v[ind].copy(deep)
             assert len(c) == v.len_ind(ind)
         assert c.space == v.space
-        if len(c) > 0:
+        if len(c) > 0 and not np.all(c.norm() == 0):
             c *= 2
             if ind is None:
                 assert not np.all(almost_equal(c, v))

--- a/src/pymortests/vectorarray.py
+++ b/src/pymortests/vectorarray.py
@@ -266,6 +266,29 @@ def test_copy(vectors_and_indices):
             pass
 
 
+@pyst.given_vector_arrays(index_strategy=pyst.valid_indices)
+def test_COW(vectors_and_indices):
+    v, ind = vectors_and_indices
+    for deep in (True, False):
+        if ind is None:
+            c = v.copy(deep)
+            assert len(c) == len(v)
+        else:
+            c = v[ind].copy(deep)
+            assert len(c) == v.len_ind(ind)
+        assert c.space == v.space
+        if len(c) > 0:
+            c *= 2
+            if ind is None:
+                assert not np.all(almost_equal(c, v))
+            else:
+                assert not np.all(almost_equal(c, v[ind]))
+            try:
+                assert np.allclose(c.to_numpy(), 2*indexed(v.to_numpy(), ind))
+            except NotImplementedError:
+                pass
+
+
 @pyst.given_vector_arrays()
 def test_copy_repeated_index(vector_array):
     v = vector_array


### PR DESCRIPTION
This adds a test for copy on write of VectorArrays and increases the `max_examples` count to 20 in `dev` and `debug` sessions.

I stumbled upon broken COW functionality when binding a vector from an external PDE solver, and this was not catched by our tests.

Regarding the increase in `max_examples`: when adding an additional backend to the `strategies.py`, it is most likely not tested by hypothesis (don't know why, perhaps since last in list after `numpy`, `numpy_list` and `block`). In addition, there are rarely any `valid_indices` chosen apart from `[]`. Increasing the count to 20 helped a lot here.