### PR TITLE
Improvements to API documentation

### DIFF
--- a/docs/source/_static/pymor.css
+++ b/docs/source/_static/pymor.css
@@ -6,7 +6,9 @@
 }
 
 .md-typeset .admonition{
-    overflow:hidden;
+    overflow: hidden;
+    border-left: .2rem solid #ffd042;
+    margin-right: .6rem;
 }
 
 .output.text_html {
@@ -88,4 +90,26 @@ div.cell_output .output.stream, div.cell_output .output.text_plain {
 
 div.lm-Widget.p-Widget.lm-Panel.p-Panel.jp-OutputArea-child {
     float: left !important;
+}
+
+.py.class, .py.function {
+    padding: 0 0 .1rem 0rem !important;
+    border-left: .2rem solid #448aff !important;
+    border-radius: .1rem !important;
+    margin-bottom: 2.5rem !important;
+    box-shadow: 0 2px 2px 0 rgba(0,0,0,.14),0 1px 5px 0 rgba(0,0,0,.12),0 3px 1px -2px rgba(0,0,0,.2) !important;
+}
+
+.sig.sig-object.py {
+    padding: .4rem .6rem .4rem .6rem !important;
+    border-bottom: .05rem rgba(68,138,255,.1) solid !important;
+    background-color: rgba(68,138,255,.1) !important;
+    margin-top: 0 !important;
+}
+
+.md-typeset .admonition > .admonition-title::before,
+.md-typeset .admonition > summary::before,
+.md-typeset details > .admonition-title::before,
+.md-typeset details > summary::before {
+    color: rgba(0,0,0,.87) !important;
 }

--- a/docs/source/_static/pymor.css
+++ b/docs/source/_static/pymor.css
@@ -8,7 +8,6 @@
 .md-typeset .admonition{
     overflow: hidden;
     border-left: .2rem solid #ffd042;
-    margin-right: .6rem;
 }
 
 .output.text_html {
@@ -96,8 +95,13 @@ div.lm-Widget.p-Widget.lm-Panel.p-Panel.jp-OutputArea-child {
     padding: 0 0 .1rem 0rem !important;
     border-left: .2rem solid #448aff !important;
     border-radius: .1rem !important;
-    margin-bottom: 2.5rem !important;
+    margin-bottom: 1.25rem !important;
+    margin-top: 1.25rem !important;
     box-shadow: 0 2px 2px 0 rgba(0,0,0,.14),0 1px 5px 0 rgba(0,0,0,.12),0 3px 1px -2px rgba(0,0,0,.2) !important;
+}
+
+.py.class dd, .py.function dd {
+    padding-right: .6rem;
 }
 
 .sig.sig-object.py {
@@ -112,4 +116,34 @@ div.lm-Widget.p-Widget.lm-Panel.p-Panel.jp-OutputArea-child {
 .md-typeset details > .admonition-title::before,
 .md-typeset details > summary::before {
     color: rgba(0,0,0,.87) !important;
+}
+
+html .md-typeset .admonition > :last-child, html .md-typeset details > :last-child {
+    margin-top: .6rem !important;
+}
+
+.admonition-raises.admonition {
+    border-left: .2rem solid #ff7142;
+}
+
+.admonition-raises.admonition .admonition-title {
+    border-bottom: .05rem solid #ff7142;
+    background-color: #ffc6b3;
+}
+
+.py.class .admonition, .py.function .admonition {
+    border-left: None;
+}
+
+.py.class > dd > .admonition.admonition-parameters {
+    border-left: .2rem solid #ffd042;
+}
+
+.py.class > dd > .admonition.admonition-parameters .admonition-title {
+    border-bottom: .05rem solid #ffd042;
+    background-color: #ffecb3;
+}
+
+.py.method, .py.function {
+    border-left: .1rem solid #448aff !important;
 }

--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -4,4 +4,20 @@
 {# Call the parent block #}
 {{ super() }}
 <link rel="stylesheet" href="{{ pathto('_static/pymor.css', 1) }}"/>
+
+<script language="javascript">
+    function scrollToTarget() {
+        target_position = $(":target").offset().top;
+        header_height = $('header').height();
+        $(window).scrollTop(target_position - header_height);
+    }
+
+    $(document).ready(function(){
+        window.setTimeout(function() {
+            scrollToTarget();
+        }, 15);
+    });
+
+    window.onhashchange = scrollToTarget;
+</script>
 {%- endblock %}


### PR DESCRIPTION
To improve the appearance of the API documentation, I made some changes to the custom CSS file. The result looks like this:
![image](https://user-images.githubusercontent.com/28065234/141781830-d77db05e-4bd6-4538-87d1-fd5f6670e472.png)

One can take a closer look here: https://docs.pymor.org/github-push-improvements-docs/autoapi/index.html
