### PR TITLE
Fix VectorArray slicing and disable slice filtering in VectorArray tests

### DIFF
--- a/src/pymor/vectorarrays/block.py
+++ b/src/pymor/vectorarrays/block.py
@@ -65,6 +65,9 @@ class BlockVectorArray(VectorArray):
             return 0
 
     def __getitem__(self, ind):
+        if isinstance(ind, Number) and (ind >= len(self) or ind < -len(self)):
+            raise IndexError('VectorArray index out of range')
+        assert self.check_ind(ind)
         return BlockVectorArrayView(self, ind)
 
     def __delitem__(self, ind):

--- a/src/pymor/vectorarrays/interface.py
+++ b/src/pymor/vectorarrays/interface.py
@@ -665,13 +665,16 @@ class VectorArray(BasicObject):
 
     def normalize_ind(self, ind):
         """Normalize given indices such that they are independent of the array length."""
+        l = len(self)
         if type(ind) is slice:
-            return slice(*ind.indices(len(self)))
-        elif not hasattr(ind, '__len__'):
-            ind = ind if 0 <= ind else len(self)+ind
+            start, stop, step = ind.indices(l)
+            if start == stop:
+                return slice(0, 0, 1)
+            assert start >= 0
+            assert stop >= 0 or (step < 0 and stop >= -1)
+            ind = ind if 0 <= ind else l+ind
             return slice(ind, ind+1)
         else:
-            l = len(self)
             return [i if 0 <= i else l+i for i in ind]
 
     def sub_index(self, ind, ind_ind):

--- a/src/pymor/vectorarrays/interface.py
+++ b/src/pymor/vectorarrays/interface.py
@@ -664,7 +664,10 @@ class VectorArray(BasicObject):
         return len({i if i >= 0 else l+i for i in ind})
 
     def normalize_ind(self, ind):
-        """Normalize given indices such that they are independent of the array length."""
+        """Normalize given indices such that they are independent of the array length.
+
+        Does not check validity of the indices.
+        """
         l = len(self)
         if type(ind) is slice:
             start, stop, step = ind.indices(l)
@@ -672,6 +675,8 @@ class VectorArray(BasicObject):
                 return slice(0, 0, 1)
             assert start >= 0
             assert stop >= 0 or (step < 0 and stop >= -1)
+            return slice(start, None if stop == -1 else stop, step)
+        elif not hasattr(ind, '__len__'):
             ind = ind if 0 <= ind else l+ind
             return slice(ind, ind+1)
         else:

--- a/src/pymor/vectorarrays/list.py
+++ b/src/pymor/vectorarrays/list.py
@@ -385,6 +385,7 @@ class ListVectorArray(VectorArray):
     def __getitem__(self, ind):
         if isinstance(ind, Number) and (ind >= len(self) or ind < -len(self)):
             raise IndexError('VectorArray index out of range')
+        assert self.check_ind(ind)
         return ListVectorArrayView(self, ind)
 
     def __delitem__(self, ind):

--- a/src/pymor/vectorarrays/mpi.py
+++ b/src/pymor/vectorarrays/mpi.py
@@ -13,6 +13,8 @@ The implementations are based on the event loop provided
 by :mod:`pymor.tools.mpi`.
 """
 
+from numbers import Number
+
 import numpy as np
 
 from pymor.core.pickle import unpicklable
@@ -56,12 +58,14 @@ class MPIVectorArray(VectorArray):
     def __getitem__(self, ind):
         if isinstance(ind, Number) and (ind >= len(self) or ind < -len(self)):
             raise IndexError('VectorArray index out of range')
+        assert self.check_ind(ind)
         U = type(self)(mpi.call(mpi.method_call_manage, self.obj_id, '__getitem__', ind),
                        self.space)
         U.is_view = True
         return U
 
     def __delitem__(self, ind):
+        assert self.check_ind(ind)
         mpi.call(mpi.method_call, self.obj_id, '__delitem__', ind)
 
     def copy(self, deep=False):

--- a/src/pymor/vectorarrays/mpi.py
+++ b/src/pymor/vectorarrays/mpi.py
@@ -54,6 +54,8 @@ class MPIVectorArray(VectorArray):
         return mpi.call(mpi.method_call, self.obj_id, '__len__')
 
     def __getitem__(self, ind):
+        if isinstance(ind, Number) and (ind >= len(self) or ind < -len(self)):
+            raise IndexError('VectorArray index out of range')
         U = type(self)(mpi.call(mpi.method_call_manage, self.obj_id, '__getitem__', ind),
                        self.space)
         U.is_view = True

--- a/src/pymor/vectorarrays/numpy.py
+++ b/src/pymor/vectorarrays/numpy.py
@@ -70,6 +70,7 @@ class NumpyVectorArray(VectorArray):
     def __getitem__(self, ind):
         if isinstance(ind, Number) and (ind >= self._len or ind < -self._len):
             raise IndexError('VectorArray index out of range')
+        assert self.check_ind(ind)
         return NumpyVectorArrayView(self, ind)
 
     def __delitem__(self, ind):
@@ -451,7 +452,6 @@ class NumpyVectorArrayView(NumpyVectorArray):
     is_view = True
 
     def __init__(self, array, ind):
-        assert array.check_ind(ind)
         self.base = array
         self.ind = array.normalize_ind(ind)
         self.space = array.space

--- a/src/pymortests/strategies.py
+++ b/src/pymortests/strategies.py
@@ -254,20 +254,15 @@ def valid_inds(v, length=None, random_module=None):
         yield []
 
 
-# TODO: remove old assumptions on slice values
-def _filtered_slices(length):
-    def _filter(sl):
-        return sl.step is None or sl.step > 0
-    return hyst.slices(length).filter(_filter)
-
-
 @hyst.composite
 def valid_indices(draw, array_strategy, length=None):
     v = draw(array_strategy)
     ints = hyst.integers(min_value=-len(v), max_value=max(len(v)-1, 0))
     indices = hyst.nothing()
     if length is None:
-        indices = indices | hyst.just([]) | hyst.lists(ints, max_size=2*len(v)) | _filtered_slices(len(v))
+        indices = indices | hyst.just([]) | hyst.lists(ints, max_size=2*len(v))
+    else:
+        indices = indices | hyst.slices(length)
     if len(v) > 0:
         inds = [-len(v), 0, len(v) - 1]
         if len(v) == length:
@@ -317,13 +312,13 @@ def st_valid_inds_of_same_length(draw, v1, v2):
     # `| hynp.integer_array_indices(shape=(LEN_X,))`
     if len1 == len2:
         ints = hyst.integers(min_value=-len1, max_value=max(len1 - 1, 0))
-        slicer = _filtered_slices(len1) | hyst.lists(ints, max_size=len1)
+        slicer = hyst.slices(len1) | hyst.lists(ints, max_size=len1)
         ret = ret | hyst.tuples(hyst.shared(slicer, key="st_valid_inds_of_same_length"),
                                 hyst.shared(slicer, key="st_valid_inds_of_same_length"))
     if len1 > 0 and len2 > 0:
         mlen = min(len1, len2)
         ints = hyst.integers(min_value=-mlen, max_value=max(mlen - 1, 0))
-        slicer = _filtered_slices(mlen) | ints | hyst.lists(ints, max_size=mlen)
+        slicer = hyst.slices(mlen) | ints | hyst.lists(ints, max_size=mlen)
         ret = ret | hyst.tuples(hyst.shared(slicer, key="st_valid_inds_of_same_length_uneven"),
                                 hyst.shared(slicer, key="st_valid_inds_of_same_length_uneven"))
     return draw(ret)
@@ -383,8 +378,8 @@ def st_valid_inds_of_different_length(draw, v1, v2):
 
     len1, len2 = len(v1), len(v2)
     # TODO we should include integer arrays here
-    val1 = _filtered_slices(len1)  # | hynp.integer_array_indices(shape=(len1,))
-    val2 = _filtered_slices(len2)  # | hynp.integer_array_indices(shape=(len1,))
+    val1 = hyst.slices(len1)  # | hynp.integer_array_indices(shape=(len1,))
+    val2 = hyst.slices(len2)  # | hynp.integer_array_indices(shape=(len1,))
     ret = hyst.tuples(val1, val2).filter(_filter)
     return draw(ret)
 

--- a/src/pymortests/vectorarray.py
+++ b/src/pymortests/vectorarray.py
@@ -315,6 +315,26 @@ def test_copy_repeated_index(vector_array):
             pass
 
 
+@pyst.given_vector_arrays(index_strategy=pyst.valid_indices)
+def test_normalize_ind(vectors_and_indices):
+    v, ind = vectors_and_indices
+    assert v.check_ind(ind)
+    normalized = v.normalize_ind(ind)
+    assert v.len_ind(normalized) == v.len_ind(ind)
+    assert v.len_ind_unique(normalized) == v.len_ind_unique(ind)
+
+
+@pyst.given_vector_arrays(index_strategy=pyst.pairs_same_length)
+def test_normalize_ind_invalid(vectors_and_indices):
+    v, ind = vectors_and_indices
+    # invalid indices should raise an exception
+    assume(not v.check_ind(ind))
+    with pytest.raises(Exception):
+        v.len_ind(ind)
+    with pytest.raises(Exception):
+        v.normalize_ind(ind)
+
+
 @pyst.given_vector_arrays(count=2, index_strategy=pyst.pairs_both_lengths)
 def test_append(vectors_and_indices):
     (v1, v2), (_, ind) = vectors_and_indices

--- a/src/pymortests/vectorarray.py
+++ b/src/pymortests/vectorarray.py
@@ -324,17 +324,6 @@ def test_normalize_ind(vectors_and_indices):
     assert v.len_ind_unique(normalized) == v.len_ind_unique(ind)
 
 
-@pyst.given_vector_arrays(index_strategy=pyst.pairs_same_length)
-def test_normalize_ind_invalid(vectors_and_indices):
-    v, ind = vectors_and_indices
-    # invalid indices should raise an exception
-    assume(not v.check_ind(ind))
-    with pytest.raises(Exception):
-        v.len_ind(ind)
-    with pytest.raises(Exception):
-        v.normalize_ind(ind)
-
-
 @pyst.given_vector_arrays(count=2, index_strategy=pyst.pairs_both_lengths)
 def test_append(vectors_and_indices):
     (v1, v2), (_, ind) = vectors_and_indices


### PR DESCRIPTION
This PR fixes incorrect slicing of VectorArrays in some corner cases.

It also removes the filtering of slices in VectorArray tests.


closes #1348
