### PR TITLE
Cached methods with `mu` parameters

### DIFF
--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -11,7 +11,7 @@ from pymor.algorithms.eigs import eigs
 from pymor.algorithms.lyapunov import solve_lyap_lrcf, solve_lyap_dense
 from pymor.algorithms.to_matrix import to_matrix
 from pymor.core.base import abstractmethod
-from pymor.core.cache import cached
+from pymor.core.cache import cached, cached_mu
 from pymor.core.config import config
 from pymor.core.defaults import defaults
 from pymor.models.interface import Model
@@ -872,7 +872,7 @@ class LTIModel(InputStateOutputModel):
                 mu=mu).to_numpy().conj()
         return dtfs
 
-    @cached
+    @cached_mu
     def gramian(self, typ, mu=None):
         """Compute a Gramian.
 


### PR DESCRIPTION
Closes #1115.

This adds the `cached_mu` function that is very similar to `cached` but additionally parses the `mu` parameter to avoid the use of `self._cached_method_call`.

For now, I only applied it to `LTIModel.gramian` method. Here is code to show that it works:

```python
import numpy as np

from pymor.models.iosys import LTIModel

n = 1000

lti = LTIModel.from_matrices(np.diag(np.arange(-1, -n-1, -1)),
                             np.ones((n, 1)), np.ones((1, n)))

lti.gramian('c_lrcf')
lti.gramian('c_lrcf', mu=lti.parameters.parse(None))
```