### PR TITLE
Improve error handling in DiskRegion / Don't disable caching in mpi_wrap_model

### DIFF
--- a/src/pymor/bindings/fenics.py
+++ b/src/pymor/bindings/fenics.py
@@ -14,6 +14,7 @@ if config.HAVE_FENICS:
 
     from pymor.core.base import ImmutableObject
     from pymor.core.defaults import defaults
+    from pymor.core.pickle import unpicklable
     from pymor.operators.constructions import ZeroOperator
     from pymor.operators.interface import Operator
     from pymor.operators.list import LinearComplexifiedListVectorArrayOperatorBase
@@ -22,6 +23,7 @@ if config.HAVE_FENICS:
     from pymor.vectorarrays.list import CopyOnWriteVector, ComplexifiedVector, ComplexifiedListVectorSpace
     from pymor.vectorarrays.numpy import NumpyVectorSpace
 
+    @unpicklable
     class FenicsVector(CopyOnWriteVector):
         """Wraps a FEniCS vector to make it usable with ListVectorArray."""
 

--- a/src/pymor/core/cache.py
+++ b/src/pymor/core/cache.py
@@ -78,7 +78,7 @@ import numpy as np
 
 from pymor.core.base import ImmutableObject
 from pymor.core.defaults import defaults, defaults_changes
-from pymor.core.exceptions import CacheKeyGenerationError
+from pymor.core.exceptions import CacheKeyGenerationError, UnpicklableError
 from pymor.core.logger import getLogger
 from pymor.core.pickle import dumps
 from pymor.parameters.base import Mu
@@ -186,7 +186,12 @@ class DiskRegion(CacheRegion):
         if has_key:
             getLogger('pymor.core.cache.DiskRegion').warning('Key already present in cache region, ignoring.')
             return
-        self._cache.set(key, value)
+        try:
+            self._cache.set(key, value)
+        except UnpicklableError as e:
+            getLogger('pymor.core.cache.DiskRegion').warning(f'{e.cls} cannot be pickled. Not caching result.')
+        except (TypeError, AttributeError) as e:
+            getLogger('pymor.core.cache.DiskRegion').warning(f'Pickling failed. Not caching result (error: {e}).')
 
     def clear(self):
         self._cache.clear()

--- a/src/pymor/core/exceptions.py
+++ b/src/pymor/core/exceptions.py
@@ -89,3 +89,11 @@ class IOLibsMissing(ImportError):
     def __init__(self, msg=None):
         msg = msg or 'meshio, pyevtk, xmljson and lxml are needed for full file I/O functionality'
         super().__init__(msg)
+
+
+class UnpicklableError(Exception):
+    def __init__(self, cls):
+        self.cls = cls
+
+    def __str__(self):
+        return f'{self.cls} cannot be pickled.'

--- a/src/pymor/core/pickle.py
+++ b/src/pymor/core/pickle.py
@@ -21,6 +21,8 @@ import pickle
 from io import BytesIO as IOtype
 import platform
 
+from pymor.core.exceptions import UnpicklableError
+
 
 PicklingError = pickle.PicklingError
 UnpicklingError = pickle.UnpicklingError
@@ -60,6 +62,15 @@ else:
     dumps = partial(pickle.dumps, protocol=PROTOCOL)
     load = pickle.load
     loads = pickle.loads
+
+
+def unpicklable(cls):
+    """Class decorator to mark a class as unpicklable."""
+    def __getstate__(self):
+        raise UnpicklableError(cls)
+
+    cls.__getstate__ = __getstate__
+    return cls
 
 
 def _generate_opcode(code_object):

--- a/src/pymor/models/mpi.py
+++ b/src/pymor/models/mpi.py
@@ -139,7 +139,6 @@ def mpi_wrap_model(local_models, mpi_spaces=('STATE',), use_with=True, with_appl
         if m.visualizer:
             wrapped_attributes['visualizer'] = MPIVisualizer(local_models)
         m = m.with_(**wrapped_attributes)
-        m.disable_caching()
         return m
     else:
 

--- a/src/pymor/vectorarrays/mpi.py
+++ b/src/pymor/vectorarrays/mpi.py
@@ -15,10 +15,12 @@ by :mod:`pymor.tools.mpi`.
 
 import numpy as np
 
+from pymor.core.pickle import unpicklable
 from pymor.tools import mpi
 from pymor.vectorarrays.interface import VectorArray, VectorSpace
 
 
+@unpicklable
 class MPIVectorArray(VectorArray):
     """MPI distributed |VectorArray|.
 


### PR DESCRIPTION
- Don't generally disable caching in `mpi_wrap_model` (see #1328).
- Let `DiskRegion` log a warning instead of failing when a value cannot be pickled.
- Add `unpicklable` class decorator which produces an `UnpicklableError` when the decorated class is pickled.
- Catch `UnpicklableError` in `DiskRegion.set` to generate better error messages.

Supersedes #1335.