### PR TITLE
[docs] Use `envvar` directives to describe environment

### DIFF
--- a/docs/source/developer_docs.md
+++ b/docs/source/developer_docs.md
@@ -35,7 +35,7 @@ pip install -e '.[full]'
 ### Environment with docker-compose
 
 To get a shell in a preconfigured container run
-(if required set `PYMOR_SUDO=1` in your environment to execute docker with elevated rights):
+(if required set {envvar}`PYMOR_SUDO=1` in your environment to execute docker with elevated rights):
 
 ```
 make docker_run
@@ -109,8 +109,8 @@ so that updated images become available to CI after entering the new commit hash
 ## The Makefile
 
 Via the `Makefile` it is possible to execute tests close to how they are run on CI with `make docker_test`.
-All jobs described in {ref}`Gitlab CI Test Stage <ref_gitlab_ci_stage_test>` can be run this way by setting `PYMOR_TEST_SCRIPT`
-accordingly. You can pass additional arguments to pytest by setting `PYMOR_PYTEST_EXTRA`.
+All jobs described in {ref}`Gitlab CI Test Stage <ref_gitlab_ci_stage_test>` can be run this way by setting {envvar}`PYMOR_TEST_SCRIPT`
+accordingly. You can pass additional arguments to pytest by setting {envvar}`PYMOR_PYTEST_EXTRA`.
 To run the test suite without docker,
 simply execute `make test` in the base directory of the pyMOR repository. This will
 run the pytest suite with the default hypothesis profile "dev". For available profiles

--- a/docs/source/environment.rst
+++ b/docs/source/environment.rst
@@ -6,34 +6,41 @@ Environment Variables
 
 pyMOR respects the following environment variables:
 
-PYMOR_CACHE_DISABLE
+.. envvar:: PYMOR_CACHE_DISABLE
+
     If ``1``, disable caching globally, overriding calls to
     :func:`~pymor.core.cache.enable_caching`. This is mainly
     useful for debugging. See :mod:`pymor.core.cache` for more
     details.
 
-PYMOR_COLORS_DISABLE
+.. envvar:: PYMOR_COLORS_DISABLE
+
     If ``1``, disable coloring of logging output.
 
-PYMOR_WITH_SPHINX
+.. envvar:: PYMOR_WITH_SPHINX
+
     This variable is set to `1` during API documentation generation
     using sphinx.
 
-PYMOR_DEFAULTS
+.. envvar:: PYMOR_DEFAULTS
+
     If empty or ``NONE``, do not load any :mod:`~pymor.core.defaults`
     from file. Otherwise, a ``:``-separated list of the paths to a
     Python scripts containing defaults.
 
-PYMOR_HYPOTHESIS_PROFILE
+.. envvar:: PYMOR_HYPOTHESIS_PROFILE
+
     Controls which profile the hypothesis pytest plugin uses to execute our
     test suites. Defaults to the "dev" profile which runs fewer variations than
     the "ci" or "ci_pr" which get used in our Gitlab-CI.
 
-PYMOR_MPI_FINALIZE
+.. envvar:: PYMOR_MPI_FINALIZE
+
     If set controls the value for `mpi4py.rc.finalize`. If `PYMOR_MPI_FINALIZE` is unset the value
     of `mpi4py.rc.finalize` remains unchanged, unless `mpi4py.rc.finalize is None` in which
     case it is defaulted to `False`.
 
-PYMOR_ALLOW_DEADLINE_EXCESS
+.. envvar:: PYMOR_ALLOW_DEADLINE_EXCESS
+
     If set, test functions decorated with :func:`~pymortests.base.might_exceed_deadline` are allowed
     to exceed the default test deadline set in :mod:`~pymortests.conftest`.


### PR DESCRIPTION
While converting the developer docs docuemnt to markdown I stumbled
upon the `envvar` directive. I think it would be nice to use that generally,
but it needs some work. For one all variables from `environment.rst` show
up as second level TOC entries in the main navigation now. Which is something
we do not want. The developer docs should also use the referencing mechanism
and maybe we want to add all the buildsystem/testing variables
added/sorted into their own section in `environment.rst`.

I will not work on this anytime soon and would be very happy if somebody wants 
to take over this PR
