### PR TITLE
Ensure that output_functional is never None

### DIFF
--- a/src/pymor/models/interface.py
+++ b/src/pymor/models/interface.py
@@ -103,10 +103,7 @@ class Model(CacheableObject, ParametricObject):
         |NumPy array| with the computed output or a dict which at least
         must contain the key `'output'`.
         """
-        if not getattr(self, 'output_functional', None):
-            return np.zeros((len(solution), 0))
-        else:
-            return self.output_functional.apply(solution, mu=mu).to_numpy()
+        return self.output_functional.apply(solution, mu=mu).to_numpy()
 
     def _compute_solution_d_mu_single_direction(self, parameter, index, solution, mu=None, **kwargs):
         """Compute the partial derivative of the solution w.r.t. a parameter index

--- a/src/pymor/models/neural_network.py
+++ b/src/pymor/models/neural_network.py
@@ -21,6 +21,7 @@ if config.HAVE_TORCH:
 
     from pymor.core.base import BasicObject
     from pymor.models.interface import Model
+    from pymor.operators.constructions import ZeroOperator
     from pymor.vectorarrays.numpy import NumpyVectorSpace
 
     class NeuralNetworkModel(Model):
@@ -71,8 +72,9 @@ if config.HAVE_TORCH:
 
             self.__auto_init(locals())
             self.solution_space = NumpyVectorSpace(neural_network.output_dimension)
-            if output_functional is not None:
-                self.dim_output = output_functional.range.dim
+            output_functional = output_functional or ZeroOperator(NumpyVectorSpace(0), self.solution_space)
+            assert output_functional.source == self.solution_space
+            self.dim_output = output_functional.range.dim
 
         def _compute_solution(self, mu=None, **kwargs):
 

--- a/src/pymor/reductors/basic.py
+++ b/src/pymor/reductors/basic.py
@@ -178,7 +178,7 @@ class StationaryRBReductor(ProjectionBasedReductor):
             'operator':          project(fom.operator, RB, RB),
             'rhs':               project(fom.rhs, RB, None),
             'products':          {k: project(v, RB, RB) for k, v in fom.products.items()},
-            'output_functional': project(fom.output_functional, None, RB) if fom.output_functional else None
+            'output_functional': project(fom.output_functional, None, RB)
         }
         return projected_operators
 
@@ -189,8 +189,7 @@ class StationaryRBReductor(ProjectionBasedReductor):
             'operator':          project_to_subbasis(rom.operator, dim, dim),
             'rhs':               project_to_subbasis(rom.rhs, dim, None),
             'products':          {k: project_to_subbasis(v, dim, dim) for k, v in rom.products.items()},
-            'output_functional': (project_to_subbasis(rom.output_functional, None, dim)
-                                  if rom.output_functional else None)
+            'output_functional': project_to_subbasis(rom.output_functional, None, dim)
         }
         return projected_operators
 
@@ -256,7 +255,7 @@ class InstationaryRBReductor(ProjectionBasedReductor):
             'rhs':               project(fom.rhs, RB, None),
             'initial_data':      projected_initial_data,
             'products':          {k: project(v, RB, RB) for k, v in fom.products.items()},
-            'output_functional': project(fom.output_functional, None, RB) if fom.output_functional else None
+            'output_functional': project(fom.output_functional, None, RB)
         }
 
         return projected_operators
@@ -283,8 +282,7 @@ class InstationaryRBReductor(ProjectionBasedReductor):
             'rhs':               project_to_subbasis(rom.rhs, dim, None),
             'initial_data':      projected_initial_data,
             'products':          {k: project_to_subbasis(v, dim, dim) for k, v in rom.products.items()},
-            'output_functional': (project_to_subbasis(rom.output_functional, None, dim)
-                                  if rom.output_functional else None)
+            'output_functional': project_to_subbasis(rom.output_functional, None, dim)
         }
         return projected_operators
 

--- a/src/pymor/reductors/neural_network.py
+++ b/src/pymor/reductors/neural_network.py
@@ -248,8 +248,7 @@ if config.HAVE_TORCH:
         def _build_rom(self):
             """Construct the reduced order model."""
             with self.logger.block('Building ROM ...'):
-                projected_output_functional = (project(self.fom.output_functional, None, self.reduced_basis)
-                                               if self.fom.output_functional else None)
+                projected_output_functional = project(self.fom.output_functional, None, self.reduced_basis)
                 rom = NeuralNetworkModel(self.neural_network, parameters=self.fom.parameters,
                                          output_functional=projected_output_functional,
                                          name=f'{self.fom.name}_reduced')
@@ -439,8 +438,7 @@ if config.HAVE_TORCH:
         def _build_rom(self):
             """Construct the reduced order model."""
             with self.logger.block('Building ROM ...'):
-                projected_output_functional = (project(self.fom.output_functional, None, self.reduced_basis)
-                                               if self.fom.output_functional else None)
+                projected_output_functional = project(self.fom.output_functional, None, self.reduced_basis)
                 rom = NeuralNetworkInstationaryModel(self.fom.T, self.nt, self.neural_network,
                                                      parameters=self.fom.parameters,
                                                      output_functional=projected_output_functional,


### PR DESCRIPTION
So far, `StationaryModel`, `InstationaryModel` and `NeuralNetworkModel` allowed `output_functional` to be `None`. This PR changes the behavior to set `output_functional` to `ZeroOperator(NumpyVectorSpace(0), self.solution_space)` in case no functional is provided.

This reduced the need for special cases, better aligns these `Models` with a mathematical definition and is in line with what is done for the system-theoretic `Models`.