### PR TITLE
Warn when __init__ of a ParametricObject takes a variable number of arguments

### DIFF
--- a/src/pymor/core/base.py
+++ b/src/pymor/core/base.py
@@ -144,13 +144,20 @@ class UberMeta(abc.ABCMeta):
 
         init_sig = inspect.signature(c.__init__)
         init_args = []
+        has_args, has_kwargs = False, False
         for arg, description in init_sig.parameters.items():
             if arg == 'self':
                 continue
             if description.kind in (description.POSITIONAL_OR_KEYWORD, description.POSITIONAL_ONLY,
                                     description.KEYWORD_ONLY):
                 init_args.append(arg)
-        c._init_arguments = tuple(init_args)
+            elif description.kind == description.VAR_POSITIONAL:
+                has_args = True
+            elif description.kind == description.VAR_KEYWORD:
+                has_kwargs = True
+            else:
+                raise NotImplementedError(f'Unknown argument type {description.kind}')
+        c._init_arguments, c._init_has_args, c._init_has_kwargs = tuple(init_args), has_args, has_kwargs
 
         return c
 

--- a/src/pymor/core/base.py
+++ b/src/pymor/core/base.py
@@ -142,16 +142,13 @@ class UberMeta(abc.ABCMeta):
         # by updating the qualified name we make filtering in sphinx possible
         getattr(c, auto_init_name).__qualname__ = auto_init_name
 
-        # getargspec is deprecated and does not work with keyword only args
         init_sig = inspect.signature(c.__init__)
         init_args = []
         for arg, description in init_sig.parameters.items():
             if arg == 'self':
                 continue
-            if description.kind == description.POSITIONAL_ONLY:
-                raise TypeError('It should not be possible that {}.__init__ has POSITIONAL_ONLY arguments'.
-                                format(c))
-            if description.kind in (description.POSITIONAL_OR_KEYWORD, description.KEYWORD_ONLY):
+            if description.kind in (description.POSITIONAL_OR_KEYWORD, description.POSITIONAL_ONLY,
+                                    description.KEYWORD_ONLY):
                 init_args.append(arg)
         c._init_arguments = tuple(init_args)
 

--- a/src/pymor/parameters/base.py
+++ b/src/pymor/parameters/base.py
@@ -435,6 +435,11 @@ class ParametricObject(ImmutableObject):
             return self._parameters
         assert self._locked, 'parameters attribute can only be accessed after class initialization'
         params = Parameters.of(*(getattr(self, arg) for arg in self._init_arguments))
+        if (self._init_has_args or self._init_has_kwargs) and getattr(self, '_parameters_varargs_warning', True):
+            import warnings
+            warnings.warn(f'Class {type(self).__name__} takes *arg/**kwargs. '
+                          f'Parameters of objects passed via these arguments will not be inherited. '
+                          f'To silence this warning set {type(self).__name__}._parameters_varargs_warning = False')
         if self.parameters_own:
             params = params | self.parameters_own
         if self.parameters_internal:


### PR DESCRIPTION
`*args/**kwargs` are not considered when inheriting `Parameters`. This PR causes `ParametricObjects` for which `__init__` takes a variable number of arguments to produce a warning when the `parameters` attribute is accessed.

This is a safety feature for developers to ensure that such arguments are handled correctly. The warning can be silenced by setting the `_parameters_varargs_warn` class attribute to `False`.