### PR TITLE
update mailmap and add CI check

### DIFF
--- a/.ci/check_mailmap.py
+++ b/.ci/check_mailmap.py
@@ -25,9 +25,13 @@ missing = [(u, e) for u, e in seen_set if u in contents and e not in contents]
 # name occurs with multiple mails, but no mailmap entry
 duplicates = [(u, mails) for u, mails in seen.items() if len(mails) > 1]
 
+lines = [l for l in open(mailmap).readlines() if not l.startswith("#")]
+unsorted = [u for u, s in zip(lines, sorted(lines)) if u != s]
 for user, email in missing:
     print(f"missing mailmap entry for {user} {email}")
 for user, emails in duplicates:
     print(f"multiple emails for {user}: {emails}")
+for line in unsorted:
+    print(f"line not sorted properly: {line}")
 
-sys.exit(len(missing) + len(duplicates))
+sys.exit(len(missing) + len(duplicates) + len(unsorted))

--- a/.ci/check_mailmap.py
+++ b/.ci/check_mailmap.py
@@ -30,4 +30,4 @@ for user, email in missing:
 for user, emails in duplicates:
     print(f"multiple emails for {user}: {emails}")
 
-sys.exit(len(missing) == len(duplicates) == 0)
+sys.exit(len(missing) + len(duplicates))

--- a/.ci/check_mailmap.py
+++ b/.ci/check_mailmap.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+
+from subprocess import check_output
+from pathlib import Path
+import sys
+from collections import defaultdict
+
+namesep = "??"
+fmtsep = "||"
+cmd = ["git", "log", f"--format=%an{namesep}%ae{fmtsep}%aN{namesep}%aE"]
+seen_set = set()
+seen = defaultdict(list)
+for user in (f.split(fmtsep) for f in set(check_output(cmd, universal_newlines=True).strip().split('\n'))):
+    if user[0] != user[1]:
+        # has a mailmap entry
+        continue
+    name, email = user[0].split(namesep)
+    seen_set.add((name, email))
+    seen[name].append(email)
+
+mailmap = Path(sys.argv[1]).resolve()
+contents = open(mailmap).read()
+# name is in mailmap, but email is new
+missing = [(u, e) for u, e in seen_set if u in contents and e not in contents]
+# name occurs with multiple mails, but no mailmap entry
+duplicates = [(u, mails) for u, mails in seen.items() if len(mails) > 1]
+
+for user, email in missing:
+    print(f"missing mailmap entry for {user} {email}")
+for user, emails in duplicates:
+    print(f"multiple emails for {user}: {emails}")
+
+sys.exit(len(missing) == len(duplicates) == 0)

--- a/.ci/gitlab/ci_sanity_check.bash
+++ b/.ci/gitlab/ci_sanity_check.bash
@@ -13,3 +13,6 @@ PYTHONS="${1}"
 
 # performs the image+tag in registry check
 ./.ci/gitlab/template.ci.py "${GITLAB_API_RO}"
+
+# makes sure mailmap is up-to-date
+./.ci/check_mailmap.py ./.mailmap

--- a/.mailmap
+++ b/.mailmap
@@ -21,6 +21,8 @@ Geordie McBain <gdmcbain@protonmail.com>
 Hendrik Kleikamp <hendrik.kleikamp@uni-muenster.de>
 Hendrik Kleikamp <hendrik.kleikamp@uni-muenster.de> <h_klei18@uni-muenster.de>
 Josefine Zeller <josefine_zeller@web.de> josefinez <josefine.zeller@web.de>
+Jonas Nicodemus <jonas.nicodemus@icloud.com>
+Jonas Nicodemus <jonas.nicodemus@icloud.com> <44996273+Jonas-Nicodemus@users.noreply.github.com>
 Linus Balicki <balicki@vt.edu>
 Linus Balicki <balicki@vt.edu> <38659258+lbalicki@users.noreply.github.com>
 Linus Balicki <balicki@vt.edu> <linus.balicki@ovgu.de>

--- a/.mailmap
+++ b/.mailmap
@@ -1,3 +1,11 @@
+# Prevent git from showing duplicate names with commands like "git shortlog"
+# See the manpage of git-shortlog for details (git help shortlog).
+#
+# This file is up-to-date if the command git log --format="%aN <%aE>" | sort -u
+# gives no duplicates.
+#
+# The list below should be sorted alphabetically.
+
 Christian Himpe <himpe@mpi-magdeburg.mpg.de>
 Dennis Eickhorn <d.eickhorn@uni-muenster.de>
 Dennis Eickhorn <d.eickhorn@uni-muenster.de> <d.eickhorn@mail.de>

--- a/.mailmap
+++ b/.mailmap
@@ -20,9 +20,9 @@ Felix Schindler <felix.schindler@wwu.de> <mail@felixalbrecht.de>
 Geordie McBain <gdmcbain@protonmail.com>
 Hendrik Kleikamp <hendrik.kleikamp@uni-muenster.de>
 Hendrik Kleikamp <hendrik.kleikamp@uni-muenster.de> <h_klei18@uni-muenster.de>
-Josefine Zeller <josefine_zeller@web.de> josefinez <josefine.zeller@web.de>
 Jonas Nicodemus <jonas.nicodemus@icloud.com>
 Jonas Nicodemus <jonas.nicodemus@icloud.com> <44996273+Jonas-Nicodemus@users.noreply.github.com>
+Josefine Zeller <josefine_zeller@web.de> josefinez <josefine.zeller@web.de>
 Linus Balicki <balicki@vt.edu>
 Linus Balicki <balicki@vt.edu> <38659258+lbalicki@users.noreply.github.com>
 Linus Balicki <balicki@vt.edu> <linus.balicki@ovgu.de>

--- a/.mailmap
+++ b/.mailmap
@@ -20,6 +20,7 @@ Felix Schindler <felix.schindler@wwu.de> <mail@felixalbrecht.de>
 Geordie McBain <gdmcbain@protonmail.com>
 Hendrik Kleikamp <hendrik.kleikamp@uni-muenster.de>
 Hendrik Kleikamp <hendrik.kleikamp@uni-muenster.de> <h_klei18@uni-muenster.de>
+Josefine Zeller <josefine_zeller@web.de> josefinez <josefine.zeller@web.de>
 Linus Balicki <balicki@vt.edu>
 Linus Balicki <balicki@vt.edu> <38659258+lbalicki@users.noreply.github.com>
 Linus Balicki <balicki@vt.edu> <linus.balicki@ovgu.de>

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -27,6 +27,6 @@
  1. [ ] Add a new section in
         [`docker/docs/releases/Dockerfile`](https://github.com/pymor/docker/blob/main/docs/releases/Dockerfile).
  1. [ ] All developers check if (stale) branches can be pruned.
- 1. [ ] All developers check if for mailmap correctness.
+ 1. [ ] All developers check for mailmap correctness.
  1. [ ] Remove deprecated features in main.
  1. [ ] Close the [GitHub milestone](https://github.com/pymor/pymor/milestones) for the release.

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -27,5 +27,6 @@
  1. [ ] Add a new section in
         [`docker/docs/releases/Dockerfile`](https://github.com/pymor/docker/blob/main/docs/releases/Dockerfile).
  1. [ ] All developers check if (stale) branches can be pruned.
+ 1. [ ] All developers check if for mailmap correctness.
  1. [ ] Remove deprecated features in main.
  1. [ ] Close the [GitHub milestone](https://github.com/pymor/pymor/milestones) for the release.


### PR DESCRIPTION
Compared to #1491 this drops adding mailmap updates from release checklist,
and adds a gitlab CI check instead.
