### PR TITLE
Add input parameter to interface methods of Model

### DIFF
--- a/src/pymor/models/basic.py
+++ b/src/pymor/models/basic.py
@@ -298,7 +298,8 @@ class InstationaryModel(Model):
         except IndexError:
             dim_input = 0
 
-        super().__init__(dim_input=dim_input, products=products, error_estimator=error_estimator, visualizer=visualizer, name=name)
+        super().__init__(dim_input=dim_input, products=products, error_estimator=error_estimator,
+                         visualizer=visualizer, name=name)
 
         self.parameters_internal = dict(self.parameters_internal, t=1)
         self.__auto_init(locals())

--- a/src/pymor/models/basic.py
+++ b/src/pymor/models/basic.py
@@ -292,9 +292,15 @@ class InstationaryModel(Model):
         assert mass.linear and mass.source == mass.range == operator.source
         assert output_functional.source == operator.source
 
-        super().__init__(products=products, error_estimator=error_estimator, visualizer=visualizer, name=name)
+        try:
+            dim_input = [op.parameters['input']
+                         for op in [operator, rhs, output_functional] if 'input' in op.parameters].pop()
+        except IndexError:
+            dim_input = 0
 
-        self.parameters_internal = {'t': 1}
+        super().__init__(dim_input=dim_input, products=products, error_estimator=error_estimator, visualizer=visualizer, name=name)
+
+        self.parameters_internal = dict(self.parameters_internal, t=1)
         self.__auto_init(locals())
         self.solution_space = operator.source
         self.linear = operator.linear and (output_functional is None or output_functional.linear)
@@ -307,6 +313,7 @@ class InstationaryModel(Model):
             f'    {"linear" if self.linear else "non-linear"}\n'
             f'    T: {self.T}\n'
             f'    solution_space:  {self.solution_space}\n'
+            f'    dim_input:       {self.dim_input}\n'
             f'    dim_output:      {self.dim_output}\n'
         )
 

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -37,7 +37,7 @@ class InputOutputModel(Model):
     def __init__(self, dim_input, dim_output, cont_time=True,
                  error_estimator=None, visualizer=None, name=None):
         assert cont_time in (True, False)
-        super().__init__(error_estimator=error_estimator, visualizer=visualizer, name=name)
+        super().__init__(dim_input=dim_input, error_estimator=error_estimator, visualizer=visualizer, name=name)
         self.__auto_init(locals())
 
     @abstractmethod


### PR DESCRIPTION
This PR adds an `input` parameter to `Model.compute` and related methods. As we want to treat inputs internally as time-dependent parameter values, the value of `input` is added to `mu` in `compute` before called methods such as `_compute_solution`.

Further, to allow transparent handling of `Operators` of the `Model` which take the `input` as a parameter, `Model.__init__` now expects `dim_input` as an additional argument and automatically sets `parameters_internal` to `{'input': dim_input}`, thus, preventing `input` from appearing as a parameter of the `Model`.