### PR TITLE
Ensure that mu arguments are parsed before cache keys are built

### DIFF
--- a/src/pymor/core/cache.py
+++ b/src/pymor/core/cache.py
@@ -345,6 +345,11 @@ class CacheableObject(ImmutableObject):
         if defaults:
             kwargs = dict(defaults, **kwargs)
 
+        # assume that all parameters named mu expect parameter values
+        # in case the value is not a Mu instance parse it to avoid cache misses
+        if 'mu' in kwargs and not isinstance(kwargs['mu'], Mu):
+            kwargs['mu'] = self.parameters.parse(kwargs['mu'])
+
         key = build_cache_key((method.__name__, self_id, kwargs))
         found, value = region.get(key)
 


### PR DESCRIPTION
This change will cause `@cached` to fail in case the decorated function has an argument `mu` which does not take `Mu` instances. However, I do not think that this will happen and it makes `@cached` quite a bit more convenient to use.