### PR TITLE
fix windows azure CI

### DIFF
--- a/.ci/azure/pipeline-win.yml
+++ b/.ci/azure/pipeline-win.yml
@@ -73,7 +73,8 @@ jobs:
       python .ci/azure/run_tests.py -k "not hapod" --cov --cov-config=setup.cfg --cov-context=test || echo "ignoring python exit code"
       type pytest.azure.success || exit 127
   - script: |
-      choco install codecov
+      call activate myEnvironment
+      choco install -y codecov
       coverage xml
       codecov.exe -f coverage.xml
     displayName: 'Upload to codecov.io'

--- a/.ci/azure/pipeline-win.yml
+++ b/.ci/azure/pipeline-win.yml
@@ -18,9 +18,9 @@ jobs:
         curl --output mesa.7z -L https://github.com/pal1000/mesa-dist-win/releases/download/20.1.1-2/mesa3d-20.1.1-release-mingw.7z
         7z x mesa.7z -omesa -y
 
-        # The script requires user input (choice of options) so need to
-        # fiddle to get it to run automatically. Not a clean way to do it,
-        # but works.
+        :: The script requires user input (choice of options) so need to
+        :: fiddle to get it to run automatically. Not a clean way to do it,
+        :: but works.
         sed -i 's/@echo Please make a deployment choice:/@GOTO desktopgl/g' mesa\systemwidedeploy.cmd
         sed -i 's/@echo Desktop OpenGL drivers deploy complete./@exit/g' mesa\systemwidedeploy.cmd
         mesa\systemwidedeploy.cmd
@@ -62,12 +62,12 @@ jobs:
       set QT_API=pyside2
       set PYMOR_ALLOW_DEADLINE_EXCESS=1
 
-      # this allows azure-specific defaults
+      :: this allows azure-specific defaults
       cp .ci/azure/pymor_defaults.py_win pymor_defaults.py
-      # async + converage data in sqlite -> errors
-      # ignore random interpreter error and rely on pytest exit instead
+      :: async + converage data in sqlite -> errors
+      :: ignore random interpreter error and rely on pytest exit instead
       python .ci/azure/run_tests.py -k hapod || echo "ignoring python exit code"
-      # cat equivalent will fail if tests did not succeed
+      :: cat equivalent will fail if tests did not succeed
       type pytest.azure.success || exit 127
 
       python .ci/azure/run_tests.py -k "not hapod" --cov --cov-config=setup.cfg --cov-context=test || echo "ignoring python exit code"

--- a/.ci/azure/pipeline-win.yml
+++ b/.ci/azure/pipeline-win.yml
@@ -1,7 +1,7 @@
 jobs:
 - job: 'Windows_CI'
   pool:
-    vmImage: 'vs2017-win2016'
+    vmImage: 'windows-2022'
   timeoutInMinutes: 75
   variables:
       PYMOR_HYPOTHESIS_PROFILE: ci

--- a/.ci/azure/pipeline-win.yml
+++ b/.ci/azure/pipeline-win.yml
@@ -15,7 +15,7 @@ jobs:
 
   steps:
   - script: |
-        curl --output mesa.7z -L https://github.com/pal1000/mesa-dist-win/releases/download/20.1.1-2/mesa3d-20.1.1-release-mingw.7z
+        curl --output mesa.7z -L https://github.com/pal1000/mesa-dist-win/releases/download/20.3.4/mesa3d-20.3.4-release-msvc.7z
         7z x mesa.7z -omesa -y
 
         :: The script requires user input (choice of options) so need to

--- a/.ci/azure/pipeline-win.yml
+++ b/.ci/azure/pipeline-win.yml
@@ -30,22 +30,22 @@ jobs:
     displayName: Add conda to PATH
 
   - script: conda update -n base -c defaults conda
-    displayName: Create Anaconda environment
+    displayName: Update base Anaconda environment
   - script: conda create -v --yes --name myEnvironment python=$(python.version)
     displayName: Create Anaconda environment
   - script: |
       call activate myEnvironment
       conda config --set channel_priority strict
       conda install -v -c conda-forge --yes --name myEnvironment numpy pip
-    displayName: Conda 1/4
+    displayName: Conda 1/3
   - script: |
       call activate myEnvironment
       conda install -v -c conda-forge --yes --name myEnvironment --only-deps pymor
-    displayName: Conda 2/4
+    displayName: Conda 2/3
   - script: |
       call activate myEnvironment
       conda install -v -c conda-forge --yes --name myEnvironment pyopengl cython pyevtk slycot cython pytest pytest-cov curl hypothesis pyside2==5.13.2 qtpy typer click==7.1.2
-    displayName: Conda 3/4
+    displayName: Conda 3/3
 
   - script: |
       call activate myEnvironment

--- a/.ci/azure/pipeline-win.yml
+++ b/.ci/azure/pipeline-win.yml
@@ -31,12 +31,12 @@ jobs:
 
   - script: conda update -n base -c defaults conda
     displayName: Create Anaconda environment
-  - script: conda create --yes --name myEnvironment
+  - script: conda create -v --yes --name myEnvironment python=$(python.version)
     displayName: Create Anaconda environment
   - script: |
       call activate myEnvironment
       conda config --set channel_priority strict
-      conda install -v -c conda-forge --yes --name myEnvironment python=$(python.version) numpy pip
+      conda install -v -c conda-forge --yes --name myEnvironment numpy pip
     displayName: Conda 1/4
   - script: |
       call activate myEnvironment

--- a/src/pymortests/demos.py
+++ b/src/pymortests/demos.py
@@ -184,7 +184,13 @@ def _test_demo(demo):
 
     try:
         from matplotlib import pyplot
-        pyplot.ion()
+        if sys.version_info[:2] > (3, 7) or (
+                sys.version_info[0] == 3 and sys.version_info[1] == 6):
+            pyplot.ion()
+        else:
+            # the ion switch results in interpreter segfaults during multiple
+            # demo tests on 3.7 -> fall back on old monkeying solution
+            pyplot.show = nop
     except ImportError:
         pass
     try:


### PR DESCRIPTION
- [ci|azure] move python setting to env creation
- [ci|azure] use correct comment statement
- [ci|azure] replace deprecated windows platform with most current one
- [ci|azure] fix wrong section displayNames
- [ci|azure] switch mesa installer version
- Revert "Revert "[tests] fall back on `plt.show = nop` for python 3.7""

Supersedes #1494
