### PR TITLE
Simple output estimator with dual norm

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -10,6 +10,11 @@
 
 ## Contributors
 
+### pyMOR 2021.2
+
+* Tim Keil, tim.keil@uni-muenster.de
+  * Simple output estimation for elliptic and parabolic problems
+
 ### pyMOR 2021.1
 
 * Meret Behrens, mbehrens@mpi-magdeburg.mpg.de

--- a/src/pymor/models/basic.py
+++ b/src/pymor/models/basic.py
@@ -273,6 +273,8 @@ class InstationaryModel(Model):
         Name of the model.
     """
 
+    _compute_allowed_kwargs = frozenset({'return_error_sequence'})
+
     def __init__(self, T, initial_data, operator, rhs, mass=None, time_stepper=None, num_values=None,
                  output_functional=None, products=None, error_estimator=None, visualizer=None, name=None):
 

--- a/src/pymor/models/basic.py
+++ b/src/pymor/models/basic.py
@@ -56,6 +56,8 @@ class StationaryModel(Model):
         Name of the model.
     """
 
+    _compute_allowed_kwargs = frozenset({'use_adjoint', 'return_estimate_vector'})
+
     def __init__(self, operator, rhs, output_functional=None, products=None,
                  error_estimator=None, visualizer=None, name=None):
 
@@ -91,8 +93,6 @@ class StationaryModel(Model):
         rhs_d_mu = self.rhs.d_mu(parameter, index).as_range_array(mu)
         rhs = rhs_d_mu - lhs_d_mu
         return self.operator.jacobian(solution, mu=mu).apply_inverse(rhs)
-
-    _compute_allowed_kwargs = frozenset({'use_adjoint'})
 
     def _compute_output_d_mu(self, solution, mu, return_array=False, use_adjoint=None):
         """Compute the gradient of the output functional  w.r.t. the parameters.
@@ -273,7 +273,7 @@ class InstationaryModel(Model):
         Name of the model.
     """
 
-    _compute_allowed_kwargs = frozenset({'return_error_sequence'})
+    _compute_allowed_kwargs = frozenset({'return_error_sequence', 'return_estimate_vector'})
 
     def __init__(self, T, initial_data, operator, rhs, mass=None, time_stepper=None, num_values=None,
                  output_functional=None, products=None, error_estimator=None, visualizer=None, name=None):

--- a/src/pymor/models/basic.py
+++ b/src/pymor/models/basic.py
@@ -56,7 +56,7 @@ class StationaryModel(Model):
         Name of the model.
     """
 
-    _compute_allowed_kwargs = frozenset({'use_adjoint', 'return_estimate_vector'})
+    _compute_allowed_kwargs = frozenset({'use_adjoint'})
 
     def __init__(self, operator, rhs, output_functional=None, products=None,
                  error_estimator=None, visualizer=None, name=None):
@@ -273,7 +273,7 @@ class InstationaryModel(Model):
         Name of the model.
     """
 
-    _compute_allowed_kwargs = frozenset({'return_error_sequence', 'return_estimate_vector'})
+    _compute_allowed_kwargs = frozenset({'return_error_sequence'})
 
     def __init__(self, T, initial_data, operator, rhs, mass=None, time_stepper=None, num_values=None,
                  output_functional=None, products=None, error_estimator=None, visualizer=None, name=None):

--- a/src/pymor/models/interface.py
+++ b/src/pymor/models/interface.py
@@ -244,6 +244,9 @@ class Model(CacheableObject, ParametricObject):
             Internal model state for the given |parameter values|.
         mu
             |Parameter values| for which to compute the error estimate.
+        return_vector
+            If `True`, return the output estimate as a |NumPy array|.
+            Otherwise, return the euclidian norm of the estimate.
         kwargs
             Additional keyword arguments to customize how the error estimate is
             computed or to select additional data to be returned.
@@ -299,8 +302,11 @@ class Model(CacheableObject, ParametricObject):
         output_error_estimate
             If `True`, return an error estimate for the computed output.
         output_d_mu_return_array
-            if `True`, return the output gradient as a |NumPy array|.
+            If `True`, return the output gradient as a |NumPy array|.
             Otherwise, return a dict of gradients for each |Parameter|.
+        output_error_estimate_return_vector
+            If `True`, return the output error estimate as a |NumPy array|.
+            Otherwise, return the euclidian norm of the estimate.
         mu
             |Parameter values| for which to compute the values.
         input
@@ -469,6 +475,9 @@ class Model(CacheableObject, ParametricObject):
             Can be `None` if `self.dim_input == 0`.
         return_error_estimate
             If `True`, also return an error estimate for the computed output.
+        return_error_estimate_vector
+            if `True`, return the output estimate as a |NumPy array|.
+            Otherwise, return the euclidian norm of the estimate.
         kwargs
             Additional keyword arguments passed to :meth:`compute` that
             might affect how the solution is computed.
@@ -614,6 +623,9 @@ class Model(CacheableObject, ParametricObject):
             mapping time to input, or a `str` expression whith `t` as variable that
             can be used to instatiate an |ExpressionFunction| of this type.
             Can be `None` if `self.dim_input == 0`.
+        return_vector
+            if `True`, return the output estimate as a |NumPy array|.
+            Otherwise, return the euclidian norm of the estimate .
         kwargs
             Additional keyword arguments passed to :meth:`compute` that
             might affect how the error estimate (or the output) is computed.

--- a/src/pymor/models/interface.py
+++ b/src/pymor/models/interface.py
@@ -245,8 +245,10 @@ class Model(CacheableObject, ParametricObject):
         mu
             |Parameter values| for which to compute the error estimate.
         return_vector
-            If `True`, return the output estimate as a |NumPy array|.
-            Otherwise, return the euclidian norm of the estimate.
+            If `True`, return the output estimate as a |NumPy array|,
+            where each component corresponds to the respective component
+            of the :attr:`output_functional`.
+            Otherwise, return the euclidian norm of all components.
         kwargs
             Additional keyword arguments to customize how the error estimate is
             computed or to select additional data to be returned.
@@ -305,8 +307,10 @@ class Model(CacheableObject, ParametricObject):
             If `True`, return the output gradient as a |NumPy array|.
             Otherwise, return a dict of gradients for each |Parameter|.
         output_error_estimate_return_vector
-            If `True`, return the output error estimate as a |NumPy array|.
-            Otherwise, return the euclidian norm of the estimate.
+            If `True`, return the output estimate as a |NumPy array|,
+            where each component corresponds to the respective component
+            of the :attr:`output_functional`.
+            Otherwise, return the euclidian norm of all components.
         mu
             |Parameter values| for which to compute the values.
         input
@@ -476,8 +480,10 @@ class Model(CacheableObject, ParametricObject):
         return_error_estimate
             If `True`, also return an error estimate for the computed output.
         return_error_estimate_vector
-            if `True`, return the output estimate as a |NumPy array|.
-            Otherwise, return the euclidian norm of the estimate.
+            If `True`, return the output estimate as a |NumPy array|,
+            where each component corresponds to the respective component
+            of the :attr:`output_functional`.
+            Otherwise, return the euclidian norm of all components.
         kwargs
             Additional keyword arguments passed to :meth:`compute` that
             might affect how the solution is computed.
@@ -624,8 +630,10 @@ class Model(CacheableObject, ParametricObject):
             can be used to instatiate an |ExpressionFunction| of this type.
             Can be `None` if `self.dim_input == 0`.
         return_vector
-            if `True`, return the output estimate as a |NumPy array|.
-            Otherwise, return the euclidian norm of the estimate .
+            If `True`, return the output estimate as a |NumPy array|,
+            where each component corresponds to the respective component
+            of the :attr:`output_functional`.
+            Otherwise, return the euclidian norm of all components.
         kwargs
             Additional keyword arguments passed to :meth:`compute` that
             might affect how the error estimate (or the output) is computed.

--- a/src/pymor/reductors/coercive.py
+++ b/src/pymor/reductors/coercive.py
@@ -226,12 +226,14 @@ class SimpleCoerciveRBReductor(StationaryRBReductor):
         return error_estimator
 
     def assemble_output_error_estimator(self):
-        output_estimator_matrices, output_functional_coeffs = [], []
         output_func = self.fom.output_functional
         product = self.products['RB']
         if not isinstance(output_func, LincombOperator):
             output_func = LincombOperator([output_func, ], [1, ])
+        assert all(not op.parametric for op in output_func.operators)
+        assert all(op.linear for op in output_func.operators)
         # compute gramian of the riesz representatives
+        output_estimator_matrices, output_functional_coeffs = [], []
         for d in range(self.fom.dim_output):
             riesz_representatives = [product.apply_inverse(func.as_source_array()[d])
                                      for func in output_func.operators]

--- a/src/pymor/reductors/coercive.py
+++ b/src/pymor/reductors/coercive.py
@@ -83,14 +83,14 @@ class CoerciveRBEstimator(ImmutableObject):
             est /= self.coercivity_estimator(mu)
         return est
 
-    def estimate_output_error(self, U, mu, m, return_estimate_vector=False):
+    def estimate_output_error(self, U, mu, m, return_vector=False):
         if self.projected_output_adjoint is None:
             raise NotImplementedError
         estimate = self.estimate_error(U, mu, m)
         # scale with dual norm of the output functional
         output_functional_norms = self.projected_output_adjoint.as_range_array(mu).norm()
         errs = estimate * output_functional_norms
-        if return_estimate_vector:
+        if return_vector:
             return errs
         else:
             return np.linalg.norm(errs)
@@ -285,7 +285,7 @@ class SimpleCoerciveRBEstimator(ImmutableObject):
 
         return est
 
-    def estimate_output_error(self, U, mu, m, return_estimate_vector=False):
+    def estimate_output_error(self, U, mu, m, return_vector=False):
         if not self.output_estimator_matrices or not self.output_functional_coeffs:
             raise NotImplementedError
         estimate = self.estimate_error(U, mu, m)
@@ -295,7 +295,7 @@ class SimpleCoerciveRBEstimator(ImmutableObject):
         for d in range(m.dim_output):
             dual_norms.append(np.sqrt(coeff_vals.T@(self.output_estimator_matrices[d]@coeff_vals)))
         errs = estimate * dual_norms
-        if return_estimate_vector:
+        if return_vector:
             return errs
         else:
             return np.linalg.norm(errs)

--- a/src/pymor/reductors/coercive.py
+++ b/src/pymor/reductors/coercive.py
@@ -4,6 +4,8 @@
 
 import numpy as np
 
+from pymor.algorithms.image import estimate_image
+from pymor.algorithms.projection import project
 from pymor.core.base import ImmutableObject
 from pymor.operators.constructions import LincombOperator, induced_norm
 from pymor.operators.numpy import NumpyMatrixOperator
@@ -52,31 +54,15 @@ class CoerciveRBReductor(StationaryRBReductor):
 
         # optional output estimate
         if self.assemble_output_error_estimate and self.fom.output_functional.linear:
-            output_estimator_matrices, output_functional_coeffs = self.assemble_output_error_estimator()
+            output_adjoint = self.fom.output_functional.H
+            output_adjoint_riesz_range = estimate_image(vectors=(output_adjoint,), orthonormalize=True,
+                                                        product=self.products['RB'], riesz_representatives=True)
+            projected_output_adjoint = project(output_adjoint, output_adjoint_riesz_range, None)
         else:
-            output_estimator_matrices = output_functional_coeffs = None
+            projected_output_adjoint = None
 
         return CoerciveRBEstimator(residual, tuple(self.residual_reductor.residual_range_dims),
-                                   self.coercivity_estimator, output_estimator_matrices, output_functional_coeffs)
-
-    def assemble_output_error_estimator(self):
-        output_estimator_matrices, output_functional_coeffs = [], []
-        output_func = self.fom.output_functional
-        product = self.products['RB']
-        if not isinstance(output_func, LincombOperator):
-            output_func = LincombOperator([output_func, ], [1, ])
-        # compute gramian of the riesz representatives
-        for d in range(self.fom.dim_output):
-            riesz_representatives = [product.apply_inverse(func.as_source_array()[d])
-                                     for func in output_func.operators]
-            output_estimator_matrix = np.array([[product.apply2(rr, ss)[0][0] for rr in riesz_representatives]
-                                                for ss in riesz_representatives])
-            del riesz_representatives
-            output_estimator_matrices.append(output_estimator_matrix)
-        # wrap coefficient functionals if required
-        output_functional_coeffs = [c if isinstance(c, ParameterFunctional) else ConstantParameterFunctional(c)
-                                    for c in output_func.coefficients]
-        return output_estimator_matrices, output_functional_coeffs
+                                   self.coercivity_estimator, projected_output_adjoint)
 
     def assemble_error_estimator_for_subbasis(self, dims):
         return self._last_rom.error_estimator.restricted_to_subbasis(dims['RB'], m=self._last_rom)
@@ -88,8 +74,7 @@ class CoerciveRBEstimator(ImmutableObject):
     Not to be used directly.
     """
 
-    def __init__(self, residual, residual_range_dims, coercivity_estimator, output_estimator_matrices=None,
-                 output_functional_coeffs=None):
+    def __init__(self, residual, residual_range_dims, coercivity_estimator, projected_output_adjoint=None):
         self.__auto_init(locals())
 
     def estimate_error(self, U, mu, m):
@@ -99,28 +84,23 @@ class CoerciveRBEstimator(ImmutableObject):
         return est
 
     def estimate_output_error(self, U, mu, m):
-        if not self.output_estimator_matrices or not self.output_functional_coeffs:
+        if self.projected_output_adjoint is None:
             raise NotImplementedError
         estimate = self.estimate_error(U, mu, m)
         # scale with dual norm of the output functional
-        coeff_vals = np.array([c.evaluate(mu) for c in self.output_functional_coeffs])
-        dual_norms = []
-        for d in range(m.dim_output):
-            dual_norms.append(np.sqrt(coeff_vals.T@(self.output_estimator_matrices[d]@coeff_vals)))
-        return estimate * dual_norms
+        output_functional_norms = self.projected_output_adjoint.as_range_array(mu).norm()
+        return estimate * output_functional_norms
 
     def restricted_to_subbasis(self, dim, m):
         if self.residual_range_dims:
             residual_range_dims = self.residual_range_dims[:dim + 1]
             residual = self.residual.projected_to_subbasis(residual_range_dims[-1], dim)
             return CoerciveRBEstimator(residual, residual_range_dims, self.coercivity_estimator,
-                                       self.output_estimator_matrices,
-                                       self.output_functional_coeffs)
+                                       self.projected_output_adjoint)
         else:
             self.logger.warning('Cannot efficiently reduce to subbasis')
             return CoerciveRBEstimator(self.residual.projected_to_subbasis(None, dim), None,
-                                       self.coercivity_estimator, self.output_estimator_matrices,
-                                       self.output_functional_coeffs)
+                                       self.coercivity_estimator, self.projected_output_adjoint)
 
 
 class SimpleCoerciveRBReductor(StationaryRBReductor):

--- a/src/pymor/reductors/coercive.py
+++ b/src/pymor/reductors/coercive.py
@@ -60,7 +60,7 @@ class CoerciveRBReductor(StationaryRBReductor):
                                    self.coercivity_estimator, output_estimator_matrices, output_functional_coeffs)
 
     def assemble_output_error_estimator(self):
-        output_estimator_matrices = output_functional_coeffs = []
+        output_estimator_matrices, output_functional_coeffs = [], []
         output_func = self.fom.output_functional
         product = self.products['RB']
         if not isinstance(output_func, LincombOperator):
@@ -246,7 +246,7 @@ class SimpleCoerciveRBReductor(StationaryRBReductor):
         return error_estimator
 
     def assemble_output_error_estimator(self):
-        output_estimator_matrices = output_functional_coeffs = []
+        output_estimator_matrices, output_functional_coeffs = [], []
         output_func = self.fom.output_functional
         product = self.products['RB']
         if not isinstance(output_func, LincombOperator):

--- a/src/pymor/reductors/coercive.py
+++ b/src/pymor/reductors/coercive.py
@@ -51,28 +51,32 @@ class CoerciveRBReductor(StationaryRBReductor):
         residual = self.residual_reductor.reduce()
 
         # optional output estimate
-        output_estimator_matrices = output_functional_coeffs = None
-        if hasattr(self.fom, 'output_functional') and self.fom.output_functional \
-                and self.fom.output_functional.linear:
-            output_estimator_matrices = output_functional_coeffs = []
-            output_func = self.fom.output_functional
-            product = self.products['RB']
-            if not isinstance(output_func, LincombOperator):
-                output_func = LincombOperator([output_func, ], [1, ])
-            # compute gramian of the riesz representatives
-            for d in range(self.fom.dim_output):
-                riesz_representatives = [product.apply_inverse(func.as_source_array()[d])
-                                         for func in output_func.operators]
-                output_estimator_matrix = np.array([[product.apply2(rr, ss)[0][0] for rr in riesz_representatives]
-                                                    for ss in riesz_representatives])
-                del riesz_representatives
-                output_estimator_matrices.append(output_estimator_matrix)
-            # wrap coefficient functionals if required
-            output_functional_coeffs = [c if isinstance(c, ParameterFunctional) else ConstantParameterFunctional(c)
-                                        for c in output_func.coefficients]
+        if self.assemble_output_error_estimate and self.fom.output_functional.linear:
+            output_estimator_matrices, output_functional_coeffs = self.assemble_output_error_estimator()
+        else:
+            output_estimator_matrices = output_functional_coeffs = None
 
         return CoerciveRBEstimator(residual, tuple(self.residual_reductor.residual_range_dims),
                                    self.coercivity_estimator, output_estimator_matrices, output_functional_coeffs)
+
+    def assemble_output_error_estimator(self):
+        output_estimator_matrices = output_functional_coeffs = []
+        output_func = self.fom.output_functional
+        product = self.products['RB']
+        if not isinstance(output_func, LincombOperator):
+            output_func = LincombOperator([output_func, ], [1, ])
+        # compute gramian of the riesz representatives
+        for d in range(self.fom.dim_output):
+            riesz_representatives = [product.apply_inverse(func.as_source_array()[d])
+                                     for func in output_func.operators]
+            output_estimator_matrix = np.array([[product.apply2(rr, ss)[0][0] for rr in riesz_representatives]
+                                                for ss in riesz_representatives])
+            del riesz_representatives
+            output_estimator_matrices.append(output_estimator_matrix)
+        # wrap coefficient functionals if required
+        output_functional_coeffs = [c if isinstance(c, ParameterFunctional) else ConstantParameterFunctional(c)
+                                    for c in output_func.coefficients]
+        return output_estimator_matrices, output_functional_coeffs
 
     def assemble_error_estimator_for_subbasis(self, dims):
         return self._last_rom.error_estimator.restricted_to_subbasis(dims['RB'], m=self._last_rom)
@@ -230,31 +234,35 @@ class SimpleCoerciveRBReductor(StationaryRBReductor):
         estimator_matrix = NumpyMatrixOperator(estimator_matrix)
 
         # optional output estimate
-        output_estimator_matrices = output_functional_coeffs = None
-        if hasattr(self.fom, 'output_functional') and self.fom.output_functional \
-                and self.fom.output_functional.linear:
-            output_estimator_matrices = output_functional_coeffs = []
-            output_func = self.fom.output_functional
-            product = self.products['RB']
-            if not isinstance(output_func, LincombOperator):
-                output_func = LincombOperator([output_func, ], [1, ])
-            # compute gramian of the riesz representatives
-            for d in range(self.fom.dim_output):
-                riesz_representatives = [product.apply_inverse(func.as_source_array()[d])
-                                         for func in output_func.operators]
-                output_estimator_matrix = np.array([[product.apply2(rr, ss)[0][0] for rr in riesz_representatives]
-                                                    for ss in riesz_representatives])
-                del riesz_representatives
-                output_estimator_matrices.append(output_estimator_matrix)
-            # wrap coefficient functionals if required
-            output_functional_coeffs = [c if isinstance(c, ParameterFunctional) else ConstantParameterFunctional(c)
-                                        for c in output_func.coefficients]
+        if self.assemble_output_error_estimate and self.fom.output_functional.linear:
+            output_estimator_matrices, output_functional_coeffs = self.assemble_output_error_estimator()
+        else:
+            output_estimator_matrices = output_functional_coeffs = None
 
         error_estimator = SimpleCoerciveRBEstimator(estimator_matrix, self.coercivity_estimator,
                                                     output_estimator_matrices, output_functional_coeffs)
         self.extends = (len(RB), dict(R_R=R_R, RR_R=RR_R, R_Os=R_Os, RR_Os=RR_Os))
 
         return error_estimator
+
+    def assemble_output_error_estimator(self):
+        output_estimator_matrices = output_functional_coeffs = []
+        output_func = self.fom.output_functional
+        product = self.products['RB']
+        if not isinstance(output_func, LincombOperator):
+            output_func = LincombOperator([output_func, ], [1, ])
+        # compute gramian of the riesz representatives
+        for d in range(self.fom.dim_output):
+            riesz_representatives = [product.apply_inverse(func.as_source_array()[d])
+                                     for func in output_func.operators]
+            output_estimator_matrix = np.array([[product.apply2(rr, ss)[0][0] for rr in riesz_representatives]
+                                                for ss in riesz_representatives])
+            del riesz_representatives
+            output_estimator_matrices.append(output_estimator_matrix)
+        # wrap coefficient functionals if required
+        output_functional_coeffs = [c if isinstance(c, ParameterFunctional) else ConstantParameterFunctional(c)
+                                    for c in output_func.coefficients]
+        return output_estimator_matrices, output_functional_coeffs
 
     def assemble_error_estimator_for_subbasis(self, dims):
         return self._last_rom.error_estimator.restricted_to_subbasis(dims['RB'], m=self._last_rom)

--- a/src/pymor/reductors/coercive.py
+++ b/src/pymor/reductors/coercive.py
@@ -83,13 +83,17 @@ class CoerciveRBEstimator(ImmutableObject):
             est /= self.coercivity_estimator(mu)
         return est
 
-    def estimate_output_error(self, U, mu, m):
+    def estimate_output_error(self, U, mu, m, return_estimate_vector=False):
         if self.projected_output_adjoint is None:
             raise NotImplementedError
         estimate = self.estimate_error(U, mu, m)
         # scale with dual norm of the output functional
         output_functional_norms = self.projected_output_adjoint.as_range_array(mu).norm()
-        return estimate * output_functional_norms
+        errs = estimate * output_functional_norms
+        if return_estimate_vector:
+            return errs
+        else:
+            return np.linalg.norm(errs)
 
     def restricted_to_subbasis(self, dim, m):
         if self.residual_range_dims:
@@ -281,7 +285,7 @@ class SimpleCoerciveRBEstimator(ImmutableObject):
 
         return est
 
-    def estimate_output_error(self, U, mu, m):
+    def estimate_output_error(self, U, mu, m, return_estimate_vector=False):
         if not self.output_estimator_matrices or not self.output_functional_coeffs:
             raise NotImplementedError
         estimate = self.estimate_error(U, mu, m)
@@ -290,7 +294,11 @@ class SimpleCoerciveRBEstimator(ImmutableObject):
         dual_norms = []
         for d in range(m.dim_output):
             dual_norms.append(np.sqrt(coeff_vals.T@(self.output_estimator_matrices[d]@coeff_vals)))
-        return estimate * dual_norms
+        errs = estimate * dual_norms
+        if return_estimate_vector:
+            return errs
+        else:
+            return np.linalg.norm(errs)
 
     def restricted_to_subbasis(self, dim, m):
         cr = 1 if not m.rhs.parametric else len(m.rhs.operators)

--- a/src/pymor/reductors/coercive.py
+++ b/src/pymor/reductors/coercive.py
@@ -5,7 +5,7 @@
 import numpy as np
 
 from pymor.core.base import ImmutableObject
-from pymor.operators.constructions import LincombOperator, induced_norm, VectorOperator
+from pymor.operators.constructions import LincombOperator, induced_norm
 from pymor.operators.numpy import NumpyMatrixOperator
 from pymor.parameters.functionals import ParameterFunctional, ConstantParameterFunctional
 from pymor.reductors.basic import StationaryRBReductor
@@ -58,12 +58,13 @@ class CoerciveRBReductor(StationaryRBReductor):
             output_func = self.fom.output_functional
             product = self.products['RB']
             if not isinstance(output_func, LincombOperator):
-                output_func = LincombOperator([output_func,], [1,])
+                output_func = LincombOperator([output_func, ], [1, ])
             # compute gramian of the riesz representatives
             for d in range(self.fom.dim_output):
-                riesz_representatives = [product.apply_inverse(func.as_source_array()[d]) for func in output_func.operators]
-                output_estimator_matrix = np.array(
-                        [[product.apply2(rr, ss)[0][0] for rr in riesz_representatives] for ss in riesz_representatives])
+                riesz_representatives = [product.apply_inverse(func.as_source_array()[d])
+                                         for func in output_func.operators]
+                output_estimator_matrix = np.array([[product.apply2(rr, ss)[0][0] for rr in riesz_representatives]
+                                                    for ss in riesz_representatives])
                 del riesz_representatives
                 output_estimator_matrices.append(output_estimator_matrix)
             # wrap coefficient functionals if required
@@ -236,12 +237,13 @@ class SimpleCoerciveRBReductor(StationaryRBReductor):
             output_func = self.fom.output_functional
             product = self.products['RB']
             if not isinstance(output_func, LincombOperator):
-                output_func = LincombOperator([output_func,], [1,])
+                output_func = LincombOperator([output_func, ], [1, ])
             # compute gramian of the riesz representatives
             for d in range(self.fom.dim_output):
-                riesz_representatives = [product.apply_inverse(func.as_source_array()[d]) for func in output_func.operators]
-                output_estimator_matrix = np.array(
-                        [[product.apply2(rr, ss)[0][0] for rr in riesz_representatives] for ss in riesz_representatives])
+                riesz_representatives = [product.apply_inverse(func.as_source_array()[d])
+                                         for func in output_func.operators]
+                output_estimator_matrix = np.array([[product.apply2(rr, ss)[0][0] for rr in riesz_representatives]
+                                                    for ss in riesz_representatives])
                 del riesz_representatives
                 output_estimator_matrices.append(output_estimator_matrix)
             # wrap coefficient functionals if required
@@ -310,4 +312,4 @@ class SimpleCoerciveRBEstimator(ImmutableObject):
         matrix = self.estimator_matrix.matrix[indices, :][:, indices]
 
         return SimpleCoerciveRBEstimator(NumpyMatrixOperator(matrix), self.coercivity_estimator,
-                self.output_estimator_matrices, self.output_functional_coeffs)
+                                         self.output_estimator_matrices, self.output_functional_coeffs)

--- a/src/pymor/reductors/coercive.py
+++ b/src/pymor/reductors/coercive.py
@@ -52,8 +52,8 @@ class CoerciveRBReductor(StationaryRBReductor):
     def assemble_error_estimator(self):
         residual = self.residual_reductor.reduce()
 
-        # optional output estimate
-        if self.assemble_output_error_estimate and self.fom.output_functional.linear:
+        # output estimate
+        if self.fom.output_functional.linear:
             output_adjoint = self.fom.output_functional.H
             output_adjoint_riesz_range = estimate_image(vectors=(output_adjoint,), orthonormalize=True,
                                                         product=self.products['RB'], riesz_representatives=True)
@@ -213,8 +213,8 @@ class SimpleCoerciveRBReductor(StationaryRBReductor):
 
         estimator_matrix = NumpyMatrixOperator(estimator_matrix)
 
-        # optional output estimate
-        if self.assemble_output_error_estimate and self.fom.output_functional.linear:
+        # output estimate
+        if self.fom.output_functional.linear:
             output_estimator_matrices, output_functional_coeffs = self.assemble_output_error_estimator()
         else:
             output_estimator_matrices = output_functional_coeffs = None

--- a/src/pymor/reductors/coercive.py
+++ b/src/pymor/reductors/coercive.py
@@ -108,11 +108,14 @@ class CoerciveRBEstimator(ImmutableObject):
         if self.residual_range_dims:
             residual_range_dims = self.residual_range_dims[:dim + 1]
             residual = self.residual.projected_to_subbasis(residual_range_dims[-1], dim)
-            return CoerciveRBEstimator(residual, residual_range_dims, self.coercivity_estimator)
+            return CoerciveRBEstimator(residual, residual_range_dims, self.coercivity_estimator,
+                                       self.output_estimator_matrices,
+                                       self.output_functional_coeffs)
         else:
             self.logger.warning('Cannot efficiently reduce to subbasis')
             return CoerciveRBEstimator(self.residual.projected_to_subbasis(None, dim), None,
-                                       self.coercivity_estimator)
+                                       self.coercivity_estimator, self.output_estimator_matrices,
+                                       self.output_functional_coeffs)
 
 
 class SimpleCoerciveRBReductor(StationaryRBReductor):
@@ -252,7 +255,7 @@ class SimpleCoerciveRBReductor(StationaryRBReductor):
         return error_estimator
 
     def assemble_error_estimator_for_subbasis(self, dims):
-        return self._last_rom.estimator.restricted_to_subbasis(dims['RB'], m=self._last_rom)
+        return self._last_rom.error_estimator.restricted_to_subbasis(dims['RB'], m=self._last_rom)
 
 
 class SimpleCoerciveRBEstimator(ImmutableObject):
@@ -306,4 +309,5 @@ class SimpleCoerciveRBEstimator(ImmutableObject):
                                  ((np.arange(co)*old_dim)[..., np.newaxis] + np.arange(dim)).ravel() + cr))
         matrix = self.estimator_matrix.matrix[indices, :][:, indices]
 
-        return SimpleCoerciveRBEstimator(NumpyMatrixOperator(matrix), self.coercivity_estimator)
+        return SimpleCoerciveRBEstimator(NumpyMatrixOperator(matrix), self.coercivity_estimator,
+                self.output_estimator_matrices, self.output_functional_coeffs)

--- a/src/pymor/reductors/parabolic.py
+++ b/src/pymor/reductors/parabolic.py
@@ -130,14 +130,14 @@ class ParabolicRBEstimator(ImmutableObject):
 
         return est if return_error_sequence else est[-1]
 
-    def estimate_output_error(self, U, mu, m, return_error_sequence=False, return_estimate_vector=False):
+    def estimate_output_error(self, U, mu, m, return_error_sequence=False, return_vector=False):
         if self.projected_output_adjoint is None:
             raise NotImplementedError
         estimate = self.estimate_error(U, mu, m, return_error_sequence=return_error_sequence)
         # scale with dual norm of the output functional
         output_functional_norms = self.projected_output_adjoint.as_range_array(mu).norm()
         errs = (estimate * output_functional_norms[:, np.newaxis]).T
-        if return_estimate_vector:
+        if return_vector:
             return errs
         else:
             return np.linalg.norm(errs, axis=1)

--- a/src/pymor/reductors/parabolic.py
+++ b/src/pymor/reductors/parabolic.py
@@ -92,12 +92,13 @@ class ParabolicRBReductor(InstationaryRBReductor):
             output_func = self.fom.output_functional
             product = self.products['RB']
             if not isinstance(output_func, LincombOperator):
-                output_func = LincombOperator([output_func,], [1,])
+                output_func = LincombOperator([output_func, ], [1, ])
             # compute gramian of the riesz representatives
             for d in range(self.fom.dim_output):
-                riesz_representatives = [product.apply_inverse(func.as_source_array()[d]) for func in output_func.operators]
-                output_estimator_matrix = np.array(
-                        [[product.apply2(rr, ss)[0][0] for rr in riesz_representatives] for ss in riesz_representatives])
+                riesz_representatives = [product.apply_inverse(func.as_source_array()[d])
+                                         for func in output_func.operators]
+                output_estimator_matrix = np.array([[product.apply2(rr, ss)[0][0] for rr in riesz_representatives]
+                                                    for ss in riesz_representatives])
                 del riesz_representatives
                 output_estimator_matrices.append(output_estimator_matrix)
             # wrap coefficient functionals if required
@@ -143,7 +144,7 @@ class ParabolicRBEstimator(ImmutableObject):
 
     def estimate_output_error(self, U, mu, m, return_error_sequence=False):
         if not self.output_estimator_matrices or not self.output_functional_coeffs:
-            raise NotImplemented
+            raise NotImplementedError
         estimate = self.estimate_error(U, mu, m, return_error_sequence=return_error_sequence)
         # scale with dual norm of the output functional
         coeff_vals = np.array([c.evaluate(mu) for c in self.output_functional_coeffs])

--- a/src/pymor/reductors/parabolic.py
+++ b/src/pymor/reductors/parabolic.py
@@ -95,7 +95,7 @@ class ParabolicRBReductor(InstationaryRBReductor):
 
     def assemble_output_error_estimator(self):
         # optional output estimate
-        output_estimator_matrices = output_functional_coeffs = []
+        output_estimator_matrices, output_functional_coeffs = [], []
         output_func = self.fom.output_functional
         product = self.products['RB']
         if not isinstance(output_func, LincombOperator):

--- a/src/pymor/reductors/parabolic.py
+++ b/src/pymor/reductors/parabolic.py
@@ -8,8 +8,7 @@ from pymor.algorithms.image import estimate_image
 from pymor.algorithms.projection import project
 from pymor.algorithms.timestepping import ImplicitEulerTimeStepper
 from pymor.core.base import ImmutableObject
-from pymor.operators.constructions import IdentityOperator, LincombOperator
-from pymor.parameters.functionals import ParameterFunctional, ConstantParameterFunctional
+from pymor.operators.constructions import IdentityOperator
 from pymor.reductors.basic import InstationaryRBReductor
 from pymor.reductors.residual import ResidualReductor, ImplicitEulerResidualReductor
 
@@ -86,7 +85,7 @@ class ParabolicRBReductor(InstationaryRBReductor):
         residual = self.residual_reductor.reduce()
         initial_residual = self.initial_residual_reductor.reduce()
 
-        if self.assemble_output_error_estimate and self.fom.output_functional.linear:
+        if self.fom.output_functional.linear:
             output_adjoint = self.fom.output_functional.H
             output_adjoint_riesz_range = estimate_image(vectors=(output_adjoint,), orthonormalize=True,
                                                         product=self.products['RB'], riesz_representatives=True)

--- a/src/pymor/reductors/parabolic.py
+++ b/src/pymor/reductors/parabolic.py
@@ -148,10 +148,10 @@ class ParabolicRBEstimator(ImmutableObject):
         estimate = self.estimate_error(U, mu, m, return_error_sequence=return_error_sequence)
         # scale with dual norm of the output functional
         coeff_vals = np.array([c.evaluate(mu) for c in self.output_functional_coeffs])
-        dual_norms = []
+        dual_norms = np.empty((m.dim_output, 1))
         for d in range(m.dim_output):
-            dual_norms.append(np.sqrt(coeff_vals.T@(self.output_estimator_matrices[d]@coeff_vals)))
-        return estimate * dual_norms
+            dual_norms[d] = np.sqrt(coeff_vals.T@(self.output_estimator_matrices[d]@coeff_vals))
+        return (estimate * dual_norms).T
 
     def restricted_to_subbasis(self, dim, m):
         if self.residual_range_dims and self.initial_residual_range_dims:

--- a/src/pymor/reductors/parabolic.py
+++ b/src/pymor/reductors/parabolic.py
@@ -130,13 +130,17 @@ class ParabolicRBEstimator(ImmutableObject):
 
         return est if return_error_sequence else est[-1]
 
-    def estimate_output_error(self, U, mu, m, return_error_sequence=False):
+    def estimate_output_error(self, U, mu, m, return_error_sequence=False, return_estimate_vector=False):
         if self.projected_output_adjoint is None:
             raise NotImplementedError
         estimate = self.estimate_error(U, mu, m, return_error_sequence=return_error_sequence)
         # scale with dual norm of the output functional
         output_functional_norms = self.projected_output_adjoint.as_range_array(mu).norm()
-        return (estimate * output_functional_norms[:, np.newaxis]).T
+        errs = (estimate * output_functional_norms[:, np.newaxis]).T
+        if return_estimate_vector:
+            return errs
+        else:
+            return np.linalg.norm(errs, axis=1)
 
     def restricted_to_subbasis(self, dim, m):
         if self.residual_range_dims and self.initial_residual_range_dims:

--- a/src/pymor/reductors/parabolic.py
+++ b/src/pymor/reductors/parabolic.py
@@ -4,6 +4,8 @@
 
 import numpy as np
 
+from pymor.algorithms.image import estimate_image
+from pymor.algorithms.projection import project
 from pymor.algorithms.timestepping import ImplicitEulerTimeStepper
 from pymor.core.base import ImmutableObject
 from pymor.operators.constructions import IdentityOperator, LincombOperator
@@ -85,33 +87,16 @@ class ParabolicRBReductor(InstationaryRBReductor):
         initial_residual = self.initial_residual_reductor.reduce()
 
         if self.assemble_output_error_estimate and self.fom.output_functional.linear:
-            output_estimator_matrices, output_functional_coeffs = self.assemble_output_error_estimator()
+            output_adjoint = self.fom.output_functional.H
+            output_adjoint_riesz_range = estimate_image(vectors=(output_adjoint,), orthonormalize=True,
+                                                        product=self.products['RB'], riesz_representatives=True)
+            projected_output_adjoint = project(output_adjoint, output_adjoint_riesz_range, None)
         else:
-            output_estimator_matrices = output_functional_coeffs = None
+            projected_output_adjoint = None
 
         return ParabolicRBEstimator(residual, self.residual_reductor.residual_range_dims, initial_residual,
                                     self.initial_residual_reductor.residual_range_dims, self.coercivity_estimator,
-                                    output_estimator_matrices, output_functional_coeffs)
-
-    def assemble_output_error_estimator(self):
-        # optional output estimate
-        output_estimator_matrices, output_functional_coeffs = [], []
-        output_func = self.fom.output_functional
-        product = self.products['RB']
-        if not isinstance(output_func, LincombOperator):
-            output_func = LincombOperator([output_func, ], [1, ])
-        # compute gramian of the riesz representatives
-        for d in range(self.fom.dim_output):
-            riesz_representatives = [product.apply_inverse(func.as_source_array()[d])
-                                     for func in output_func.operators]
-            output_estimator_matrix = np.array([[product.apply2(rr, ss)[0][0] for rr in riesz_representatives]
-                                                for ss in riesz_representatives])
-            del riesz_representatives
-            output_estimator_matrices.append(output_estimator_matrix)
-        # wrap coefficient functionals if required
-        output_functional_coeffs = [c if isinstance(c, ParameterFunctional) else ConstantParameterFunctional(c)
-                                    for c in output_func.coefficients]
-        return output_estimator_matrices, output_functional_coeffs
+                                    projected_output_adjoint)
 
     def assemble_error_estimator_for_subbasis(self, dims):
         return self._last_rom.error_estimator.restricted_to_subbasis(dims['RB'], m=self._last_rom)
@@ -124,7 +109,7 @@ class ParabolicRBEstimator(ImmutableObject):
     """
 
     def __init__(self, residual, residual_range_dims, initial_residual, initial_residual_range_dims,
-                 coercivity_estimator, output_estimator_matrices=None, output_functional_coeffs=None):
+                 coercivity_estimator, projected_output_adjoint=None):
         self.__auto_init(locals())
 
     def estimate_error(self, U, mu, m, return_error_sequence=False):
@@ -147,15 +132,12 @@ class ParabolicRBEstimator(ImmutableObject):
         return est if return_error_sequence else est[-1]
 
     def estimate_output_error(self, U, mu, m, return_error_sequence=False):
-        if not self.output_estimator_matrices or not self.output_functional_coeffs:
+        if self.projected_output_adjoint is None:
             raise NotImplementedError
         estimate = self.estimate_error(U, mu, m, return_error_sequence=return_error_sequence)
         # scale with dual norm of the output functional
-        coeff_vals = np.array([c.evaluate(mu) for c in self.output_functional_coeffs])
-        dual_norms = np.empty((m.dim_output, 1))
-        for d in range(m.dim_output):
-            dual_norms[d] = np.sqrt(coeff_vals.T@(self.output_estimator_matrices[d]@coeff_vals))
-        return (estimate * dual_norms).T
+        output_functional_norms = self.projected_output_adjoint.as_range_array(mu).norm()
+        return (estimate * output_functional_norms[:, np.newaxis]).T
 
     def restricted_to_subbasis(self, dim, m):
         if self.residual_range_dims and self.initial_residual_range_dims:
@@ -165,11 +147,9 @@ class ParabolicRBEstimator(ImmutableObject):
             initial_residual = self.initial_residual.projected_to_subbasis(initial_residual_range_dims[-1], dim)
             return ParabolicRBEstimator(residual, residual_range_dims,
                                         initial_residual, initial_residual_range_dims,
-                                        self.coercivity_estimator, self.output_estimator_matrices,
-                                        self.output_functional_coeffs)
+                                        self.coercivity_estimator, self.projected_output_adjoint)
         else:
             self.logger.warning('Cannot efficiently reduce to subbasis')
             return ParabolicRBEstimator(self.residual.projected_to_subbasis(None, dim), None,
                                         self.initial_residual.projected_to_subbasis(None, dim), None,
-                                        self.coercivity_estimator, self.output_estimator_matrices,
-                                        self.output_functional_coeffs)
+                                        self.coercivity_estimator, self.projected_output_adjoint)

--- a/src/pymordemos/output_error_estimation.py
+++ b/src/pymordemos/output_error_estimation.py
@@ -16,7 +16,7 @@ def main(
     verification_samples: int = Argument(..., help='Number of samples used for verification of the output error.')
 ):
     set_log_levels({'pymor': 'WARN'})
-    """Example script for using the DWR output error estimation"""
+    """Example script for using output error estimation"""
     # real valued output
     fom_1 = create_fom(grid_intervals, vector_valued_output=False)
 

--- a/src/pymordemos/output_error_estimation.py
+++ b/src/pymordemos/output_error_estimation.py
@@ -130,7 +130,7 @@ def main(
     plt.legend()
 
     # estimator study for smaller number of basis functions
-    modes_set = np.arange(1, modes+1)
+    modes_set = np.arange(1, rom.solution_space.dim+1)
     max_errs, max_ests, min_errs, min_ests = [], [], [], []
     for mode in modes_set:
         max_err, max_est, min_err, min_est = 0, 0, 1000, 1000

--- a/src/pymordemos/output_error_estimation.py
+++ b/src/pymordemos/output_error_estimation.py
@@ -97,15 +97,28 @@ def main(
     results_full = {'fom': [], 'rom': [], 'err': [], 'est': []}
     for mu in training_set:
         s_fom = fom.output(mu=mu)
-
         s_rom, s_est = rom.output(return_error_estimate=True, mu=mu, return_estimate_vector=False)
         results_full['fom'].append(s_fom)
         results_full['rom'].append(s_rom)
-        results_full['err'].append(np.linalg.norm(np.abs(s_fom-s_rom)))
+        results_full['err'].append(np.linalg.norm(np.abs(s_fom[-1]-s_rom[-1])))
         results_full['est'].append(s_est)
 
         # just for testing purpose
         assert np.linalg.norm(np.abs(s_rom-s_fom)) <= s_est + 1e-8
+
+        # also test return_estimate_vector and return_error_sequence functionality but do not use it
+        s_rom_, s_est_ = rom.output(return_error_estimate=True, mu=mu, return_estimate_vector=True)
+        assert np.allclose(s_rom, s_rom_)
+        assert s_est == np.linalg.norm(s_est_)
+
+        if fom_number in [3, 4]:
+            s_rom__, s_est__ = rom.output(return_error_estimate=True, mu=mu, return_error_sequence=True)
+            s_rom___, s_est___ = rom.output(return_error_estimate=True, mu=mu, return_estimate_vector=True,
+                                            return_error_sequence=True)
+            # s_rom always stays the same
+            assert np.allclose(s_rom, s_rom__, s_rom___)
+            assert s_est__[-1] == s_est
+            assert np.allclose(s_est__, np.linalg.norm(s_est___, axis=1))
 
     # plot result
     plt.figure()

--- a/src/pymordemos/output_error_estimation.py
+++ b/src/pymordemos/output_error_estimation.py
@@ -96,7 +96,8 @@ def main(
     results_full = {'fom': [], 'rom': [], 'err': [], 'est': []}
     for i, mu in enumerate(training_set):
         s_fom = fom_outputs[i]
-        s_rom, s_est = rom.output(return_error_estimate=True, mu=mu, return_estimate_vector=False)
+        s_rom, s_est = rom.output(return_error_estimate=True, mu=mu,
+                                  return_error_estimate_vector=False)
         results_full['fom'].append(s_fom)
         results_full['rom'].append(s_rom)
         results_full['err'].append(np.linalg.norm(np.abs(s_fom[-1]-s_rom[-1])))
@@ -106,13 +107,15 @@ def main(
         assert np.linalg.norm(np.abs(s_rom-s_fom)) <= s_est + 1e-8
 
         # also test return_estimate_vector and return_error_sequence functionality but do not use it
-        s_rom_, s_est_ = rom.output(return_error_estimate=True, mu=mu, return_estimate_vector=True)
+        s_rom_, s_est_ = rom.output(return_error_estimate=True, mu=mu,
+                                    return_error_estimate_vector=True)
         assert np.allclose(s_rom, s_rom_)
         assert s_est == np.linalg.norm(s_est_)
 
         if fom_number in [3, 4]:
             s_rom__, s_est__ = rom.output(return_error_estimate=True, mu=mu, return_error_sequence=True)
-            s_rom___, s_est___ = rom.output(return_error_estimate=True, mu=mu, return_estimate_vector=True,
+            s_rom___, s_est___ = rom.output(return_error_estimate=True, mu=mu,
+                                            return_error_estimate_vector=True,
                                             return_error_sequence=True)
             # s_rom always stays the same
             assert np.allclose(s_rom, s_rom__, s_rom___)
@@ -135,7 +138,7 @@ def main(
 
         for i, mu in enumerate(training_set):
             s_fom = fom_outputs[i]
-            s_rom, s_est = rom.output(return_error_estimate=True, mu=mu, return_estimate_vector=False)
+            s_rom, s_est = rom.output(return_error_estimate=True, mu=mu)
             max_err = max(max_err, np.linalg.norm(np.abs(s_fom-s_rom)))
             max_est = max(max_est, s_est)
             min_err = min(min_err, np.linalg.norm(np.abs(s_fom-s_rom)))

--- a/src/pymordemos/output_error_estimation.py
+++ b/src/pymordemos/output_error_estimation.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python
+# This file is part of the pyMOR project (https://www.pymor.org).
+# Copyright 2013-2021 pyMOR developers and contributors. All rights reserved.
+# License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
+
+
+import numpy as np
+from typer import Argument, run
+
+from pymor.basic import *
+
+
+def main(
+    grid_intervals: int = Argument(..., help='Grid interval count.'),
+    training_samples: int = Argument(..., help='Number of samples used for training the reduced basis.'),
+    verification_samples: int = Argument(..., help='Number of samples used for verification of the output error.')
+):
+    set_log_levels({'pymor': 'WARN'})
+    """Example script for using the DWR output error estimation"""
+    # real valued output
+    fom_1 = create_fom(grid_intervals, vector_valued_output=False)
+
+    # vector valued output (with BlockColumnOperator)
+    fom_2 = create_fom(grid_intervals, vector_valued_output=True)
+
+    # an output which is actually a lincomb operator
+    dim_source = fom_1.output_functional.source.dim
+    np.random.seed(1)
+    random_matrix_1 = np.random.rand(2, dim_source)
+    random_matrix_2 = np.random.rand(2, dim_source)
+    op1 = NumpyMatrixOperator(random_matrix_1, source_id='STATE')
+    op2 = NumpyMatrixOperator(random_matrix_2, source_id='STATE')
+    ops = [op1, op2]
+    lincomb_op = LincombOperator(ops, [1., 0.5])
+    fom_3 = fom_2.with_(output_functional=lincomb_op)
+
+    # all foms with different output_functionals
+    foms = [fom_1, fom_2, fom_3]
+
+    standard_reductor = SimpleCoerciveRBReductor
+    simple_reductor = CoerciveRBReductor
+    reductors = [standard_reductor, simple_reductor]
+
+    # Parameter space and operator are equal for all foms
+    parameter_space = fom_1.parameters.space(0.1, 1)
+    training_set = parameter_space.sample_uniformly(training_samples)
+    random_set = parameter_space.sample_randomly(verification_samples, seed=22)
+    coercivity_estimator = ExpressionParameterFunctional('min(diffusion)', fom_1.parameters)
+
+    estimator_values = []
+    for fom in foms:
+        for reductor in reductors:
+            print(f'reductor: {reductor}')
+            # generate solution snapshots
+            primal_snapshots = fom.solution_space.empty()
+            modes = 8
+
+            # construct training data
+            for mu in training_set:
+                primal_snapshots.append(fom.solve(mu))
+
+            # apply POD on bases
+            primal_reduced_basis = pod(primal_snapshots, modes=modes)[0]
+            from pymor.operators.constructions import IdentityOperator
+            product = IdentityOperator(fom.solution_space)
+
+            RB_reductor = reductor(fom, RB=primal_reduced_basis,
+                                   product=product,
+                                   coercivity_estimator=coercivity_estimator)
+
+            # two different roms
+            rom_standard = RB_reductor.reduce()
+            rom_restricted = RB_reductor.reduce(2)
+
+            for mu in random_set:
+                s_fom = fom.output(mu=mu)
+                for rom in [rom_standard, rom_restricted]:
+                    s_rom, s_est = rom.output(return_error_estimate=True, mu=mu)
+                    for s_r, s_f, s_e in np.dstack((s_rom, s_fom, s_est))[0]:
+                        print(f'error : {np.abs(s_r - s_f):.6f} < {s_e:.6f}')
+                        assert np.abs(s_r-s_f) <= s_e + 1e-8
+
+    # parabolic reductor
+    from pymordemos.parabolic_mor import discretize_pymor, reduce_pod
+    fom = discretize_pymor()
+    fom_1 = fom.with_(output_functional=fom.rhs.operators[0].H)
+    random_matrix_1 = np.random.rand(2, fom.solution_space.dim)
+    op = NumpyMatrixOperator(random_matrix_1, source_id='STATE')
+    fom_2 = fom.with_(output_functional=op)
+    parameter_space = fom.parameters.space(1, 100)
+    random_set = parameter_space.sample_randomly(verification_samples, seed=22)
+
+    for fom in [fom_1, fom_2]:
+        reductor = ParabolicRBReductor(fom, product=fom.h1_0_semi_product)
+        rom = reduce_pod(fom, reductor, parameter_space, training_samples*2, modes)
+
+        print(f'reductor: {ParabolicRBReductor}')
+
+        for mu in random_set:
+            s_fom = fom.output(mu=mu)
+            s_rom, s_est = rom.output(return_error_estimate=True, mu=mu,
+                                      return_error_sequence=True)
+            estimator_values.append(s_est)
+            for s_r, s_f, s_e in np.dstack((s_rom, s_fom, s_est)).reshape(np.prod(np.shape(s_rom)), 3):
+                print(f'error : {np.abs(s_r - s_f):.6f} < {s_e:.6f}')
+                assert np.abs(s_r-s_f) <= s_e + 1e-8
+
+
+def create_fom(grid_intervals, vector_valued_output=False):
+    p = thermal_block_problem([2, 2])
+    f = ConstantFunction(1, dim_domain=2)
+
+    if vector_valued_output:
+        p = p.with_(outputs=[('l2', f), ('l2', f * 0.5)])
+    else:
+        p = p.with_(outputs=[('l2', f)])
+
+    fom, _ = discretize_stationary_cg(p, diameter=1./grid_intervals)
+    return fom
+
+
+if __name__ == '__main__':
+    run(main)

--- a/src/pymortests/demos.py
+++ b/src/pymortests/demos.py
@@ -131,6 +131,7 @@ OUTPUT_FUNCTIONAL_ARGS = (
     ('output_error_estimation', [2, 10, 4, 10, 1]),
     ('output_error_estimation', [3, 10, 10, 10, 1]),
     ('output_error_estimation', [4, 10, 10, 10, 1]),
+)
 
 DMD_ARGS = (
     ('burgers_dmd', [1.5, '--grid=10', '--nt=100']),

--- a/src/pymortests/demos.py
+++ b/src/pymortests/demos.py
@@ -43,6 +43,7 @@ DISCRETIZATION_ARGS = (
     ('burgers', ['--num-flux=engquist_osher', '0.1']),
     ('burgers', ['--num-flux=simplified_engquist_osher', '0.1']),
     ('linear_optimization', [40, 20]),
+    ('output_error_estimation', [10, 4, 5]),
     ('parabolic', ['heat', 1]),
     ('parabolic', ['heat', '--rect', 1]),
     ('parabolic', ['heat', '--fv', 1]),

--- a/src/pymortests/demos.py
+++ b/src/pymortests/demos.py
@@ -42,8 +42,6 @@ DISCRETIZATION_ARGS = (
     ('burgers', ['--num-flux=lax_friedrichs', '0.1']),
     ('burgers', ['--num-flux=engquist_osher', '0.1']),
     ('burgers', ['--num-flux=simplified_engquist_osher', '0.1']),
-    ('linear_optimization', [40, 20]),
-    ('output_error_estimation', [10, 4, 5]),
     ('parabolic', ['heat', 1]),
     ('parabolic', ['heat', '--rect', 1]),
     ('parabolic', ['heat', '--fv', 1]),
@@ -124,6 +122,17 @@ FUNCTION_EI_ARGS = (
     ('function_ei', ['--grid=10', 3, 2, 3, 2]),
 )
 
+OUTPUT_FUNCTIONAL_ARGS = (
+    ('linear_optimization', [40, 20]),
+    ('output_error_estimation', [0, 10, 4, 10, 0]),
+    ('output_error_estimation', [0, 10, 4, 10, 1]),
+    ('output_error_estimation', [1, 10, 4, 10, 1]),
+    ('output_error_estimation', [2, 10, 4, 10, 0]),
+    ('output_error_estimation', [2, 10, 4, 10, 1]),
+    ('output_error_estimation', [3, 10, 10, 10, 1]),
+    ('output_error_estimation', [4, 10, 10, 10, 1]),
+)
+
 DEMO_ARGS = (
     DISCRETIZATION_ARGS
     + THERMALBLOCK_ARGS
@@ -136,6 +145,7 @@ DEMO_ARGS = (
     + HAPOD_ARGS
     + FENICS_NONLINEAR_ARGS
     + FUNCTION_EI_ARGS
+    + OUTPUT_FUNCTIONAL_ARGS
 )
 DEMO_ARGS = [(f'pymordemos.{a}', b) for (a, b) in DEMO_ARGS]
 


### PR DESCRIPTION
This supersedes #1337 . We added the following items:

1. Move the computation of the gramian to a separate function `assemble_output_error_estimate`.
2. Make it possible to have vector valued outputs.
3. Add a small test case for the coercive and parabolic case.
4. Use features of `CoerciveRBReductor` for computation of gramian

I am also currently preparing a PR that will supersede #1418. However, the code has no intersection with this PR. Thus, we merge it separately.