### PR TITLE
Prevent invalid conversion of an Expression to bool

### DIFF
--- a/src/pymor/analyticalproblems/expressions.py
+++ b/src/pymor/analyticalproblems/expressions.py
@@ -167,6 +167,9 @@ class Expression(ParametricObject):
     def __gt__(self, other):
         return GT(self, _convert_to_expression(other))
 
+    def __bool__(self):
+        raise TypeError("Cannot convert Expression to bool. (Don't use boolean operators or two-sided comparisons.)")
+
 
 class BaseConstant(Expression):
     """A constant value."""

--- a/src/pymortests/function.py
+++ b/src/pymortests/function.py
@@ -5,7 +5,7 @@
 import numpy as np
 import pytest
 
-from pymor.analyticalproblems.functions import ConstantFunction, GenericFunction
+from pymor.analyticalproblems.functions import ConstantFunction, GenericFunction, ExpressionFunction
 from pymor.core.pickle import dumps, loads
 from pymortests.fixtures.function import function_argument
 from pymortests.fixtures.parameter import mu_of_type
@@ -77,3 +77,10 @@ def test_pickle_by_evaluation(function):
     for arg in function_argument(f, 10, 42):
         mu = next(mus)
         assert np.all(f.evaluate(arg, mu) == f2.evaluate(arg, mu))
+
+
+def test_invalid_expressions():
+    with pytest.raises(TypeError):
+        ExpressionFunction('-1 < x[0] < 1', 1)
+    with pytest.raises(TypeError):
+        ExpressionFunction('(-1 < x[0]) and (x[0] < 1)', 1)


### PR DESCRIPTION
Fixes #1426.
Fixes #1425.
Supersedes #1431.