### PR TITLE
Wachspress' shifts

### DIFF
--- a/docs/source/bibliography.bib
+++ b/docs/source/bibliography.bib
@@ -267,6 +267,18 @@
   school={Shaker Verlag Aachen}
 }
 
+@Article{LiW02,
+  author =       {J.-R. Li and J. White},
+  title =        {Low Rank Solution of {L}yapunov Equations},
+  journal =      SIAMMatrix,
+  year =         2002,
+  volume =       24,
+  number =       1,
+  pages =        {260--280},
+  issn =         {0895-4798},
+  doi =          {10.1137/S0895479801384937}
+}
+
 @Article{MS96,
   author =       {Meyer, D.~G. and Srinivasan, S.},
   title =        {Balancing and model reduction for second-order form linear

--- a/docs/source/bibliography.bib
+++ b/docs/source/bibliography.bib
@@ -270,7 +270,7 @@
 @Article{LiW02,
   author =       {J.-R. Li and J. White},
   title =        {Low Rank Solution of {L}yapunov Equations},
-  journal =      SIAMMatrix,
+  journal =      {SIAM J. Matrix Anal. Appl.},
   year =         2002,
   volume =       24,
   number =       1,

--- a/src/pymor/algorithms/lradi.py
+++ b/src/pymor/algorithms/lradi.py
@@ -105,7 +105,7 @@ def solve_lyap_lrcf(A, E, B, trans=False, options=None):
     if shift_options['type'] == 'projection_shifts':
         init_shifts = projection_shifts_init
         iteration_shifts = projection_shifts
-    if shift_options['type'] == 'wachspress_shifts':
+    elif shift_options['type'] == 'wachspress_shifts':
         init_shifts = wachspress_shifts_init
         iteration_shifts = cycle_shifts
     else:

--- a/src/pymor/algorithms/lradi.py
+++ b/src/pymor/algorithms/lradi.py
@@ -24,8 +24,8 @@ def lyap_lrcf_solver_options(lradi_tol=1e-10,
                              projection_shifts_init_maxiter=20,
                              projection_shifts_init_seed=None,
                              projection_shifts_subspace_columns=6,
-                             large_ritz_num=50,
-                             small_ritz_num=25,
+                             wachspress_large_ritz_num=50,
+                             wachspress_small_ritz_num=25,
                              wachspress_tol=1e-10):
     """Return available Lyapunov solvers with default options.
 
@@ -62,8 +62,8 @@ def lyap_lrcf_solver_options(lradi_tol=1e-10,
                                              'init_seed': projection_shifts_init_seed,
                                              'subspace_columns': projection_shifts_subspace_columns},
                        'wachspress_shifts': {'type': 'wachspress_shifts',
-                                             'large_ritz_num': large_ritz_num,
-                                             'small_ritz_num': small_ritz_num,
+                                             'large_ritz_num': wachspress_large_ritz_num,
+                                             'small_ritz_num': wachspress_small_ritz_num,
                                              'tol': wachspress_tol}}}}
 
 
@@ -252,7 +252,8 @@ def wachspress_shifts_init(A, E, B, shift_options):
 
     This method computes optimal shift parameters for the LR-ADI iteration
     based on Wachspress' method which is discussed in :cite:`LiW02`. This
-    implementation assumes that :math:`A` and :math:`E` are both symmetric.
+    implementation assumes that :math:`A` and :math:`E` are both real and
+    symmetric.
     """
     b = B[0]  # this will work with an arbitrary vector
     _, Hl, _ = _arnoldi(InverseOperator(E) @ A, shift_options['large_ritz_num'], b, True)
@@ -272,10 +273,10 @@ def wachspress_shifts_init(A, E, B, shift_options):
         m = 2 * np.cos(alpha)**2 / cos2b - 1
         if m < 1:
             # shifts are complex, method not applicable
-            raise NotImplementedError
+            raise NotImplementedError('LR-ADI shift parameter strategy can not handle complex shifts.')
         kp = 1 / (m + np.sqrt(m**2 - 1))
 
-    # make sure k is not exactly 1 since the method won't work otherwise
+    # make sure k is not exactly 1
     k = min(1 - np.spacing(1), np.sqrt(1 - kp**2))
 
     # computes elliptic integral

--- a/src/pymor/algorithms/lradi.py
+++ b/src/pymor/algorithms/lradi.py
@@ -257,10 +257,26 @@ def wachspress_shifts_init(A, E, B, shift_options):
     based on Wachspress' method which is discussed in :cite:`LiW02`. This
     implementation assumes that :math:`A` and :math:`E` are both real and
     symmetric.
+
+    Parameters
+    ----------
+    A
+        The |Operator| A from the corresponding Lyapunov equation.
+    E
+        The |Operator| E from the corresponding Lyapunov equation.
+    B
+        The |VectorArray| B from the corresponding Lyapunov equation.
+    shift_options
+        The shift options to use (see :func:`lyap_lrcf_solver_options`).
+
+    Returns
+    -------
+    shifts
+        A |NumPy array| containing a set of stable shift parameters.
     """
     b = B[0]  # this will work with an arbitrary vector
-    _, Hl, _ = _arnoldi(InverseOperator(E) @ A, shift_options['large_ritz_num'], b, True)
-    _, Hs, _ = _arnoldi(InverseOperator(A) @ E, shift_options['small_ritz_num'], b, True)
+    _, Hl, _ = _arnoldi(InverseOperator(E) @ A, shift_options['large_ritz_num'], b, False)
+    _, Hs, _ = _arnoldi(InverseOperator(A) @ E, shift_options['small_ritz_num'], b, False)
 
     rvs = np.concatenate((spla.eigvals(Hl), 1 / spla.eigvals(Hs)))
 

--- a/src/pymor/algorithms/lradi.py
+++ b/src/pymor/algorithms/lradi.py
@@ -17,7 +17,8 @@ from pymor.vectorarrays.constructions import cat_arrays
 
 
 @defaults('lradi_tol', 'lradi_maxiter', 'lradi_shifts', 'projection_shifts_init_maxiter',
-          'projection_shifts_init_seed', 'projection_shifts_subspace_columns')
+          'projection_shifts_init_seed', 'projection_shifts_subspace_columns',
+          'wachspress_large_ritz_num', 'wachspress_small_ritz_num', 'wachspress_tol')
 def lyap_lrcf_solver_options(lradi_tol=1e-10,
                              lradi_maxiter=500,
                              lradi_shifts='projection_shifts',
@@ -43,9 +44,9 @@ def lyap_lrcf_solver_options(lradi_tol=1e-10,
         See :func:`projection_shifts_init`.
     projection_shifts_subspace_columns
         See :func:`projection_shifts`.
-    large_ritz_num
+    wachspress_large_ritz_num
         See :func:`wachspress_shifts_init`.
-    small_ritz_num
+    wachspress_small_ritz_num
         See :func:`wachspress_shifts_init`.
 
     Returns

--- a/src/pymor/algorithms/lradi.py
+++ b/src/pymor/algorithms/lradi.py
@@ -5,12 +5,13 @@
 import numpy as np
 import scipy.linalg as spla
 
+from pymor.algorithms.eigs import _arnoldi
 from pymor.algorithms.genericsolvers import _parse_options
 from pymor.algorithms.gram_schmidt import gram_schmidt
 from pymor.algorithms.lyapunov import _solve_lyap_lrcf_check_args
 from pymor.core.defaults import defaults
 from pymor.core.logger import getLogger
-from pymor.operators.constructions import IdentityOperator
+from pymor.operators.constructions import IdentityOperator, InverseOperator
 from pymor.tools.random import get_random_state
 from pymor.vectorarrays.constructions import cat_arrays
 
@@ -22,7 +23,10 @@ def lyap_lrcf_solver_options(lradi_tol=1e-10,
                              lradi_shifts='projection_shifts',
                              projection_shifts_init_maxiter=20,
                              projection_shifts_init_seed=None,
-                             projection_shifts_subspace_columns=6):
+                             projection_shifts_subspace_columns=6,
+                             large_ritz_num=50,
+                             small_ritz_num=25,
+                             wachspress_tol=1e-10):
     """Return available Lyapunov solvers with default options.
 
     Parameters
@@ -39,6 +43,10 @@ def lyap_lrcf_solver_options(lradi_tol=1e-10,
         See :func:`projection_shifts_init`.
     projection_shifts_subspace_columns
         See :func:`projection_shifts`.
+    large_ritz_num
+        See :func:`wachspress_shifts_init`.
+    small_ritz_num
+        See :func:`wachspress_shifts_init`.
 
     Returns
     -------
@@ -52,7 +60,11 @@ def lyap_lrcf_solver_options(lradi_tol=1e-10,
                       {'projection_shifts': {'type': 'projection_shifts',
                                              'init_maxiter': projection_shifts_init_maxiter,
                                              'init_seed': projection_shifts_init_seed,
-                                             'subspace_columns': projection_shifts_subspace_columns}}}}
+                                             'subspace_columns': projection_shifts_subspace_columns},
+                       'wachspress_shifts': {'type': 'wachspress_shifts',
+                                             'large_ritz_num': large_ritz_num,
+                                             'small_ritz_num': small_ritz_num,
+                                             'tol': wachspress_tol}}}}
 
 
 def solve_lyap_lrcf(A, E, B, trans=False, options=None):
@@ -93,6 +105,9 @@ def solve_lyap_lrcf(A, E, B, trans=False, options=None):
     if shift_options['type'] == 'projection_shifts':
         init_shifts = projection_shifts_init
         iteration_shifts = projection_shifts
+    if shift_options['type'] == 'wachspress_shifts':
+        init_shifts = wachspress_shifts_init
+        iteration_shifts = cycle_shifts
     else:
         raise ValueError('Unknown low-rank ADI shift strategy.')
 
@@ -230,3 +245,107 @@ def projection_shifts(A, E, V, Z, prev_shifts, shift_options):
         shifts.imag[-shifts.imag / shifts.real < 1e-12] = 0
         shifts = shifts[np.abs(shifts).argsort()]
         return shifts
+
+
+def wachspress_shifts_init(A, E, B, shift_options):
+    """Compute optimal shifts for symmetric matrices.
+
+    This method computes optimal shift parameters for the LR-ADI iteration
+    based on Wachspress' method which is discussed in :cite:`LiW02`. This
+    implementation assumes that :math:`A` and :math:`E` are both symmetric.
+    """
+    b = B[0]  # this will work with an arbitrary vector
+    _, Hl, _ = _arnoldi(InverseOperator(E) @ A, shift_options['large_ritz_num'], b, True)
+    _, Hs, _ = _arnoldi(InverseOperator(A) @ E, shift_options['small_ritz_num'], b, True)
+
+    rvs = np.concatenate((spla.eigvals(Hl), 1 / spla.eigvals(Hs)))
+
+    a = min(np.abs(np.real(rvs)))
+    b = max(np.abs(np.real(rvs)))
+
+    alpha = np.arctan(max(np.imag(rvs)/np.real(rvs)))
+
+    if alpha == 0:
+        kp = a / b
+    else:
+        cos2b = 2 / (1 + 0.5 * (a/b + b/a))
+        m = 2 * np.cos(alpha)**2 / cos2b - 1
+        if m < 1:
+            # shifts are complex, method not applicable
+            raise NotImplementedError
+        kp = 1 / (m + np.sqrt(m**2 - 1))
+
+    # make sure k is not exactly 1 since the method won't work otherwise
+    k = min(1 - np.spacing(1), np.sqrt(1 - kp**2))
+
+    # computes elliptic integral
+    def ell_int(k, phi):
+        g = 0.
+        a0 = 1.
+        b0 = min(1 - np.spacing(1), np.sqrt(1 - k**2))
+        d0 = phi
+        r = k**2
+        fac = 1.
+        for _ in range(40):
+            a = (a0+b0) / 2
+            b = np.sqrt(a0 * b0)
+            c = (a0-b0) / 2
+            fac = 2 * fac
+            r = r + fac * c * c
+            if phi != np.pi / 2:
+                d = d0 + np.arctan((b0/a0) * np.tan(d0))
+                g = g + c * np.sin(d)
+                d0 = d + np.pi * np.fix(d / np.pi + 0.5)
+            a0 = a
+            b0 = b
+            if (c < 1.0e-15):
+                break
+        ck = np.pi / (2.0 * a)
+        if phi == np.pi / 2:
+            F = ck
+        else:
+            F = d0 / (fac * a)
+        return F
+
+    # evaluates elliptic function
+    def ell_val(u, k):
+        a = np.array([1])
+        b = np.array([min(1 - np.spacing(1), np.sqrt(1 - k**2))])
+        c = np.array([k])
+        i = 0
+        while np.abs(c[i] > np.spacing(1)):
+            a = np.append(a, (a[i] + b[i]) / 2)
+            b = np.append(b, np.sqrt(a[i] * b[i]))
+            c = np.append(c, (a[i] - b[i]) / 2)
+            i = i + 1
+
+        p1 = 2**i * a[i] * u
+        p0 = 0
+
+        for j in range(i, 0, -1):
+            if j < i:
+                p1 = p0
+            p0 = (p1 + np.arcsin(c[j] * np.sin(np.fmod(p1, 2*np.pi)) / a[j])) / 2
+        arg = 1 - k**2 * np.sin(np.fmod(p0, np.pi))**2
+        if arg < 1:
+            return np.sqrt(arg)
+        else:
+            return np.cos(np.fmod(p0, 2 * np.pi)) / np.cos(p1 - p0)
+
+    K = ell_int(k, np.pi / 2)
+    if alpha == 0:
+        v = ell_int(kp, np.pi / 2)
+    else:
+        v = ell_int(kp, np.arcsin(np.sqrt(a / (b * kp))))
+
+    J = int(np.ceil(K / (2*v*np.pi) * np.log(4/shift_options['tol'])))
+    p = np.empty(J)
+    for i in range(J):
+        p[i] = -np.sqrt(a*b/kp)*ell_val((i+0.5)*K/J, k)
+
+    return p
+
+
+def cycle_shifts(A, E, V, Z, prev_shifts, shift_options):
+    """Return previously computed shifts."""
+    return prev_shifts

--- a/src/pymor/algorithms/lradi.py
+++ b/src/pymor/algorithms/lradi.py
@@ -48,6 +48,8 @@ def lyap_lrcf_solver_options(lradi_tol=1e-10,
         See :func:`wachspress_shifts_init`.
     wachspress_small_ritz_num
         See :func:`wachspress_shifts_init`.
+    wachspress_tol
+        See :func:`wachspress_shifts_init`.
 
     Returns
     -------

--- a/src/pymordemos/heat.py
+++ b/src/pymordemos/heat.py
@@ -8,6 +8,7 @@ import matplotlib.pyplot as plt
 from typer import Argument, run
 
 
+from pymor.algorithms.lradi import lyap_lrcf_solver_options
 from pymor.analyticalproblems.domaindescriptions import RectDomain
 from pymor.analyticalproblems.elliptic import StationaryProblem
 from pymor.analyticalproblems.functions import ConstantFunction, ExpressionFunction
@@ -80,7 +81,8 @@ def run_mor_method(lti, w, reductor, reductor_short_name, r, **reduce_kwargs):
     """
     # Reduction
     rom = reductor.reduce(r, **reduce_kwargs)
-    err = lti - rom
+    solver_options = {'lyap_lrcf': lyap_lrcf_solver_options(lradi_shifts='projection_shifts')['lradi']}
+    err = (lti - rom).with_(solver_options=solver_options)
 
     # Errors
     from pymor.models.iosys import TransferFunction
@@ -155,7 +157,8 @@ def main(
     fom.visualize(fom.solve())
 
     # LTI system
-    lti = fom.to_lti()
+    solver_options = {'lyap_lrcf': lyap_lrcf_solver_options(lradi_shifts='wachspress_shifts')['lradi']}
+    lti = fom.to_lti().with_(solver_options=solver_options)
 
     # System properties
     w = np.logspace(-1, 3, 100)

--- a/src/pymordemos/heat.py
+++ b/src/pymordemos/heat.py
@@ -81,8 +81,10 @@ def run_mor_method(lti, w, reductor, reductor_short_name, r, **reduce_kwargs):
     """
     # Reduction
     rom = reductor.reduce(r, **reduce_kwargs)
-    solver_options = {'lyap_lrcf': lyap_lrcf_solver_options(lradi_shifts='projection_shifts')['lradi']}
-    err = (lti - rom).with_(solver_options=solver_options)
+    err = lti - rom
+    if isinstance(err, LTIModel):
+        solver_options = {'lyap_lrcf': lyap_lrcf_solver_options(lradi_shifts='projection_shifts')['lradi']}
+        err = err.with_(solver_options=solver_options)
 
     # Errors
     from pymor.models.iosys import TransferFunction


### PR DESCRIPTION
This PR adds a new shift selection to the Low-Rank ADI iteration. The shifts are optimal but can only be expected to work for symmetric system matrices. The shifts are tested in the `heat.py` demo.