### PR TITLE
DWR reductor for output estimation with primal-dual approach

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -11,6 +11,11 @@
 
 ## Contributors
 
+### pyMOR 2022.2
+
+* Tim Keil, tim.keil@uni-muenster.de
+  * Dual-weighted residual (DWR) output estimation for elliptic problems
+
 ### pyMOR 2022.1
 
 * Patrick Buchfink, patrick.buchfink@ians.uni-stuttgart.de

--- a/src/pymor/reductors/dwr.py
+++ b/src/pymor/reductors/dwr.py
@@ -1,0 +1,266 @@
+# This file is part of the pyMOR project (https://www.pymor.org).
+# Copyright 2013-2021 pyMOR developers and contributors. All rights reserved.
+# License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
+
+import numpy as np
+from numbers import Number
+
+from pymor.core.base import ImmutableObject, BasicObject
+from pymor.algorithms.projection import project
+from pymor.operators.interface import Operator
+from pymor.operators.constructions import VectorOperator
+from pymor.reductors.coercive import CoerciveRBReductor, CoerciveRBEstimator
+from pymor.reductors.residual import ResidualOperator
+
+
+class DWRCoerciveRBReductor(BasicObject):
+    """Reduced Basis reductor for |StationaryModels| with coercive linear operator.
+
+    This class can be used as a replacement for
+    :class:`~pymor.reductors.coercive.CoerciveRBReductor` for a corrected output
+    functional with the DWR approach. (see :cite:`Haa17` (Definition 2.26)).
+    This also enables a DWR based error estimator for the corrected output functional.
+    The DWR approach requires a dual problems for every output dimension of the output functional
+    Each dual problem is then constructed with the dual operator and the appropriate component of
+    the output functional as right hand side. See also :meth:`~pymor.reductors.dwr.dual_model`.
+
+    Parameters
+    ----------
+    fom
+        The |Model| which is to be reduced.
+    RB
+        |VectorArray| containing the reduced basis on which to project.
+    product
+        Inner product for the orthonormalization of `RB`, the projection of the
+        |Operators| given by `vector_ranged_operators` and for the computation of
+        Riesz representatives of the residual. If `None`, the Euclidean product is used.
+    coercivity_estimator
+        `None` or a |Parameterfunctional| returning a lower bound for the coercivity
+        constant of the given problem. Note that the computed error estimate is only
+        guaranteed to be an upper bound for the error when an appropriate coercivity
+        estimate is specified.
+    operator_is_symmetric
+        If the operator of `fom` is symmetric (in theory), it can make sense to consider
+        the same operator also for the adjoint case for the dual models. In this case
+        `operator_is_symmetric` as `True`, means to use the same operator for both the
+        primal as well as for the dual model. If `False` the adjoint operator is used.
+    dual_bases
+        List of |VectorArrays| contraining reduced basis for the dual models that are
+        constructed with :meth:`~pymor.reductors.dwr.dual_model`, where each entry
+        of the list corresponds to the dimensions of the output functional.
+    """
+
+    def __init__(self, fom, RB=None, product=None, coercivity_estimator=None,
+                 operator_is_symmetric=False, dual_bases=None, check_orthonormality=None,
+                 check_tol=None, assemble_error_estimate=True, assemble_output_error_estimate=True):
+        self.__auto_init(locals())
+        self._last_rom = None
+        self.bases = dict(RB=RB)
+
+        if dual_bases is not None:
+            assert len(dual_bases) == fom.dim_output
+
+        self.primal_reductor = CoerciveRBReductor(fom, RB, product, coercivity_estimator, check_tol,
+                                                  assemble_error_estimate,
+                                                  assemble_output_error_estimate=False)
+        self.dual_reductors = []
+        assert (fom.output_functional is not None and fom.output_functional.linear), \
+            'The features of the DWR reductor cannot be used, you should use CoerciveRBReductor instead.'
+
+        # either needed for estimation or just for the corrected output
+        for d in range(fom.dim_output):
+            # construct dual model
+            dual_model = self.dual_model(fom, d, operator_is_symmetric)
+            # choose dual basis
+            dual_basis = dual_bases[d]
+            # define dual reductors
+            dual_reductor = CoerciveRBReductor(dual_model, dual_basis, product, coercivity_estimator,
+                                               check_orthonormality, check_tol)
+            self.dual_reductors.append(dual_reductor)
+
+    def reduce(self, dims=None):
+        if dims is None:
+            dims = {k: len(v) for k, v in self.bases.items()}
+        if isinstance(dims, Number):
+            dims = {k: dims for k in self.bases}
+        if set(dims.keys()) != set(self.bases.keys()):
+            raise ValueError(f'Must specify dimensions for {set(self.bases.keys())}')
+        for k, d in dims.items():
+            if d < 0:
+                raise ValueError(f'Reduced state dimension must be larger than zero {k}')
+            if d > len(self.bases[k]):
+                raise ValueError(f'Specified reduced state dimension larger than reduced basis {k}')
+
+        if self._last_rom is None or any(dims[b] > self._last_rom_dims[b] for b in dims):
+            self._last_rom = self._reduce()
+            self._last_rom_dims = {k: len(v) for k, v in self.bases.items()}
+
+        if dims == self._last_rom_dims:
+            return self._last_rom
+        else:
+            return self._reduce_to_subbasis(dims)
+
+    def _reduce(self):
+        primal_rom = self.primal_reductor.reduce()
+
+        # reduce dual models
+        reduced_dual_models = [red.reduce() for red in self.dual_reductors]
+
+        # build corrected output
+        dual_projected_primal_residuals = []
+        for dual_reductor in self.dual_reductors:
+            dual_basis = dual_reductor.bases['RB']
+            op = project(self.fom.operator, dual_basis, self.bases['RB'])
+            rhs = project(self.fom.rhs, dual_basis, None)
+            primal_residual = ResidualOperator(op, rhs, name='dual_projected_residual')
+            dual_projected_primal_residuals.append(primal_residual)
+        corrected_output = CorrectedOutputFunctional(primal_rom.output_functional,
+                                                     reduced_dual_models,
+                                                     dual_projected_primal_residuals)
+
+        # build error estimator
+        dual_estimators = [dual_reductor.assemble_error_estimator()
+                           for dual_reductor in self.dual_reductors]
+        error_estimator = DWRCoerciveRBEstimator(primal_rom.error_estimator, dual_estimators,
+                                                 reduced_dual_models, self.dual_reductors)
+
+        # build rom
+        rom = primal_rom.with_(output_functional=corrected_output, error_estimator=error_estimator)
+        return rom
+
+    def _reduce_to_subbasis(self, dims):
+        projected_operators = self.project_operators_to_subbasis(dims)
+        error_estimator = self.assemble_error_estimator_for_subbasis(dims)
+        rom = self.build_rom(projected_operators, error_estimator)
+        rom = rom.with_(name=f'{self.fom.name}_reduced')
+        rom.disable_logging()
+        return rom
+
+    def build_rom(self, projected_operators, error_estimator):
+        rom = super().build_rom(projected_operators, error_estimator)
+        # replace the output functional by the corrected output functional
+        corrected_output = self.build_corrected_output(rom, rom.solution_space.dim)
+        rom = rom.with_(output_functional=corrected_output)
+        return rom
+
+    def build_corrected_output(self, rom, dim):
+        dual_projected_primal_residuals = []
+        for dual_reductor in self.dual_reductors:
+            dual_basis = dual_reductor.bases['RB'][:dim]
+            op = project(self.fom.operator, dual_basis, self.bases['RB'][:dim])
+            rhs = project(self.fom.rhs, dual_basis, None)
+            primal_residual = ResidualOperator(op, rhs, name='dual_projected_residual')
+            dual_projected_primal_residuals.append(primal_residual)
+        if dim < self.reduced_dual_models[0].solution_space.dim:
+            # dimension does not fit anymore
+            self.reduced_dual_models = [red.reduce(dim) for red in self.dual_reductors]
+        return CorrectedOutputFunctional(rom.output_functional, self.reduced_dual_models,
+                                         dual_projected_primal_residuals)
+
+    def assemble_error_estimator(self):
+        residual = self.residual_reductor.reduce()
+        dual_estimators = [dual_reductor.assemble_error_estimator()
+                           for dual_reductor in self.dual_reductors]
+        primal_estimator = CoerciveRBEstimator(residual, tuple(self.residual_reductor.residual_range_dims),
+                                               self.coercivity_estimator)
+        self.reduced_dual_models = [red.reduce() for red in self.dual_reductors]
+        error_estimator = DWRCoerciveRBEstimator(primal_estimator, dual_estimators, self.reduced_dual_models,
+                                                 self.dual_reductors)
+        return error_estimator
+
+    @classmethod
+    def dual_model(cls, model, dim=0, operator_is_symmetric=False):
+        """Return dual model with the output as right hand side.
+
+        See :cite:`Haa17` (Definition 2.26)
+
+        Parameters
+        ----------
+        model
+            The |Model| for which to construct the dual model
+        dim
+            The dimension of the `fom.output_functional` for which the dual model is to be built.
+        operator_is_symmetric
+            If `True`, `fom.operator` is used for the dual problem.
+            This is only feasable if the operator is symmetric (in theory).
+            If `False` the adjoint `fom.operator.H` is used instead.
+
+        Returns
+        -------
+        A |Model| with the adjoint operator and the corresponding right hand side
+        """
+        assert 0 <= dim < model.dim_output
+        e_i_vec = model.output_functional.range.from_numpy(np.eye(1, model.dim_output, dim))
+        dual_rhs = - model.output_functional.H @ VectorOperator(e_i_vec)
+        dual_operator = model.operator if operator_is_symmetric else model.operator.H
+        dual_model = model.with_(operator=dual_operator, rhs=dual_rhs,
+                                 output_functional=None, name=model.name + '_dual')
+        return dual_model
+
+    def project_operators_to_subbasis(self, dims):
+        self._last_rom = self._last_rom.with_(
+            output_functional=self._last_rom.output_functional.output_functional)
+        return super().project_operators_to_subbasis(dims)
+
+    def assemble_error_estimator_for_subbasis(self, dims):
+        return self._last_rom.error_estimator.restricted_to_subbasis(dims['RB'], m=self._last_rom)
+
+
+class DWRCoerciveRBEstimator(ImmutableObject):
+    """Instantiated by :class:`DWRCoerciveRBReductor`.
+
+    Not to be used directly.
+    """
+
+    def __init__(self, primal_estimator, dual_estimators, dual_models, dual_reductors):
+        self.__auto_init(locals())
+
+    def estimate_error(self, U, mu, m):
+        return self.primal_estimator.estimate_error(U, mu, m)
+
+    def estimate_output_error(self, U, mu, m):
+        est_pr = self.estimate_error(U, mu, m)
+        est_dus = []
+        for d in range(m.dim_output):
+            dual_solution = self.dual_models[d].solve(mu)
+            est_dus.append(self.dual_estimators[d].estimate_error(dual_solution, mu, m))
+        return (est_pr * est_dus).T
+
+    def restricted_to_subbasis(self, dim, m):
+        primal_estimator = self.primal_estimator.restricted_to_subbasis(dim, m)
+        dual_models = [red.reduce(dim) for red in self.dual_reductors]
+        dual_estimators = [dual_estimator.restricted_to_subbasis(dim, m) for dual_estimator
+                           in self.dual_estimators]
+        return DWRCoerciveRBEstimator(primal_estimator, dual_estimators, dual_models, self.dual_reductors)
+
+
+class CorrectedOutputFunctional(Operator):
+    """|Operator| representing the corrected output functional from :cite:`Haa17` (Definition 2.26)
+
+    Parameters
+    ----------
+    output_functional
+        Original output_functional
+    dual_models
+        dual models for the corrected output
+    dual_projected_primal_residuals
+        The evaluated primal residuals
+    """
+
+    linear = False
+
+    def __init__(self, output_functional, dual_models, dual_projected_primal_residuals):
+        self.__auto_init(locals())
+        self.source = output_functional.source
+        self.range = output_functional.range
+
+    def apply(self, solution, mu=None):
+        # compute corrected output functional
+        output = self.output_functional.apply(solution, mu=mu).to_numpy()
+        correction = np.empty((self.range.dim, len(solution)))
+        for d, (dual_m, dual_res) in enumerate(zip(self.dual_models, self.dual_projected_primal_residuals)):
+            dual_solution = dual_m.solve(mu)
+            dual_correction = dual_res.apply2(dual_solution, solution, mu)
+            correction[d] = dual_correction
+        corrected_output = output + correction.T
+        return self.range.from_numpy(corrected_output)

--- a/src/pymor/reductors/dwr.py
+++ b/src/pymor/reductors/dwr.py
@@ -1,14 +1,14 @@
 # This file is part of the pyMOR project (https://www.pymor.org).
-# Copyright 2013-2021 pyMOR developers and contributors. All rights reserved.
+# Copyright pyMOR developers and contributors. All rights reserved.
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
 import numpy as np
 from numbers import Number
 
-from pymor.core.base import ImmutableObject, BasicObject
 from pymor.algorithms.projection import project
-from pymor.operators.interface import Operator
+from pymor.core.base import ImmutableObject, BasicObject
 from pymor.operators.constructions import VectorOperator
+from pymor.operators.interface import Operator
 from pymor.reductors.coercive import CoerciveRBReductor
 from pymor.reductors.residual import ResidualOperator
 
@@ -17,12 +17,12 @@ class DWRCoerciveRBReductor(BasicObject):
     """Reduced Basis reductor for |StationaryModels| with coercive linear operator
 
     This class can be used as a replacement for
-    :class:`~pymor.reductors.coercive.CoerciveRBReductor` to obtain a corrected reduced 
+    :class:`~pymor.reductors.coercive.CoerciveRBReductor` to obtain a corrected reduced
     output  functional with the DWR approach. (see :cite:`Haa17` (Definition 2.31)).
     This also implements a DWR-based error estimator for the corrected output functional.
-    The DWR approach requires the reduction of a dual problem for every dimension of the output functional.
-    Each dual problem is defined by the dual operator and the corresponding component of
-    the output functional as right-hand side. See also :meth:`~pymor.reductors.dwr.dual_model`.
+    The DWR approach requires the reduction of a dual problem for every dimension of the output
+    functional. Each dual problem is defined by the dual operator and the corresponding component
+    of the output functional as right-hand side. See also :meth:`~pymor.reductors.dwr.dual_model`.
 
     Parameters
     ----------

--- a/src/pymor/reductors/dwr.py
+++ b/src/pymor/reductors/dwr.py
@@ -60,8 +60,10 @@ class DWRCoerciveRBReductor(BasicObject):
         if dual_bases is not None:
             assert len(dual_bases) == fom.dim_output
 
-        self.primal_reductor = CoerciveRBReductor(fom, primal_basis, product,
-                                                  coercivity_estimator, check_tol)
+        self.primal_reductor = CoerciveRBReductor(fom, RB=primal_basis, product=product,
+                                                  coercivity_estimator=coercivity_estimator,
+                                                  check_orthonormality=check_orthonormality,
+                                                  check_tol=check_tol)
         self.dual_reductors = []
         assert (fom.output_functional is not None and fom.output_functional.linear), \
             'The features of the DWR reductor cannot be used, ' + \
@@ -77,8 +79,10 @@ class DWRCoerciveRBReductor(BasicObject):
             else:
                 dual_basis = primal_basis
             # define dual reductors (with None as coercivity_estimator)
-            dual_reductor = CoerciveRBReductor(dual_model, dual_basis, product, None,
-                                               check_orthonormality, check_tol)
+            dual_reductor = CoerciveRBReductor(dual_model, RB=dual_basis, product=product,
+                                               coercivity_estimator=None,
+                                               check_orthonormality=check_orthonormality,
+                                               check_tol=check_tol)
             self.dual_reductors.append(dual_reductor)
 
     def reduce(self, dim=None):

--- a/src/pymor/reductors/dwr.py
+++ b/src/pymor/reductors/dwr.py
@@ -19,7 +19,7 @@ class DWRCoerciveRBReductor(BasicObject):
 
     This class can be used as a replacement for
     :class:`~pymor.reductors.coercive.CoerciveRBReductor` to obtain a corrected reduced
-    output  functional with the DWR approach. (see :cite:`Haa17` (Definition 2.31)).
+    output functional with the DWR approach (see :cite:`Haa17` (Definition 2.31, Proposition 2.32)).
     This also implements a DWR-based error estimator for the corrected output functional.
     The DWR approach requires the reduction of a dual problem for every dimension of the output
     functional. Each dual problem is defined by the dual operator and the corresponding component
@@ -149,14 +149,15 @@ class DWRCoerciveRBReductor(BasicObject):
 
     @classmethod
     def create_dual_model(cls, model, dim=0):
-        """Return dual model with the output as right hand side.
+        r"""Return dual model with the output as right hand side.
 
-        The dual equation is defined as to find the solution p such that
+        The dual equation is defined as to find the solution :math:`p` such that
 
-            a(q, p) = - l_dim(q),       for all q,
+        .. math::
+            a(q, p) = - l_d(q),\qquad\text{for all }q,
 
-        where l_dim denotes the dim-th component of the output functional l.
-        See :cite:`Haa17` (Definition 2.26)
+        where :math:`l_d` denotes the :math:`d`-th component of the output functional :math:`l`.
+        See :cite:`Haa17` (Definition 2.31).
 
         Parameters
         ----------

--- a/src/pymor/reductors/dwr.py
+++ b/src/pymor/reductors/dwr.py
@@ -17,12 +17,12 @@ class DWRCoerciveRBReductor(BasicObject):
     """Reduced Basis reductor for |StationaryModels| with coercive linear operator
 
     This class can be used as a replacement for
-    :class:`~pymor.reductors.coercive.CoerciveRBReductor` for a corrected output
-    functional with the DWR approach. (see :cite:`Haa17` (Definition 2.31)).
-    This also enables a DWR based error estimator for the corrected output functional.
-    The DWR approach requires a dual problem for every dimension of the output functional.
+    :class:`~pymor.reductors.coercive.CoerciveRBReductor` to obtain a corrected reduced 
+    output  functional with the DWR approach. (see :cite:`Haa17` (Definition 2.31)).
+    This also implements a DWR-based error estimator for the corrected output functional.
+    The DWR approach requires the reduction of a dual problem for every dimension of the output functional.
     Each dual problem is defined by the dual operator and the corresponding component of
-    the output functional as right hand side. See also :meth:`~pymor.reductors.dwr.dual_model`.
+    the output functional as right-hand side. See also :meth:`~pymor.reductors.dwr.dual_model`.
 
     Parameters
     ----------
@@ -35,9 +35,9 @@ class DWRCoerciveRBReductor(BasicObject):
     primal_RB
         |VectorArray| containing the reduced basis on which to project the fom.
     dual_RBs
-        List of |VectorArrays| containing the reduced basis on which to project the `dual_foms`,
-         where each entry of the list corresponds to the dimensions of the output functional.
-         If `dual_bases` is `None`, the primal bases are used.
+        List of |VectorArrays| containing the reduced bases on which to project the `dual_foms`,
+        where each entry of the list corresponds to the dimensions of the output functional.
+        If `dual_bases` is `None`, the primal basis are used.
     product
         See :class:`~pymor.reductors.coercive.CoerciveRBReductor`.
     coercivity_estimator
@@ -56,8 +56,8 @@ class DWRCoerciveRBReductor(BasicObject):
         if dual_RBs is not None:
             assert len(dual_RBs) == fom.dim_output
         assert (fom.output_functional is not None and fom.output_functional.linear), \
-            'The features of the DWR reductor cannot be used, ' + \
-            'please use CoerciveRBReductor instead.'
+            'DWRCoerciveRBReductor requires a linear ouput functional. ' + \
+            'Please use CoerciveRBReductor instead.'
 
         self.primal_reductor = CoerciveRBReductor(fom, RB=primal_RB, product=product,
                                                   coercivity_estimator=coercivity_estimator,
@@ -157,7 +157,7 @@ class DWRCoerciveRBReductor(BasicObject):
 
         Returns
         -------
-        A |Model| with the adjoint operator and the corresponding right hand side
+        A |Model| with the adjoint operator and the corresponding right-hand side
         """
         assert 0 <= dim < model.dim_output
         e_i_vec = model.output_functional.range.from_numpy(np.eye(1, model.dim_output, dim))

--- a/src/pymordemos/output_error_estimation_with_dwr.py
+++ b/src/pymordemos/output_error_estimation_with_dwr.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python
+# This file is part of the pyMOR project (https://www.pymor.org).
+# Copyright 2013-2021 pyMOR developers and contributors. All rights reserved.
+# License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
+
+
+import numpy as np
+import matplotlib.pyplot as plt
+from typer import Argument, run
+
+from pymor.basic import *
+from pymor.reductors.dwr import DWRCoerciveRBReductor
+
+
+def main(
+    fom_number: int = Argument(..., help='Selects FOMs [0, 1, 2] for elliptic problems '
+                                         + 'with scalar and vector valued outputs '),
+    grid_intervals: int = Argument(..., help='Grid interval count.'),
+    training_samples: int = Argument(..., help='Number of samples used for training the reduced basis.'),
+    modes: int = Argument(..., help='Number of basis functions for the RB spaces (generated with POD)')
+):
+    set_log_levels({'pymor': 'WARN'})
+    """Example script for using output error estimation compared with dwr approach"""
+
+    assert fom_number in [0, 1, 2], f'No FOM available for fom_number {fom_number}'
+
+    # elliptic case
+    if fom_number == 0:
+        # real valued output
+        fom = create_fom(grid_intervals, vector_valued_output=False)
+    elif fom_number == 1:
+        # vector valued output (with BlockColumnOperator)
+        fom = create_fom(grid_intervals, vector_valued_output=True)
+    elif fom_number == 2:
+        # an output which is actually a lincomb operator
+        fom = create_fom(grid_intervals, vector_valued_output=True)
+        dim_source = fom.output_functional.source.dim
+        np.random.seed(1)
+        random_matrix_1 = np.random.rand(2, dim_source)
+        random_matrix_2 = np.random.rand(2, dim_source)
+        op1 = NumpyMatrixOperator(random_matrix_1, source_id='STATE')
+        op2 = NumpyMatrixOperator(random_matrix_2, source_id='STATE')
+        ops = [op1, op2]
+        lincomb_op = LincombOperator(ops, [1., 0.5])
+        fom = fom.with_(output_functional=lincomb_op)
+
+    standard_reductor = CoerciveRBReductor
+    dwr_reductor = DWRCoerciveRBReductor
+
+    # Parameter space and operator are equal for all fom
+    parameter_space = fom.parameters.space(0.1, 1)
+    coercivity_estimator = ExpressionParameterFunctional('min(diffusion)', fom.parameters)
+    training_set = parameter_space.sample_uniformly(training_samples)
+
+    # generate solution snapshots
+    primal_snapshots = fom.solution_space.empty()
+    fom_outputs = []
+
+    # construct training data
+    for mu in training_set:
+        comp_data = fom.compute(output=True, solution=True, mu=mu)
+        primal_snapshots.append(comp_data['solution'])
+        fom_outputs.append(comp_data['output'])
+
+    # apply POD on bases
+    product = fom.h1_0_semi_product
+    primal_reduced_basis, _ = pod(primal_snapshots, modes=modes, product=product)
+
+    standard_RB_reductor = standard_reductor(fom, RB=primal_reduced_basis, product=product,
+                                             coercivity_estimator=coercivity_estimator)
+
+    # also construct dual bases for dwr
+    # take the operator as the dual operator if it is symmetric
+    symmetries = [True, False]
+    dwr_reductors = []
+    for operator_symmetric in symmetries:
+        dual_reduced_bases = []
+        for d in range(fom.dim_output):
+            dual_snapshots = fom.solution_space.empty()
+            # initialize dual model from reductor
+            dual_fom = dwr_reductor.dual_model(fom, d, operator_symmetric)
+            for mu in training_set:
+                dual_snapshots.append(dual_fom.solve(mu))
+            dual_reduced_bases.append(pod(dual_snapshots, modes=modes, product=product)[0])
+
+        dwr_RB_reductor = dwr_reductor(fom,
+                                       primal_basis=primal_reduced_basis,
+                                       product=product,
+                                       dual_bases=dual_reduced_bases,
+                                       coercivity_estimator=coercivity_estimator,
+                                       operator_is_symmetric=operator_symmetric)
+        dwr_reductors.append(dwr_RB_reductor)
+
+    # rom
+    standard_rom = standard_RB_reductor.reduce()
+    dwr_roms = [dwr_red.reduce() for dwr_red in dwr_reductors]
+    roms = [standard_rom, dwr_roms[0], dwr_roms[1]]
+
+    results = []
+    for rom in roms:
+        results_full = {'fom': [], 'rom': [], 'err': [], 'est': []}
+        for i, mu in enumerate(training_set):
+            s_fom = fom_outputs[i]
+            s_rom, s_est = rom.output(return_error_estimate=True, mu=mu,
+                                      return_error_estimate_vector=False)
+            results_full['fom'].append(s_fom)
+            results_full['rom'].append(s_rom)
+            results_full['err'].append(np.linalg.norm(np.abs(s_fom[-1]-s_rom[-1])))
+            results_full['est'].append(s_est)
+
+            # just for testing purpose
+            assert np.linalg.norm(np.abs(s_rom-s_fom)) <= s_est + 1e-7
+        results.append(results_full)
+
+    # plot result
+    plt.figure()
+    plt.semilogy(np.arange(len(training_set)), results[0]['err'], 'k',
+                 label=f'standard output error basis size {modes}')
+    plt.semilogy(np.arange(len(training_set)), results[0]['est'], 'k--',
+                 label=f'standard output estimate basis size {modes}')
+    plt.semilogy(np.arange(len(training_set)), results[1]['err'], 'g',
+                 label=f'dwr output error basis size {modes}, 1')
+    plt.semilogy(np.arange(len(training_set)), results[1]['est'], 'g--',
+                 label=f'dwr output estimate basis size {modes}, 1')
+    plt.semilogy(np.arange(len(training_set)), results[2]['err'], 'r',
+                 label=f'dwr output error basis size {modes}, 2')
+    plt.semilogy(np.arange(len(training_set)), results[2]['est'], 'r--',
+                 label=f'dwr output estimate basis size {modes}, 2')
+    plt.title(f'Error and estimate for {modes} basis functions for parameters in training set')
+    plt.legend()
+    # plt.show()
+
+    # estimator study for smaller number of basis functions
+    modes_set = np.arange(1, len(primal_reduced_basis)+1)
+    max_errss, max_estss, min_errss, min_estss = [], [], [], []
+    for reductor in [standard_RB_reductor, dwr_reductors[0], dwr_reductors[1]]:
+        max_errs, max_ests, min_errs, min_ests = [], [], [], []
+        for mode in modes_set:
+            max_err, max_est, min_err, min_est = 0, 0, 1000, 1000
+            rom = reductor.reduce(mode)
+
+            for i, mu in enumerate(training_set):
+                s_fom = fom_outputs[i]
+                s_rom, s_est = rom.output(return_error_estimate=True, mu=mu)
+                max_err = max(max_err, np.linalg.norm(np.abs(s_fom-s_rom)))
+                max_est = max(max_est, s_est)
+                min_err = min(min_err, np.linalg.norm(np.abs(s_fom-s_rom)))
+                min_est = min(min_est, s_est)
+
+            max_errs.append(max_err)
+            max_ests.append(max_est)
+            min_errs.append(min_err)
+            min_ests.append(min_est)
+
+        max_errss.append(max_errs)
+        max_estss.append(max_ests)
+        min_errss.append(min_errs)
+        min_estss.append(min_ests)
+
+    plt.figure()
+    # plt.semilogy(modes_set, max_errss[0], 'k', label='standard max error')
+    # plt.semilogy(modes_set, max_estss[0], 'k--', label='standard max estimate')
+    plt.semilogy(modes_set, min_errss[0], 'g', label='standard min error')
+    plt.semilogy(modes_set, min_estss[0], 'g--', label='standard min estimate')
+    # plt.semilogy(modes_set, max_errss[1], 'r', label='dwr max error, 1')
+    # plt.semilogy(modes_set, max_estss[1], 'r--', label='dwr max estimate, 1')
+    plt.semilogy(modes_set, min_errss[1], 'b', label='dwr min error, 1')
+    plt.semilogy(modes_set, min_estss[1], 'b--', label='dwr min estimate, 1')
+    # plt.semilogy(modes_set, max_errss[2], 'y', label='dwr max error, 2')
+    # plt.semilogy(modes_set, max_estss[2], 'y--', label='dwr max estimate, 2')
+    plt.semilogy(modes_set, min_errss[2], 'm', label='dwr min error, 2')
+    plt.semilogy(modes_set, min_estss[2], 'm--', label='dwr min estimate, 2')
+    plt.legend()
+    plt.title('Evolution of maximum error and estimate for different RB sizes')
+    plt.show()
+
+
+def create_fom(grid_intervals, vector_valued_output=False):
+    p = thermal_block_problem([2, 2])
+    f = ConstantFunction(1, dim_domain=2)
+
+    if vector_valued_output:
+        p = p.with_(outputs=[('l2', f), ('l2', f * 0.5)])
+    else:
+        p = p.with_(outputs=[('l2', f)])
+
+    fom, _ = discretize_stationary_cg(p, diameter=1./grid_intervals)
+    return fom
+
+
+if __name__ == '__main__':
+    run(main)

--- a/src/pymordemos/output_error_estimation_with_dwr.py
+++ b/src/pymordemos/output_error_estimation_with_dwr.py
@@ -91,10 +91,18 @@ def main(
                                        operator_is_symmetric=operator_symmetric)
         dwr_reductors.append(dwr_RB_reductor)
 
+    # dwr reductor without dual basis
+    dwr_reductor_primal = dwr_reductor(fom,
+                                       primal_basis=primal_reduced_basis,
+                                       product=product,
+                                       coercivity_estimator=coercivity_estimator,
+                                       operator_is_symmetric=operator_symmetric)
+    dwr_reductors.append(dwr_reductor_primal)
+
     # rom
     standard_rom = standard_RB_reductor.reduce()
     dwr_roms = [dwr_red.reduce() for dwr_red in dwr_reductors]
-    roms = [standard_rom, dwr_roms[0], dwr_roms[1]]
+    roms = [standard_rom, dwr_roms[0], dwr_roms[1], dwr_roms[2]]
 
     results = []
     for rom in roms:
@@ -119,13 +127,17 @@ def main(
     plt.semilogy(np.arange(len(training_set)), results[0]['est'], 'k--',
                  label=f'standard output estimate basis size {modes}')
     plt.semilogy(np.arange(len(training_set)), results[1]['err'], 'g',
-                 label=f'dwr output error basis size {modes}, 1')
+                 label=f'dwr output error basis size {modes}, operator_symmetric=True')
     plt.semilogy(np.arange(len(training_set)), results[1]['est'], 'g--',
-                 label=f'dwr output estimate basis size {modes}, 1')
+                 label=f'dwr output estimate basis size {modes}, operator_symmetric=True')
     plt.semilogy(np.arange(len(training_set)), results[2]['err'], 'r',
-                 label=f'dwr output error basis size {modes}, 2')
+                 label=f'dwr output error basis size {modes}, operator_symmetric=False')
     plt.semilogy(np.arange(len(training_set)), results[2]['est'], 'r--',
-                 label=f'dwr output estimate basis size {modes}, 2')
+                 label=f'dwr output estimate basis size {modes}, operator_symmetric=False')
+    plt.semilogy(np.arange(len(training_set)), results[3]['err'], 'y',
+                 label=f'dwr output error basis size {modes}, no dual_bases')
+    plt.semilogy(np.arange(len(training_set)), results[3]['est'], 'y--',
+                 label=f'dwr output estimate basis size {modes}, no dual_basis')
     plt.title(f'Error and estimate for {modes} basis functions for parameters in training set')
     plt.legend()
     # plt.show()
@@ -164,12 +176,16 @@ def main(
     plt.semilogy(modes_set, min_estss[0], 'g--', label='standard min estimate')
     # plt.semilogy(modes_set, max_errss[1], 'r', label='dwr max error, 1')
     # plt.semilogy(modes_set, max_estss[1], 'r--', label='dwr max estimate, 1')
-    plt.semilogy(modes_set, min_errss[1], 'b', label='dwr min error, 1')
-    plt.semilogy(modes_set, min_estss[1], 'b--', label='dwr min estimate, 1')
+    plt.semilogy(modes_set, min_errss[1], 'b',
+                 label='dwr min error, operator_symmetric=True')
+    plt.semilogy(modes_set, min_estss[1], 'b--',
+                 label='dwr min estimate, operator_symmetric=True')
     # plt.semilogy(modes_set, max_errss[2], 'y', label='dwr max error, 2')
     # plt.semilogy(modes_set, max_estss[2], 'y--', label='dwr max estimate, 2')
-    plt.semilogy(modes_set, min_errss[2], 'm', label='dwr min error, 2')
-    plt.semilogy(modes_set, min_estss[2], 'm--', label='dwr min estimate, 2')
+    plt.semilogy(modes_set, min_errss[2], 'm',
+                 label='dwr min error, operator_symmetric=False')
+    plt.semilogy(modes_set, min_estss[2], 'm--',
+                 label='dwr min estimate, operator_symmetric=False')
     plt.legend()
     plt.title('Evolution of maximum error and estimate for different RB sizes')
     plt.show()

--- a/src/pymordemos/output_error_estimation_with_dwr.py
+++ b/src/pymordemos/output_error_estimation_with_dwr.py
@@ -19,8 +19,8 @@ def main(
     training_samples: int = Argument(..., help='Number of samples used for training the reduced basis.'),
     modes: int = Argument(..., help='Number of basis functions for the RB spaces (generated with POD)')
 ):
+    """Demo script for using DWR-based output error estimation."""
     set_log_levels({'pymor': 'INFO'})
-    """Example script for using output error estimation compared with DWR approach"""
 
     assert fom_number in [0, 1], f'No FOM available for fom_number {fom_number}'
 

--- a/src/pymordemos/output_error_estimation_with_dwr.py
+++ b/src/pymordemos/output_error_estimation_with_dwr.py
@@ -121,7 +121,7 @@ def main(
     plt.legend()
 
     # estimator study for smaller number of basis functions
-    modes_set = np.arange(1, len(primal_RB)+1)
+    modes_set = np.arange(0, len(primal_RB)+1)
     max_errss, max_estss, min_errss, min_estss = [], [], [], []
     for reductor in [standard_RB_reductor, dwr_reductors[0], dwr_reductors[1]]:
         max_errs, max_ests, min_errs, min_ests = [], [], [], []

--- a/src/pymordemos/output_error_estimation_with_dwr.py
+++ b/src/pymordemos/output_error_estimation_with_dwr.py
@@ -115,7 +115,7 @@ def main(
                  label=f'standard output error basis size {modes}')
     plt.semilogy(np.arange(len(training_set)), results[0]['est'], 'k--',
                  label=f'standard output estimate basis size {modes}')
-    plt.semilogy(np.arange(len(training_set)), results[1]['err'], 'g',
+    plt.semilogy(np.arange(len(training_set)), results[1]['err'], 'g-o',
                  label=f'dwr output error basis size {modes}, operator_symmetric=True')
     plt.semilogy(np.arange(len(training_set)), results[1]['est'], 'g--',
                  label=f'dwr output estimate basis size {modes}, operator_symmetric=True')
@@ -159,18 +159,18 @@ def main(
         min_estss.append(min_ests)
 
     plt.figure()
-    plt.semilogy(modes_set, min_errss[0], 'g', label='standard min error')
+    plt.semilogy(modes_set, min_errss[0], 'g-o', label='standard min error')
     plt.semilogy(modes_set, min_estss[0], 'g--', label='standard min estimate')
-    plt.semilogy(modes_set, min_errss[1], 'b',
+    plt.semilogy(modes_set, min_errss[1], 'b-o',
                  label='dwr min error, operator_symmetric=True')
     plt.semilogy(modes_set, min_estss[1], 'b--',
                  label='dwr min estimate, operator_symmetric=True')
-    plt.semilogy(modes_set, min_errss[2], 'm',
+    plt.semilogy(modes_set, min_errss[2], 'm-o',
                  label='dwr min error, operator_symmetric=False')
     plt.semilogy(modes_set, min_estss[2], 'm--',
                  label='dwr min estimate, operator_symmetric=False')
     plt.legend()
-    plt.title('Evolution of maximum error and estimate for different RB sizes')
+    plt.title('Evolution of minimum error and estimate for different RB sizes')
     plt.show()
 
 

--- a/src/pymordemos/output_error_estimation_with_dwr.py
+++ b/src/pymordemos/output_error_estimation_with_dwr.py
@@ -68,7 +68,7 @@ def main(
         dual_fom = dual_foms[d]
         for mu in training_set:
             dual_snapshots.append(dual_fom.solve(mu))
-        # use one mode more to test the case where the size it not the same
+        # use one mode more to test the case where the size is not the same
         dual_RBs.append(pod(dual_snapshots, modes=modes+1, product=product)[0])
 
     # extend basis
@@ -115,7 +115,7 @@ def main(
     plt.semilogy(np.arange(len(training_set)), results[2]['err'], 'yo-', alpha=.5,
                  label=f'dwr output error basis size {modes}, no dual_bases')
     plt.semilogy(np.arange(len(training_set)), results[2]['est'], 'y--', alpha=.5,
-                 label=f'dwr output estimate basis size {modes}, no dual_basis')
+                 label=f'dwr output estimate basis size {modes}, no dual_bases')
     plt.title(f'Error and estimate for {modes} basis functions for parameters in training set')
     plt.xlim(10, 50)
     plt.legend()

--- a/src/pymordemos/output_error_estimation_with_dwr.py
+++ b/src/pymordemos/output_error_estimation_with_dwr.py
@@ -1,6 +1,5 @@
-#!/usr/bin/env python
 # This file is part of the pyMOR project (https://www.pymor.org).
-# Copyright 2013-2021 pyMOR developers and contributors. All rights reserved.
+# Copyright pyMOR developers and contributors. All rights reserved.
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
 
@@ -50,7 +49,7 @@ def main(
 
     # apply POD on bases
     product = fom.h1_0_product
-    primal_RB, _ = pod(primal_snapshots, modes=modes-1, product=product)
+    primal_RB, _ = pod(primal_snapshots, modes=modes, product=product)
 
     # standard RB reductor for comparison
     standard_RB_reductor = CoerciveRBReductor(fom, RB=primal_RB, product=product,

--- a/src/pymordemos/output_error_estimation_with_dwr.py
+++ b/src/pymordemos/output_error_estimation_with_dwr.py
@@ -127,7 +127,10 @@ def main(
         max_errs, max_ests, min_errs, min_ests = [], [], [], []
         for mode in modes_set:
             max_err, max_est, min_err, min_est = 0, 0, np.inf, np.inf
-            rom = reductor.reduce(mode)
+            if isinstance(reductor, DWRCoerciveRBReductor):
+                rom = reductor.reduce(mode, mode)
+            else:
+                rom = reductor.reduce(mode)
 
             for i, mu in enumerate(training_set):
                 s_fom = fom_outputs[i]

--- a/src/pymortests/demos.py
+++ b/src/pymortests/demos.py
@@ -134,9 +134,8 @@ OUTPUT_FUNCTIONAL_ARGS = (
     ('output_error_estimation', [2, 10, 4, 10, 1]),
     ('output_error_estimation', [3, 10, 10, 10, 1]),
     ('output_error_estimation', [4, 10, 10, 10, 1]),
-    ('output_error_estimation_with_dwr', [0, 10, 4, 20]),
-    ('output_error_estimation_with_dwr', [1, 10, 4, 20]),
-    ('output_error_estimation_with_dwr', [2, 10, 4, 20]),
+    ('output_error_estimation_with_dwr', [0, 10, 4, 12]),
+    ('output_error_estimation_with_dwr', [1, 10, 4, 8]),
 )
 
 DMD_ARGS = (

--- a/src/pymortests/demos.py
+++ b/src/pymortests/demos.py
@@ -134,6 +134,9 @@ OUTPUT_FUNCTIONAL_ARGS = (
     ('output_error_estimation', [2, 10, 4, 10, 1]),
     ('output_error_estimation', [3, 10, 10, 10, 1]),
     ('output_error_estimation', [4, 10, 10, 10, 1]),
+    ('output_error_estimation_with_dwr', [0, 10, 4, 20]),
+    ('output_error_estimation_with_dwr', [1, 10, 4, 20]),
+    ('output_error_estimation_with_dwr', [2, 10, 4, 20]),
 )
 
 DMD_ARGS = (


### PR DESCRIPTION
This PR supersedes #1418. We introduce a complete new `DWRCoerciveRBReductor` (not as subclass of `CoerciveRBReductor`) which is only used for the dual weighted residual (DWR) or primal-dual residual approach as discussed in [haa17], section 2.4. 

The `DWRCoerciveRBReductor` can be used for using the corrected output functional (only available for linear outputs for now) as well as the better output estimation. Furthermore, the reductor can be used to construct the corresponding dual models.

In the demofile `output_error_estimation_with_dwr`, we compare this approach to the standard output estimation from #1474.