### PR TITLE
Remove 'if config.HAVE_...' checks in modules that require optional dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [pycodestyle]
 max-line-length = 120
 max-doc-length = 100
-ignore = E221,E226,E241,E242, E731, E741, W0105, W503, N803, N806,\
+ignore = E221,E226,E241,E242,E402,E731,E741,W0105, W503, N803, N806,\
   D100,D101,D102,D103,D105,D106,D107,\
   D400,D401,D414,\
   F403,F405,F722,\
@@ -10,6 +10,7 @@ ignore = E221,E226,E241,E242, E731, E741, W0105, W503, N803, N806,\
 # E226 missing whitespace around arithmetic operator  [ignored by default]
 # E241 multiple spaces after ':'                      [ignored by default]
 # E242 tab after `,'                                  [ignored by default]
+# E402 module level import not at top of file
 # E731 do not assign a lambda expression, use a def
 # E741 do not use variables named 'l', 'O', or 'I'
 # F405, F403 star import usage from pymor.basic
@@ -26,7 +27,7 @@ ignore = E221,E226,E241,E242, E731, E741, W0105, W503, N803, N806,\
 [flake8]
 max-line-length = 120
 max-doc-length = 100
-ignore = E221,E226,E241,E242, E731, E741, W0105, W503, N803, N806,\
+ignore = E221,E226,E241,E242,E402,E731,E741,W0105,W503,N803,N806,\
   D100,D101,D102,D103,D105,D106,D107,\
   D400,D401,D414,\
   F403,F405,F722,\

--- a/src/pymor/bindings/dunegdt.py
+++ b/src/pymor/bindings/dunegdt.py
@@ -3,237 +3,231 @@
 # Copyright 2013-2016 pyMOR developers and contributors. All rights reserved.
 # License: BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
 
-from pymor.core.config import config
+from pymor.core.config import require_dependency
+require_dependency('DUNEGDT')
 
 
-if config.HAVE_DUNEGDT:
+import numpy as np
 
-    import numpy as np
+from dune.xt.la import IstlVector
 
-    from dune.xt.la import IstlVector
-
-    from pymor.operators.list import LinearComplexifiedListVectorArrayOperatorBase
-    from pymor.vectorarrays.interface import _create_random_values
-    from pymor.vectorarrays.list import (
-        ComplexifiedListVectorSpace, ComplexifiedVector, CopyOnWriteVector, NumpyVector)
-
-    class DuneXTVector(CopyOnWriteVector):
-        """Wraps a vector from dune-xt to make it usable with ListVectorArray.
-
-        Parameters
-        ----------
-        impl
-            The actual vector from dune.xt.la, usually IstlVector.
-        """
-
-        def __init__(self, impl):
-            self.impl = impl
-
-        @classmethod
-        def from_instance(cls, instance):
-            return cls(instance.impl)
-
-        def _copy_data(self):
-            self.impl = self.impl.copy(True)
-
-        def _scal(self, alpha):
-            self.impl.scal(alpha)
-
-        def _axpy(self, alpha, x):
-            self.impl.axpy(alpha, x.impl)
-
-        def inner(self, other):
-            return self.impl.dot(other.impl)
-
-        def norm(self):
-            return self.impl.l2_norm()
-
-        def norm2(self):
-            return self.impl.l2_norm() ** 2
-
-        def sup_norm(self):
-            return self.impl.sup_norm()
-
-        def dofs(self, dof_indices):
-            impl = self.impl
-            return np.array([impl[i] for i in dof_indices])
-
-        def amax(self):
-            _amax = self.impl.amax()
-            return _amax[0], _amax[1]
-
-        def __add__(self, other):
-            return DuneXTVector(self.impl + other.impl)
-
-        def __iadd__(self, other):
-            self.impl += other.impl
-            return self
-
-        __radd__ = __add__
-
-        def __sub__(self, other):
-            return DuneXTVector(self.impl - other.impl)
-
-        def __isub__(self, other):
-            self.impl -= other.impl
-            return self
-
-        def __mul__(self, other):
-            return DuneXTVector(self.impl * other)
-
-        def __imul__(self, other):
-            self.impl *= other
-            return self
-
-        def __neg__(self):
-            return self * (-1)
-
-        def to_numpy(self, ensure_copy=False):
-            return np.array(self.impl, copy=ensure_copy)
+from pymor.operators.list import LinearComplexifiedListVectorArrayOperatorBase
+from pymor.vectorarrays.interface import _create_random_values
+from pymor.vectorarrays.list import (
+    ComplexifiedListVectorSpace, ComplexifiedVector, CopyOnWriteVector, NumpyVector)
 
 
-if config.HAVE_DUNEGDT:
+class DuneXTVector(CopyOnWriteVector):
+    """Wraps a vector from dune-xt to make it usable with ListVectorArray.
 
-    class ComplexifiedDuneXTVector(ComplexifiedVector):
-        """Required for DuneXTVectorSpace, Usually not to be used directly."""
+    Parameters
+    ----------
+    impl
+        The actual vector from dune.xt.la, usually IstlVector.
+    """
 
-        def amax(self):
-            if self.imag_part is None:
-                return self.real_part.amax()
-            else:
-                real = np.array(self.real_part.impl, copy=False)
-                imag = np.array(self.imag_part.impl, copy=False)
-                return NumpyVector(real + imag * 1j).amax()
+    def __init__(self, impl):
+        self.impl = impl
+
+    @classmethod
+    def from_instance(cls, instance):
+        return cls(instance.impl)
+
+    def _copy_data(self):
+        self.impl = self.impl.copy(True)
+
+    def _scal(self, alpha):
+        self.impl.scal(alpha)
+
+    def _axpy(self, alpha, x):
+        self.impl.axpy(alpha, x.impl)
+
+    def inner(self, other):
+        return self.impl.dot(other.impl)
+
+    def norm(self):
+        return self.impl.l2_norm()
+
+    def norm2(self):
+        return self.impl.l2_norm() ** 2
+
+    def sup_norm(self):
+        return self.impl.sup_norm()
+
+    def dofs(self, dof_indices):
+        impl = self.impl
+        return np.array([impl[i] for i in dof_indices])
+
+    def amax(self):
+        _amax = self.impl.amax()
+        return _amax[0], _amax[1]
+
+    def __add__(self, other):
+        return DuneXTVector(self.impl + other.impl)
+
+    def __iadd__(self, other):
+        self.impl += other.impl
+        return self
+
+    __radd__ = __add__
+
+    def __sub__(self, other):
+        return DuneXTVector(self.impl - other.impl)
+
+    def __isub__(self, other):
+        self.impl -= other.impl
+        return self
+
+    def __mul__(self, other):
+        return DuneXTVector(self.impl * other)
+
+    def __imul__(self, other):
+        self.impl *= other
+        return self
+
+    def __neg__(self):
+        return self * (-1)
+
+    def to_numpy(self, ensure_copy=False):
+        return np.array(self.impl, copy=ensure_copy)
 
 
-if config.HAVE_DUNEGDT:
+class ComplexifiedDuneXTVector(ComplexifiedVector):
+    """Required for DuneXTVectorSpace, Usually not to be used directly."""
 
-    class DuneXTVectorSpace(ComplexifiedListVectorSpace):
-        """A |VectorSpace| yielding DuneXTVector
-
-        Parameters
-        ----------
-        dim
-            Dimension of the |VectorSpace|, i.e., length of the resulting vectors.
-        vector_type
-            Type of the actual vector from dune.xt.la, usually IstlVector.
-        id
-            Identifier of the |VectorSpace|.
-        """
-
-        real_vector_type = DuneXTVector
-        vector_type = ComplexifiedDuneXTVector
-
-        def __init__(self, dim, dune_vector_type=IstlVector, id='STATE'):
-            self.__auto_init(locals())
-
-        def __eq__(self, other):
-            return type(other) is DuneXTVectorSpace \
-                and self.dune_vector_type == other.dune_vector_type \
-                and self.dim == other.dim \
-                and self.id == other.id
-
-        # since we implement __eq__, we also need to implement __hash__
-        def __hash__(self):
-            return id(self.dune_vector_type) + hash(self.dim)
-
-        def real_zero_vector(self):
-            return DuneXTVector(self.dune_vector_type(self.dim, 0.))
-
-        def real_full_vector(self, value):
-            return DuneXTVector(self.dune_vector_type(self.dim, value))
-
-        def real_random_vector(self, distribution, random_state, **kwargs):
-            values = _create_random_values(self.dim, distribution, random_state, **kwargs)
-            return self.real_vector_from_numpy(values)
-
-        def real_vector_from_numpy(self, data, ensure_copy=False):
-            v = self.real_zero_vector()
-            np_view = np.array(v.impl, copy=False)
-            np_view[:] = data
-            return v
-
-        def real_make_vector(self, obj):
-            return DuneXTVector(obj)
+    def amax(self):
+        if self.imag_part is None:
+            return self.real_part.amax()
+        else:
+            real = np.array(self.real_part.impl, copy=False)
+            imag = np.array(self.imag_part.impl, copy=False)
+            return NumpyVector(real + imag * 1j).amax()
 
 
-if config.HAVE_DUNEGDT:
+class DuneXTVectorSpace(ComplexifiedListVectorSpace):
+    """A |VectorSpace| yielding DuneXTVector
 
-    class DuneXTMatrixOperator(LinearComplexifiedListVectorArrayOperatorBase):
-        """Wraps a dune-xt matrix as an |Operator|.
+    Parameters
+    ----------
+    dim
+        Dimension of the |VectorSpace|, i.e., length of the resulting vectors.
+    vector_type
+        Type of the actual vector from dune.xt.la, usually IstlVector.
+    id
+        Identifier of the |VectorSpace|.
+    """
 
-        Parameters
-        ----------
-        matrix
-            The actual matrix from dune.xt.la, usually IstlMatrix.
-        source_id
-            Identifier of the source |VectorSpace|.
-        range_id
-            Identifier of the source |VectorSpace|.
-        solver_options
-            If specified, either a string or a dict specifying the solver used in apply_inverse. See
-            https://zivgitlab.uni-muenster.de/ag-ohlberger/dune-community/dune-xt/-/tree/master/dune/xt/la/solver
-            for available options, depending on the type of `matrix`. E.g., for
-            dune.xt.la.IstlSparseMatrix, (as can be queried from dune.xt.la.IstlSparseMatrixSolver
-            via `types()` and `options(type)`):
-            - 'bicgstab.ssor'
-            - 'bicgstab.amg.ssor'
-            - 'bicgstab.amg.ilu0'
-            - 'bicgstab.ilut'
-            - 'bicgstab'
-            - 'cg'
-        name
-            Optional name of the resulting |Operator|.
-        """
+    real_vector_type = DuneXTVector
+    vector_type = ComplexifiedDuneXTVector
 
-        linear = True
+    def __init__(self, dim, dune_vector_type=IstlVector, id='STATE'):
+        self.__auto_init(locals())
 
-        def __init__(self, matrix, source_id='STATE', range_id='STATE', solver_options=None, name=None):
-            self.source = DuneXTVectorSpace(matrix.cols, matrix.vector_type(), source_id)
-            self.range = DuneXTVectorSpace(matrix.rows, matrix.vector_type(), range_id)
-            self.__auto_init(locals())
+    def __eq__(self, other):
+        return type(other) is DuneXTVectorSpace \
+            and self.dune_vector_type == other.dune_vector_type \
+            and self.dim == other.dim \
+            and self.id == other.id
 
-        def _real_apply_one_vector(self, u, mu=None, prepare_data=None):
-            r = self.range.real_zero_vector()
-            self.matrix.mv(u.impl, r.impl)
-            return r
+    # since we implement __eq__, we also need to implement __hash__
+    def __hash__(self):
+        return id(self.dune_vector_type) + hash(self.dim)
 
-        def _apply_adjoint_one_vector(self, v, mu=None, prepare_data=None):
-            r = self.source.real_zero_vector()
-            self.matrix.mtv(v.impl, r.impl)
-            return r
+    def real_zero_vector(self):
+        return DuneXTVector(self.dune_vector_type(self.dim, 0.))
 
-        def _real_apply_inverse_one_vector(self, v, mu=None, initial_guess=None,
-                                           least_squares=False, prepare_data=None):
-            if least_squares:
-                raise NotImplementedError
-            r = (self.source.real_zero_vector() if initial_guess is None else
-                 initial_guess.copy(deep=True))
-            options = self.solver_options.get('inverse') if self.solver_options else None
+    def real_full_vector(self, value):
+        return DuneXTVector(self.dune_vector_type(self.dim, value))
 
-            from dune.xt.la import make_solver
-            solver = make_solver(self.matrix)
-            if options:
-                solver.apply(v.impl, r.impl, options)
-            else:
-                solver.apply(v.impl, r.impl)
-            return r
+    def real_random_vector(self, distribution, random_state, **kwargs):
+        values = _create_random_values(self.dim, distribution, random_state, **kwargs)
+        return self.real_vector_from_numpy(values)
 
-        def _assemble_lincomb(self, operators, coefficients, identity_shift=0., solver_options=None, name=None):
-            if not all(isinstance(op, DuneXTMatrixOperator) for op in operators):
-                return None
-            if identity_shift != 0:
-                return None
-            if np.iscomplexobj(coefficients):
-                return None
+    def real_vector_from_numpy(self, data, ensure_copy=False):
+        v = self.real_zero_vector()
+        np_view = np.array(v.impl, copy=False)
+        np_view[:] = data
+        return v
 
-            if coefficients[0] == 1:
-                matrix = operators[0].matrix.copy()
-            else:
-                matrix = operators[0].matrix * coefficients[0]
-            for op, c in zip(operators[1:], coefficients[1:]):
-                matrix.axpy(c, op.matrix)  # TODO: Not guaranteed to work for all backends! For different
-                # sparsity patterns one would have to extract the patterns from the pruned
-                # matrices, merge them and create a new matrix.
+    def real_make_vector(self, obj):
+        return DuneXTVector(obj)
 
-            return DuneXTMatrixOperator(matrix, self.source.id, self.range.id, solver_options=solver_options, name=name)
+
+class DuneXTMatrixOperator(LinearComplexifiedListVectorArrayOperatorBase):
+    """Wraps a dune-xt matrix as an |Operator|.
+
+    Parameters
+    ----------
+    matrix
+        The actual matrix from dune.xt.la, usually IstlMatrix.
+    source_id
+        Identifier of the source |VectorSpace|.
+    range_id
+        Identifier of the source |VectorSpace|.
+    solver_options
+        If specified, either a string or a dict specifying the solver used in apply_inverse. See
+        https://zivgitlab.uni-muenster.de/ag-ohlberger/dune-community/dune-xt/-/tree/master/dune/xt/la/solver
+        for available options, depending on the type of `matrix`. E.g., for
+        dune.xt.la.IstlSparseMatrix, (as can be queried from dune.xt.la.IstlSparseMatrixSolver
+        via `types()` and `options(type)`):
+        - 'bicgstab.ssor'
+        - 'bicgstab.amg.ssor'
+        - 'bicgstab.amg.ilu0'
+        - 'bicgstab.ilut'
+        - 'bicgstab'
+        - 'cg'
+    name
+        Optional name of the resulting |Operator|.
+    """
+
+    linear = True
+
+    def __init__(self, matrix, source_id='STATE', range_id='STATE', solver_options=None, name=None):
+        self.source = DuneXTVectorSpace(matrix.cols, matrix.vector_type(), source_id)
+        self.range = DuneXTVectorSpace(matrix.rows, matrix.vector_type(), range_id)
+        self.__auto_init(locals())
+
+    def _real_apply_one_vector(self, u, mu=None, prepare_data=None):
+        r = self.range.real_zero_vector()
+        self.matrix.mv(u.impl, r.impl)
+        return r
+
+    def _apply_adjoint_one_vector(self, v, mu=None, prepare_data=None):
+        r = self.source.real_zero_vector()
+        self.matrix.mtv(v.impl, r.impl)
+        return r
+
+    def _real_apply_inverse_one_vector(self, v, mu=None, initial_guess=None,
+                                       least_squares=False, prepare_data=None):
+        if least_squares:
+            raise NotImplementedError
+        r = (self.source.real_zero_vector() if initial_guess is None else
+             initial_guess.copy(deep=True))
+        options = self.solver_options.get('inverse') if self.solver_options else None
+
+        from dune.xt.la import make_solver
+        solver = make_solver(self.matrix)
+        if options:
+            solver.apply(v.impl, r.impl, options)
+        else:
+            solver.apply(v.impl, r.impl)
+        return r
+
+    def _assemble_lincomb(self, operators, coefficients, identity_shift=0., solver_options=None, name=None):
+        if not all(isinstance(op, DuneXTMatrixOperator) for op in operators):
+            return None
+        if identity_shift != 0:
+            return None
+        if np.iscomplexobj(coefficients):
+            return None
+
+        if coefficients[0] == 1:
+            matrix = operators[0].matrix.copy()
+        else:
+            matrix = operators[0].matrix * coefficients[0]
+        for op, c in zip(operators[1:], coefficients[1:]):
+            matrix.axpy(c, op.matrix)  # TODO: Not guaranteed to work for all backends! For different
+            # sparsity patterns one would have to extract the patterns from the pruned
+            # matrices, merge them and create a new matrix.
+
+        return DuneXTMatrixOperator(matrix, self.source.id, self.range.id, solver_options=solver_options, name=name)

--- a/src/pymor/bindings/dunegdt.py
+++ b/src/pymor/bindings/dunegdt.py
@@ -3,8 +3,8 @@
 # Copyright 2013-2016 pyMOR developers and contributors. All rights reserved.
 # License: BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
 
-from pymor.core.config import require_dependency
-require_dependency('DUNEGDT')
+from pymor.core.config import config
+config.require('DUNEGDT')
 
 
 import numpy as np

--- a/src/pymor/bindings/fenics.py
+++ b/src/pymor/bindings/fenics.py
@@ -2,640 +2,628 @@
 # Copyright 2013-2021 pyMOR developers and contributors. All rights reserved.
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
-from pymor.core.config import config
+from pymor.core.config import require_dependency
+require_dependency('FENICS')
 
 
-if config.HAVE_FENICS:
-    import dolfin as df
-    import ufl
-    import numpy as np
-    import sys
-    from pathlib import Path
+import dolfin as df
+import ufl
+import numpy as np
+import sys
+from pathlib import Path
 
-    from pymor.core.base import ImmutableObject
-    from pymor.core.defaults import defaults
-    from pymor.core.pickle import unpicklable
-    from pymor.operators.constructions import ZeroOperator
-    from pymor.operators.interface import Operator
-    from pymor.operators.list import LinearComplexifiedListVectorArrayOperatorBase
-    from pymor.operators.numpy import NumpyMatrixOperator
-    from pymor.vectorarrays.interface import _create_random_values
-    from pymor.vectorarrays.list import CopyOnWriteVector, ComplexifiedVector, ComplexifiedListVectorSpace
-    from pymor.vectorarrays.numpy import NumpyVectorSpace
-
-    @unpicklable
-    class FenicsVector(CopyOnWriteVector):
-        """Wraps a FEniCS vector to make it usable with ListVectorArray."""
-
-        def __init__(self, impl):
-            self.impl = impl
-
-        @classmethod
-        def from_instance(cls, instance):
-            return cls(instance.impl)
-
-        def _copy_data(self):
-            self.impl = self.impl.copy()
-
-        def to_numpy(self, ensure_copy=False):
-            return self.impl.get_local()  # always returns a copy
-
-        def _scal(self, alpha):
-            self.impl *= alpha
-
-        def _axpy(self, alpha, x):
-            if x is self:
-                self.scal(1. + alpha)
-            else:
-                self.impl.axpy(alpha, x.impl)
-
-        def inner(self, other):
-            return self.impl.inner(other.impl)
-
-        def norm(self):
-            return self.impl.norm('l2')
-
-        def norm2(self):
-            return self.impl.norm('l2') ** 2
-
-        def sup_norm(self):
-            return self.impl.norm('linf')
-
-        def dofs(self, dof_indices):
-            dof_indices = np.array(dof_indices, dtype=np.intc)
-            if len(dof_indices) == 0:
-                return np.array([], dtype=np.intc)
-            assert 0 <= np.min(dof_indices)
-            assert np.max(dof_indices) < self.impl.size()
-            dofs = self.impl.gather(dof_indices)
-            # in the mpi distributed case, gather returns the values
-            # at the *global* dof_indices on each rank
-            return dofs
-
-        def amax(self):
-            raise NotImplementedError  # is implemented for complexified vector
-
-        def __add__(self, other):
-            return FenicsVector(self.impl + other.impl)
-
-        def __iadd__(self, other):
-            self._copy_data_if_needed()
-            self.impl += other.impl
-            return self
-
-        __radd__ = __add__
-
-        def __sub__(self, other):
-            return FenicsVector(self.impl - other.impl)
-
-        def __isub__(self, other):
-            self._copy_data_if_needed()
-            self.impl -= other.impl
-            return self
-
-        def __mul__(self, other):
-            return FenicsVector(self.impl * other)
-
-        def __neg__(self):
-            return FenicsVector(-self.impl)
+from pymor.core.base import ImmutableObject
+from pymor.core.defaults import defaults
+from pymor.core.pickle import unpicklable
+from pymor.operators.constructions import ZeroOperator
+from pymor.operators.interface import Operator
+from pymor.operators.list import LinearComplexifiedListVectorArrayOperatorBase
+from pymor.operators.numpy import NumpyMatrixOperator
+from pymor.vectorarrays.interface import _create_random_values
+from pymor.vectorarrays.list import CopyOnWriteVector, ComplexifiedVector, ComplexifiedListVectorSpace
+from pymor.vectorarrays.numpy import NumpyVectorSpace
 
 
-if config.HAVE_FENICS:
+@unpicklable
+class FenicsVector(CopyOnWriteVector):
+    """Wraps a FEniCS vector to make it usable with ListVectorArray."""
 
-    class ComplexifiedFenicsVector(ComplexifiedVector):
+    def __init__(self, impl):
+        self.impl = impl
 
-        def amax(self):
-            if self.imag_part is None:
-                A = np.abs(self.real_part.impl.get_local())
-            else:
-                A = np.abs(self.real_part.impl.get_local() + self.imag_part.impl.get_local() * 1j)
-            # there seems to be no way in the interface to compute amax without making a copy.
-            max_ind_on_rank = np.argmax(A)
-            max_val_on_rank = A[max_ind_on_rank]
-            from pymor.tools import mpi
-            if not mpi.parallel:
-                return max_ind_on_rank, max_val_on_rank
-            else:
-                max_global_ind_on_rank = max_ind_on_rank + self.real_part.impl.local_range()[0]
-                comm = self.real_part.impl.mpi_comm()
-                comm_size = comm.Get_size()
+    @classmethod
+    def from_instance(cls, instance):
+        return cls(instance.impl)
 
-                max_inds = np.empty(comm_size, dtype='i')
-                comm.Allgather(np.array(max_global_ind_on_rank, dtype='i'), max_inds)
+    def _copy_data(self):
+        self.impl = self.impl.copy()
 
-                max_vals = np.empty(comm_size, dtype=np.float64)
-                comm.Allgather(np.array(max_val_on_rank), max_vals)
+    def to_numpy(self, ensure_copy=False):
+        return self.impl.get_local()  # always returns a copy
 
-                i = np.argmax(max_vals)
-                return max_inds[i], max_vals[i]
+    def _scal(self, alpha):
+        self.impl *= alpha
+
+    def _axpy(self, alpha, x):
+        if x is self:
+            self.scal(1. + alpha)
+        else:
+            self.impl.axpy(alpha, x.impl)
+
+    def inner(self, other):
+        return self.impl.inner(other.impl)
+
+    def norm(self):
+        return self.impl.norm('l2')
+
+    def norm2(self):
+        return self.impl.norm('l2') ** 2
+
+    def sup_norm(self):
+        return self.impl.norm('linf')
+
+    def dofs(self, dof_indices):
+        dof_indices = np.array(dof_indices, dtype=np.intc)
+        if len(dof_indices) == 0:
+            return np.array([], dtype=np.intc)
+        assert 0 <= np.min(dof_indices)
+        assert np.max(dof_indices) < self.impl.size()
+        dofs = self.impl.gather(dof_indices)
+        # in the mpi distributed case, gather returns the values
+        # at the *global* dof_indices on each rank
+        return dofs
+
+    def amax(self):
+        raise NotImplementedError  # is implemented for complexified vector
+
+    def __add__(self, other):
+        return FenicsVector(self.impl + other.impl)
+
+    def __iadd__(self, other):
+        self._copy_data_if_needed()
+        self.impl += other.impl
+        return self
+
+    __radd__ = __add__
+
+    def __sub__(self, other):
+        return FenicsVector(self.impl - other.impl)
+
+    def __isub__(self, other):
+        self._copy_data_if_needed()
+        self.impl -= other.impl
+        return self
+
+    def __mul__(self, other):
+        return FenicsVector(self.impl * other)
+
+    def __neg__(self):
+        return FenicsVector(-self.impl)
 
 
-if config.HAVE_FENICS:
+class ComplexifiedFenicsVector(ComplexifiedVector):
 
-    class FenicsVectorSpace(ComplexifiedListVectorSpace):
+    def amax(self):
+        if self.imag_part is None:
+            A = np.abs(self.real_part.impl.get_local())
+        else:
+            A = np.abs(self.real_part.impl.get_local() + self.imag_part.impl.get_local() * 1j)
+        # there seems to be no way in the interface to compute amax without making a copy.
+        max_ind_on_rank = np.argmax(A)
+        max_val_on_rank = A[max_ind_on_rank]
+        from pymor.tools import mpi
+        if not mpi.parallel:
+            return max_ind_on_rank, max_val_on_rank
+        else:
+            max_global_ind_on_rank = max_ind_on_rank + self.real_part.impl.local_range()[0]
+            comm = self.real_part.impl.mpi_comm()
+            comm_size = comm.Get_size()
 
-        real_vector_type = FenicsVector
-        vector_type = ComplexifiedFenicsVector
+            max_inds = np.empty(comm_size, dtype='i')
+            comm.Allgather(np.array(max_global_ind_on_rank, dtype='i'), max_inds)
 
-        def __init__(self, V, id='STATE'):
-            self.__auto_init(locals())
+            max_vals = np.empty(comm_size, dtype=np.float64)
+            comm.Allgather(np.array(max_val_on_rank), max_vals)
 
-        @property
-        def dim(self):
-            return df.Function(self.V).vector().size()
-
-        def __eq__(self, other):
-            return type(other) is FenicsVectorSpace and self.V == other.V and self.id == other.id
-
-        # since we implement __eq__, we also need to implement __hash__
-        def __hash__(self):
-            return id(self.V) + hash(self.id)
-
-        def real_zero_vector(self):
-            impl = df.Function(self.V).vector()
-            return FenicsVector(impl)
-
-        def real_full_vector(self, value):
-            impl = df.Function(self.V).vector()
-            impl += value
-            return FenicsVector(impl)
-
-        def real_random_vector(self, distribution, random_state, **kwargs):
-            impl = df.Function(self.V).vector()
-            values = _create_random_values(impl.local_size(), distribution, random_state, **kwargs)
-            impl[:] = np.ascontiguousarray(values)
-            return FenicsVector(impl)
-
-        def real_vector_from_numpy(self, data, ensure_copy=False):
-            impl = df.Function(self.V).vector()
-            impl[:] = np.ascontiguousarray(data)
-            return FenicsVector(impl)
-
-        def real_make_vector(self, obj):
-            return FenicsVector(obj)
+            i = np.argmax(max_vals)
+            return max_inds[i], max_vals[i]
 
 
-if config.HAVE_FENICS:
+class FenicsVectorSpace(ComplexifiedListVectorSpace):
 
-    class FenicsMatrixOperator(LinearComplexifiedListVectorArrayOperatorBase):
-        """Wraps a FEniCS matrix as an |Operator|."""
+    real_vector_type = FenicsVector
+    vector_type = ComplexifiedFenicsVector
 
-        def __init__(self, matrix, source_space, range_space, solver_options=None, name=None):
-            assert matrix.rank() == 2
-            self.__auto_init(locals())
-            self.source = FenicsVectorSpace(source_space)
-            self.range = FenicsVectorSpace(range_space)
+    def __init__(self, V, id='STATE'):
+        self.__auto_init(locals())
 
-        def _solver_options(self, adjoint=False):
-            if adjoint:
-                options = self.solver_options.get('inverse_adjoint') if self.solver_options else None
-                if options is None:
-                    options = self.solver_options.get('inverse') if self.solver_options else None
-            else:
+    @property
+    def dim(self):
+        return df.Function(self.V).vector().size()
+
+    def __eq__(self, other):
+        return type(other) is FenicsVectorSpace and self.V == other.V and self.id == other.id
+
+    # since we implement __eq__, we also need to implement __hash__
+    def __hash__(self):
+        return id(self.V) + hash(self.id)
+
+    def real_zero_vector(self):
+        impl = df.Function(self.V).vector()
+        return FenicsVector(impl)
+
+    def real_full_vector(self, value):
+        impl = df.Function(self.V).vector()
+        impl += value
+        return FenicsVector(impl)
+
+    def real_random_vector(self, distribution, random_state, **kwargs):
+        impl = df.Function(self.V).vector()
+        values = _create_random_values(impl.local_size(), distribution, random_state, **kwargs)
+        impl[:] = np.ascontiguousarray(values)
+        return FenicsVector(impl)
+
+    def real_vector_from_numpy(self, data, ensure_copy=False):
+        impl = df.Function(self.V).vector()
+        impl[:] = np.ascontiguousarray(data)
+        return FenicsVector(impl)
+
+    def real_make_vector(self, obj):
+        return FenicsVector(obj)
+
+
+class FenicsMatrixOperator(LinearComplexifiedListVectorArrayOperatorBase):
+    """Wraps a FEniCS matrix as an |Operator|."""
+
+    def __init__(self, matrix, source_space, range_space, solver_options=None, name=None):
+        assert matrix.rank() == 2
+        self.__auto_init(locals())
+        self.source = FenicsVectorSpace(source_space)
+        self.range = FenicsVectorSpace(range_space)
+
+    def _solver_options(self, adjoint=False):
+        if adjoint:
+            options = self.solver_options.get('inverse_adjoint') if self.solver_options else None
+            if options is None:
                 options = self.solver_options.get('inverse') if self.solver_options else None
-            return options or _solver_options()
+        else:
+            options = self.solver_options.get('inverse') if self.solver_options else None
+        return options or _solver_options()
 
-        def _create_solver(self, adjoint=False):
-            options = self._solver_options(adjoint)
-            if adjoint:
-                try:
-                    matrix = self._matrix_transpose
-                except AttributeError:
-                    raise RuntimeError('_create_solver called before _matrix_transpose has been initialized.')
-            else:
-                matrix = self.matrix
-            method = options.get('solver')
-            preconditioner = options.get('preconditioner')
-            if method == 'lu' or method in df.lu_solver_methods():
-                method = 'default' if method == 'lu' else method
-                solver = df.LUSolver(matrix, method)
-            else:
-                solver = df.KrylovSolver(matrix, method, preconditioner)
-            return solver
-
-        def _apply_inverse(self, r, v, adjoint=False):
+    def _create_solver(self, adjoint=False):
+        options = self._solver_options(adjoint)
+        if adjoint:
             try:
-                solver = self._adjoint_solver if adjoint else self._solver
+                matrix = self._matrix_transpose
             except AttributeError:
-                solver = self._create_solver(adjoint)
-            solver.solve(r, v)
-            if _solver_options()['keep_solver']:
-                if adjoint:
-                    self._adjoint_solver = solver
-                else:
-                    self._solver = solver
+                raise RuntimeError('_create_solver called before _matrix_transpose has been initialized.')
+        else:
+            matrix = self.matrix
+        method = options.get('solver')
+        preconditioner = options.get('preconditioner')
+        if method == 'lu' or method in df.lu_solver_methods():
+            method = 'default' if method == 'lu' else method
+            solver = df.LUSolver(matrix, method)
+        else:
+            solver = df.KrylovSolver(matrix, method, preconditioner)
+        return solver
 
-        def _real_apply_one_vector(self, u, mu=None, prepare_data=None):
-            r = self.range.real_zero_vector()
-            self.matrix.mult(u.impl, r.impl)
-            return r
-
-        def _real_apply_adjoint_one_vector(self, v, mu=None, prepare_data=None):
-            r = self.source.real_zero_vector()
-            self.matrix.transpmult(v.impl, r.impl)
-            return r
-
-        def _real_apply_inverse_one_vector(self, v, mu=None, initial_guess=None,
-                                           least_squares=False, prepare_data=None):
-            if least_squares:
-                raise NotImplementedError
-            r = (self.source.real_zero_vector() if initial_guess is None else
-                 initial_guess.copy(deep=True))
-            self._apply_inverse(r.impl, v.impl)
-            return r
-
-        def _real_apply_inverse_adjoint_one_vector(self, u, mu=None, initial_guess=None,
-                                                   least_squares=False, prepare_data=None):
-            if least_squares:
-                raise NotImplementedError
-            r = (self.range.real_zero_vector() if initial_guess is None else
-                 initial_guess.copy(deep=True))
-
-            # since dolfin does not have "apply_inverse_adjoint", we assume
-            # PETSc is used as backend and transpose the matrix
-            if not hasattr(self, '_matrix_transpose'):
-                self._matrix_transpose = self.matrix.copy()
-                mat = df.as_backend_type(self.matrix).mat()
-                mat_tr = df.as_backend_type(self._matrix_transpose).mat()
-                mat.transpose(mat_tr)
-            self._apply_inverse(r.impl, u.impl, adjoint=True)
-            return r
-
-        def _assemble_lincomb(self, operators, coefficients, identity_shift=0., solver_options=None, name=None):
-            if not all(isinstance(op, FenicsMatrixOperator) for op in operators):
-                return None
-            if identity_shift != 0:
-                return None
-            if np.iscomplexobj(coefficients):
-                return None
-
-            if coefficients[0] == 1:
-                matrix = operators[0].matrix.copy()
+    def _apply_inverse(self, r, v, adjoint=False):
+        try:
+            solver = self._adjoint_solver if adjoint else self._solver
+        except AttributeError:
+            solver = self._create_solver(adjoint)
+        solver.solve(r, v)
+        if _solver_options()['keep_solver']:
+            if adjoint:
+                self._adjoint_solver = solver
             else:
-                matrix = operators[0].matrix * coefficients[0]
-            for op, c in zip(operators[1:], coefficients[1:]):
-                matrix.axpy(c, op.matrix, False)
-                # in general, we cannot assume the same nonzero pattern for
-                # all matrices. how to improve this?
+                self._solver = solver
 
-            return FenicsMatrixOperator(matrix, self.source.V, self.range.V, solver_options=solver_options, name=name)
+    def _real_apply_one_vector(self, u, mu=None, prepare_data=None):
+        r = self.range.real_zero_vector()
+        self.matrix.mult(u.impl, r.impl)
+        return r
+
+    def _real_apply_adjoint_one_vector(self, v, mu=None, prepare_data=None):
+        r = self.source.real_zero_vector()
+        self.matrix.transpmult(v.impl, r.impl)
+        return r
+
+    def _real_apply_inverse_one_vector(self, v, mu=None, initial_guess=None,
+                                       least_squares=False, prepare_data=None):
+        if least_squares:
+            raise NotImplementedError
+        r = (self.source.real_zero_vector() if initial_guess is None else
+             initial_guess.copy(deep=True))
+        self._apply_inverse(r.impl, v.impl)
+        return r
+
+    def _real_apply_inverse_adjoint_one_vector(self, u, mu=None, initial_guess=None,
+                                               least_squares=False, prepare_data=None):
+        if least_squares:
+            raise NotImplementedError
+        r = (self.range.real_zero_vector() if initial_guess is None else
+             initial_guess.copy(deep=True))
+
+        # since dolfin does not have "apply_inverse_adjoint", we assume
+        # PETSc is used as backend and transpose the matrix
+        if not hasattr(self, '_matrix_transpose'):
+            self._matrix_transpose = self.matrix.copy()
+            mat = df.as_backend_type(self.matrix).mat()
+            mat_tr = df.as_backend_type(self._matrix_transpose).mat()
+            mat.transpose(mat_tr)
+        self._apply_inverse(r.impl, u.impl, adjoint=True)
+        return r
+
+    def _assemble_lincomb(self, operators, coefficients, identity_shift=0., solver_options=None, name=None):
+        if not all(isinstance(op, FenicsMatrixOperator) for op in operators):
+            return None
+        if identity_shift != 0:
+            return None
+        if np.iscomplexobj(coefficients):
+            return None
+
+        if coefficients[0] == 1:
+            matrix = operators[0].matrix.copy()
+        else:
+            matrix = operators[0].matrix * coefficients[0]
+        for op, c in zip(operators[1:], coefficients[1:]):
+            matrix.axpy(c, op.matrix, False)
+            # in general, we cannot assume the same nonzero pattern for
+            # all matrices. how to improve this?
+
+        return FenicsMatrixOperator(matrix, self.source.V, self.range.V, solver_options=solver_options, name=name)
 
 
-if config.HAVE_FENICS:
+class FenicsOperator(Operator):
+    """Wraps a FEniCS form as an |Operator|."""
 
-    class FenicsOperator(Operator):
-        """Wraps a FEniCS form as an |Operator|."""
+    linear = False
 
-        linear = False
+    def __init__(self, form, source_space, range_space, source_function, dirichlet_bcs=(),
+                 parameter_setter=None, parameters={}, solver_options=None, name=None):
+        assert len(form.arguments()) == 1
+        self.__auto_init(locals())
+        self.source = source_space
+        self.range = range_space
+        self.parameters_own = parameters
 
-        def __init__(self, form, source_space, range_space, source_function, dirichlet_bcs=(),
-                     parameter_setter=None, parameters={}, solver_options=None, name=None):
-            assert len(form.arguments()) == 1
-            self.__auto_init(locals())
-            self.source = source_space
-            self.range = range_space
-            self.parameters_own = parameters
+    def _set_mu(self, mu=None):
+        assert self.parameters.assert_compatible(mu)
+        if self.parameter_setter:
+            self.parameter_setter(mu)
 
-        def _set_mu(self, mu=None):
-            assert self.parameters.assert_compatible(mu)
-            if self.parameter_setter:
-                self.parameter_setter(mu)
-
-        def apply(self, U, mu=None):
-            assert U in self.source
-            self._set_mu(mu)
-            R = []
-            source_vec = self.source_function.vector()
-            for u in U._list:
-                if u.imag_part is not None:
-                    raise NotImplementedError
-                source_vec[:] = u.real_part.impl
-                r = df.assemble(self.form)
-                for bc in self.dirichlet_bcs:
-                    bc.apply(r, source_vec)
-                R.append(r)
-            return self.range.make_array(R)
-
-        def jacobian(self, U, mu=None):
-            assert U in self.source and len(U) == 1
-            if U._list[0].imag_part is not None:
+    def apply(self, U, mu=None):
+        assert U in self.source
+        self._set_mu(mu)
+        R = []
+        source_vec = self.source_function.vector()
+        for u in U._list:
+            if u.imag_part is not None:
                 raise NotImplementedError
-            self._set_mu(mu)
-            source_vec = self.source_function.vector()
-            source_vec[:] = U._list[0].real_part.impl
-            matrix = df.assemble(df.derivative(self.form, self.source_function))
+            source_vec[:] = u.real_part.impl
+            r = df.assemble(self.form)
             for bc in self.dirichlet_bcs:
-                bc.apply(matrix)
-            return FenicsMatrixOperator(matrix, self.source.V, self.range.V)
+                bc.apply(r, source_vec)
+            R.append(r)
+        return self.range.make_array(R)
 
-        def restricted(self, dofs):
-            from pymor.tools.mpi import parallel
-            if parallel:
-                raise NotImplementedError('SubMesh does not work in parallel')
-            with self.logger.block(f'Restricting operator to {len(dofs)} dofs ...'):
-                if len(dofs) == 0:
-                    return ZeroOperator(NumpyVectorSpace(0), NumpyVectorSpace(0)), np.array([], dtype=int)
+    def jacobian(self, U, mu=None):
+        assert U in self.source and len(U) == 1
+        if U._list[0].imag_part is not None:
+            raise NotImplementedError
+        self._set_mu(mu)
+        source_vec = self.source_function.vector()
+        source_vec[:] = U._list[0].real_part.impl
+        matrix = df.assemble(df.derivative(self.form, self.source_function))
+        for bc in self.dirichlet_bcs:
+            bc.apply(matrix)
+        return FenicsMatrixOperator(matrix, self.source.V, self.range.V)
 
-                if self.source.V.mesh().id() != self.range.V.mesh().id():
-                    raise NotImplementedError
+    def restricted(self, dofs):
+        from pymor.tools.mpi import parallel
+        if parallel:
+            raise NotImplementedError('SubMesh does not work in parallel')
+        with self.logger.block(f'Restricting operator to {len(dofs)} dofs ...'):
+            if len(dofs) == 0:
+                return ZeroOperator(NumpyVectorSpace(0), NumpyVectorSpace(0)), np.array([], dtype=int)
 
-                self.logger.info('Computing affected cells ...')
-                mesh = self.source.V.mesh()
-                range_dofmap = self.range.V.dofmap()
-                affected_cell_indices = set()
-                for c in df.cells(mesh):
-                    cell_index = c.index()
-                    local_dofs = range_dofmap.cell_dofs(cell_index)
-                    for ld in local_dofs:
-                        if ld in dofs:
-                            affected_cell_indices.add(cell_index)
-                            continue
-                affected_cell_indices = list(sorted(affected_cell_indices))
-
-                if any(i.integral_type() not in ('cell', 'exterior_facet')
-                       for i in self.form.integrals()):
-                    # enlarge affected_cell_indices if needed
-                    raise NotImplementedError
-
-                self.logger.info('Computing source DOFs ...')
-                source_dofmap = self.source.V.dofmap()
-                source_dofs = set()
-                for cell_index in affected_cell_indices:
-                    local_dofs = source_dofmap.cell_dofs(cell_index)
-                    source_dofs.update(local_dofs)
-                source_dofs = np.array(sorted(source_dofs), dtype=np.intc)
-
-                self.logger.info('Building submesh ...')
-                subdomain = df.MeshFunction('size_t', mesh, mesh.geometry().dim())
-                for ci in affected_cell_indices:
-                    subdomain.set_value(ci, 1)
-                submesh = df.SubMesh(mesh, subdomain, 1)
-
-                self.logger.info('Building UFL form on submesh ...')
-                form_r, V_r_source, V_r_range, source_function_r = self._restrict_form(submesh, source_dofs)
-
-                self.logger.info('Building DirichletBCs on submesh ...')
-                bc_r = self._restrict_dirichlet_bcs(submesh, source_dofs, V_r_source)
-
-                self.logger.info('Computing source DOF mapping ...')
-                restricted_source_dofs = self._build_dof_map(self.source.V, V_r_source, source_dofs)
-
-                self.logger.info('Computing range DOF mapping ...')
-                restricted_range_dofs = self._build_dof_map(self.range.V, V_r_range, dofs)
-
-                op_r = FenicsOperator(form_r, FenicsVectorSpace(V_r_source), FenicsVectorSpace(V_r_range),
-                                      source_function_r, dirichlet_bcs=bc_r, parameter_setter=self.parameter_setter,
-                                      parameters=self.parameters)
-
-                return (RestrictedFenicsOperator(op_r, restricted_range_dofs),
-                        source_dofs[np.argsort(restricted_source_dofs)])
-
-        def _restrict_form(self, submesh, source_dofs):
-            V_r_source = df.FunctionSpace(submesh, self.source.V.ufl_element())
-            V_r_range = df.FunctionSpace(submesh, self.range.V.ufl_element())
-            assert V_r_source.dim() == len(source_dofs)
-
-            if self.source.V != self.range.V:
-                assert all(arg.ufl_function_space() != self.source.V for arg in self.form.arguments())
-            args = tuple((df.function.argument.Argument(V_r_range, arg.number(), arg.part())
-                          if arg.ufl_function_space() == self.range.V else arg)
-                         for arg in self.form.arguments())
-
-            if any(isinstance(coeff, df.Function) and coeff != self.source_function for coeff in
-                   self.form.coefficients()):
+            if self.source.V.mesh().id() != self.range.V.mesh().id():
                 raise NotImplementedError
 
-            source_function_r = df.Function(V_r_source)
-            form_r = ufl.replace_integral_domains(
-                self.form(*args, coefficients={self.source_function: source_function_r}),
-                submesh.ufl_domain()
-            )
-
-            return form_r, V_r_source, V_r_range, source_function_r
-
-        def _restrict_dirichlet_bcs(self, submesh, source_dofs, V_r_source):
+            self.logger.info('Computing affected cells ...')
             mesh = self.source.V.mesh()
-            parent_facet_indices = compute_parent_facet_indices(submesh, mesh)
+            range_dofmap = self.range.V.dofmap()
+            affected_cell_indices = set()
+            for c in df.cells(mesh):
+                cell_index = c.index()
+                local_dofs = range_dofmap.cell_dofs(cell_index)
+                for ld in local_dofs:
+                    if ld in dofs:
+                        affected_cell_indices.add(cell_index)
+                        continue
+            affected_cell_indices = list(sorted(affected_cell_indices))
 
-            def restrict_dirichlet_bc(bc):
-                # ensure that markers are initialized
-                bc.get_boundary_values()
-                facets = np.zeros(mesh.num_facets(), dtype=np.uint)
-                facets[bc.markers()] = 1
-                facets_r = facets[parent_facet_indices]
-                sub_domains = df.MeshFunction('size_t', submesh, mesh.topology().dim() - 1)
-                sub_domains.array()[:] = facets_r
+            if any(i.integral_type() not in ('cell', 'exterior_facet')
+                   for i in self.form.integrals()):
+                # enlarge affected_cell_indices if needed
+                raise NotImplementedError
 
-                bc_r = df.DirichletBC(V_r_source, bc.value(), sub_domains, 1, bc.method())
-                return bc_r
+            self.logger.info('Computing source DOFs ...')
+            source_dofmap = self.source.V.dofmap()
+            source_dofs = set()
+            for cell_index in affected_cell_indices:
+                local_dofs = source_dofmap.cell_dofs(cell_index)
+                source_dofs.update(local_dofs)
+            source_dofs = np.array(sorted(source_dofs), dtype=np.intc)
 
-            return tuple(restrict_dirichlet_bc(bc) for bc in self.dirichlet_bcs)
+            self.logger.info('Building submesh ...')
+            subdomain = df.MeshFunction('size_t', mesh, mesh.geometry().dim())
+            for ci in affected_cell_indices:
+                subdomain.set_value(ci, 1)
+            submesh = df.SubMesh(mesh, subdomain, 1)
 
-        def _build_dof_map(self, V, V_r, dofs):
-            u = df.Function(V)
-            u_vec = u.vector()
-            restricted_dofs = []
-            for dof in dofs:
-                u_vec.zero()
-                u_vec[dof] = 1
-                u_r = df.interpolate(u, V_r)
-                u_r = u_r.vector().get_local()
-                if not np.all(np.logical_or(np.abs(u_r) < 1e-10, np.abs(u_r - 1.) < 1e-10)):
-                    raise NotImplementedError
-                r_dof = np.where(np.abs(u_r - 1.) < 1e-10)[0]
-                if not len(r_dof) == 1:
-                    raise NotImplementedError
-                restricted_dofs.append(r_dof[0])
-            restricted_dofs = np.array(restricted_dofs, dtype=np.int32)
-            assert len(set(restricted_dofs)) == len(set(dofs))
-            return restricted_dofs
+            self.logger.info('Building UFL form on submesh ...')
+            form_r, V_r_source, V_r_range, source_function_r = self._restrict_form(submesh, source_dofs)
+
+            self.logger.info('Building DirichletBCs on submesh ...')
+            bc_r = self._restrict_dirichlet_bcs(submesh, source_dofs, V_r_source)
+
+            self.logger.info('Computing source DOF mapping ...')
+            restricted_source_dofs = self._build_dof_map(self.source.V, V_r_source, source_dofs)
+
+            self.logger.info('Computing range DOF mapping ...')
+            restricted_range_dofs = self._build_dof_map(self.range.V, V_r_range, dofs)
+
+            op_r = FenicsOperator(form_r, FenicsVectorSpace(V_r_source), FenicsVectorSpace(V_r_range),
+                                  source_function_r, dirichlet_bcs=bc_r, parameter_setter=self.parameter_setter,
+                                  parameters=self.parameters)
+
+            return (RestrictedFenicsOperator(op_r, restricted_range_dofs),
+                    source_dofs[np.argsort(restricted_source_dofs)])
+
+    def _restrict_form(self, submesh, source_dofs):
+        V_r_source = df.FunctionSpace(submesh, self.source.V.ufl_element())
+        V_r_range = df.FunctionSpace(submesh, self.range.V.ufl_element())
+        assert V_r_source.dim() == len(source_dofs)
+
+        if self.source.V != self.range.V:
+            assert all(arg.ufl_function_space() != self.source.V for arg in self.form.arguments())
+        args = tuple((df.function.argument.Argument(V_r_range, arg.number(), arg.part())
+                      if arg.ufl_function_space() == self.range.V else arg)
+                     for arg in self.form.arguments())
+
+        if any(isinstance(coeff, df.Function) and coeff != self.source_function for coeff in
+               self.form.coefficients()):
+            raise NotImplementedError
+
+        source_function_r = df.Function(V_r_source)
+        form_r = ufl.replace_integral_domains(
+            self.form(*args, coefficients={self.source_function: source_function_r}),
+            submesh.ufl_domain()
+        )
+
+        return form_r, V_r_source, V_r_range, source_function_r
+
+    def _restrict_dirichlet_bcs(self, submesh, source_dofs, V_r_source):
+        mesh = self.source.V.mesh()
+        parent_facet_indices = compute_parent_facet_indices(submesh, mesh)
+
+        def restrict_dirichlet_bc(bc):
+            # ensure that markers are initialized
+            bc.get_boundary_values()
+            facets = np.zeros(mesh.num_facets(), dtype=np.uint)
+            facets[bc.markers()] = 1
+            facets_r = facets[parent_facet_indices]
+            sub_domains = df.MeshFunction('size_t', submesh, mesh.topology().dim() - 1)
+            sub_domains.array()[:] = facets_r
+
+            bc_r = df.DirichletBC(V_r_source, bc.value(), sub_domains, 1, bc.method())
+            return bc_r
+
+        return tuple(restrict_dirichlet_bc(bc) for bc in self.dirichlet_bcs)
+
+    def _build_dof_map(self, V, V_r, dofs):
+        u = df.Function(V)
+        u_vec = u.vector()
+        restricted_dofs = []
+        for dof in dofs:
+            u_vec.zero()
+            u_vec[dof] = 1
+            u_r = df.interpolate(u, V_r)
+            u_r = u_r.vector().get_local()
+            if not np.all(np.logical_or(np.abs(u_r) < 1e-10, np.abs(u_r - 1.) < 1e-10)):
+                raise NotImplementedError
+            r_dof = np.where(np.abs(u_r - 1.) < 1e-10)[0]
+            if not len(r_dof) == 1:
+                raise NotImplementedError
+            restricted_dofs.append(r_dof[0])
+        restricted_dofs = np.array(restricted_dofs, dtype=np.int32)
+        assert len(set(restricted_dofs)) == len(set(dofs))
+        return restricted_dofs
 
 
-if config.HAVE_FENICS:
+class RestrictedFenicsOperator(Operator):
 
-    class RestrictedFenicsOperator(Operator):
+    linear = False
 
-        linear = False
+    def __init__(self, op, restricted_range_dofs):
+        self.source = NumpyVectorSpace(op.source.dim)
+        self.range = NumpyVectorSpace(len(restricted_range_dofs))
+        self.op = op
+        self.restricted_range_dofs = restricted_range_dofs
 
-        def __init__(self, op, restricted_range_dofs):
-            self.source = NumpyVectorSpace(op.source.dim)
-            self.range = NumpyVectorSpace(len(restricted_range_dofs))
-            self.op = op
-            self.restricted_range_dofs = restricted_range_dofs
+    def apply(self, U, mu=None):
+        assert U in self.source
+        UU = self.op.source.zeros(len(U))
+        for uu, u in zip(UU._list, U.to_numpy()):
+            uu.real_part.impl[:] = np.ascontiguousarray(u)
+        VV = self.op.apply(UU, mu=mu)
+        V = self.range.zeros(len(VV))
+        for v, vv in zip(V.to_numpy(), VV._list):
+            v[:] = vv.real_part.impl[self.restricted_range_dofs]
+        return V
 
-        def apply(self, U, mu=None):
-            assert U in self.source
-            UU = self.op.source.zeros(len(U))
-            for uu, u in zip(UU._list, U.to_numpy()):
-                uu.real_part.impl[:] = np.ascontiguousarray(u)
-            VV = self.op.apply(UU, mu=mu)
-            V = self.range.zeros(len(VV))
-            for v, vv in zip(V.to_numpy(), VV._list):
-                v[:] = vv.real_part.impl[self.restricted_range_dofs]
-            return V
-
-        def jacobian(self, U, mu=None):
-            assert U in self.source and len(U) == 1
-            UU = self.op.source.zeros()
-            UU._list[0].real_part.impl[:] = np.ascontiguousarray(U.to_numpy()[0])
-            JJ = self.op.jacobian(UU, mu=mu)
-            return NumpyMatrixOperator(JJ.matrix.array()[self.restricted_range_dofs, :])
-
-    @defaults('solver', 'preconditioner', 'keep_solver')
-    def _solver_options(solver='mumps' if 'mumps' in df.linear_solver_methods() else 'default',
-                        preconditioner=None, keep_solver=True):
-        return {'solver': solver, 'preconditioner': preconditioner, 'keep_solver': keep_solver}
+    def jacobian(self, U, mu=None):
+        assert U in self.source and len(U) == 1
+        UU = self.op.source.zeros()
+        UU._list[0].real_part.impl[:] = np.ascontiguousarray(U.to_numpy()[0])
+        JJ = self.op.jacobian(UU, mu=mu)
+        return NumpyMatrixOperator(JJ.matrix.array()[self.restricted_range_dofs, :])
 
 
-if config.HAVE_FENICS:
+@defaults('solver', 'preconditioner', 'keep_solver')
+def _solver_options(solver='mumps' if 'mumps' in df.linear_solver_methods() else 'default',
+                    preconditioner=None, keep_solver=True):
+    return {'solver': solver, 'preconditioner': preconditioner, 'keep_solver': keep_solver}
 
-    class FenicsVisualizer(ImmutableObject):
-        """Visualize a FEniCS grid function.
+
+class FenicsVisualizer(ImmutableObject):
+    """Visualize a FEniCS grid function.
+
+    Parameters
+    ----------
+    space
+        The `FenicsVectorSpace` for which we want to visualize DOF vectors.
+    mesh_refinements
+        Number of uniform mesh refinements to perform for vtk visualization
+        (of functions from higher-order FE spaces).
+    """
+
+    def __init__(self, space, mesh_refinements=0):
+        self.space = space
+        self.mesh_refinements = mesh_refinements
+
+    def visualize(self, U, title='', legend=None, filename=None, block=True,
+                  separate_colorbars=True):
+        """Visualize the provided data.
 
         Parameters
         ----------
-        space
-            The `FenicsVectorSpace` for which we want to visualize DOF vectors.
-        mesh_refinements
-            Number of uniform mesh refinements to perform for vtk visualization
-            (of functions from higher-order FE spaces).
+        U
+            |VectorArray| of the data to visualize (length must be 1). Alternatively,
+            a tuple of |VectorArrays| which will be visualized in separate windows.
+            If `filename` is specified, only one |VectorArray| may be provided which,
+            however, is allowed to contain multiple vectors that will be interpreted
+            as a time series.
+        title
+            Title of the plot.
+        legend
+            Description of the data that is plotted. If `U` is a tuple of |VectorArrays|,
+            `legend` has to be a tuple of the same length.
+        filename
+            If specified, write the data to that file. `filename` needs to have an extension
+            supported by FEniCS (e.g. `.pvd`).
+        separate_colorbars
+            If `True`, use separate colorbars for each subplot.
+        block
+            If `True`, block execution until the plot window is closed.
         """
-
-        def __init__(self, space, mesh_refinements=0):
-            self.space = space
-            self.mesh_refinements = mesh_refinements
-
-        def visualize(self, U, title='', legend=None, filename=None, block=True,
-                      separate_colorbars=True):
-            """Visualize the provided data.
-
-            Parameters
-            ----------
-            U
-                |VectorArray| of the data to visualize (length must be 1). Alternatively,
-                a tuple of |VectorArrays| which will be visualized in separate windows.
-                If `filename` is specified, only one |VectorArray| may be provided which,
-                however, is allowed to contain multiple vectors that will be interpreted
-                as a time series.
-            title
-                Title of the plot.
-            legend
-                Description of the data that is plotted. If `U` is a tuple of |VectorArrays|,
-                `legend` has to be a tuple of the same length.
-            filename
-                If specified, write the data to that file. `filename` needs to have an extension
-                supported by FEniCS (e.g. `.pvd`).
-            separate_colorbars
-                If `True`, use separate colorbars for each subplot.
-            block
-                If `True`, block execution until the plot window is closed.
-            """
-            if filename:
-                assert not isinstance(U, tuple)
-                assert U in self.space
-                if block:
-                    self.logger.warning('visualize with filename!=None, block=True will not block')
-                supported = (".x3d", ".xml", ".pvd", ".raw")
-                suffix = Path(filename).suffix
-                if suffix not in supported:
-                    msg = ('FenicsVisualizer needs a filename with a suffix indicating a supported backend\n'
-                           + f'defaulting to .pvd (possible choices: {supported})')
-                    self.logger.warning(msg)
-                    filename = f'{filename}.pvd'
-                f = df.File(str(filename))
-                coarse_function = df.Function(self.space.V)
-                if self.mesh_refinements:
-                    mesh = self.space.V.mesh()
-                    for _ in range(self.mesh_refinements):
-                        mesh = df.refine(mesh)
-                    V_fine = df.FunctionSpace(mesh, self.space.V.ufl_element())
-                    function = df.Function(V_fine)
-                else:
-                    function = coarse_function
-                if legend:
-                    function.rename(legend, legend)
-                for u in U._list:
-                    if u.imag_part is not None:
-                        raise NotImplementedError
-                    coarse_function.vector()[:] = u.real_part.impl
-                    if self.mesh_refinements:
-                        function.vector()[:] = df.interpolate(coarse_function, V_fine).vector()
-                    f.write(function)
+        if filename:
+            assert not isinstance(U, tuple)
+            assert U in self.space
+            if block:
+                self.logger.warning('visualize with filename!=None, block=True will not block')
+            supported = (".x3d", ".xml", ".pvd", ".raw")
+            suffix = Path(filename).suffix
+            if suffix not in supported:
+                msg = ('FenicsVisualizer needs a filename with a suffix indicating a supported backend\n'
+                       + f'defaulting to .pvd (possible choices: {supported})')
+                self.logger.warning(msg)
+                filename = f'{filename}.pvd'
+            f = df.File(str(filename))
+            coarse_function = df.Function(self.space.V)
+            if self.mesh_refinements:
+                mesh = self.space.V.mesh()
+                for _ in range(self.mesh_refinements):
+                    mesh = df.refine(mesh)
+                V_fine = df.FunctionSpace(mesh, self.space.V.ufl_element())
+                function = df.Function(V_fine)
             else:
-                from matplotlib import pyplot as plt
+                function = coarse_function
+            if legend:
+                function.rename(legend, legend)
+            for u in U._list:
+                if u.imag_part is not None:
+                    raise NotImplementedError
+                coarse_function.vector()[:] = u.real_part.impl
+                if self.mesh_refinements:
+                    function.vector()[:] = df.interpolate(coarse_function, V_fine).vector()
+                f.write(function)
+        else:
+            from matplotlib import pyplot as plt
 
-                assert U in self.space and len(U) == 1 \
-                    or (isinstance(U, tuple) and all(u in self.space for u in U) and all(len(u) == 1 for u in U))
-                if not isinstance(U, tuple):
-                    U = (U,)
-                if isinstance(legend, str):
-                    legend = (legend,)
-                assert legend is None or len(legend) == len(U)
+            assert U in self.space and len(U) == 1 \
+                or (isinstance(U, tuple) and all(u in self.space for u in U) and all(len(u) == 1 for u in U))
+            if not isinstance(U, tuple):
+                U = (U,)
+            if isinstance(legend, str):
+                legend = (legend,)
+            assert legend is None or len(legend) == len(U)
 
-                if not separate_colorbars:
-                    vmin = np.inf
-                    vmax = -np.inf
-                    for u in U:
-                        vec = u._list[0].real_part.impl
-                        vmin = min(vmin, vec.min())
-                        vmax = max(vmax, vec.max())
+            if not separate_colorbars:
+                vmin = np.inf
+                vmax = -np.inf
+                for u in U:
+                    vec = u._list[0].real_part.impl
+                    vmin = min(vmin, vec.min())
+                    vmax = max(vmax, vec.max())
 
-                for i, u in enumerate(U):
-                    if u._list[0].imag_part is not None:
-                        raise NotImplementedError
-                    function = df.Function(self.space.V)
-                    function.vector()[:] = u._list[0].real_part.impl
-                    if legend:
-                        tit = title + ' -- ' if title else ''
-                        tit += legend[i]
-                    else:
-                        tit = title
-                    if separate_colorbars:
-                        plt.figure()
-                        df.plot(function, title=tit)
-                    else:
-                        plt.figure()
-                        df.plot(function, title=tit,
-                                range_min=vmin, range_max=vmax)
-                if getattr(sys, '_called_from_test', False):
-                    plt.show(block=False)
+            for i, u in enumerate(U):
+                if u._list[0].imag_part is not None:
+                    raise NotImplementedError
+                function = df.Function(self.space.V)
+                function.vector()[:] = u._list[0].real_part.impl
+                if legend:
+                    tit = title + ' -- ' if title else ''
+                    tit += legend[i]
                 else:
-                    plt.show(block=block)
+                    tit = title
+                if separate_colorbars:
+                    plt.figure()
+                    df.plot(function, title=tit)
+                else:
+                    plt.figure()
+                    df.plot(function, title=tit,
+                            range_min=vmin, range_max=vmax)
+            if getattr(sys, '_called_from_test', False):
+                plt.show(block=False)
+            else:
+                plt.show(block=block)
 
 
-if config.HAVE_FENICS:
+# adapted from dolfin.mesh.ale.init_parent_edge_indices
+def compute_parent_facet_indices(submesh, mesh):
+    dim = mesh.topology().dim()
+    facet_dim = dim - 1
+    submesh.init(facet_dim)
+    mesh.init(facet_dim)
 
-    # adapted from dolfin.mesh.ale.init_parent_edge_indices
-    def compute_parent_facet_indices(submesh, mesh):
-        dim = mesh.topology().dim()
-        facet_dim = dim - 1
-        submesh.init(facet_dim)
-        mesh.init(facet_dim)
+    # Make sure we have vertex-facet connectivity for parent mesh
+    mesh.init(0, facet_dim)
 
-        # Make sure we have vertex-facet connectivity for parent mesh
-        mesh.init(0, facet_dim)
+    parent_vertex_indices = submesh.data().array("parent_vertex_indices", 0)
+    # Create the fact map
+    parent_facet_indices = np.full(submesh.num_facets(), -1)
 
-        parent_vertex_indices = submesh.data().array("parent_vertex_indices", 0)
-        # Create the fact map
-        parent_facet_indices = np.full(submesh.num_facets(), -1)
+    # Iterate over the edges and figure out their parent number
+    for local_facet in df.facets(submesh):
 
-        # Iterate over the edges and figure out their parent number
-        for local_facet in df.facets(submesh):
+        # Get parent indices for edge vertices
+        vs = local_facet.entities(0)
+        Vs = [df.Vertex(mesh, parent_vertex_indices[int(v)]) for v in vs]
 
-            # Get parent indices for edge vertices
-            vs = local_facet.entities(0)
-            Vs = [df.Vertex(mesh, parent_vertex_indices[int(v)]) for v in vs]
+        # Get outgoing facets from the two parent vertices
+        facets = [set(V.entities(facet_dim)) for V in Vs]
 
-            # Get outgoing facets from the two parent vertices
-            facets = [set(V.entities(facet_dim)) for V in Vs]
+        # Check intersection
+        common_facets = facets[0]
+        for f in facets[1:]:
+            common_facets = common_facets.intersection(f)
+        assert len(common_facets) == 1
+        parent_facet_index = list(common_facets)[0]
 
-            # Check intersection
-            common_facets = facets[0]
-            for f in facets[1:]:
-                common_facets = common_facets.intersection(f)
-            assert len(common_facets) == 1
-            parent_facet_index = list(common_facets)[0]
-
-            # Set value
-            parent_facet_indices[local_facet.index()] = parent_facet_index
-        return parent_facet_indices
+        # Set value
+        parent_facet_indices[local_facet.index()] = parent_facet_index
+    return parent_facet_indices

--- a/src/pymor/bindings/fenics.py
+++ b/src/pymor/bindings/fenics.py
@@ -473,8 +473,11 @@ class RestrictedFenicsOperator(Operator):
         return NumpyMatrixOperator(JJ.matrix.array()[self.restricted_range_dofs, :])
 
 
+_DEFAULT_SOVLER = 'mumps' if 'mumps' in df.linear_solver_methods() else 'default'
+
+
 @defaults('solver', 'preconditioner', 'keep_solver')
-def _solver_options(solver='mumps' if 'mumps' in df.linear_solver_methods() else 'default',
+def _solver_options(solver=_DEFAULT_SOVLER,
                     preconditioner=None, keep_solver=True):
     return {'solver': solver, 'preconditioner': preconditioner, 'keep_solver': keep_solver}
 

--- a/src/pymor/bindings/fenics.py
+++ b/src/pymor/bindings/fenics.py
@@ -2,8 +2,8 @@
 # Copyright 2013-2021 pyMOR developers and contributors. All rights reserved.
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
-from pymor.core.config import require_dependency
-require_dependency('FENICS')
+from pymor.core.config import config
+config.require('FENICS')
 
 
 import dolfin as df

--- a/src/pymor/bindings/ngsolve.py
+++ b/src/pymor/bindings/ngsolve.py
@@ -3,8 +3,8 @@
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 from pathlib import Path
 
-from pymor.core.config import require_dependency
-require_dependency('NGSOLVE')
+from pymor.core.config import config
+config.require('NGSOLVE')
 
 
 from pymor.core.defaults import defaults

--- a/src/pymor/bindings/ngsolve.py
+++ b/src/pymor/bindings/ngsolve.py
@@ -3,216 +3,210 @@
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 from pathlib import Path
 
-from pymor.core.config import config
+from pymor.core.config import require_dependency
+require_dependency('NGSOLVE')
+
+
 from pymor.core.defaults import defaults
 from pymor.tools.io import change_to_directory
 
-if config.HAVE_NGSOLVE:
-    import ngsolve as ngs
-    import numpy as np
 
-    from pymor.core.base import ImmutableObject
-    from pymor.operators.list import LinearComplexifiedListVectorArrayOperatorBase
-    from pymor.vectorarrays.interface import VectorArray
-    from pymor.vectorarrays.numpy import NumpyVectorSpace
-    from pymor.vectorarrays.list import CopyOnWriteVector, ComplexifiedVector, ComplexifiedListVectorSpace
+import ngsolve as ngs
+import numpy as np
 
-    class NGSolveVectorCommon:
-        def amax(self):
-            A = np.abs(self.to_numpy())
-            max_ind = np.argmax(A)
-            max_val = A[max_ind]
-            return max_ind, max_val
-
-        def dofs(self, dof_indices):
-            return self.to_numpy()[dof_indices]
+from pymor.core.base import ImmutableObject
+from pymor.operators.list import LinearComplexifiedListVectorArrayOperatorBase
+from pymor.vectorarrays.interface import VectorArray
+from pymor.vectorarrays.numpy import NumpyVectorSpace
+from pymor.vectorarrays.list import CopyOnWriteVector, ComplexifiedVector, ComplexifiedListVectorSpace
 
 
-if config.HAVE_NGSOLVE:
+class NGSolveVectorCommon:
+    def amax(self):
+        A = np.abs(self.to_numpy())
+        max_ind = np.argmax(A)
+        max_val = A[max_ind]
+        return max_ind, max_val
 
-    class NGSolveVector(NGSolveVectorCommon, CopyOnWriteVector):
-        """Wraps a NGSolve BaseVector to make it usable with ListVectorArray."""
-
-        def __init__(self, impl):
-            self.impl = impl
-
-        @classmethod
-        def from_instance(cls, instance):
-            return cls(instance.impl)
-
-        def _copy_data(self):
-            new_impl = ngs.GridFunction(self.impl.space)
-            new_impl.vec.data = self.impl.vec
-            self.impl = new_impl
-
-        def to_numpy(self, ensure_copy=False):
-            if ensure_copy:
-                return self.impl.vec.FV().NumPy().copy()
-            self._copy_data_if_needed()
-            return self.impl.vec.FV().NumPy()
-
-        def _scal(self, alpha):
-            self.impl.vec.data = float(alpha) * self.impl.vec
-
-        def _axpy(self, alpha, x):
-            self.impl.vec.data = self.impl.vec + float(alpha) * x.impl.vec
-
-        def inner(self, other):
-            return self.impl.vec.InnerProduct(other.impl.vec)
-
-        def norm(self):
-            return self.impl.vec.Norm()
-
-        def norm2(self):
-            return self.impl.vec.Norm() ** 2
+    def dofs(self, dof_indices):
+        return self.to_numpy()[dof_indices]
 
 
-if config.HAVE_NGSOLVE:
+class NGSolveVector(NGSolveVectorCommon, CopyOnWriteVector):
+    """Wraps a NGSolve BaseVector to make it usable with ListVectorArray."""
 
-    class ComplexifiedNGSolveVector(NGSolveVectorCommon, ComplexifiedVector):
-        pass
+    def __init__(self, impl):
+        self.impl = impl
 
+    @classmethod
+    def from_instance(cls, instance):
+        return cls(instance.impl)
 
-if config.HAVE_NGSOLVE:
+    def _copy_data(self):
+        new_impl = ngs.GridFunction(self.impl.space)
+        new_impl.vec.data = self.impl.vec
+        self.impl = new_impl
 
-    class NGSolveVectorSpace(ComplexifiedListVectorSpace):
+    def to_numpy(self, ensure_copy=False):
+        if ensure_copy:
+            return self.impl.vec.FV().NumPy().copy()
+        self._copy_data_if_needed()
+        return self.impl.vec.FV().NumPy()
 
-        real_vector_type = NGSolveVector
-        vector_type = ComplexifiedNGSolveVector
+    def _scal(self, alpha):
+        self.impl.vec.data = float(alpha) * self.impl.vec
 
-        def __init__(self, V, id='STATE'):
-            self.__auto_init(locals())
+    def _axpy(self, alpha, x):
+        self.impl.vec.data = self.impl.vec + float(alpha) * x.impl.vec
 
-        def __eq__(self, other):
-            return type(other) is NGSolveVectorSpace and self.V == other.V and self.id == other.id
+    def inner(self, other):
+        return self.impl.vec.InnerProduct(other.impl.vec)
 
-        def __hash__(self):
-            return hash(self.V) + hash(self.id)
+    def norm(self):
+        return self.impl.vec.Norm()
 
-        @property
-        def value_dim(self):
-            u = self.V.TrialFunction()
-            if isinstance(u, list):
-                return u[0].dim
-            else:
-                return u.dim
-
-        @property
-        def dim(self):
-            return self.V.ndofglobal * self.value_dim
-
-        @classmethod
-        def space_from_vector_obj(cls, vec, id):
-            return cls(vec.space, id)
-
-        def real_zero_vector(self):
-            impl = ngs.GridFunction(self.V)
-            return NGSolveVector(impl)
-
-        def real_make_vector(self, obj):
-            return NGSolveVector(obj)
-
-        def real_vector_from_numpy(self, data, ensure_copy=False):
-            v = self.real_zero_vector()
-            v.to_numpy()[:] = data
-            return v
+    def norm2(self):
+        return self.impl.vec.Norm() ** 2
 
 
-if config.HAVE_NGSOLVE:
-
-    class NGSolveMatrixOperator(LinearComplexifiedListVectorArrayOperatorBase):
-        """Wraps a NGSolve matrix as an |Operator|."""
-
-        def __init__(self, matrix, range, source, solver_options=None, name=None):
-            self.__auto_init(locals())
-
-        @defaults('default_solver')
-        def _prepare_apply(self, U, mu, kind, least_squares=False, default_solver=''):
-            if kind == 'apply_inverse':
-                if least_squares:
-                    raise NotImplementedError
-                solver = self.solver_options.get('inverse', default_solver) if self.solver_options else default_solver
-                inv = self.matrix.Inverse(self.source.V.FreeDofs(), inverse=solver)
-                return inv
-
-        def _real_apply_one_vector(self, u, mu=None, prepare_data=None):
-            r = self.range.real_zero_vector()
-            self.matrix.Mult(u.impl.vec, r.impl.vec)
-            return r
-
-        def _real_apply_adjoint_one_vector(self, v, mu=None, prepare_data=None):
-            u = self.source.real_zero_vector()
-            try:
-                mat = self.matrix.Transpose()
-            except AttributeError:
-                mat = self.matrix.T
-            mat.Mult(v.impl.vec, u.impl.vec)
-            return u
-
-        def _real_apply_inverse_one_vector(self, v, mu=None, initial_guess=None,
-                                           least_squares=False, prepare_data=None):
-            inv = prepare_data
-            r = self.source.real_zero_vector()
-            r.impl.vec.data = inv * v.impl.vec
-            return r
-
-        def _assemble_lincomb(self, operators, coefficients, identity_shift=0., solver_options=None, name=None):
-            if not all(isinstance(op, NGSolveMatrixOperator) for op in operators):
-                return None
-            if identity_shift != 0:
-                return None
-
-            matrix = operators[0].matrix.CreateMatrix()
-            matrix.AsVector().data = float(coefficients[0]) * matrix.AsVector()
-            for op, c in zip(operators[1:], coefficients[1:]):
-                matrix.AsVector().data += float(c) * op.matrix.AsVector()
-            return NGSolveMatrixOperator(matrix, self.range, self.source, solver_options=solver_options, name=name)
-
-        def as_vector(self, copy=True):
-            vec = self.matrix.AsVector().FV().NumPy()
-            return NumpyVectorSpace.make_array(vec.copy() if copy else vec)
+class ComplexifiedNGSolveVector(NGSolveVectorCommon, ComplexifiedVector):
+    pass
 
 
-if config.HAVE_NGSOLVE:
+class NGSolveVectorSpace(ComplexifiedListVectorSpace):
 
-    class NGSolveVisualizer(ImmutableObject):
-        """Visualize an NGSolve grid function."""
+    real_vector_type = NGSolveVector
+    vector_type = ComplexifiedNGSolveVector
 
-        def __init__(self, mesh, fespace):
-            self.__auto_init(locals())
-            self.space = NGSolveVectorSpace(fespace)
+    def __init__(self, V, id='STATE'):
+        self.__auto_init(locals())
 
-        def visualize(self, U, legend=None, separate_colorbars=True, filename=None, block=True):
-            """Visualize the provided data."""
-            if isinstance(U, VectorArray):
-                U = (U,)
-            assert all(u in self.space for u in U)
-            if any(len(u) != 1 for u in U):
+    def __eq__(self, other):
+        return type(other) is NGSolveVectorSpace and self.V == other.V and self.id == other.id
+
+    def __hash__(self):
+        return hash(self.V) + hash(self.id)
+
+    @property
+    def value_dim(self):
+        u = self.V.TrialFunction()
+        if isinstance(u, list):
+            return u[0].dim
+        else:
+            return u.dim
+
+    @property
+    def dim(self):
+        return self.V.ndofglobal * self.value_dim
+
+    @classmethod
+    def space_from_vector_obj(cls, vec, id):
+        return cls(vec.space, id)
+
+    def real_zero_vector(self):
+        impl = ngs.GridFunction(self.V)
+        return NGSolveVector(impl)
+
+    def real_make_vector(self, obj):
+        return NGSolveVector(obj)
+
+    def real_vector_from_numpy(self, data, ensure_copy=False):
+        v = self.real_zero_vector()
+        v.to_numpy()[:] = data
+        return v
+
+
+class NGSolveMatrixOperator(LinearComplexifiedListVectorArrayOperatorBase):
+    """Wraps a NGSolve matrix as an |Operator|."""
+
+    def __init__(self, matrix, range, source, solver_options=None, name=None):
+        self.__auto_init(locals())
+
+    @defaults('default_solver')
+    def _prepare_apply(self, U, mu, kind, least_squares=False, default_solver=''):
+        if kind == 'apply_inverse':
+            if least_squares:
                 raise NotImplementedError
-            if any(u._list[0].imag_part is not None for u in U):
-                raise NotImplementedError
-            if legend is None:
-                legend = [f'VectorArray{i}' for i in range(len(U))]
-            if isinstance(legend, str):
-                legend = [legend]
-            assert len(legend) == len(U)
-            legend = [l.replace(' ', '_') for l in legend]  # NGSolve GUI will fail otherwise
+            solver = self.solver_options.get('inverse', default_solver) if self.solver_options else default_solver
+            inv = self.matrix.Inverse(self.source.V.FreeDofs(), inverse=solver)
+            return inv
 
-            if filename:
-                # ngsolve unconditionally appends ".vtk"
-                filename = Path(filename).resolve()
-                if filename.suffix == '.vtk':
-                    filename = filename.parent / filename.stem
-                else:
-                    self.logger.warning(f'NGSolve set VTKOutput filename to {filename}.vtk')
-                coeffs = [u._list[0].real_part.impl for u in U]
-                # ngsolve cannot handle full paths for filenames
-                with change_to_directory(filename.parent):
-                    vtk = ngs.VTKOutput(ma=self.mesh, coefs=coeffs, names=legend, filename=str(filename), subdivision=0)
-                    vtk.Do()
+    def _real_apply_one_vector(self, u, mu=None, prepare_data=None):
+        r = self.range.real_zero_vector()
+        self.matrix.Mult(u.impl.vec, r.impl.vec)
+        return r
+
+    def _real_apply_adjoint_one_vector(self, v, mu=None, prepare_data=None):
+        u = self.source.real_zero_vector()
+        try:
+            mat = self.matrix.Transpose()
+        except AttributeError:
+            mat = self.matrix.T
+        mat.Mult(v.impl.vec, u.impl.vec)
+        return u
+
+    def _real_apply_inverse_one_vector(self, v, mu=None, initial_guess=None,
+                                       least_squares=False, prepare_data=None):
+        inv = prepare_data
+        r = self.source.real_zero_vector()
+        r.impl.vec.data = inv * v.impl.vec
+        return r
+
+    def _assemble_lincomb(self, operators, coefficients, identity_shift=0., solver_options=None, name=None):
+        if not all(isinstance(op, NGSolveMatrixOperator) for op in operators):
+            return None
+        if identity_shift != 0:
+            return None
+
+        matrix = operators[0].matrix.CreateMatrix()
+        matrix.AsVector().data = float(coefficients[0]) * matrix.AsVector()
+        for op, c in zip(operators[1:], coefficients[1:]):
+            matrix.AsVector().data += float(c) * op.matrix.AsVector()
+        return NGSolveMatrixOperator(matrix, self.range, self.source, solver_options=solver_options, name=name)
+
+    def as_vector(self, copy=True):
+        vec = self.matrix.AsVector().FV().NumPy()
+        return NumpyVectorSpace.make_array(vec.copy() if copy else vec)
+
+
+class NGSolveVisualizer(ImmutableObject):
+    """Visualize an NGSolve grid function."""
+
+    def __init__(self, mesh, fespace):
+        self.__auto_init(locals())
+        self.space = NGSolveVectorSpace(fespace)
+
+    def visualize(self, U, legend=None, separate_colorbars=True, filename=None, block=True):
+        """Visualize the provided data."""
+        if isinstance(U, VectorArray):
+            U = (U,)
+        assert all(u in self.space for u in U)
+        if any(len(u) != 1 for u in U):
+            raise NotImplementedError
+        if any(u._list[0].imag_part is not None for u in U):
+            raise NotImplementedError
+        if legend is None:
+            legend = [f'VectorArray{i}' for i in range(len(U))]
+        if isinstance(legend, str):
+            legend = [legend]
+        assert len(legend) == len(U)
+        legend = [l.replace(' ', '_') for l in legend]  # NGSolve GUI will fail otherwise
+
+        if filename:
+            # ngsolve unconditionally appends ".vtk"
+            filename = Path(filename).resolve()
+            if filename.suffix == '.vtk':
+                filename = filename.parent / filename.stem
             else:
-                if not separate_colorbars:
-                    raise NotImplementedError
+                self.logger.warning(f'NGSolve set VTKOutput filename to {filename}.vtk')
+            coeffs = [u._list[0].real_part.impl for u in U]
+            # ngsolve cannot handle full paths for filenames
+            with change_to_directory(filename.parent):
+                vtk = ngs.VTKOutput(ma=self.mesh, coefs=coeffs, names=legend, filename=str(filename), subdivision=0)
+                vtk.Do()
+        else:
+            if not separate_colorbars:
+                raise NotImplementedError
 
-                for u, name in zip(U, legend):
-                    ngs.Draw(u._list[0].real_part.impl, self.mesh, name=name)
+            for u, name in zip(U, legend):
+                ngs.Draw(u._list[0].real_part.impl, self.mesh, name=name)

--- a/src/pymor/bindings/pymess.py
+++ b/src/pymor/bindings/pymess.py
@@ -2,8 +2,8 @@
 # Copyright 2013-2021 pyMOR developers and contributors. All rights reserved.
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
-from pymor.core.config import require_dependency
-require_dependency('PYMESS')
+from pymor.core.config import config
+config.require('PYMESS')
 
 
 import numpy as np

--- a/src/pymor/bindings/pymess.py
+++ b/src/pymor/bindings/pymess.py
@@ -2,758 +2,733 @@
 # Copyright 2013-2021 pyMOR developers and contributors. All rights reserved.
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
-from pymor.core.config import config
-
-
-if config.HAVE_PYMESS:
-    import numpy as np
-    import scipy.linalg as spla
-    import pymess
-
-    from pymor.algorithms.genericsolvers import _parse_options
-    from pymor.algorithms.lyapunov import (mat_eqn_sparse_min_size, _solve_lyap_lrcf_check_args,
-                                           _solve_lyap_dense_check_args, _chol)
-    from pymor.algorithms.to_matrix import to_matrix
-    from pymor.bindings.scipy import _solve_ricc_check_args
-    from pymor.core.defaults import defaults
-    from pymor.core.logger import getLogger
-    from pymor.operators.constructions import IdentityOperator
-
-    @defaults('adi_maxit', 'adi_memory_usage', 'adi_output', 'adi_rel_change_tol', 'adi_res2_tol', 'adi_res2c_tol',
-              'adi_shifts_arp_m', 'adi_shifts_arp_p', 'adi_shifts_b0', 'adi_shifts_l0', 'adi_shifts_p',
-              'adi_shifts_paratype')
-    def lradi_solver_options(adi_maxit=500,
-                             adi_memory_usage=pymess.MESS_MEMORY_MID,
-                             adi_output=1,
-                             adi_rel_change_tol=1e-10,
-                             adi_res2_tol=1e-10,
-                             adi_res2c_tol=1e-11,
-                             adi_shifts_arp_m=32,
-                             adi_shifts_arp_p=48,
-                             adi_shifts_b0=None,
-                             adi_shifts_l0=16,
-                             adi_shifts_p=None,
-                             adi_shifts_paratype=pymess.MESS_LRCFADI_PARA_ADAPTIVE_Z):
-        """Return available adi solver options with default values for the pymess backend.
-
-        Parameters
-        ----------
-        adi_maxit
-            See `pymess.OptionsAdi`.
-        adi_memory_usage
-            See `pymess.OptionsAdi`.
-        adi_output
-            See `pymess.OptionsAdi`.
-        adi_rel_change_tol
-            See `pymess.OptionsAdi`.
-        adi_res2_tol
-            See `pymess.OptionsAdi`.
-        adi_res2c_tol
-            See `pymess.OptionsAdi`.
-        adi_shifts_arp_m
-            See `pymess.OptionsAdiShifts`.
-        adi_shifts_arp_p
-            See `pymess.OptionsAdiShifts`.
-        adi_shifts_b0
-            See `pymess.OptionsAdiShifts`.
-        adi_shifts_l0
-            See `pymess.OptionsAdiShifts`.
-        adi_shifts_p
-            See `pymess.OptionsAdiShifts`.
-        adi_shifts_paratype
-            See `pymess.OptionsAdiShifts`.
-
-        Returns
-        -------
-        A dict of available solvers with default solver options.
-        """
-        lradi_opts = pymess.Options()
-        lradi_opts.adi.maxit = adi_maxit
-        lradi_opts.adi.memory_usage = adi_memory_usage
-        lradi_opts.adi.output = adi_output
-        lradi_opts.adi.rel_change_tol = adi_rel_change_tol
-        lradi_opts.adi.res2_tol = adi_res2_tol
-        lradi_opts.adi.res2c_tol = adi_res2c_tol
-        lradi_opts.adi.shifts.arp_m = adi_shifts_arp_m
-        lradi_opts.adi.shifts.arp_p = adi_shifts_arp_p
-        lradi_opts.adi.shifts.b0 = adi_shifts_b0
-        lradi_opts.adi.shifts.l0 = adi_shifts_l0
-        lradi_opts.adi.shifts.p = adi_shifts_p
-        lradi_opts.adi.shifts.paratype = adi_shifts_paratype
-        return lradi_opts
-
-
-if config.HAVE_PYMESS:
-
-    def lyap_lrcf_solver_options():
-        """Return available Lyapunov solvers with default options for the pymess backend.
-
-        Also see :func:`lradi_solver_options`.
-
-        Returns
-        -------
-        A dict of available solvers with default solver options.
-        """
-        return {'pymess_glyap': {'type': 'pymess_glyap'},
-                'pymess_lradi': {'type': 'pymess_lradi',
-                                 'opts': lradi_solver_options()}}
-
-
-if config.HAVE_PYMESS:
-
-    @defaults('default_solver')
-    def solve_lyap_lrcf(A, E, B, trans=False, options=None, default_solver=None):
-        """Compute an approximate low-rank solution of a Lyapunov equation.
-
-        See :func:`pymor.algorithms.lyapunov.solve_lyap_lrcf` for a
-        general description.
-
-        This function uses `pymess.glyap` and `pymess.lradi`.
-        For both methods,
-        :meth:`~pymor.vectorarrays.interface.VectorArray.to_numpy`
-        and
-        :meth:`~pymor.vectorarrays.interface.VectorSpace.from_numpy`
-        need to be implemented for `A.source`.
-        Additionally, since `glyap` is a dense solver, it expects
-        :func:`~pymor.algorithms.to_matrix.to_matrix` to work for A and
-        E.
-
-        If the solver is not specified using the options or
-        default_solver arguments, `glyap` is used for small problems
-        (smaller than defined with
-        :func:`~pymor.algorithms.lyapunov.mat_eqn_sparse_min_size`) and
-        `lradi` for large problems.
-
-        Parameters
-        ----------
-        A
-            The non-parametric |Operator| A.
-        E
-            The non-parametric |Operator| E or `None`.
-        B
-            The operator B as a |VectorArray| from `A.source`.
-        trans
-            Whether the first |Operator| in the Lyapunov equation is
-            transposed.
-        options
-            The solver options to use (see
-            :func:`lyap_lrcf_solver_options`).
-        default_solver
-            Default solver to use (pymess_lradi, pymess_glyap).
-            If `None`, choose solver depending on the dimension of A.
-
-        Returns
-        -------
-        Z
-            Low-rank Cholesky factor of the Lyapunov equation solution,
-            |VectorArray| from `A.source`.
-        """
-        _solve_lyap_lrcf_check_args(A, E, B, trans)
-        if default_solver is None:
-            default_solver = 'pymess_lradi' if A.source.dim >= mat_eqn_sparse_min_size() else 'pymess_glyap'
-        options = _parse_options(options, lyap_lrcf_solver_options(), default_solver, None, False)
-
-        if options['type'] == 'pymess_glyap':
-            X = solve_lyap_dense(to_matrix(A, format='dense'),
-                                 to_matrix(E, format='dense') if E else None,
-                                 B.to_numpy().T if not trans else B.to_numpy(),
-                                 trans=trans, options=options)
-            Z = _chol(X)
-        elif options['type'] == 'pymess_lradi':
-            opts = options['opts']
-            opts.type = pymess.MESS_OP_NONE if not trans else pymess.MESS_OP_TRANSPOSE
-            eqn = LyapunovEquation(opts, A, E, B)
-            Z, status = pymess.lradi(eqn, opts)
-            relres = status.res2_norm / status.res2_0
-            if relres > opts.adi.res2_tol:
-                logger = getLogger('pymor.bindings.pymess.solve_lyap_lrcf')
-                logger.warning(f'Desired relative residual tolerance was not achieved '
-                               f'({relres:e} > {opts.adi.res2_tol:e}).')
-        else:
-            raise ValueError(f'Unexpected Lyapunov equation solver ({options["type"]}).')
-
-        return A.source.from_numpy(Z.T)
-
-
-if config.HAVE_PYMESS:
-
-    def lyap_dense_solver_options():
-        """Return available Lyapunov solvers with default options for the pymess backend.
-
-        Returns
-        -------
-        A dict of available solvers with default solver options.
-        """
-        return {'pymess_glyap': {'type': 'pymess_glyap'}}
-
-
-if config.HAVE_PYMESS:
-
-    def solve_lyap_dense(A, E, B, trans=False, options=None):
-        """Compute the solution of a Lyapunov equation.
-
-        See :func:`pymor.algorithms.lyapunov.solve_lyap_dense` for a
-        general description.
-
-        This function uses `pymess.glyap`.
-
-        Parameters
-        ----------
-        A
-            The matrix A as a 2D |NumPy array|.
-        E
-            The matrix E as a 2D |NumPy array| or `None`.
-        B
-            The matrix B as a 2D |NumPy array|.
-        trans
-            Whether the first operator in the Lyapunov equation is
-            transposed.
-        options
-            The solver options to use (see
-            :func:`lyap_dense_solver_options`).
-
-        Returns
-        -------
-        X
-            Lyapunov equation solution as a |NumPy array|.
-        """
-        _solve_lyap_dense_check_args(A, E, B, trans)
-        options = _parse_options(options, lyap_lrcf_solver_options(), 'pymess_glyap', None, False)
-
-        if options['type'] == 'pymess_glyap':
-            Y = B.dot(B.T) if not trans else B.T.dot(B)
-            op = pymess.MESS_OP_NONE if not trans else pymess.MESS_OP_TRANSPOSE
-            X = pymess.glyap(A, E, Y, op=op)[0]
-            X = np.asarray(X)
-        else:
-            raise ValueError(f'Unexpected Lyapunov equation solver ({options["type"]}).')
-
-        return X
-
-
-if config.HAVE_PYMESS:
-
-    @defaults('linesearch', 'maxit', 'absres_tol', 'relres_tol', 'nrm')
-    def dense_nm_gmpcare_solver_options(linesearch=False,
-                                        maxit=50,
-                                        absres_tol=1e-11,
-                                        relres_tol=1e-12,
-                                        nrm=0):
-        """Return available Riccati solvers with default options for the pymess backend.
-
-        Also see :func:`lradi_solver_options`.
-
-        Parameters
-        ----------
-        linesearch
-            See `pymess.dense_nm_gmpcare`.
-        maxit
-            See `pymess.dense_nm_gmpcare`.
-        absres_tol
-            See `pymess.dense_nm_gmpcare`.
-        relres_tol
-            See `pymess.dense_nm_gmpcare`.
-        nrm
-            See `pymess.dense_nm_gmpcare`.
-
-        Returns
-        -------
-        A dict of available solvers with default solver options.
-        """
-        return {'linesearch': linesearch,
-                'maxit':      maxit,
-                'absres_tol': absres_tol,
-                'relres_tol': relres_tol,
-                'nrm':        nrm}
-
-
-if config.HAVE_PYMESS:
-
-    @defaults('newton_gstep', 'newton_k0', 'newton_linesearch', 'newton_maxit', 'newton_output', 'newton_res2_tol',
-              'newton_singleshifts')
-    def lrnm_solver_options(newton_gstep=0,
-                            newton_k0=None,
-                            newton_linesearch=0,
-                            newton_maxit=30,
-                            newton_output=1,
-                            newton_res2_tol=1e-10,
-                            newton_singleshifts=0):
-        """Return available adi solver options with default values for the pymess backend.
-
-        Parameters
-        ----------
-        newton_gstep
-          See `pymess.OptionsNewton`.
-        newton_k0
-          See `pymess.OptionsNewton`.
-        newton_linesearch
-          See `pymess.OptionsNewton`.
-        newton_maxit
-          See `pymess.OptionsNewton`.
-        newton_output
-          See `pymess.OptionsNewton`.
-        newton_res2_tol
-          See `pymess.OptionsNewton`.
-        newton_singleshifts
-          See `pymess.OptionsNewton`.
-
-        Returns
-        -------
-        A dict of available solvers with default solver options.
-        """
-        lrnm_opts = lradi_solver_options()
-        lrnm_opts.nm.gstep = newton_gstep
-        lrnm_opts.nm.k0 = newton_k0
-        lrnm_opts.nm.linesearch = newton_linesearch
-        lrnm_opts.nm.maxit = newton_maxit
-        lrnm_opts.nm.output = newton_output
-        lrnm_opts.nm.res2_tol = newton_res2_tol
-        lrnm_opts.nm.singleshifts = newton_singleshifts
-
-        return lrnm_opts
-
-
-if config.HAVE_PYMESS:
-
-    def ricc_lrcf_solver_options():
-        """Return available Riccati solvers with default options for the pymess backend.
-
-        Also see :func:`dense_nm_gmpcare_solver_options` and
-        :func:`lrnm_solver_options`.
-
-        Returns
-        -------
-        A dict of available solvers with default solver options.
-        """
-        return {'pymess_dense_nm_gmpcare': {'type': 'pymess_dense_nm_gmpcare',
-                                            'opts': dense_nm_gmpcare_solver_options()},
-                'pymess_lrnm':             {'type': 'pymess_lrnm',
-                                            'opts': lrnm_solver_options()}}
-
-
-if config.HAVE_PYMESS:
-
-    @defaults('default_solver')
-    def solve_ricc_lrcf(A, E, B, C, R=None, trans=False, options=None, default_solver=None):
-        """Compute an approximate low-rank solution of a Riccati equation.
-
-        See :func:`pymor.algorithms.riccati.solve_ricc_lrcf` for a
-        general description.
-
-        This function uses `pymess.dense_nm_gmpcare` and `pymess.lrnm`.
-        For both methods,
-        :meth:`~pymor.vectorarrays.interface.VectorArray.to_numpy`
-        and
-        :meth:`~pymor.vectorarrays.interface.VectorSpace.from_numpy`
-        need to be implemented for `A.source`.
-        Additionally, since `dense_nm_gmpcare` is a dense solver, it
-        expects :func:`~pymor.algorithms.to_matrix.to_matrix` to work
-        for A and E.
-
-        If the solver is not specified using the options or
-        default_solver arguments, `dense_nm_gmpcare` is used for small
-        problems (smaller than defined with
-        :func:`~pymor.algorithms.lyapunov.mat_eqn_sparse_min_size`) and
-        `lrnm` for large problems.
-
-        Parameters
-        ----------
-        A
-            The non-parametric |Operator| A.
-        E
-            The non-parametric |Operator| E or `None`.
-        B
-            The operator B as a |VectorArray| from `A.source`.
-        C
-            The operator C as a |VectorArray| from `A.source`.
-        R
-            The matrix R as a 2D |NumPy array| or `None`.
-        trans
-            Whether the first |Operator| in the Riccati equation is
-            transposed.
-        options
-            The solver options to use (see
-            :func:`ricc_lrcf_solver_options`).
-        default_solver
-            Default solver to use (pymess_lrnm,
-            pymess_dense_nm_gmpcare).
-            If `None`, chose solver depending on dimension `A`.
-
-        Returns
-        -------
-        Z
-            Low-rank Cholesky factor of the Riccati equation solution,
-            |VectorArray| from `A.source`.
-        """
-        _solve_ricc_check_args(A, E, B, C, R, trans)
-        if default_solver is None:
-            default_solver = 'pymess_lrnm' if A.source.dim >= mat_eqn_sparse_min_size() else 'pymess_dense_nm_gmpcare'
-        options = _parse_options(options, ricc_lrcf_solver_options(), default_solver, None, False)
-
-        if options['type'] == 'pymess_dense_nm_gmpcare':
-            X = _call_pymess_dense_nm_gmpare(A, E, B, C, R, trans=trans, options=options['opts'], plus=False,
-                                             method_name='solve_ricc_lrcf')
-            Z = _chol(X)
-        elif options['type'] == 'pymess_lrnm':
-            if R is not None:
-                import scipy.linalg as spla
-                Rc = spla.cholesky(R)                                 # R = Rc^T * Rc
-                Rci = spla.solve_triangular(Rc, np.eye(Rc.shape[0]))  # R^{-1} = Rci * Rci^T
-                if not trans:
-                    C = C.lincomb(Rci.T)  # C <- Rci^T * C = (C^T * Rci)^T
-                else:
-                    B = B.lincomb(Rci.T)  # B <- B * Rci
-            opts = options['opts']
-            opts.type = pymess.MESS_OP_NONE if not trans else pymess.MESS_OP_TRANSPOSE
-            eqn = RiccatiEquation(opts, A, E, B, C)
-            Z, status = pymess.lrnm(eqn, opts)
-            relres = status.res2_norm / status.res2_0
-            if relres > opts.adi.res2_tol:
-                logger = getLogger('pymor.bindings.pymess.solve_ricc_lrcf')
-                logger.warning(f'Desired relative residual tolerance was not achieved '
-                               f'({relres:e} > {opts.adi.res2_tol:e}).')
-        else:
-            raise ValueError(f'Unexpected Riccati equation solver ({options["type"]}).')
-
-        return A.source.from_numpy(Z.T)
-
-
-if config.HAVE_PYMESS:
-
-    def pos_ricc_lrcf_solver_options():
-        """Return available positive Riccati solvers with default options for the pymess backend.
-
-        Returns
-        -------
-        A dict of available solvers with default solver options.
-        """
-        return {'pymess_dense_nm_gmpcare': {'type': 'pymess_dense_nm_gmpcare',
-                                            'opts': dense_nm_gmpcare_solver_options()}}
-
-
-if config.HAVE_PYMESS:
-
-    def solve_pos_ricc_lrcf(A, E, B, C, R=None, trans=False, options=None):
-        """Compute an approximate low-rank solution of a positive Riccati equation.
-
-        See :func:`pymor.algorithms.riccati.solve_pos_ricc_lrcf` for a
-        general description.
-
-        This function uses `pymess.dense_nm_gmpcare`.
-
-        Parameters
-        ----------
-        A
-            The non-parametric |Operator| A.
-        E
-            The non-parametric |Operator| E or `None`.
-        B
-            The operator B as a |VectorArray| from `A.source`.
-        C
-            The operator C as a |VectorArray| from `A.source`.
-        R
-            The matrix R as a 2D |NumPy array| or `None`.
-        trans
-            Whether the first |Operator| in the Riccati equation is
-            transposed.
-        options
-            The solver options to use (see
-            :func:`pos_ricc_lrcf_solver_options`).
-
-        Returns
-        -------
-        Z
-            Low-rank Cholesky factor of the Riccati equation solution,
-            |VectorArray| from `A.source`.
-        """
-        _solve_ricc_check_args(A, E, B, C, R, trans)
-        options = _parse_options(options, pos_ricc_lrcf_solver_options(), 'pymess_dense_nm_gmpcare', None, False)
-
-        if options['type'] == 'pymess_dense_nm_gmpcare':
-            X = _call_pymess_dense_nm_gmpare(A, E, B, C, R, trans=trans, options=options['opts'], plus=True,
-                                             method_name='solve_pos_ricc_lrcf')
-            Z = _chol(X)
-        else:
-            raise ValueError(f'Unexpected positive Riccati equation solver ({options["type"]}).')
-
-        return A.source.from_numpy(Z.T)
-
-
-if config.HAVE_PYMESS:
-
-    def _call_pymess_dense_nm_gmpare(A, E, B, C, R, trans=False, options=None, plus=False, method_name=''):
-        """Return the solution from pymess.dense_nm_gmpare solver."""
-        A = to_matrix(A, format='dense')
-        E = to_matrix(E, format='dense') if E else None
-        B = B.to_numpy().T
-        C = C.to_numpy()
-
-        Q = B.dot(B.T) if not trans else C.T.dot(C)
-        pymess_trans = pymess.MESS_OP_NONE if not trans else pymess.MESS_OP_TRANSPOSE
-        if not trans:
-            RinvC = spla.solve(R, C) if R is not None else C
-            G = C.T.dot(RinvC)
-        else:
-            RinvBT = spla.solve(R, B.T) if R is not None else B.T
-            G = B.dot(RinvBT)
-        X, absres, relres = pymess.dense_nm_gmpare(None,
-                                                   A, E, Q, G,
-                                                   plus=plus, trans=pymess_trans,
-                                                   linesearch=options['linesearch'],
-                                                   maxit=options['maxit'],
-                                                   absres_tol=options['absres_tol'],
-                                                   relres_tol=options['relres_tol'],
-                                                   nrm=options['nrm'])
-        if absres > options['absres_tol']:
-            logger = getLogger('pymor.bindings.pymess.' + method_name)
-            logger.warning(f'Desired absolute residual tolerance was not achieved '
-                           f'({absres:e} > {options["absres_tol"]:e}).')
-        if relres > options['relres_tol']:
-            logger = getLogger('pymor.bindings.pymess.' + method_name)
+from pymor.core.config import require_dependency
+require_dependency('PYMESS')
+
+
+import numpy as np
+import scipy.linalg as spla
+import pymess
+
+from pymor.algorithms.genericsolvers import _parse_options
+from pymor.algorithms.lyapunov import (mat_eqn_sparse_min_size, _solve_lyap_lrcf_check_args,
+                                       _solve_lyap_dense_check_args, _chol)
+from pymor.algorithms.to_matrix import to_matrix
+from pymor.bindings.scipy import _solve_ricc_check_args
+from pymor.core.defaults import defaults
+from pymor.core.logger import getLogger
+from pymor.operators.constructions import IdentityOperator
+
+
+@defaults('adi_maxit', 'adi_memory_usage', 'adi_output', 'adi_rel_change_tol', 'adi_res2_tol', 'adi_res2c_tol',
+          'adi_shifts_arp_m', 'adi_shifts_arp_p', 'adi_shifts_b0', 'adi_shifts_l0', 'adi_shifts_p',
+          'adi_shifts_paratype')
+def lradi_solver_options(adi_maxit=500,
+                         adi_memory_usage=pymess.MESS_MEMORY_MID,
+                         adi_output=1,
+                         adi_rel_change_tol=1e-10,
+                         adi_res2_tol=1e-10,
+                         adi_res2c_tol=1e-11,
+                         adi_shifts_arp_m=32,
+                         adi_shifts_arp_p=48,
+                         adi_shifts_b0=None,
+                         adi_shifts_l0=16,
+                         adi_shifts_p=None,
+                         adi_shifts_paratype=pymess.MESS_LRCFADI_PARA_ADAPTIVE_Z):
+    """Return available adi solver options with default values for the pymess backend.
+
+    Parameters
+    ----------
+    adi_maxit
+        See `pymess.OptionsAdi`.
+    adi_memory_usage
+        See `pymess.OptionsAdi`.
+    adi_output
+        See `pymess.OptionsAdi`.
+    adi_rel_change_tol
+        See `pymess.OptionsAdi`.
+    adi_res2_tol
+        See `pymess.OptionsAdi`.
+    adi_res2c_tol
+        See `pymess.OptionsAdi`.
+    adi_shifts_arp_m
+        See `pymess.OptionsAdiShifts`.
+    adi_shifts_arp_p
+        See `pymess.OptionsAdiShifts`.
+    adi_shifts_b0
+        See `pymess.OptionsAdiShifts`.
+    adi_shifts_l0
+        See `pymess.OptionsAdiShifts`.
+    adi_shifts_p
+        See `pymess.OptionsAdiShifts`.
+    adi_shifts_paratype
+        See `pymess.OptionsAdiShifts`.
+
+    Returns
+    -------
+    A dict of available solvers with default solver options.
+    """
+    lradi_opts = pymess.Options()
+    lradi_opts.adi.maxit = adi_maxit
+    lradi_opts.adi.memory_usage = adi_memory_usage
+    lradi_opts.adi.output = adi_output
+    lradi_opts.adi.rel_change_tol = adi_rel_change_tol
+    lradi_opts.adi.res2_tol = adi_res2_tol
+    lradi_opts.adi.res2c_tol = adi_res2c_tol
+    lradi_opts.adi.shifts.arp_m = adi_shifts_arp_m
+    lradi_opts.adi.shifts.arp_p = adi_shifts_arp_p
+    lradi_opts.adi.shifts.b0 = adi_shifts_b0
+    lradi_opts.adi.shifts.l0 = adi_shifts_l0
+    lradi_opts.adi.shifts.p = adi_shifts_p
+    lradi_opts.adi.shifts.paratype = adi_shifts_paratype
+    return lradi_opts
+
+
+def lyap_lrcf_solver_options():
+    """Return available Lyapunov solvers with default options for the pymess backend.
+
+    Also see :func:`lradi_solver_options`.
+
+    Returns
+    -------
+    A dict of available solvers with default solver options.
+    """
+    return {'pymess_glyap': {'type': 'pymess_glyap'},
+            'pymess_lradi': {'type': 'pymess_lradi',
+                             'opts': lradi_solver_options()}}
+
+
+@defaults('default_solver')
+def solve_lyap_lrcf(A, E, B, trans=False, options=None, default_solver=None):
+    """Compute an approximate low-rank solution of a Lyapunov equation.
+
+    See :func:`pymor.algorithms.lyapunov.solve_lyap_lrcf` for a
+    general description.
+
+    This function uses `pymess.glyap` and `pymess.lradi`.
+    For both methods,
+    :meth:`~pymor.vectorarrays.interface.VectorArray.to_numpy`
+    and
+    :meth:`~pymor.vectorarrays.interface.VectorSpace.from_numpy`
+    need to be implemented for `A.source`.
+    Additionally, since `glyap` is a dense solver, it expects
+    :func:`~pymor.algorithms.to_matrix.to_matrix` to work for A and
+    E.
+
+    If the solver is not specified using the options or
+    default_solver arguments, `glyap` is used for small problems
+    (smaller than defined with
+    :func:`~pymor.algorithms.lyapunov.mat_eqn_sparse_min_size`) and
+    `lradi` for large problems.
+
+    Parameters
+    ----------
+    A
+        The non-parametric |Operator| A.
+    E
+        The non-parametric |Operator| E or `None`.
+    B
+        The operator B as a |VectorArray| from `A.source`.
+    trans
+        Whether the first |Operator| in the Lyapunov equation is
+        transposed.
+    options
+        The solver options to use (see
+        :func:`lyap_lrcf_solver_options`).
+    default_solver
+        Default solver to use (pymess_lradi, pymess_glyap).
+        If `None`, choose solver depending on the dimension of A.
+
+    Returns
+    -------
+    Z
+        Low-rank Cholesky factor of the Lyapunov equation solution,
+        |VectorArray| from `A.source`.
+    """
+    _solve_lyap_lrcf_check_args(A, E, B, trans)
+    if default_solver is None:
+        default_solver = 'pymess_lradi' if A.source.dim >= mat_eqn_sparse_min_size() else 'pymess_glyap'
+    options = _parse_options(options, lyap_lrcf_solver_options(), default_solver, None, False)
+
+    if options['type'] == 'pymess_glyap':
+        X = solve_lyap_dense(to_matrix(A, format='dense'),
+                             to_matrix(E, format='dense') if E else None,
+                             B.to_numpy().T if not trans else B.to_numpy(),
+                             trans=trans, options=options)
+        Z = _chol(X)
+    elif options['type'] == 'pymess_lradi':
+        opts = options['opts']
+        opts.type = pymess.MESS_OP_NONE if not trans else pymess.MESS_OP_TRANSPOSE
+        eqn = LyapunovEquation(opts, A, E, B)
+        Z, status = pymess.lradi(eqn, opts)
+        relres = status.res2_norm / status.res2_0
+        if relres > opts.adi.res2_tol:
+            logger = getLogger('pymor.bindings.pymess.solve_lyap_lrcf')
             logger.warning(f'Desired relative residual tolerance was not achieved '
-                           f'({relres:e} > {options["relres_tol"]:e}).')
+                           f'({relres:e} > {opts.adi.res2_tol:e}).')
+    else:
+        raise ValueError(f'Unexpected Lyapunov equation solver ({options["type"]}).')
 
-        return X
+    return A.source.from_numpy(Z.T)
 
 
-if config.HAVE_PYMESS:
+def lyap_dense_solver_options():
+    """Return available Lyapunov solvers with default options for the pymess backend.
 
-    class LyapunovEquation(pymess.Equation):
-        """Lyapunov equation class for pymess
+    Returns
+    -------
+    A dict of available solvers with default solver options.
+    """
+    return {'pymess_glyap': {'type': 'pymess_glyap'}}
 
-        Represents a (generalized) continuous-time algebraic Lyapunov
-        equation:
 
-        - if opt.type is `pymess.MESS_OP_NONE` and E is `None`:
+def solve_lyap_dense(A, E, B, trans=False, options=None):
+    """Compute the solution of a Lyapunov equation.
 
-          .. math::
-              A X + X A^T + B B^T = 0,
+    See :func:`pymor.algorithms.lyapunov.solve_lyap_dense` for a
+    general description.
 
-        - if opt.type is `pymess.MESS_OP_NONE` and E is not `None`:
+    This function uses `pymess.glyap`.
 
-          .. math::
-              A X E^T + E X A^T + B B^T = 0,
+    Parameters
+    ----------
+    A
+        The matrix A as a 2D |NumPy array|.
+    E
+        The matrix E as a 2D |NumPy array| or `None`.
+    B
+        The matrix B as a 2D |NumPy array|.
+    trans
+        Whether the first operator in the Lyapunov equation is
+        transposed.
+    options
+        The solver options to use (see
+        :func:`lyap_dense_solver_options`).
 
-        - if opt.type is `pymess.MESS_OP_TRANSPOSE` and E is `None`:
+    Returns
+    -------
+    X
+        Lyapunov equation solution as a |NumPy array|.
+    """
+    _solve_lyap_dense_check_args(A, E, B, trans)
+    options = _parse_options(options, lyap_lrcf_solver_options(), 'pymess_glyap', None, False)
 
-          .. math::
-              A^T X + X A + B^T B = 0,
+    if options['type'] == 'pymess_glyap':
+        Y = B.dot(B.T) if not trans else B.T.dot(B)
+        op = pymess.MESS_OP_NONE if not trans else pymess.MESS_OP_TRANSPOSE
+        X = pymess.glyap(A, E, Y, op=op)[0]
+        X = np.asarray(X)
+    else:
+        raise ValueError(f'Unexpected Lyapunov equation solver ({options["type"]}).')
 
-        - if opt.type is `pymess.MESS_OP_TRANSPOSE` and E is not `None`:
+    return X
 
-          .. math::
-              A^T X E + E^T X A + B^T B = 0.
 
-        Parameters
-        ----------
-        opt
-            pymess Options structure.
-        A
-            The non-parametric |Operator| A.
-        E
-            The non-parametric |Operator| E or `None`.
-        B
-            The operator B as a |VectorArray| from `A.source`.
-        """
+@defaults('linesearch', 'maxit', 'absres_tol', 'relres_tol', 'nrm')
+def dense_nm_gmpcare_solver_options(linesearch=False,
+                                    maxit=50,
+                                    absres_tol=1e-11,
+                                    relres_tol=1e-12,
+                                    nrm=0):
+    """Return available Riccati solvers with default options for the pymess backend.
 
-        def __init__(self, opt, A, E, B):
-            super().__init__(name='LyapunovEquation', opt=opt, dim=A.source.dim)
-            self.a = A
-            self.e = E
-            self.rhs = B.to_numpy().T
-            self.p = []
+    Also see :func:`lradi_solver_options`.
 
-        def ax_apply(self, op, y):
-            y = self.a.source.from_numpy(y.T)
-            if op == pymess.MESS_OP_NONE:
-                x = self.a.apply(y)
+    Parameters
+    ----------
+    linesearch
+        See `pymess.dense_nm_gmpcare`.
+    maxit
+        See `pymess.dense_nm_gmpcare`.
+    absres_tol
+        See `pymess.dense_nm_gmpcare`.
+    relres_tol
+        See `pymess.dense_nm_gmpcare`.
+    nrm
+        See `pymess.dense_nm_gmpcare`.
+
+    Returns
+    -------
+    A dict of available solvers with default solver options.
+    """
+    return {'linesearch': linesearch,
+            'maxit':      maxit,
+            'absres_tol': absres_tol,
+            'relres_tol': relres_tol,
+            'nrm':        nrm}
+
+
+@defaults('newton_gstep', 'newton_k0', 'newton_linesearch', 'newton_maxit', 'newton_output', 'newton_res2_tol',
+          'newton_singleshifts')
+def lrnm_solver_options(newton_gstep=0,
+                        newton_k0=None,
+                        newton_linesearch=0,
+                        newton_maxit=30,
+                        newton_output=1,
+                        newton_res2_tol=1e-10,
+                        newton_singleshifts=0):
+    """Return available adi solver options with default values for the pymess backend.
+
+    Parameters
+    ----------
+    newton_gstep
+      See `pymess.OptionsNewton`.
+    newton_k0
+      See `pymess.OptionsNewton`.
+    newton_linesearch
+      See `pymess.OptionsNewton`.
+    newton_maxit
+      See `pymess.OptionsNewton`.
+    newton_output
+      See `pymess.OptionsNewton`.
+    newton_res2_tol
+      See `pymess.OptionsNewton`.
+    newton_singleshifts
+      See `pymess.OptionsNewton`.
+
+    Returns
+    -------
+    A dict of available solvers with default solver options.
+    """
+    lrnm_opts = lradi_solver_options()
+    lrnm_opts.nm.gstep = newton_gstep
+    lrnm_opts.nm.k0 = newton_k0
+    lrnm_opts.nm.linesearch = newton_linesearch
+    lrnm_opts.nm.maxit = newton_maxit
+    lrnm_opts.nm.output = newton_output
+    lrnm_opts.nm.res2_tol = newton_res2_tol
+    lrnm_opts.nm.singleshifts = newton_singleshifts
+
+    return lrnm_opts
+
+
+def ricc_lrcf_solver_options():
+    """Return available Riccati solvers with default options for the pymess backend.
+
+    Also see :func:`dense_nm_gmpcare_solver_options` and
+    :func:`lrnm_solver_options`.
+
+    Returns
+    -------
+    A dict of available solvers with default solver options.
+    """
+    return {'pymess_dense_nm_gmpcare': {'type': 'pymess_dense_nm_gmpcare',
+                                        'opts': dense_nm_gmpcare_solver_options()},
+            'pymess_lrnm':             {'type': 'pymess_lrnm',
+                                        'opts': lrnm_solver_options()}}
+
+
+@defaults('default_solver')
+def solve_ricc_lrcf(A, E, B, C, R=None, trans=False, options=None, default_solver=None):
+    """Compute an approximate low-rank solution of a Riccati equation.
+
+    See :func:`pymor.algorithms.riccati.solve_ricc_lrcf` for a
+    general description.
+
+    This function uses `pymess.dense_nm_gmpcare` and `pymess.lrnm`.
+    For both methods,
+    :meth:`~pymor.vectorarrays.interface.VectorArray.to_numpy`
+    and
+    :meth:`~pymor.vectorarrays.interface.VectorSpace.from_numpy`
+    need to be implemented for `A.source`.
+    Additionally, since `dense_nm_gmpcare` is a dense solver, it
+    expects :func:`~pymor.algorithms.to_matrix.to_matrix` to work
+    for A and E.
+
+    If the solver is not specified using the options or
+    default_solver arguments, `dense_nm_gmpcare` is used for small
+    problems (smaller than defined with
+    :func:`~pymor.algorithms.lyapunov.mat_eqn_sparse_min_size`) and
+    `lrnm` for large problems.
+
+    Parameters
+    ----------
+    A
+        The non-parametric |Operator| A.
+    E
+        The non-parametric |Operator| E or `None`.
+    B
+        The operator B as a |VectorArray| from `A.source`.
+    C
+        The operator C as a |VectorArray| from `A.source`.
+    R
+        The matrix R as a 2D |NumPy array| or `None`.
+    trans
+        Whether the first |Operator| in the Riccati equation is
+        transposed.
+    options
+        The solver options to use (see
+        :func:`ricc_lrcf_solver_options`).
+    default_solver
+        Default solver to use (pymess_lrnm,
+        pymess_dense_nm_gmpcare).
+        If `None`, chose solver depending on dimension `A`.
+
+    Returns
+    -------
+    Z
+        Low-rank Cholesky factor of the Riccati equation solution,
+        |VectorArray| from `A.source`.
+    """
+    _solve_ricc_check_args(A, E, B, C, R, trans)
+    if default_solver is None:
+        default_solver = 'pymess_lrnm' if A.source.dim >= mat_eqn_sparse_min_size() else 'pymess_dense_nm_gmpcare'
+    options = _parse_options(options, ricc_lrcf_solver_options(), default_solver, None, False)
+
+    if options['type'] == 'pymess_dense_nm_gmpcare':
+        X = _call_pymess_dense_nm_gmpare(A, E, B, C, R, trans=trans, options=options['opts'], plus=False,
+                                         method_name='solve_ricc_lrcf')
+        Z = _chol(X)
+    elif options['type'] == 'pymess_lrnm':
+        if R is not None:
+            import scipy.linalg as spla
+            Rc = spla.cholesky(R)                                 # R = Rc^T * Rc
+            Rci = spla.solve_triangular(Rc, np.eye(Rc.shape[0]))  # R^{-1} = Rci * Rci^T
+            if not trans:
+                C = C.lincomb(Rci.T)  # C <- Rci^T * C = (C^T * Rci)^T
             else:
-                x = self.a.apply_adjoint(y)
-            return x.to_numpy().T
+                B = B.lincomb(Rci.T)  # B <- B * Rci
+        opts = options['opts']
+        opts.type = pymess.MESS_OP_NONE if not trans else pymess.MESS_OP_TRANSPOSE
+        eqn = RiccatiEquation(opts, A, E, B, C)
+        Z, status = pymess.lrnm(eqn, opts)
+        relres = status.res2_norm / status.res2_0
+        if relres > opts.adi.res2_tol:
+            logger = getLogger('pymor.bindings.pymess.solve_ricc_lrcf')
+            logger.warning(f'Desired relative residual tolerance was not achieved '
+                           f'({relres:e} > {opts.adi.res2_tol:e}).')
+    else:
+        raise ValueError(f'Unexpected Riccati equation solver ({options["type"]}).')
 
-        def ex_apply(self, op, y):
+    return A.source.from_numpy(Z.T)
+
+
+def pos_ricc_lrcf_solver_options():
+    """Return available positive Riccati solvers with default options for the pymess backend.
+
+    Returns
+    -------
+    A dict of available solvers with default solver options.
+    """
+    return {'pymess_dense_nm_gmpcare': {'type': 'pymess_dense_nm_gmpcare',
+                                        'opts': dense_nm_gmpcare_solver_options()}}
+
+
+def solve_pos_ricc_lrcf(A, E, B, C, R=None, trans=False, options=None):
+    """Compute an approximate low-rank solution of a positive Riccati equation.
+
+    See :func:`pymor.algorithms.riccati.solve_pos_ricc_lrcf` for a
+    general description.
+
+    This function uses `pymess.dense_nm_gmpcare`.
+
+    Parameters
+    ----------
+    A
+        The non-parametric |Operator| A.
+    E
+        The non-parametric |Operator| E or `None`.
+    B
+        The operator B as a |VectorArray| from `A.source`.
+    C
+        The operator C as a |VectorArray| from `A.source`.
+    R
+        The matrix R as a 2D |NumPy array| or `None`.
+    trans
+        Whether the first |Operator| in the Riccati equation is
+        transposed.
+    options
+        The solver options to use (see
+        :func:`pos_ricc_lrcf_solver_options`).
+
+    Returns
+    -------
+    Z
+        Low-rank Cholesky factor of the Riccati equation solution,
+        |VectorArray| from `A.source`.
+    """
+    _solve_ricc_check_args(A, E, B, C, R, trans)
+    options = _parse_options(options, pos_ricc_lrcf_solver_options(), 'pymess_dense_nm_gmpcare', None, False)
+
+    if options['type'] == 'pymess_dense_nm_gmpcare':
+        X = _call_pymess_dense_nm_gmpare(A, E, B, C, R, trans=trans, options=options['opts'], plus=True,
+                                         method_name='solve_pos_ricc_lrcf')
+        Z = _chol(X)
+    else:
+        raise ValueError(f'Unexpected positive Riccati equation solver ({options["type"]}).')
+
+    return A.source.from_numpy(Z.T)
+
+
+def _call_pymess_dense_nm_gmpare(A, E, B, C, R, trans=False, options=None, plus=False, method_name=''):
+    """Return the solution from pymess.dense_nm_gmpare solver."""
+    A = to_matrix(A, format='dense')
+    E = to_matrix(E, format='dense') if E else None
+    B = B.to_numpy().T
+    C = C.to_numpy()
+
+    Q = B.dot(B.T) if not trans else C.T.dot(C)
+    pymess_trans = pymess.MESS_OP_NONE if not trans else pymess.MESS_OP_TRANSPOSE
+    if not trans:
+        RinvC = spla.solve(R, C) if R is not None else C
+        G = C.T.dot(RinvC)
+    else:
+        RinvBT = spla.solve(R, B.T) if R is not None else B.T
+        G = B.dot(RinvBT)
+    X, absres, relres = pymess.dense_nm_gmpare(None,
+                                               A, E, Q, G,
+                                               plus=plus, trans=pymess_trans,
+                                               linesearch=options['linesearch'],
+                                               maxit=options['maxit'],
+                                               absres_tol=options['absres_tol'],
+                                               relres_tol=options['relres_tol'],
+                                               nrm=options['nrm'])
+    if absres > options['absres_tol']:
+        logger = getLogger('pymor.bindings.pymess.' + method_name)
+        logger.warning(f'Desired absolute residual tolerance was not achieved '
+                       f'({absres:e} > {options["absres_tol"]:e}).')
+    if relres > options['relres_tol']:
+        logger = getLogger('pymor.bindings.pymess.' + method_name)
+        logger.warning(f'Desired relative residual tolerance was not achieved '
+                       f'({relres:e} > {options["relres_tol"]:e}).')
+
+    return X
+
+
+class LyapunovEquation(pymess.Equation):
+    """Lyapunov equation class for pymess
+
+    Represents a (generalized) continuous-time algebraic Lyapunov
+    equation:
+
+    - if opt.type is `pymess.MESS_OP_NONE` and E is `None`:
+
+      .. math::
+          A X + X A^T + B B^T = 0,
+
+    - if opt.type is `pymess.MESS_OP_NONE` and E is not `None`:
+
+      .. math::
+          A X E^T + E X A^T + B B^T = 0,
+
+    - if opt.type is `pymess.MESS_OP_TRANSPOSE` and E is `None`:
+
+      .. math::
+          A^T X + X A + B^T B = 0,
+
+    - if opt.type is `pymess.MESS_OP_TRANSPOSE` and E is not `None`:
+
+      .. math::
+          A^T X E + E^T X A + B^T B = 0.
+
+    Parameters
+    ----------
+    opt
+        pymess Options structure.
+    A
+        The non-parametric |Operator| A.
+    E
+        The non-parametric |Operator| E or `None`.
+    B
+        The operator B as a |VectorArray| from `A.source`.
+    """
+
+    def __init__(self, opt, A, E, B):
+        super().__init__(name='LyapunovEquation', opt=opt, dim=A.source.dim)
+        self.a = A
+        self.e = E
+        self.rhs = B.to_numpy().T
+        self.p = []
+
+    def ax_apply(self, op, y):
+        y = self.a.source.from_numpy(y.T)
+        if op == pymess.MESS_OP_NONE:
+            x = self.a.apply(y)
+        else:
+            x = self.a.apply_adjoint(y)
+        return x.to_numpy().T
+
+    def ex_apply(self, op, y):
+        if self.e is None:
+            return y
+
+        y = self.a.source.from_numpy(y.T)
+        if op == pymess.MESS_OP_NONE:
+            x = self.e.apply(y)
+        else:
+            x = self.e.apply_adjoint(y)
+        return x.to_numpy().T
+
+    def ainv_apply(self, op, y):
+        y = self.a.source.from_numpy(y.T)
+        if op == pymess.MESS_OP_NONE:
+            x = self.a.apply_inverse(y)
+        else:
+            x = self.a.apply_inverse_adjoint(y)
+        return x.to_numpy().T
+
+    def einv_apply(self, op, y):
+        if self.e is None:
+            return y
+
+        y = self.a.source.from_numpy(y.T)
+        if op == pymess.MESS_OP_NONE:
+            x = self.e.apply_inverse(y)
+        else:
+            x = self.e.apply_inverse_adjoint(y)
+        return x.to_numpy().T
+
+    def apex_apply(self, op, p, idx_p, y):
+        y = self.a.source.from_numpy(y.T)
+        if op == pymess.MESS_OP_NONE:
+            x = self.a.apply(y)
             if self.e is None:
-                return y
-
-            y = self.a.source.from_numpy(y.T)
-            if op == pymess.MESS_OP_NONE:
-                x = self.e.apply(y)
+                x += p * y
             else:
-                x = self.e.apply_adjoint(y)
-            return x.to_numpy().T
-
-        def ainv_apply(self, op, y):
-            y = self.a.source.from_numpy(y.T)
-            if op == pymess.MESS_OP_NONE:
-                x = self.a.apply_inverse(y)
-            else:
-                x = self.a.apply_inverse_adjoint(y)
-            return x.to_numpy().T
-
-        def einv_apply(self, op, y):
+                x += p * self.e.apply(y)
+        else:
+            x = self.a.apply_adjoint(y)
             if self.e is None:
-                return y
-
-            y = self.a.source.from_numpy(y.T)
-            if op == pymess.MESS_OP_NONE:
-                x = self.e.apply_inverse(y)
+                x += p.conjugate() * y
             else:
-                x = self.e.apply_inverse_adjoint(y)
-            return x.to_numpy().T
+                x += p.conjugate() * self.e.apply_adjoint(y)
+        return x.to_numpy().T
 
-        def apex_apply(self, op, p, idx_p, y):
-            y = self.a.source.from_numpy(y.T)
-            if op == pymess.MESS_OP_NONE:
-                x = self.a.apply(y)
-                if self.e is None:
-                    x += p * y
-                else:
-                    x += p * self.e.apply(y)
-            else:
-                x = self.a.apply_adjoint(y)
-                if self.e is None:
-                    x += p.conjugate() * y
-                else:
-                    x += p.conjugate() * self.e.apply_adjoint(y)
-            return x.to_numpy().T
+    def apeinv_apply(self, op, p, idx_p, y):
+        y = self.a.source.from_numpy(y.T)
+        e = IdentityOperator(self.a.source) if self.e is None else self.e
 
-        def apeinv_apply(self, op, p, idx_p, y):
-            y = self.a.source.from_numpy(y.T)
-            e = IdentityOperator(self.a.source) if self.e is None else self.e
+        if p.imag == 0:
+            ape = self.a + p.real * e
+        else:
+            ape = self.a + p * e
 
-            if p.imag == 0:
-                ape = self.a + p.real * e
-            else:
-                ape = self.a + p * e
+        if op == pymess.MESS_OP_NONE:
+            x = ape.apply_inverse(y)
+        else:
+            x = ape.apply_inverse_adjoint(y.conj()).conj()
+        return x.to_numpy().T
 
-            if op == pymess.MESS_OP_NONE:
-                x = ape.apply_inverse(y)
-            else:
-                x = ape.apply_inverse_adjoint(y.conj()).conj()
-            return x.to_numpy().T
-
-        def parameter(self, arp_p, arp_m, B=None, K=None):
-            return None
+    def parameter(self, arp_p, arp_m, B=None, K=None):
+        return None
 
 
-if config.HAVE_PYMESS:
+class RiccatiEquation(pymess.Equation):
+    """Riccati equation class for pymess
 
-    class RiccatiEquation(pymess.Equation):
-        """Riccati equation class for pymess
+    Represents a Riccati equation
 
-        Represents a Riccati equation
+    - if opt.type is `pymess.MESS_OP_NONE` and E is `None`:
 
-        - if opt.type is `pymess.MESS_OP_NONE` and E is `None`:
+      .. math::
+          A X + X A^T - X C^T C X + B B^T = 0,
 
-          .. math::
-              A X + X A^T - X C^T C X + B B^T = 0,
+    - if opt.type is `pymess.MESS_OP_NONE` and E is not `None`:
 
-        - if opt.type is `pymess.MESS_OP_NONE` and E is not `None`:
+      .. math::
+          A X E^T + E X A^T - E X C^T C X E^T + B B^T = 0,
 
-          .. math::
-              A X E^T + E X A^T - E X C^T C X E^T + B B^T = 0,
+    - if opt.type is `pymess.MESS_OP_TRANSPOSE` and E is `None`:
 
-        - if opt.type is `pymess.MESS_OP_TRANSPOSE` and E is `None`:
+      .. math::
+          A^T X + X A - X B B^T X + C^T C = 0,
 
-          .. math::
-              A^T X + X A - X B B^T X + C^T C = 0,
+    - if opt.type is `pymess.MESS_OP_TRANSPOSE` and E is not `None`:
 
-        - if opt.type is `pymess.MESS_OP_TRANSPOSE` and E is not `None`:
+      .. math::
+          A^T X E + E^T X A - E X B B^T X E^T + C^T C = 0.
 
-          .. math::
-              A^T X E + E^T X A - E X B B^T X E^T + C^T C = 0.
+    Parameters
+    ----------
+    opt
+        pymess Options structure.
+    A
+        The non-parametric |Operator| A.
+    E
+        The non-parametric |Operator| E or `None`.
+    B
+        The operator B as a |VectorArray| from `A.source`.
+    C
+        The operator C as a |VectorArray| from `A.source`.
+    """
 
-        Parameters
-        ----------
-        opt
-            pymess Options structure.
-        A
-            The non-parametric |Operator| A.
-        E
-            The non-parametric |Operator| E or `None`.
-        B
-            The operator B as a |VectorArray| from `A.source`.
-        C
-            The operator C as a |VectorArray| from `A.source`.
-        """
+    def __init__(self, opt, A, E, B, C):
+        super().__init__(name='RiccatiEquation', opt=opt, dim=A.source.dim)
+        self.a = A
+        self.e = E
+        self.b = B.to_numpy().T
+        self.c = C.to_numpy()
+        self.rhs = self.b if opt.type == pymess.MESS_OP_NONE else self.c.T
+        self.p = []
 
-        def __init__(self, opt, A, E, B, C):
-            super().__init__(name='RiccatiEquation', opt=opt, dim=A.source.dim)
-            self.a = A
-            self.e = E
-            self.b = B.to_numpy().T
-            self.c = C.to_numpy()
-            self.rhs = self.b if opt.type == pymess.MESS_OP_NONE else self.c.T
-            self.p = []
+    def ax_apply(self, op, y):
+        y = self.a.source.from_numpy(y.T)
+        if op == pymess.MESS_OP_NONE:
+            x = self.a.apply(y)
+        else:
+            x = self.a.apply_adjoint(y)
+        return x.to_numpy().T
 
-        def ax_apply(self, op, y):
-            y = self.a.source.from_numpy(y.T)
-            if op == pymess.MESS_OP_NONE:
-                x = self.a.apply(y)
-            else:
-                x = self.a.apply_adjoint(y)
-            return x.to_numpy().T
+    def ex_apply(self, op, y):
+        if self.e is None:
+            return y
 
-        def ex_apply(self, op, y):
+        y = self.a.source.from_numpy(y.T)
+        if op == pymess.MESS_OP_NONE:
+            x = self.e.apply(y)
+        else:
+            x = self.e.apply_adjoint(y)
+        return x.to_numpy().T
+
+    def ainv_apply(self, op, y):
+        y = self.a.source.from_numpy(y.T)
+        if op == pymess.MESS_OP_NONE:
+            x = self.a.apply_inverse(y)
+        else:
+            x = self.a.apply_inverse_adjoint(y)
+        return x.to_numpy().T
+
+    def einv_apply(self, op, y):
+        if self.e is None:
+            return y
+
+        y = self.a.source.from_numpy(y.T)
+        if op == pymess.MESS_OP_NONE:
+            x = self.e.apply_inverse(y)
+        else:
+            x = self.e.apply_inverse_adjoint(y)
+        return x.to_numpy().T
+
+    def apex_apply(self, op, p, idx_p, y):
+        y = self.a.source.from_numpy(y.T)
+        if op == pymess.MESS_OP_NONE:
+            x = self.a.apply(y)
             if self.e is None:
-                return y
-
-            y = self.a.source.from_numpy(y.T)
-            if op == pymess.MESS_OP_NONE:
-                x = self.e.apply(y)
+                x += p * y
             else:
-                x = self.e.apply_adjoint(y)
-            return x.to_numpy().T
-
-        def ainv_apply(self, op, y):
-            y = self.a.source.from_numpy(y.T)
-            if op == pymess.MESS_OP_NONE:
-                x = self.a.apply_inverse(y)
-            else:
-                x = self.a.apply_inverse_adjoint(y)
-            return x.to_numpy().T
-
-        def einv_apply(self, op, y):
+                x += p * self.e.apply(y)
+        else:
+            x = self.a.apply_adjoint(y)
             if self.e is None:
-                return y
-
-            y = self.a.source.from_numpy(y.T)
-            if op == pymess.MESS_OP_NONE:
-                x = self.e.apply_inverse(y)
+                x += p.conjugate() * y
             else:
-                x = self.e.apply_inverse_adjoint(y)
-            return x.to_numpy().T
+                x += p.conjugate() * self.e.apply_adjoint(y)
+        return x.to_numpy().T
 
-        def apex_apply(self, op, p, idx_p, y):
-            y = self.a.source.from_numpy(y.T)
-            if op == pymess.MESS_OP_NONE:
-                x = self.a.apply(y)
-                if self.e is None:
-                    x += p * y
-                else:
-                    x += p * self.e.apply(y)
-            else:
-                x = self.a.apply_adjoint(y)
-                if self.e is None:
-                    x += p.conjugate() * y
-                else:
-                    x += p.conjugate() * self.e.apply_adjoint(y)
-            return x.to_numpy().T
+    def apeinv_apply(self, op, p, idx_p, y):
+        y = self.a.source.from_numpy(y.T)
+        e = IdentityOperator(self.a.source) if self.e is None else self.e
 
-        def apeinv_apply(self, op, p, idx_p, y):
-            y = self.a.source.from_numpy(y.T)
-            e = IdentityOperator(self.a.source) if self.e is None else self.e
+        if p.imag == 0:
+            ape = self.a + p.real * e
+        else:
+            ape = self.a + p * e
 
-            if p.imag == 0:
-                ape = self.a + p.real * e
-            else:
-                ape = self.a + p * e
+        if op == pymess.MESS_OP_NONE:
+            x = ape.apply_inverse(y)
+        else:
+            x = ape.apply_inverse_adjoint(y.conj()).conj()
+        return x.to_numpy().T
 
-            if op == pymess.MESS_OP_NONE:
-                x = ape.apply_inverse(y)
-            else:
-                x = ape.apply_inverse_adjoint(y.conj()).conj()
-            return x.to_numpy().T
-
-        def parameter(self, arp_p, arp_m, B=None, K=None):
-            return None
+    def parameter(self, arp_p, arp_m, B=None, K=None):
+        return None

--- a/src/pymor/bindings/slycot.py
+++ b/src/pymor/bindings/slycot.py
@@ -2,8 +2,8 @@
 # Copyright 2013-2021 pyMOR developers and contributors. All rights reserved.
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
-from pymor.core.config import require_dependency
-require_dependency('SLYCOT')
+from pymor.core.config import config
+config.require('SLYCOT')
 
 
 import numpy as np

--- a/src/pymor/bindings/slycot.py
+++ b/src/pymor/bindings/slycot.py
@@ -2,395 +2,375 @@
 # Copyright 2013-2021 pyMOR developers and contributors. All rights reserved.
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
-from pymor.core.config import config
+from pymor.core.config import require_dependency
+require_dependency('SLYCOT')
 
 
-if config.HAVE_SLYCOT:
-    import numpy as np
-    import scipy.linalg as spla
-    import slycot
+import numpy as np
+import scipy.linalg as spla
+import slycot
 
-    from pymor.algorithms.genericsolvers import _parse_options
-    from pymor.algorithms.lyapunov import _solve_lyap_lrcf_check_args, _solve_lyap_dense_check_args, _chol
-    from pymor.algorithms.riccati import _solve_ricc_dense_check_args
-    from pymor.algorithms.to_matrix import to_matrix
-    from pymor.bindings.scipy import _solve_ricc_check_args
-    from pymor.core.logger import getLogger
-
-    def lyap_lrcf_solver_options():
-        """Return available Lyapunov solvers with default options for the slycot backend.
-
-        Returns
-        -------
-        A dict of available solvers with default solver options.
-        """
-        return {'slycot_bartels-stewart': {'type': 'slycot_bartels-stewart'}}
+from pymor.algorithms.genericsolvers import _parse_options
+from pymor.algorithms.lyapunov import _solve_lyap_lrcf_check_args, _solve_lyap_dense_check_args, _chol
+from pymor.algorithms.riccati import _solve_ricc_dense_check_args
+from pymor.algorithms.to_matrix import to_matrix
+from pymor.bindings.scipy import _solve_ricc_check_args
+from pymor.core.logger import getLogger
 
 
-if config.HAVE_SLYCOT:
+def lyap_lrcf_solver_options():
+    """Return available Lyapunov solvers with default options for the slycot backend.
 
-    def solve_lyap_lrcf(A, E, B, trans=False, options=None):
-        """Compute an approximate low-rank solution of a Lyapunov equation.
-
-        See :func:`pymor.algorithms.lyapunov.solve_lyap_lrcf` for a
-        general description.
-
-        This function uses `slycot.sb03md` (if `E is None`) and
-        `slycot.sg03ad` (if `E is not None`), which are dense solvers
-        based on the Bartels-Stewart algorithm.
-        Therefore, we assume A and E can be converted to |NumPy arrays|
-        using :func:`~pymor.algorithms.to_matrix.to_matrix` and that
-        `B.to_numpy` is implemented.
-
-        Parameters
-        ----------
-        A
-            The non-parametric |Operator| A.
-        E
-            The non-parametric |Operator| E or `None`.
-        B
-            The operator B as a |VectorArray| from `A.source`.
-        trans
-            Whether the first |Operator| in the Lyapunov equation is
-            transposed.
-        options
-            The solver options to use (see
-            :func:`lyap_lrcf_solver_options`).
-
-        Returns
-        -------
-        Z
-            Low-rank Cholesky factor of the Lyapunov equation solution,
-            |VectorArray| from `A.source`.
-        """
-        _solve_lyap_lrcf_check_args(A, E, B, trans)
-        options = _parse_options(options, lyap_lrcf_solver_options(), 'slycot_bartels-stewart', None, False)
-
-        if options['type'] == 'slycot_bartels-stewart':
-            X = solve_lyap_dense(to_matrix(A, format='dense'),
-                                 to_matrix(E, format='dense') if E else None,
-                                 B.to_numpy().T if not trans else B.to_numpy(),
-                                 trans=trans, options=options)
-            Z = _chol(X)
-        else:
-            raise ValueError(f"Unexpected Lyapunov equation solver ({options['type']}).")
-
-        return A.source.from_numpy(Z.T)
+    Returns
+    -------
+    A dict of available solvers with default solver options.
+    """
+    return {'slycot_bartels-stewart': {'type': 'slycot_bartels-stewart'}}
 
 
-if config.HAVE_SLYCOT:
+def solve_lyap_lrcf(A, E, B, trans=False, options=None):
+    """Compute an approximate low-rank solution of a Lyapunov equation.
 
-    def lyap_dense_solver_options():
-        """Return available Lyapunov solvers with default options for the slycot backend.
+    See :func:`pymor.algorithms.lyapunov.solve_lyap_lrcf` for a
+    general description.
 
-        Returns
-        -------
-        A dict of available solvers with default solver options.
-        """
-        return {'slycot_bartels-stewart': {'type': 'slycot_bartels-stewart'}}
+    This function uses `slycot.sb03md` (if `E is None`) and
+    `slycot.sg03ad` (if `E is not None`), which are dense solvers
+    based on the Bartels-Stewart algorithm.
+    Therefore, we assume A and E can be converted to |NumPy arrays|
+    using :func:`~pymor.algorithms.to_matrix.to_matrix` and that
+    `B.to_numpy` is implemented.
 
+    Parameters
+    ----------
+    A
+        The non-parametric |Operator| A.
+    E
+        The non-parametric |Operator| E or `None`.
+    B
+        The operator B as a |VectorArray| from `A.source`.
+    trans
+        Whether the first |Operator| in the Lyapunov equation is
+        transposed.
+    options
+        The solver options to use (see
+        :func:`lyap_lrcf_solver_options`).
 
-if config.HAVE_SLYCOT:
-    def solve_lyap_dense(A, E, B, trans=False, options=None):
-        """Compute the solution of a Lyapunov equation.
+    Returns
+    -------
+    Z
+        Low-rank Cholesky factor of the Lyapunov equation solution,
+        |VectorArray| from `A.source`.
+    """
+    _solve_lyap_lrcf_check_args(A, E, B, trans)
+    options = _parse_options(options, lyap_lrcf_solver_options(), 'slycot_bartels-stewart', None, False)
 
-        See :func:`pymor.algorithms.lyapunov.solve_lyap_dense` for a
-        general description.
+    if options['type'] == 'slycot_bartels-stewart':
+        X = solve_lyap_dense(to_matrix(A, format='dense'),
+                             to_matrix(E, format='dense') if E else None,
+                             B.to_numpy().T if not trans else B.to_numpy(),
+                             trans=trans, options=options)
+        Z = _chol(X)
+    else:
+        raise ValueError(f"Unexpected Lyapunov equation solver ({options['type']}).")
 
-        This function uses `slycot.sb03md` (if `E is None`) and
-        `slycot.sg03ad` (if `E is not None`), which are based on the
-        Bartels-Stewart algorithm.
-
-        Parameters
-        ----------
-        A
-            The matrix A as a 2D |NumPy array|.
-        E
-            The matrix E as a 2D |NumPy array| or `None`.
-        B
-            The matrix B as a 2D |NumPy array|.
-        trans
-            Whether the first matrix in the Lyapunov equation is
-            transposed.
-        options
-            The solver options to use (see
-            :func:`lyap_dense_solver_options`).
-
-        Returns
-        -------
-        X
-            Lyapunov equation solution as a |NumPy array|.
-        """
-        _solve_lyap_dense_check_args(A, E, B, trans)
-        options = _parse_options(options, lyap_dense_solver_options(), 'slycot_bartels-stewart', None, False)
-
-        if options['type'] == 'slycot_bartels-stewart':
-            n = A.shape[0]
-            C = -B.dot(B.T) if not trans else -B.T.dot(B)
-            trana = 'T' if not trans else 'N'
-            dico = 'C'
-            job = 'B'
-            if E is None:
-                U = np.zeros((n, n))
-                X, scale, sep, ferr, _ = slycot.sb03md(n, C, A, U, dico, job=job, trana=trana)
-                _solve_check(A.dtype, 'slycot.sb03md', sep, ferr)
-            else:
-                fact = 'N'
-                uplo = 'L'
-                Q = np.zeros((n, n))
-                Z = np.zeros((n, n))
-                _, _, _, _, X, scale, sep, ferr, _, _, _ = slycot.sg03ad(dico, job, fact, trana, uplo,
-                                                                         n, A, E,
-                                                                         Q, Z, C)
-                _solve_check(A.dtype, 'slycot.sg03ad', sep, ferr)
-            X /= scale
-        else:
-            raise ValueError(f"Unexpected Lyapunov equation solver ({options['type']}).")
-
-        return X
+    return A.source.from_numpy(Z.T)
 
 
-if config.HAVE_SLYCOT:
+def lyap_dense_solver_options():
+    """Return available Lyapunov solvers with default options for the slycot backend.
 
-    def solve_ricc_dense(A, E, B, C, R=None, trans=False, options=None):
-        """Compute the solution of a Riccati equation.
+    Returns
+    -------
+    A dict of available solvers with default solver options.
+    """
+    return {'slycot_bartels-stewart': {'type': 'slycot_bartels-stewart'}}
 
-        See :func:`pymor.algorithms.riccati.solve_ricc_dense` for a
-        general description.
 
-        This function uses `slycot.sb02md` (if `E is None`) which is based on
-        the Schur vector approach and `slycot.sg02ad` (if `E is not None`) which
-        is based on the method of deflating subspaces.
+def solve_lyap_dense(A, E, B, trans=False, options=None):
+    """Compute the solution of a Lyapunov equation.
 
-        Parameters
-        ----------
-        A
-            The matrix A as a 2D |NumPy array|.
-        E
-            The matrix E as a 2D |NumPy array| or `None`.
-        B
-            The matrix B as a 2D |NumPy array|.
-        C
-            The matrix C as a 2D |NumPy array|.
-        R
-            The matrix R as a 2D |NumPy array| or `None`.
-        trans
-            Whether the first matrix in the Riccati equation is
-            transposed.
-        options
-            The solver options to use (see
-            :func:`ricc_dense_solver_options`).
+    See :func:`pymor.algorithms.lyapunov.solve_lyap_dense` for a
+    general description.
 
-        Returns
-        -------
-        X
-            Riccati equation solution as a |NumPy array|.
-        """
-        _solve_ricc_dense_check_args(A, E, B, C, R, trans)
-        options = _parse_options(options, ricc_dense_solver_options(), 'slycot', None, False)
+    This function uses `slycot.sb03md` (if `E is None`) and
+    `slycot.sg03ad` (if `E is not None`), which are based on the
+    Bartels-Stewart algorithm.
 
-        if options['type'] != 'slycot':
-            raise ValueError(f"Unexpected Riccati equation solver ({options['type']}).")
+    Parameters
+    ----------
+    A
+        The matrix A as a 2D |NumPy array|.
+    E
+        The matrix E as a 2D |NumPy array| or `None`.
+    B
+        The matrix B as a 2D |NumPy array|.
+    trans
+        Whether the first matrix in the Lyapunov equation is
+        transposed.
+    options
+        The solver options to use (see
+        :func:`lyap_dense_solver_options`).
 
-        dico = 'C'
+    Returns
+    -------
+    X
+        Lyapunov equation solution as a |NumPy array|.
+    """
+    _solve_lyap_dense_check_args(A, E, B, trans)
+    options = _parse_options(options, lyap_dense_solver_options(), 'slycot_bartels-stewart', None, False)
+
+    if options['type'] == 'slycot_bartels-stewart':
         n = A.shape[0]
-        if E is not None:
-            jobb = 'B'
-            fact = 'C'
-            uplo = 'U'
-            jobl = 'Z'
-            scal = 'N'
-            sort = 'S'
-            acc = 'R'
-            m = C.shape[0] if not trans else B.shape[1]
-            p = B.shape[1] if not trans else C.shape[0]
-            if R is None:
-                R = np.eye(m)
-            S = np.empty((n, m))
-            if not trans:
-                A = A.T
-                E = E.T
-                B, C = C.T, B.T
-            out = slycot.sg02ad(dico, jobb, fact, uplo, jobl, scal, sort, acc,
-                                n, m, p,
-                                A, E, B, C, R, S)
-            X = out[1]
-            rcond = out[0]
+        C = -B.dot(B.T) if not trans else -B.T.dot(B)
+        trana = 'T' if not trans else 'N'
+        dico = 'C'
+        job = 'B'
+        if E is None:
+            U = np.zeros((n, n))
+            X, scale, sep, ferr, _ = slycot.sb03md(n, C, A, U, dico, job=job, trana=trana)
+            _solve_check(A.dtype, 'slycot.sb03md', sep, ferr)
         else:
-            if trans:
-                if R is None:
-                    G = B @ B.T
-                else:
-                    G = B @ spla.solve(R, B.T)
-                Q = C.T @ C
-                X, rcond = slycot.sb02md(n, A, G, Q, dico)[:2]
-            else:
-                if R is None:
-                    G = C.T @ C
-                else:
-                    G = C.T @ spla.solve(R, C)
-                Q = B @ B.T
-                X, rcond = slycot.sb02md(n, A.T, G, Q, dico)[:2]
-        _ricc_rcond_check('slycot.sb02md', rcond)
+            fact = 'N'
+            uplo = 'L'
+            Q = np.zeros((n, n))
+            Z = np.zeros((n, n))
+            _, _, _, _, X, scale, sep, ferr, _, _, _ = slycot.sg03ad(dico, job, fact, trana, uplo,
+                                                                     n, A, E,
+                                                                     Q, Z, C)
+            _solve_check(A.dtype, 'slycot.sg03ad', sep, ferr)
+        X /= scale
+    else:
+        raise ValueError(f"Unexpected Lyapunov equation solver ({options['type']}).")
 
-        return X
+    return X
 
 
-if config.HAVE_SLYCOT:
+def solve_ricc_dense(A, E, B, C, R=None, trans=False, options=None):
+    """Compute the solution of a Riccati equation.
 
-    def ricc_dense_solver_options():
-        """Return available Riccati solvers with default options for the slycot backend.
+    See :func:`pymor.algorithms.riccati.solve_ricc_dense` for a
+    general description.
 
-        Returns
-        -------
-        A dict of available solvers with default solver options.
-        """
-        return {'slycot': {'type': 'slycot'}}
+    This function uses `slycot.sb02md` (if `E is None`) which is based on
+    the Schur vector approach and `slycot.sg02ad` (if `E is not None`) which
+    is based on the method of deflating subspaces.
 
+    Parameters
+    ----------
+    A
+        The matrix A as a 2D |NumPy array|.
+    E
+        The matrix E as a 2D |NumPy array| or `None`.
+    B
+        The matrix B as a 2D |NumPy array|.
+    C
+        The matrix C as a 2D |NumPy array|.
+    R
+        The matrix R as a 2D |NumPy array| or `None`.
+    trans
+        Whether the first matrix in the Riccati equation is
+        transposed.
+    options
+        The solver options to use (see
+        :func:`ricc_dense_solver_options`).
 
-if config.HAVE_SLYCOT:
+    Returns
+    -------
+    X
+        Riccati equation solution as a |NumPy array|.
+    """
+    _solve_ricc_dense_check_args(A, E, B, C, R, trans)
+    options = _parse_options(options, ricc_dense_solver_options(), 'slycot', None, False)
 
-    def _solve_check(dtype, solver, sep, ferr):
-        if ferr > 1e-1:
-            logger = getLogger(solver)
-            logger.warning(f'Estimated forward relative error bound is large (ferr={ferr:e}, sep={sep:e}). '
-                           f'Result may not be accurate.')
+    if options['type'] != 'slycot':
+        raise ValueError(f"Unexpected Riccati equation solver ({options['type']}).")
 
-
-if config.HAVE_SLYCOT:
-
-    def ricc_lrcf_solver_options():
-        """Return available Riccati solvers with default options for the slycot backend.
-
-        Returns
-        -------
-        A dict of available solvers with default solver options.
-        """
-        return {'slycot': {'type': 'slycot'}}
-
-
-if config.HAVE_SLYCOT:
-
-    def solve_ricc_lrcf(A, E, B, C, R=None, trans=False, options=None):
-        """Compute an approximate low-rank solution of a Riccati equation.
-
-        See :func:`pymor.algorithms.riccati.solve_ricc_lrcf` for a
-        general description.
-
-        This function uses `slycot.sb02md` (if E is `None`) or
-        `slycot.sg03ad` (if E is not `None`), which are dense solvers.
-        Therefore, we assume all |Operators| and |VectorArrays| can be
-        converted to |NumPy arrays| using
-        :func:`~pymor.algorithms.to_matrix.to_matrix` and
-        :func:`~pymor.vectorarrays.interface.VectorArray.to_numpy`.
-
-        Parameters
-        ----------
-        A
-            The non-parametric |Operator| A.
-        E
-            The non-parametric |Operator| E or `None`.
-        B
-            The operator B as a |VectorArray| from `A.source`.
-        C
-            The operator C as a |VectorArray| from `A.source`.
-        R
-            The matrix R as a 2D |NumPy array| or `None`.
-        trans
-            Whether the first |Operator| in the Riccati equation is
-            transposed.
-        options
-            The solver options to use (see
-            :func:`ricc_lrcf_solver_options`).
-
-        Returns
-        -------
-        Z
-            Low-rank Cholesky factor of the Riccati equation solution,
-            |VectorArray| from `A.source`.
-        """
-        _solve_ricc_check_args(A, E, B, C, R, trans)
-        options = _parse_options(options, ricc_lrcf_solver_options(), 'slycot', None, False)
-        if options['type'] != 'slycot':
-            raise ValueError(f"Unexpected Riccati equation solver ({options['type']}).")
-
-        A_source = A.source
-        A = to_matrix(A, format='dense')
-        E = to_matrix(E, format='dense') if E else None
-        B = B.to_numpy().T
-        C = C.to_numpy()
-
-        X = solve_ricc_dense(A, E, B, C, R, trans, options)
-
-        return A_source.from_numpy(_chol(X).T)
-
-
-if config.HAVE_SLYCOT:
-
-    def _ricc_rcond_check(solver, rcond):
-        if rcond < np.finfo(np.float64).eps:
-            logger = getLogger(solver)
-            logger.warning(f'Estimated reciprocal condition number is small (rcond={rcond:e}). '
-                           f'Result may not be accurate.')
-
-
-if config.HAVE_SLYCOT:
-
-    def pos_ricc_lrcf_solver_options():
-        """Return available positive Riccati solvers with default options for the slycot backend.
-
-        Returns
-        -------
-        A dict of available solvers with default solver options.
-        """
-        return {'slycot': {'type': 'slycot'}}
-
-
-if config.HAVE_SLYCOT:
-
-    def solve_pos_ricc_lrcf(A, E, B, C, R=None, trans=False, options=None):
-        """Compute an approximate low-rank solution of a positive Riccati equation.
-
-        See :func:`pymor.algorithms.riccati.solve_pos_ricc_lrcf` for a
-        general description.
-
-        This function uses `slycot.sb02md` (if E is `None`) or
-        `slycot.sg03ad` (if E is not `None`), which are dense solvers.
-        Therefore, we assume all |Operators| and |VectorArrays| can be
-        converted to |NumPy arrays| using
-        :func:`~pymor.algorithms.to_matrix.to_matrix` and
-        :func:`~pymor.vectorarrays.interface.VectorArray.to_numpy`.
-
-        Parameters
-        ----------
-        A
-            The non-parametric |Operator| A.
-        E
-            The non-parametric |Operator| E or `None`.
-        B
-            The operator B as a |VectorArray| from `A.source`.
-        C
-            The operator C as a |VectorArray| from `A.source`.
-        R
-            The matrix R as a 2D |NumPy array| or `None`.
-        trans
-            Whether the first |Operator| in the positive Riccati
-            equation is transposed.
-        options
-            The solver options to use (see
-            :func:`pos_ricc_lrcf_solver_options`).
-
-        Returns
-        -------
-        Z
-            Low-rank Cholesky factor of the positive Riccati equation
-            solution, |VectorArray| from `A.source`.
-        """
-        _solve_ricc_check_args(A, E, B, C, R, trans)
-        options = _parse_options(options, pos_ricc_lrcf_solver_options(), 'slycot', None, False)
-        if options['type'] != 'slycot':
-            raise ValueError(f"Unexpected positive Riccati equation solver ({options['type']}).")
-
+    dico = 'C'
+    n = A.shape[0]
+    if E is not None:
+        jobb = 'B'
+        fact = 'C'
+        uplo = 'U'
+        jobl = 'Z'
+        scal = 'N'
+        sort = 'S'
+        acc = 'R'
+        m = C.shape[0] if not trans else B.shape[1]
+        p = B.shape[1] if not trans else C.shape[0]
         if R is None:
-            R = np.eye(len(C) if not trans else len(B))
-        return solve_ricc_lrcf(A, E, B, C, -R, trans, options)
+            R = np.eye(m)
+        S = np.empty((n, m))
+        if not trans:
+            A = A.T
+            E = E.T
+            B, C = C.T, B.T
+        out = slycot.sg02ad(dico, jobb, fact, uplo, jobl, scal, sort, acc,
+                            n, m, p,
+                            A, E, B, C, R, S)
+        X = out[1]
+        rcond = out[0]
+    else:
+        if trans:
+            if R is None:
+                G = B @ B.T
+            else:
+                G = B @ spla.solve(R, B.T)
+            Q = C.T @ C
+            X, rcond = slycot.sb02md(n, A, G, Q, dico)[:2]
+        else:
+            if R is None:
+                G = C.T @ C
+            else:
+                G = C.T @ spla.solve(R, C)
+            Q = B @ B.T
+            X, rcond = slycot.sb02md(n, A.T, G, Q, dico)[:2]
+    _ricc_rcond_check('slycot.sb02md', rcond)
+
+    return X
+
+
+def ricc_dense_solver_options():
+    """Return available Riccati solvers with default options for the slycot backend.
+
+    Returns
+    -------
+    A dict of available solvers with default solver options.
+    """
+    return {'slycot': {'type': 'slycot'}}
+
+
+def _solve_check(dtype, solver, sep, ferr):
+    if ferr > 1e-1:
+        logger = getLogger(solver)
+        logger.warning(f'Estimated forward relative error bound is large (ferr={ferr:e}, sep={sep:e}). '
+                       f'Result may not be accurate.')
+
+
+def ricc_lrcf_solver_options():
+    """Return available Riccati solvers with default options for the slycot backend.
+
+    Returns
+    -------
+    A dict of available solvers with default solver options.
+    """
+    return {'slycot': {'type': 'slycot'}}
+
+
+def solve_ricc_lrcf(A, E, B, C, R=None, trans=False, options=None):
+    """Compute an approximate low-rank solution of a Riccati equation.
+
+    See :func:`pymor.algorithms.riccati.solve_ricc_lrcf` for a
+    general description.
+
+    This function uses `slycot.sb02md` (if E is `None`) or
+    `slycot.sg03ad` (if E is not `None`), which are dense solvers.
+    Therefore, we assume all |Operators| and |VectorArrays| can be
+    converted to |NumPy arrays| using
+    :func:`~pymor.algorithms.to_matrix.to_matrix` and
+    :func:`~pymor.vectorarrays.interface.VectorArray.to_numpy`.
+
+    Parameters
+    ----------
+    A
+        The non-parametric |Operator| A.
+    E
+        The non-parametric |Operator| E or `None`.
+    B
+        The operator B as a |VectorArray| from `A.source`.
+    C
+        The operator C as a |VectorArray| from `A.source`.
+    R
+        The matrix R as a 2D |NumPy array| or `None`.
+    trans
+        Whether the first |Operator| in the Riccati equation is
+        transposed.
+    options
+        The solver options to use (see
+        :func:`ricc_lrcf_solver_options`).
+
+    Returns
+    -------
+    Z
+        Low-rank Cholesky factor of the Riccati equation solution,
+        |VectorArray| from `A.source`.
+    """
+    _solve_ricc_check_args(A, E, B, C, R, trans)
+    options = _parse_options(options, ricc_lrcf_solver_options(), 'slycot', None, False)
+    if options['type'] != 'slycot':
+        raise ValueError(f"Unexpected Riccati equation solver ({options['type']}).")
+
+    A_source = A.source
+    A = to_matrix(A, format='dense')
+    E = to_matrix(E, format='dense') if E else None
+    B = B.to_numpy().T
+    C = C.to_numpy()
+
+    X = solve_ricc_dense(A, E, B, C, R, trans, options)
+
+    return A_source.from_numpy(_chol(X).T)
+
+
+def _ricc_rcond_check(solver, rcond):
+    if rcond < np.finfo(np.float64).eps:
+        logger = getLogger(solver)
+        logger.warning(f'Estimated reciprocal condition number is small (rcond={rcond:e}). '
+                       f'Result may not be accurate.')
+
+
+def pos_ricc_lrcf_solver_options():
+    """Return available positive Riccati solvers with default options for the slycot backend.
+
+    Returns
+    -------
+    A dict of available solvers with default solver options.
+    """
+    return {'slycot': {'type': 'slycot'}}
+
+
+def solve_pos_ricc_lrcf(A, E, B, C, R=None, trans=False, options=None):
+    """Compute an approximate low-rank solution of a positive Riccati equation.
+
+    See :func:`pymor.algorithms.riccati.solve_pos_ricc_lrcf` for a
+    general description.
+
+    This function uses `slycot.sb02md` (if E is `None`) or
+    `slycot.sg03ad` (if E is not `None`), which are dense solvers.
+    Therefore, we assume all |Operators| and |VectorArrays| can be
+    converted to |NumPy arrays| using
+    :func:`~pymor.algorithms.to_matrix.to_matrix` and
+    :func:`~pymor.vectorarrays.interface.VectorArray.to_numpy`.
+
+    Parameters
+    ----------
+    A
+        The non-parametric |Operator| A.
+    E
+        The non-parametric |Operator| E or `None`.
+    B
+        The operator B as a |VectorArray| from `A.source`.
+    C
+        The operator C as a |VectorArray| from `A.source`.
+    R
+        The matrix R as a 2D |NumPy array| or `None`.
+    trans
+        Whether the first |Operator| in the positive Riccati
+        equation is transposed.
+    options
+        The solver options to use (see
+        :func:`pos_ricc_lrcf_solver_options`).
+
+    Returns
+    -------
+    Z
+        Low-rank Cholesky factor of the positive Riccati equation
+        solution, |VectorArray| from `A.source`.
+    """
+    _solve_ricc_check_args(A, E, B, C, R, trans)
+    options = _parse_options(options, pos_ricc_lrcf_solver_options(), 'slycot', None, False)
+    if options['type'] != 'slycot':
+        raise ValueError(f"Unexpected positive Riccati equation solver ({options['type']}).")
+
+    if R is None:
+        R = np.eye(len(C) if not trans else len(B))
+    return solve_ricc_lrcf(A, E, B, C, -R, trans, options)

--- a/src/pymor/core/config.py
+++ b/src/pymor/core/config.py
@@ -8,6 +8,19 @@ import platform
 import sys
 import warnings
 
+from pymor.core.exceptions import DependencyMissing, QtMissing, TorchMissing
+
+
+def require_dependency(dependency):
+    dependency = dependency.upper()
+    if not getattr(config, f'HAVE_{dependency}'):
+        if dependency == 'QT':
+            raise QtMissing
+        elif dependency == 'TORCH':
+            raise TorchMissing
+        else:
+            raise DependencyMissing(dependency)
+
 
 def _can_import(module):
     def _can_import_single(m):

--- a/src/pymor/core/config.py
+++ b/src/pymor/core/config.py
@@ -11,17 +11,6 @@ import warnings
 from pymor.core.exceptions import DependencyMissing, QtMissing, TorchMissing
 
 
-def require_dependency(dependency):
-    dependency = dependency.upper()
-    if not getattr(config, f'HAVE_{dependency}'):
-        if dependency == 'QT':
-            raise QtMissing
-        elif dependency == 'TORCH':
-            raise TorchMissing
-        else:
-            raise DependencyMissing(dependency)
-
-
 def _can_import(module):
     def _can_import_single(m):
         try:
@@ -178,6 +167,16 @@ class Config:
     def version(self):
         from pymor import __version__
         return __version__
+
+    def require(self, dependency):
+        dependency = dependency.upper()
+        if not getattr(self, f'HAVE_{dependency}'):
+            if dependency == 'QT':
+                raise QtMissing
+            elif dependency == 'TORCH':
+                raise TorchMissing
+            else:
+                raise DependencyMissing(dependency)
 
     def __getattr__(self, name):
         if name.startswith('HAVE_'):

--- a/src/pymor/core/defaults.py
+++ b/src/pymor/core/defaults.py
@@ -54,6 +54,7 @@ import pkgutil
 import textwrap
 import threading
 
+from pymor.core.exceptions import DependencyMissing
 from pymor.tools.table import format_table
 
 
@@ -253,6 +254,8 @@ def _import_all(package_name='pymor'):
         for p in pkgutil.walk_packages(package.__path__, package_name + '.', onerror=onerror):
             try:
                 importlib.import_module(p[1])
+            except DependencyMissing:
+                pass
             except ImportError:
                 from pymor.core.logger import getLogger
                 logger = getLogger('pymor.core.defaults._import_all')

--- a/src/pymor/core/exceptions.py
+++ b/src/pymor/core/exceptions.py
@@ -59,20 +59,28 @@ class NeuralNetworkTrainingFailed(Exception):
     """Is raised when training of a neural network fails."""
 
 
-class QtMissing(ImportError):
+class DependencyMissing(ImportError):
+    """Raised when optional packages are required but are not installed."""
+
+    def __init__(self, dependency, msg=None):
+        self.dependency = dependency
+        super().__init__(msg or f'optional dependency {dependency} required')
+
+
+class QtMissing(DependencyMissing):
     """Raise me where having importable Qt bindings is non-optional"""
 
     def __init__(self, msg=None):
         msg = msg or 'cannot visualize: import of Qt bindings failed'
-        super().__init__(msg)
+        super().__init__('QT', msg)
 
 
-class TorchMissing(ImportError):
+class TorchMissing(DependencyMissing):
     """Raise me where having importable torch version is non-optional"""
 
     def __init__(self, msg=None):
         msg = msg or 'cannot use neural networks: import of torch failed'
-        super().__init__(msg)
+        super().__init__('TORCH', msg)
 
 
 class RuleNotMatchingError(NotImplementedError):

--- a/src/pymor/discretizers/builtin/grids/vtkio.py
+++ b/src/pymor/discretizers/builtin/grids/vtkio.py
@@ -2,20 +2,15 @@
 # Copyright 2013-2021 pyMOR developers and contributors. All rights reserved.
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
-from pymor.core.config import config
-from pymor.core.exceptions import IOLibsMissing
+from pymor.core.config import require_dependency
+require_dependency('VTKIO')
 
-if config.HAVE_VTKIO:
 
-    from pymor.discretizers.builtin.grids.io import to_meshio
-    from pymor.tools.io.vtk import write_vtk_collection
+from pymor.discretizers.builtin.grids.io import to_meshio
+from pymor.tools.io.vtk import write_vtk_collection
 
-    def write_vtk(grid, data, filename_base, codim=2, metadata=None):
-        """Convenience function around write_vtk_collection(to_meshio(...))"""
-        return write_vtk_collection(meshes=to_meshio(grid, data, codim=codim),
-                                    filename_base=filename_base, metadata=metadata)
 
-else:
-
-    def write_vtk(*args, **kwargs):
-        raise IOLibsMissing()
+def write_vtk(grid, data, filename_base, codim=2, metadata=None):
+    """Convenience function around write_vtk_collection(to_meshio(...))"""
+    return write_vtk_collection(meshes=to_meshio(grid, data, codim=codim),
+                                filename_base=filename_base, metadata=metadata)

--- a/src/pymor/discretizers/builtin/grids/vtkio.py
+++ b/src/pymor/discretizers/builtin/grids/vtkio.py
@@ -2,8 +2,8 @@
 # Copyright 2013-2021 pyMOR developers and contributors. All rights reserved.
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
-from pymor.core.config import require_dependency
-require_dependency('VTKIO')
+from pymor.core.config import config
+config.require('VTKIO')
 
 
 from pymor.discretizers.builtin.grids.io import to_meshio

--- a/src/pymor/discretizers/builtin/gui/gl.py
+++ b/src/pymor/discretizers/builtin/gui/gl.py
@@ -11,310 +11,308 @@ intended to be used directly. Instead, use
 :class:`~pymor.discretizers.builtin.gui.qt.PatchVisualizer`.
 """
 
+from pymor.core.config import require_dependency
+require_dependency('QT')
+require_dependency('QTOPENGL')
+require_dependency('GL')
+
 import math as m
 
 import numpy as np
+import OpenGL.GL as gl
+from qtpy.QtWidgets import QSizePolicy, QOpenGLWidget
+from qtpy.QtGui import QPainter, QFontMetrics
+from ctypes import c_void_p
 
-from pymor.core.config import config
+from pymor.core.defaults import defaults
+from pymor.discretizers.builtin.grids.constructions import flatten_grid
+from pymor.discretizers.builtin.grids.referenceelements import triangle, square
 
 
-if config.HAVE_QT and config.HAVE_QTOPENGL and config.HAVE_GL:
-    import OpenGL.GL as gl
-    from qtpy.QtWidgets import QSizePolicy, QOpenGLWidget
-    from qtpy.QtGui import QPainter, QFontMetrics
-    from ctypes import c_void_p
+def compile_shader(source, vertex=True):
+    """Compile a vertex shader from source."""
+    shader_type = gl.GL_VERTEX_SHADER if vertex else gl.GL_FRAGMENT_SHADER
+    shader = gl.glCreateShader(shader_type)
+    gl.glShaderSource(shader, source)
+    gl.glCompileShader(shader)
+    # check compilation error
+    result = gl.glGetShaderiv(shader, gl.GL_COMPILE_STATUS)
+    if not result:
+        raise RuntimeError(gl.glGetShaderInfoLog(shader))
+    return shader
 
-    from pymor.core.defaults import defaults
-    from pymor.discretizers.builtin.grids.constructions import flatten_grid
-    from pymor.discretizers.builtin.grids.referenceelements import triangle, square
 
-    def compile_shader(source, vertex=True):
-        """Compile a vertex shader from source."""
-        shader_type = gl.GL_VERTEX_SHADER if vertex else gl.GL_FRAGMENT_SHADER
-        shader = gl.glCreateShader(shader_type)
-        gl.glShaderSource(shader, source)
-        gl.glCompileShader(shader)
-        # check compilation error
-        result = gl.glGetShaderiv(shader, gl.GL_COMPILE_STATUS)
-        if not result:
-            raise RuntimeError(gl.glGetShaderInfoLog(shader))
-        return shader
+def link_shader_program(shaders):
+    """Create a shader program with from compiled shaders."""
+    program = gl.glCreateProgram()
+    for shader in shaders:
+        gl.glAttachShader(program, shader)
+    gl.glLinkProgram(program)
+    # check linking error
+    result = gl.glGetProgramiv(program, gl.GL_LINK_STATUS)
+    if not result:
+        raise RuntimeError(gl.glGetProgramInfoLog(program))
+    return program
 
-    def link_shader_program(shaders):
-        """Create a shader program with from compiled shaders."""
-        program = gl.glCreateProgram()
-        for shader in shaders:
-            gl.glAttachShader(program, shader)
-        gl.glLinkProgram(program)
-        # check linking error
-        result = gl.glGetProgramiv(program, gl.GL_LINK_STATUS)
-        if not result:
-            raise RuntimeError(gl.glGetProgramInfoLog(program))
-        return program
 
-    VS = """
-    #version 120
-    // Attribute variable that contains coordinates of the vertices.
-    attribute vec3 position;
-    varying float value;
+VS = """
+#version 120
+// Attribute variable that contains coordinates of the vertices.
+attribute vec3 position;
+varying float value;
 
-    void main()
-    {
-        gl_Position.xy = position.xy;
-        gl_Position.z = 0.;
-        gl_Position.w = 1.;
-        value = position.z;
-    }
-    """
+void main()
+{
+    gl_Position.xy = position.xy;
+    gl_Position.z = 0.;
+    gl_Position.w = 1.;
+    value = position.z;
+}
+"""
 
-    FS = """
-    #version 120
+FS = """
+#version 120
 
-    uniform sampler1D colormap;
+uniform sampler1D colormap;
 
-    varying float value;
+varying float value;
 
-    void main()
-    {
-        gl_FragColor = texture1D(colormap, value);
-    }
-    """
+void main()
+{
+    gl_FragColor = texture1D(colormap, value);
+}
+"""
 
-    @defaults('name')
-    def colormap_texture(name='viridis'):
-        resolution = min(gl.GL_MAX_TEXTURE_SIZE, 1024)
-        colormap_id = gl.glGenTextures(1)
-        gl.glBindTexture(gl.GL_TEXTURE_1D, colormap_id)
-        gl.glTexParameteri(gl.GL_TEXTURE_1D, gl.GL_TEXTURE_MAG_FILTER, gl.GL_NEAREST)
-        gl.glTexParameteri(gl.GL_TEXTURE_1D, gl.GL_TEXTURE_MIN_FILTER, gl.GL_NEAREST)
-        gl.glTexParameteri(gl.GL_TEXTURE_1D, gl.GL_TEXTURE_WRAP_S, gl.GL_CLAMP_TO_EDGE)
-        colormap = np.empty((resolution, 4), dtype='f4')
-        from matplotlib.pyplot import get_cmap
-        try:
-            cmap = get_cmap(name)
-        except ValueError:
-            from pymor.core.logger import getLogger
-            # this is our default which might not exist for older matplotlib
-            # so a warning would be annoying
-            if name != 'viridis':
-                msg = f'Unknown colormap {name}, using default colormap'
-                getLogger('pymor.discretizers.builtin.gui.gl.colormap_texture').warning(msg)
-            cmap = get_cmap()
-        colormap[:] = cmap(np.linspace(0., 1., resolution))
-        gl.glTexImage1D(gl.GL_TEXTURE_1D, 0, gl.GL_RGBA, resolution, 0, gl.GL_RGBA, gl.GL_FLOAT, colormap)
-        gl.glBindTexture(gl.GL_TEXTURE_1D, 0)
-        return colormap_id
 
-    class GLPatchWidget(QOpenGLWidget):
+@defaults('name')
+def colormap_texture(name='viridis'):
+    resolution = min(gl.GL_MAX_TEXTURE_SIZE, 1024)
+    colormap_id = gl.glGenTextures(1)
+    gl.glBindTexture(gl.GL_TEXTURE_1D, colormap_id)
+    gl.glTexParameteri(gl.GL_TEXTURE_1D, gl.GL_TEXTURE_MAG_FILTER, gl.GL_NEAREST)
+    gl.glTexParameteri(gl.GL_TEXTURE_1D, gl.GL_TEXTURE_MIN_FILTER, gl.GL_NEAREST)
+    gl.glTexParameteri(gl.GL_TEXTURE_1D, gl.GL_TEXTURE_WRAP_S, gl.GL_CLAMP_TO_EDGE)
+    colormap = np.empty((resolution, 4), dtype='f4')
+    from matplotlib.pyplot import get_cmap
+    try:
+        cmap = get_cmap(name)
+    except ValueError:
+        from pymor.core.logger import getLogger
+        # this is our default which might not exist for older matplotlib
+        # so a warning would be annoying
+        if name != 'viridis':
+            msg = f'Unknown colormap {name}, using default colormap'
+            getLogger('pymor.discretizers.builtin.gui.gl.colormap_texture').warning(msg)
+        cmap = get_cmap()
+    colormap[:] = cmap(np.linspace(0., 1., resolution))
+    gl.glTexImage1D(gl.GL_TEXTURE_1D, 0, gl.GL_RGBA, resolution, 0, gl.GL_RGBA, gl.GL_FLOAT, colormap)
+    gl.glBindTexture(gl.GL_TEXTURE_1D, 0)
+    return colormap_id
 
-        def __init__(self, parent, grid, vmin=None, vmax=None, bounding_box=([0, 0], [1, 1]), codim=2):
-            assert grid.reference_element in (triangle, square)
-            assert grid.dim == 2
-            assert codim in (0, 2)
-            super().__init__(parent)
-            self.setMinimumSize(300, 300)
-            self.setSizePolicy(QSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding))
 
-            subentities, coordinates, entity_map = flatten_grid(grid)
+class GLPatchWidget(QOpenGLWidget):
 
-            self.subentities = subentities
-            self.entity_map = entity_map
-            self.reference_element = grid.reference_element
-            self.vmin = vmin
-            self.vmax = vmax
-            self.bounding_box = bounding_box
-            self.codim = codim
-            self.update_vbo = False
-            bb = self.bounding_box
-            self.size = np.array([bb[1][0] - bb[0][0], bb[1][1] - bb[0][1]])
-            self.scale = 2 / self.size
-            self.shift = - np.array(bb[0]) - self.size / 2
+    def __init__(self, parent, grid, vmin=None, vmax=None, bounding_box=([0, 0], [1, 1]), codim=2):
+        assert grid.reference_element in (triangle, square)
+        assert grid.dim == 2
+        assert codim in (0, 2)
+        super().__init__(parent)
+        self.setMinimumSize(300, 300)
+        self.setSizePolicy(QSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding))
 
-            # setup buffers
-            buffer_dtype = [('position', 'f4', 2), ('color', 'f4')]
-            if self.reference_element == triangle:
-                if codim == 2:
-                    self.vertex_data = np.empty(len(coordinates), dtype=buffer_dtype)
-                    self.indices = subentities
-                else:
-                    self.vertex_data = np.empty(len(subentities) * 3, dtype=buffer_dtype)
-                    self.indices = np.arange(len(subentities) * 3, dtype=np.uint32)
+        subentities, coordinates, entity_map = flatten_grid(grid)
+
+        self.subentities = subentities
+        self.entity_map = entity_map
+        self.reference_element = grid.reference_element
+        self.vmin = vmin
+        self.vmax = vmax
+        self.bounding_box = bounding_box
+        self.codim = codim
+        self.update_vbo = False
+        bb = self.bounding_box
+        self.size = np.array([bb[1][0] - bb[0][0], bb[1][1] - bb[0][1]])
+        self.scale = 2 / self.size
+        self.shift = - np.array(bb[0]) - self.size / 2
+
+        # setup buffers
+        buffer_dtype = [('position', 'f4', 2), ('color', 'f4')]
+        if self.reference_element == triangle:
+            if codim == 2:
+                self.vertex_data = np.empty(len(coordinates), dtype=buffer_dtype)
+                self.indices = subentities
             else:
-                if codim == 2:
-                    self.vertex_data = np.empty(len(coordinates), dtype=buffer_dtype)
-                    self.indices = np.vstack((subentities[:, 0:3], subentities[:, [0, 2, 3]]))
-                else:
-                    self.vertex_data = np.empty(len(subentities) * 6, dtype=buffer_dtype)
-                    self.indices = np.arange(len(subentities) * 6, dtype=np.uint32)
-            self.indices = np.ascontiguousarray(self.indices)
+                self.vertex_data = np.empty(len(subentities) * 3, dtype=buffer_dtype)
+                self.indices = np.arange(len(subentities) * 3, dtype=np.uint32)
+        else:
+            if codim == 2:
+                self.vertex_data = np.empty(len(coordinates), dtype=buffer_dtype)
+                self.indices = np.vstack((subentities[:, 0:3], subentities[:, [0, 2, 3]]))
+            else:
+                self.vertex_data = np.empty(len(subentities) * 6, dtype=buffer_dtype)
+                self.indices = np.arange(len(subentities) * 6, dtype=np.uint32)
+        self.indices = np.ascontiguousarray(self.indices)
 
-            self.vertex_data['color'] = 1
+        self.vertex_data['color'] = 1
 
-            self.set_coordinates(coordinates)
-            self.set(np.zeros(grid.size(codim)))
+        self.set_coordinates(coordinates)
+        self.set(np.zeros(grid.size(codim)))
 
-        def resizeGL(self, w, h):
-            gl.glViewport(0, 0, w, h)
-            gl.glLoadIdentity()
-            self.update()
+    def resizeGL(self, w, h):
+        gl.glViewport(0, 0, w, h)
+        gl.glLoadIdentity()
+        self.update()
 
-        def initializeGL(self):
-            gl.glClearColor(1.0, 1.0, 1.0, 1.0)
+    def initializeGL(self):
+        gl.glClearColor(1.0, 1.0, 1.0, 1.0)
 
-            self.shaders_program = link_shader_program([compile_shader(VS, vertex=True),
-                                                        compile_shader(FS, vertex=False)])
-            gl.glUseProgram(self.shaders_program)
+        self.shaders_program = link_shader_program([compile_shader(VS, vertex=True),
+                                                    compile_shader(FS, vertex=False)])
+        gl.glUseProgram(self.shaders_program)
 
-            self.vertices_id = gl.glGenBuffers(1)
+        self.vertices_id = gl.glGenBuffers(1)
+        gl.glBindBuffer(gl.GL_ARRAY_BUFFER, self.vertices_id)
+        gl.glBufferData(gl.GL_ARRAY_BUFFER, self.vertex_data, gl.GL_DYNAMIC_DRAW)
+        gl.glBindBuffer(gl.GL_ARRAY_BUFFER, 0)
+
+        self.indices_id = gl.glGenBuffers(1)
+        gl.glBindBuffer(gl.GL_ELEMENT_ARRAY_BUFFER, self.indices_id)
+        gl.glBufferData(gl.GL_ELEMENT_ARRAY_BUFFER, self.indices, gl.GL_STATIC_DRAW)
+        gl.glBindBuffer(gl.GL_ELEMENT_ARRAY_BUFFER, 0)
+
+        self.colormap_id = colormap_texture()
+        self.colormap_location = gl.glGetUniformLocation(self.shaders_program, 'colormap')
+
+    def paintGL(self):
+        if self.update_vbo:
             gl.glBindBuffer(gl.GL_ARRAY_BUFFER, self.vertices_id)
             gl.glBufferData(gl.GL_ARRAY_BUFFER, self.vertex_data, gl.GL_DYNAMIC_DRAW)
             gl.glBindBuffer(gl.GL_ARRAY_BUFFER, 0)
+            self.update_vbo = False
 
-            self.indices_id = gl.glGenBuffers(1)
-            gl.glBindBuffer(gl.GL_ELEMENT_ARRAY_BUFFER, self.indices_id)
-            gl.glBufferData(gl.GL_ELEMENT_ARRAY_BUFFER, self.indices, gl.GL_STATIC_DRAW)
-            gl.glBindBuffer(gl.GL_ELEMENT_ARRAY_BUFFER, 0)
+        gl.glClear(gl.GL_COLOR_BUFFER_BIT | gl.GL_DEPTH_BUFFER_BIT)
 
-            self.colormap_id = colormap_texture()
-            self.colormap_location = gl.glGetUniformLocation(self.shaders_program, 'colormap')
+        gl.glUniform1i(self.colormap_location, 0)
+        gl.glActiveTexture(gl.GL_TEXTURE0 + 0)
+        gl.glBindTexture(gl.GL_TEXTURE_1D, self.colormap_id)
 
-        def paintGL(self):
-            if self.update_vbo:
-                gl.glBindBuffer(gl.GL_ARRAY_BUFFER, self.vertices_id)
-                gl.glBufferData(gl.GL_ARRAY_BUFFER, self.vertex_data, gl.GL_DYNAMIC_DRAW)
-                gl.glBindBuffer(gl.GL_ARRAY_BUFFER, 0)
-                self.update_vbo = False
+        gl.glPushClientAttrib(gl.GL_CLIENT_VERTEX_ARRAY_BIT)
+        gl.glBindBuffer(gl.GL_ARRAY_BUFFER, self.vertices_id)
+        gl.glBindBuffer(gl.GL_ELEMENT_ARRAY_BUFFER, self.indices_id)
 
-            gl.glClear(gl.GL_COLOR_BUFFER_BIT | gl.GL_DEPTH_BUFFER_BIT)
+        gl.glVertexPointer(3, gl.GL_FLOAT, 0, c_void_p(None))
+        gl.glEnableClientState(gl.GL_VERTEX_ARRAY)
+        gl.glDrawElements(gl.GL_TRIANGLES, self.indices.size, gl.GL_UNSIGNED_INT, None)
+        gl.glBindBuffer(gl.GL_ELEMENT_ARRAY_BUFFER, 0)
+        gl.glBindBuffer(gl.GL_ARRAY_BUFFER, 0)
+        gl.glPopClientAttrib()
 
-            gl.glUniform1i(self.colormap_location, 0)
-            gl.glActiveTexture(gl.GL_TEXTURE0 + 0)
-            gl.glBindTexture(gl.GL_TEXTURE_1D, self.colormap_id)
+    def set_coordinates(self, coordinates):
+        if self.codim == 2:
+            self.vertex_data['position'][:, 0:2] = coordinates
+            self.vertex_data['position'][:, 0:2] += self.shift
+            self.vertex_data['position'][:, 0:2] *= self.scale
+        elif self.reference_element == triangle:
+            VERTEX_POS = coordinates[self.subentities]
+            VERTEX_POS += self.shift
+            VERTEX_POS *= self.scale
+            self.vertex_data['position'][:, 0:2] = VERTEX_POS.reshape((-1, 2))
+        else:
+            num_entities = len(self.subentities)
+            VERTEX_POS = coordinates[self.subentities]
+            VERTEX_POS += self.shift
+            VERTEX_POS *= self.scale
+            self.vertex_data['position'][0:num_entities * 3, 0:2] = VERTEX_POS[:, 0:3, :].reshape((-1, 2))
+            self.vertex_data['position'][num_entities * 3:, 0:2] = VERTEX_POS[:, [0, 2, 3], :].reshape((-1, 2))
+        self.update_vbo = True
+        self.update()
 
-            gl.glPushClientAttrib(gl.GL_CLIENT_VERTEX_ARRAY_BIT)
-            gl.glBindBuffer(gl.GL_ARRAY_BUFFER, self.vertices_id)
-            gl.glBindBuffer(gl.GL_ELEMENT_ARRAY_BUFFER, self.indices_id)
+    def set(self, U, vmin=None, vmax=None):
+        self.vmin = self.vmin if vmin is None else vmin
+        self.vmax = self.vmax if vmax is None else vmax
 
-            gl.glVertexPointer(3, gl.GL_FLOAT, 0, c_void_p(None))
-            gl.glEnableClientState(gl.GL_VERTEX_ARRAY)
-            gl.glDrawElements(gl.GL_TRIANGLES, self.indices.size, gl.GL_UNSIGNED_INT, None)
-            gl.glBindBuffer(gl.GL_ELEMENT_ARRAY_BUFFER, 0)
-            gl.glBindBuffer(gl.GL_ARRAY_BUFFER, 0)
-            gl.glPopClientAttrib()
+        U_buffer = self.vertex_data['color']
+        if self.codim == 2:
+            U_buffer[:] = U[self.entity_map]
+        elif self.reference_element == triangle:
+            U_buffer[:] = np.repeat(U, 3)
+        else:
+            U_buffer[:] = np.tile(np.repeat(U, 3), 2)
 
-        def set_coordinates(self, coordinates):
-            if self.codim == 2:
-                self.vertex_data['position'][:, 0:2] = coordinates
-                self.vertex_data['position'][:, 0:2] += self.shift
-                self.vertex_data['position'][:, 0:2] *= self.scale
-            elif self.reference_element == triangle:
-                VERTEX_POS = coordinates[self.subentities]
-                VERTEX_POS += self.shift
-                VERTEX_POS *= self.scale
-                self.vertex_data['position'][:, 0:2] = VERTEX_POS.reshape((-1, 2))
-            else:
-                num_entities = len(self.subentities)
-                VERTEX_POS = coordinates[self.subentities]
-                VERTEX_POS += self.shift
-                VERTEX_POS *= self.scale
-                self.vertex_data['position'][0:num_entities * 3, 0:2] = VERTEX_POS[:, 0:3, :].reshape((-1, 2))
-                self.vertex_data['position'][num_entities * 3:, 0:2] = VERTEX_POS[:, [0, 2, 3], :].reshape((-1, 2))
-            self.update_vbo = True
-            self.update()
+        # normalize
+        vmin = np.min(U) if self.vmin is None else self.vmin
+        vmax = np.max(U) if self.vmax is None else self.vmax
+        U_buffer -= vmin
+        if (vmax - vmin) > 0:
+            U_buffer /= float(vmax - vmin)
 
-        def set(self, U, vmin=None, vmax=None):
-            self.vmin = self.vmin if vmin is None else vmin
-            self.vmax = self.vmax if vmax is None else vmax
+        self.update_vbo = True
+        self.update()
 
-            U_buffer = self.vertex_data['color']
-            if self.codim == 2:
-                U_buffer[:] = U[self.entity_map]
-            elif self.reference_element == triangle:
-                U_buffer[:] = np.repeat(U, 3)
-            else:
-                U_buffer[:] = np.tile(np.repeat(U, 3), 2)
 
-            # normalize
-            vmin = np.min(U) if self.vmin is None else self.vmin
-            vmax = np.max(U) if self.vmax is None else self.vmax
-            U_buffer -= vmin
-            if (vmax - vmin) > 0:
-                U_buffer /= float(vmax - vmin)
+class ColorBarWidget(QOpenGLWidget):
 
-            self.update_vbo = True
-            self.update()
+    def __init__(self, parent, U=None, vmin=None, vmax=None):
+        super().__init__(parent)
+        self.setSizePolicy(QSizePolicy(QSizePolicy.Fixed, QSizePolicy.Expanding))
+        self.set(U, vmin, vmax)
 
-    class ColorBarWidget(QOpenGLWidget):
+    def resizeGL(self, w, h):
+        gl.glViewport(0, 0, w, h)
+        gl.glLoadIdentity()
+        self.update()
 
-        def __init__(self, parent, U=None, vmin=None, vmax=None):
-            super().__init__(parent)
-            self.setSizePolicy(QSizePolicy(QSizePolicy.Fixed, QSizePolicy.Expanding))
-            self.set(U, vmin, vmax)
+    def initializeGL(self):
+        gl.glClearColor(1.0, 1.0, 1.0, 1.0)
+        self.shaders_program = link_shader_program([compile_shader(VS, vertex=True),
+                                                    compile_shader(FS, vertex=False)])
+        gl.glUseProgram(self.shaders_program)
 
-        def resizeGL(self, w, h):
-            gl.glViewport(0, 0, w, h)
-            gl.glLoadIdentity()
-            self.update()
+        self.colormap_id = colormap_texture()
+        self.colormap_location = gl.glGetUniformLocation(self.shaders_program, 'colormap')
 
-        def initializeGL(self):
-            gl.glClearColor(1.0, 1.0, 1.0, 1.0)
-            self.shaders_program = link_shader_program([compile_shader(VS, vertex=True),
-                                                        compile_shader(FS, vertex=False)])
-            gl.glUseProgram(self.shaders_program)
+    def set(self, U=None, vmin=None, vmax=None):
+        # normalize U
+        fm = QFontMetrics(self.font())
+        self.vmin = vmin if vmin is not None else (np.min(U) if U is not None else 0.)
+        self.vmax = vmax if vmax is not None else (np.max(U) if U is not None else 1.)
+        difference = abs(self.vmin - self.vmax)
+        if difference == 0:
+            precision = 3
+        else:
+            precision = m.log(max(abs(self.vmin), abs(self.vmax)) / difference, 10) + 1
+            precision = int(min(max(precision, 3), 8))
+        self.vmin_str = format(('{:.' + str(precision) + '}').format(self.vmin))
+        self.vmax_str = format(('{:.' + str(precision) + '}').format(self.vmax))
+        self.vmin_width = fm.width(self.vmin_str)
+        self.vmax_width = fm.width(self.vmax_str)
+        self.text_height = fm.height() * 1.5
+        self.text_ascent = fm.ascent() * 1.5
+        self.text_descent = fm.descent() * 1.5
+        self.setMinimumSize(max(self.vmin_width, self.vmax_width) + 20, 300)
+        self.update()
 
-            self.colormap_id = colormap_texture()
-            self.colormap_location = gl.glGetUniformLocation(self.shaders_program, 'colormap')
+    def paintGL(self):
+        p = QPainter(self)
+        p.beginNativePainting()
+        gl.glClear(gl.GL_COLOR_BUFFER_BIT | gl.GL_DEPTH_BUFFER_BIT)
+        gl.glUseProgram(self.shaders_program)
+        gl.glUniform1i(self.colormap_location, 0)
+        gl.glActiveTexture(gl.GL_TEXTURE0 + 0)
+        gl.glBindTexture(gl.GL_TEXTURE_1D, self.colormap_id)
 
-        def set(self, U=None, vmin=None, vmax=None):
-            # normalize U
-            fm = QFontMetrics(self.font())
-            self.vmin = vmin if vmin is not None else (np.min(U) if U is not None else 0.)
-            self.vmax = vmax if vmax is not None else (np.max(U) if U is not None else 1.)
-            difference = abs(self.vmin - self.vmax)
-            if difference == 0:
-                precision = 3
-            else:
-                precision = m.log(max(abs(self.vmin), abs(self.vmax)) / difference, 10) + 1
-                precision = int(min(max(precision, 3), 8))
-            self.vmin_str = format(('{:.' + str(precision) + '}').format(self.vmin))
-            self.vmax_str = format(('{:.' + str(precision) + '}').format(self.vmax))
-            self.vmin_width = fm.width(self.vmin_str)
-            self.vmax_width = fm.width(self.vmax_str)
-            self.text_height = fm.height() * 1.5
-            self.text_ascent = fm.ascent() * 1.5
-            self.text_descent = fm.descent() * 1.5
-            self.setMinimumSize(max(self.vmin_width, self.vmax_width) + 20, 300)
-            self.update()
-
-        def paintGL(self):
-            p = QPainter(self)
-            p.beginNativePainting()
-            gl.glClear(gl.GL_COLOR_BUFFER_BIT | gl.GL_DEPTH_BUFFER_BIT)
-            gl.glUseProgram(self.shaders_program)
-            gl.glUniform1i(self.colormap_location, 0)
-            gl.glActiveTexture(gl.GL_TEXTURE0 + 0)
-            gl.glBindTexture(gl.GL_TEXTURE_1D, self.colormap_id)
-
-            gl.glBegin(gl.GL_QUAD_STRIP)
-            bar_start = -1 + self.text_height / self.height() * 2
-            bar_height = (1 - 2 * self.text_height / self.height()) * 2
-            steps = 40
-            for i in range(steps + 1):
-                y = i * (1 / steps)
-                # gl.glColor(y, 0, 0)
-                gl.glVertex(-0.5, (bar_height*y + bar_start), y)
-                gl.glVertex(0.5, (bar_height*y + bar_start), y)
-            gl.glEnd()
-            p.endNativePainting()
-            p.drawText(round((self.width() - self.vmax_width)/2), self.text_ascent, self.vmax_str)
-            p.drawText(round((self.width() - self.vmin_width)/2), self.height() - self.text_height + self.text_ascent,
-                       self.vmin_str)
-            p.end()
-
-else:
-
-    class GLPatchWidget:
-        pass
-
-    class ColorBarWidget:
-        pass
+        gl.glBegin(gl.GL_QUAD_STRIP)
+        bar_start = -1 + self.text_height / self.height() * 2
+        bar_height = (1 - 2 * self.text_height / self.height()) * 2
+        steps = 40
+        for i in range(steps + 1):
+            y = i * (1 / steps)
+            # gl.glColor(y, 0, 0)
+            gl.glVertex(-0.5, (bar_height*y + bar_start), y)
+            gl.glVertex(0.5, (bar_height*y + bar_start), y)
+        gl.glEnd()
+        p.endNativePainting()
+        p.drawText(round((self.width() - self.vmax_width)/2), self.text_ascent, self.vmax_str)
+        p.drawText(round((self.width() - self.vmin_width)/2), self.height() - self.text_height + self.text_ascent,
+                   self.vmin_str)
+        p.end()

--- a/src/pymor/discretizers/builtin/gui/gl.py
+++ b/src/pymor/discretizers/builtin/gui/gl.py
@@ -11,10 +11,10 @@ intended to be used directly. Instead, use
 :class:`~pymor.discretizers.builtin.gui.qt.PatchVisualizer`.
 """
 
-from pymor.core.config import require_dependency
-require_dependency('QT')
-require_dependency('QTOPENGL')
-require_dependency('GL')
+from pymor.core.config import config
+config.require('QT')
+config.require('QTOPENGL')
+config.require('GL')
 
 import math as m
 

--- a/src/pymor/discretizers/builtin/gui/jupyter/__init__.py
+++ b/src/pymor/discretizers/builtin/gui/jupyter/__init__.py
@@ -13,12 +13,12 @@ inside the given notebook.
 import IPython
 
 from pymor.core.defaults import defaults
-from pymor.discretizers.builtin.gui.jupyter.matplotlib import visualize_patch
 from pymor.core.config import config
 
 # AFAICT there is no robust way to query for loaded extensions
 # and we have to make sure we do not setup two redirects
 _extension_loaded = False
+
 
 @defaults('backend')
 def get_visualizer(backend='py3js'):
@@ -28,6 +28,7 @@ def get_visualizer(backend='py3js'):
         from pymor.discretizers.builtin.gui.jupyter.threejs import visualize_py3js
         return visualize_py3js
     else:
+        from pymor.discretizers.builtin.gui.jupyter.matplotlib import visualize_patch
         return visualize_patch
 
 

--- a/src/pymor/discretizers/builtin/gui/jupyter/matplotlib.py
+++ b/src/pymor/discretizers/builtin/gui/jupyter/matplotlib.py
@@ -6,7 +6,7 @@ from ipywidgets import widgets
 import matplotlib.pyplot as plt
 
 from pymor.core.config import config
-from pymor.discretizers.builtin.gui.matplotlib import MatplotlibPatchAxes, Matplotlib1DAxes
+from pymor.discretizers.builtin.gui.matplotlib_base import MatplotlibPatchAxes, Matplotlib1DAxes
 from pymor.vectorarrays.interface import VectorArray
 
 

--- a/src/pymor/discretizers/builtin/gui/matplotlib.py
+++ b/src/pymor/discretizers/builtin/gui/matplotlib.py
@@ -8,9 +8,9 @@ This module provides widgets for displaying plots of
 scalar data assigned to one- and two-dimensional grids using
 :mod:`matplotlib`. These widgets are not intended to be used directly.
 """
-from pymor.core.config import require_dependency
-require_dependency('MATPLOTLIB')
-require_dependency('QT')
+from pymor.core.config import config
+config.require('MATPLOTLIB')
+config.require('QT')
 
 import numpy as np
 from qtpy.QtWidgets import QSizePolicy

--- a/src/pymor/discretizers/builtin/gui/matplotlib.py
+++ b/src/pymor/discretizers/builtin/gui/matplotlib.py
@@ -8,284 +8,97 @@ This module provides widgets for displaying plots of
 scalar data assigned to one- and two-dimensional grids using
 :mod:`matplotlib`. These widgets are not intended to be used directly.
 """
+from pymor.core.config import require_dependency
+require_dependency('MATPLOTLIB')
+require_dependency('QT')
 
 import numpy as np
-from IPython.core.display import HTML
-from matplotlib import animation
-from pymor.core.base import abstractmethod
+from qtpy.QtWidgets import QSizePolicy
+from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
+from matplotlib.figure import Figure
 
-from pymor.core.config import config
-from pymor.discretizers.builtin.grids.constructions import flatten_grid
+from pymor.discretizers.builtin.grids.oned import OnedGrid
 from pymor.discretizers.builtin.grids.referenceelements import triangle, square
+from pymor.discretizers.builtin.gui.matplotlib_base import MatplotlibPatchAxes
 
 
-class MatplotlibAxesBase:
+# noinspection PyShadowingNames
+class Matplotlib1DWidget(FigureCanvas):
 
-    def __init__(self, figure, sync_timer, grid, U=None, vmin=None, vmax=None, codim=2, separate_axes=False, columns=2,
-                 aspect_ratio=1):
-        # aspect_ratio is height/width
-        self.vmin = vmin
-        self.vmax = vmax
+    def __init__(self, U, parent, grid, count, vmin=None, vmax=None, legend=None, codim=1,
+                 separate_plots=False, dpi=100):
+        assert isinstance(grid, OnedGrid)
+        assert codim in (0, 1)
+
+        figure = Figure(dpi=dpi)
+        if not separate_plots:
+            axes = figure.gca()
         self.codim = codim
-
-        self.grid = grid
-        if separate_axes:
-            if len(U) == 1:
-                columns = 1  # otherwise we get a sep axes object with 0 data
-            rows = int(np.ceil(len(U) / columns))
-            self.ax = figure.subplots(rows, columns, squeeze=False).flatten()
+        lines = ()
+        centers = grid.centers(1)
+        if grid.identify_left_right:
+            centers = np.concatenate((centers, [[grid.domain[1]]]), axis=0)
+            self.periodic = True
         else:
-            self.ax = (figure.gca(),)
-        for ax in self.ax:
-            ax.set_aspect(aspect_ratio)
-        self.figure = figure
-        self.codim = codim
-        self.grid = grid
-        self.separate_axes = separate_axes
-        self.count = len(U) if separate_axes or isinstance(U, tuple) else 1
-        self.aspect_ratio = aspect_ratio
-
-        self._plot_init()
-
-        # assignment delayed to ensure _plot_init works w/o data
-        self.U = U
-        # Rest is only needed with animation
-        if U is not None and not separate_axes and self.count == 1:
-            assert len(self.ax) == 1
-            delay_between_frames = 200  # ms
-            self.anim = animation.FuncAnimation(figure, self.animate,
-                                                frames=U, interval=delay_between_frames,
-                                                blit=True, event_source=sync_timer)
-            # generating the HTML instance outside this class causes the plot display to fail
-            self.html = HTML(self.anim.to_jshtml())
+            self.periodic = False
+        if codim == 1:
+            xs = centers
         else:
-            self.set(self.U)
+            xs = np.repeat(centers, 2)[1:-1]
+        for i in range(count):
+            if separate_plots:
+                figure.add_subplot(int(count / 2) + count % 2, 2, i + 1)
+                axes = figure.gca()
+                pad = (vmax[i] - vmin[i]) * 0.1
+                axes.set_ylim(vmin[i] - pad, vmax[i] + pad)
+            l, = axes.plot(xs, np.zeros_like(xs))
+            lines = lines + (l,)
+            if legend and separate_plots:
+                axes.legend([legend[i]])
+        if not separate_plots:
+            if max(vmax) == min(vmin):
+                pad = 0.5
+            else:
+                pad = (max(vmax) - min(vmin)) * 0.1
+            axes.set_ylim(min(vmin) - pad, max(vmax) + pad)
+            if legend:
+                axes.legend(legend)
+        self.lines = lines
 
-    @abstractmethod
-    def _plot_init(self):
-        """Setup MPL figure display with empty data."""
-        pass
+        super().__init__(figure)
+        self.setParent(parent)
+        self.setMinimumSize(300, 300)
+        self.setSizePolicy(QSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding))
 
-    @abstractmethod
-    def set(self, U):
-        """Load new data into existing plot objects."""
-        pass
+    def set(self, U, ind):
+        for l, u in zip(self.lines, U):
+            if self.codim == 1:
+                if self.periodic:
+                    l.set_ydata(np.concatenate((u[ind], [u[ind][0]])))
+                else:
+                    l.set_ydata(u[ind])
+            else:
+                l.set_ydata(np.repeat(u[ind], 2))
+        self.draw()
 
-    @abstractmethod
-    def animate(self, u):
-        """Load new data into existing plot objects."""
-        pass
 
+class MatplotlibPatchWidget(FigureCanvas):
 
-class MatplotlibPatchAxes(MatplotlibAxesBase):
-
-    def __init__(self, figure, grid, bounding_box=None, U=None, vmin=None, vmax=None, codim=2, columns=2,
-                 colorbar=True, sync_timer=None):
+    def __init__(self, parent, grid, bounding_box=None, vmin=None, vmax=None, codim=2, dpi=100):
         assert grid.reference_element in (triangle, square)
         assert grid.dim == 2
         assert codim in (0, 2)
 
-        subentities, coordinates, entity_map = flatten_grid(grid)
-        self.subentities = subentities if grid.reference_element is triangle \
-            else np.vstack((subentities[:, 0:3], subentities[:, [2, 3, 0]]))
-        self.coordinates = coordinates
-        self.entity_map = entity_map
-        self.reference_element = grid.reference_element
-        self.colorbar = colorbar
-        self.animate = self.set
+        self.figure = Figure(dpi=dpi)
+        super().__init__(self.figure)
 
-        if bounding_box is None:
-            bounding_box = grid.bounding_box()
-        assert len(bounding_box) == 2 and all(len(b) == 2 for b in bounding_box)
-        aspect_ratio = (bounding_box[1][1] - bounding_box[0][1]) / (bounding_box[1][0] - bounding_box[0][0])
+        self.setParent(parent)
+        self.setMinimumSize(300, 300)
+        self.setSizePolicy(QSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding))
 
-        super().__init__(U=U, figure=figure, grid=grid,  vmin=vmin, vmax=vmax, codim=codim, columns=columns,
-                         sync_timer=sync_timer, aspect_ratio=aspect_ratio)
-
-    def _plot_init(self):
-        if self.codim == 2:
-            self.p = self.ax[0].tripcolor(self.coordinates[:, 0], self.coordinates[:, 1], self.subentities,
-                                          np.zeros(len(self.coordinates)),
-                                          vmin=self.vmin, vmax=self.vmax, shading='gouraud')
-        else:
-            self.p = self.ax[0].tripcolor(self.coordinates[:, 0], self.coordinates[:, 1], self.subentities,
-                                          facecolors=np.zeros(len(self.subentities)),
-                                          vmin=self.vmin, vmax=self.vmax, shading='flat')
-        if self.colorbar:
-            # thin plots look ugly with a huge colorbar on the right
-            if self.aspect_ratio < 0.75:
-                orientation = 'horizontal'
-            else:
-                orientation = 'vertical'
-            self.figure.colorbar(self.p, ax=self.ax[0], orientation=orientation)
+        self.patch_axes = MatplotlibPatchAxes(figure=self.figure, grid=grid, bounding_box=bounding_box,
+                                              vmin=vmin, vmax=vmax, codim=codim)
 
     def set(self, U, vmin=None, vmax=None):
-        self.vmin = self.vmin if vmin is None else vmin
-        self.vmax = self.vmax if vmax is None else vmax
-        if self.codim == 2:
-            self.p.set_array(U)
-        elif self.reference_element is triangle:
-            self.p.set_array(U)
-        else:
-            self.p.set_array(np.tile(U, 2))
-        self.p.set_clim(self.vmin, self.vmax)
-        return (self.p,)
-
-
-class Matplotlib1DAxes(MatplotlibAxesBase):
-
-    def __init__(self, U, figure, grid, vmin=None, vmax=None, codim=1, separate_axes=False, sync_timer=None,
-                 columns=2, bounding_box=None):
-        assert isinstance(grid, OnedGrid)
-        assert codim in (0, 1)
-
-        if bounding_box is None:
-            bounding_box = grid.bounding_box()
-        aspect_ratio = (bounding_box[1] - bounding_box[0]) / (vmax - vmin)
-
-        super().__init__(U=U, figure=figure, grid=grid, vmin=vmin, vmax=vmax, codim=codim, columns=columns,
-                         sync_timer=sync_timer, separate_axes=separate_axes, aspect_ratio=aspect_ratio)
-
-    def _plot_init(self):
-        centers = self.grid.centers(1)
-        if self.grid.identify_left_right:
-            centers = np.concatenate((centers, [[self.grid.domain[1]]]), axis=0)
-            self.periodic = True
-        else:
-            self.periodic = False
-        if self.codim == 1:
-            xs = centers
-        else:
-            xs = np.repeat(centers, 2)[1:-1]
-        if self.separate_axes:
-            self.lines = [ax.plot(xs, np.zeros_like(xs))[0] for ax in self.ax]
-        else:
-            self.lines = [self.ax[0].plot(xs, np.zeros_like(xs))[0] for _ in range(self.count)]
-        pad = (self.vmax - self.vmin) * 0.1
-        for ax in self.ax:
-            ax.set_ylim(self.vmin - pad, self.vmax + pad)
-
-    def _set(self, u, i):
-        if self.codim == 1:
-            if self.periodic:
-                self.lines[i].set_ydata(np.concatenate((u, [self.U[0]])))
-            else:
-                self.lines[i].set_ydata(u)
-        else:
-            self.lines[i].set_ydata(np.repeat(u, 2))
-
-    def animate(self, u):
-        for i in range(len(self.ax)):
-            self._set(u, i)
-        return self.lines
-
-    def set(self, U, vmin=None, vmax=None):
-        self.vmin = self.vmin if vmin is None else vmin
-        self.vmax = self.vmax if vmax is None else vmax
-
-        if isinstance(U, tuple):
-            for i, u in enumerate(U):
-                self._set(u, i)
-        else:
-            for i, (u, _) in enumerate(zip(U, self.ax)):
-                self._set(u, i)
-        pad = (self.vmax - self.vmin) * 0.1
-        for ax in self.ax:
-            ax.set_ylim(self.vmin - pad, self.vmax + pad)
-
-
-if config.HAVE_QT and config.HAVE_MATPLOTLIB:
-    from qtpy.QtWidgets import QSizePolicy
-
-    from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
-    from matplotlib.figure import Figure
-
-    from pymor.discretizers.builtin.grids.oned import OnedGrid
-
-    # noinspection PyShadowingNames
-    class Matplotlib1DWidget(FigureCanvas):
-
-        def __init__(self, U, parent, grid, count, vmin=None, vmax=None, legend=None, codim=1,
-                     separate_plots=False, dpi=100):
-            assert isinstance(grid, OnedGrid)
-            assert codim in (0, 1)
-
-            figure = Figure(dpi=dpi)
-            if not separate_plots:
-                axes = figure.gca()
-            self.codim = codim
-            lines = ()
-            centers = grid.centers(1)
-            if grid.identify_left_right:
-                centers = np.concatenate((centers, [[grid.domain[1]]]), axis=0)
-                self.periodic = True
-            else:
-                self.periodic = False
-            if codim == 1:
-                xs = centers
-            else:
-                xs = np.repeat(centers, 2)[1:-1]
-            for i in range(count):
-                if separate_plots:
-                    figure.add_subplot(int(count / 2) + count % 2, 2, i + 1)
-                    axes = figure.gca()
-                    pad = (vmax[i] - vmin[i]) * 0.1
-                    axes.set_ylim(vmin[i] - pad, vmax[i] + pad)
-                l, = axes.plot(xs, np.zeros_like(xs))
-                lines = lines + (l,)
-                if legend and separate_plots:
-                    axes.legend([legend[i]])
-            if not separate_plots:
-                if max(vmax) == min(vmin):
-                    pad = 0.5
-                else:
-                    pad = (max(vmax) - min(vmin)) * 0.1
-                axes.set_ylim(min(vmin) - pad, max(vmax) + pad)
-                if legend:
-                    axes.legend(legend)
-            self.lines = lines
-
-            super().__init__(figure)
-            self.setParent(parent)
-            self.setMinimumSize(300, 300)
-            self.setSizePolicy(QSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding))
-
-        def set(self, U, ind):
-            for l, u in zip(self.lines, U):
-                if self.codim == 1:
-                    if self.periodic:
-                        l.set_ydata(np.concatenate((u[ind], [u[ind][0]])))
-                    else:
-                        l.set_ydata(u[ind])
-                else:
-                    l.set_ydata(np.repeat(u[ind], 2))
-            self.draw()
-
-    class MatplotlibPatchWidget(FigureCanvas):
-
-        def __init__(self, parent, grid, bounding_box=None, vmin=None, vmax=None, codim=2, dpi=100):
-            assert grid.reference_element in (triangle, square)
-            assert grid.dim == 2
-            assert codim in (0, 2)
-
-            self.figure = Figure(dpi=dpi)
-            super().__init__(self.figure)
-
-            self.setParent(parent)
-            self.setMinimumSize(300, 300)
-            self.setSizePolicy(QSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding))
-
-            self.patch_axes = MatplotlibPatchAxes(figure=self.figure, grid=grid, bounding_box=bounding_box,
-                                                  vmin=vmin, vmax=vmax, codim=codim)
-
-        def set(self, U, vmin=None, vmax=None):
-            self.patch_axes.set(U, vmin, vmax)
-            self.draw()
-
-else:
-
-    class Matplotlib1DWidget:
-        pass
-
-    class MatplotlibPatchWidget:
-        pass
+        self.patch_axes.set(U, vmin, vmax)
+        self.draw()

--- a/src/pymor/discretizers/builtin/gui/matplotlib_base.py
+++ b/src/pymor/discretizers/builtin/gui/matplotlib_base.py
@@ -1,0 +1,197 @@
+# This file is part of the pyMOR project (https://www.pymor.org).
+# Copyright 2013-2021 pyMOR developers and contributors. All rights reserved.
+# License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
+
+"""Visualization of grid data using matplotlib.
+
+This module provides widgets for displaying plots of
+scalar data assigned to one- and two-dimensional grids using
+:mod:`matplotlib`. These widgets are not intended to be used directly.
+"""
+from pymor.core.config import require_dependency
+require_dependency('MATPLOTLIB')
+
+
+import numpy as np
+from IPython.core.display import HTML
+from matplotlib import animation
+from pymor.core.base import abstractmethod
+
+from pymor.discretizers.builtin.grids.constructions import flatten_grid
+from pymor.discretizers.builtin.grids.oned import OnedGrid
+from pymor.discretizers.builtin.grids.referenceelements import triangle, square
+
+
+class MatplotlibAxesBase:
+
+    def __init__(self, figure, sync_timer, grid, U=None, vmin=None, vmax=None, codim=2, separate_axes=False, columns=2,
+                 aspect_ratio=1):
+        # aspect_ratio is height/width
+        self.vmin = vmin
+        self.vmax = vmax
+        self.codim = codim
+
+        self.grid = grid
+        if separate_axes:
+            if len(U) == 1:
+                columns = 1  # otherwise we get a sep axes object with 0 data
+            rows = int(np.ceil(len(U) / columns))
+            self.ax = figure.subplots(rows, columns, squeeze=False).flatten()
+        else:
+            self.ax = (figure.gca(),)
+        for ax in self.ax:
+            ax.set_aspect(aspect_ratio)
+        self.figure = figure
+        self.codim = codim
+        self.grid = grid
+        self.separate_axes = separate_axes
+        self.count = len(U) if separate_axes or isinstance(U, tuple) else 1
+        self.aspect_ratio = aspect_ratio
+
+        self._plot_init()
+
+        # assignment delayed to ensure _plot_init works w/o data
+        self.U = U
+        # Rest is only needed with animation
+        if U is not None and not separate_axes and self.count == 1:
+            assert len(self.ax) == 1
+            delay_between_frames = 200  # ms
+            self.anim = animation.FuncAnimation(figure, self.animate,
+                                                frames=U, interval=delay_between_frames,
+                                                blit=True, event_source=sync_timer)
+            # generating the HTML instance outside this class causes the plot display to fail
+            self.html = HTML(self.anim.to_jshtml())
+        else:
+            self.set(self.U)
+
+    @abstractmethod
+    def _plot_init(self):
+        """Setup MPL figure display with empty data."""
+        pass
+
+    @abstractmethod
+    def set(self, U):
+        """Load new data into existing plot objects."""
+        pass
+
+    @abstractmethod
+    def animate(self, u):
+        """Load new data into existing plot objects."""
+        pass
+
+
+class MatplotlibPatchAxes(MatplotlibAxesBase):
+
+    def __init__(self, figure, grid, bounding_box=None, U=None, vmin=None, vmax=None, codim=2, columns=2,
+                 colorbar=True, sync_timer=None):
+        assert grid.reference_element in (triangle, square)
+        assert grid.dim == 2
+        assert codim in (0, 2)
+
+        subentities, coordinates, entity_map = flatten_grid(grid)
+        self.subentities = subentities if grid.reference_element is triangle \
+            else np.vstack((subentities[:, 0:3], subentities[:, [2, 3, 0]]))
+        self.coordinates = coordinates
+        self.entity_map = entity_map
+        self.reference_element = grid.reference_element
+        self.colorbar = colorbar
+        self.animate = self.set
+
+        if bounding_box is None:
+            bounding_box = grid.bounding_box()
+        assert len(bounding_box) == 2 and all(len(b) == 2 for b in bounding_box)
+        aspect_ratio = (bounding_box[1][1] - bounding_box[0][1]) / (bounding_box[1][0] - bounding_box[0][0])
+
+        super().__init__(U=U, figure=figure, grid=grid,  vmin=vmin, vmax=vmax, codim=codim, columns=columns,
+                         sync_timer=sync_timer, aspect_ratio=aspect_ratio)
+
+    def _plot_init(self):
+        if self.codim == 2:
+            self.p = self.ax[0].tripcolor(self.coordinates[:, 0], self.coordinates[:, 1], self.subentities,
+                                          np.zeros(len(self.coordinates)),
+                                          vmin=self.vmin, vmax=self.vmax, shading='gouraud')
+        else:
+            self.p = self.ax[0].tripcolor(self.coordinates[:, 0], self.coordinates[:, 1], self.subentities,
+                                          facecolors=np.zeros(len(self.subentities)),
+                                          vmin=self.vmin, vmax=self.vmax, shading='flat')
+        if self.colorbar:
+            # thin plots look ugly with a huge colorbar on the right
+            if self.aspect_ratio < 0.75:
+                orientation = 'horizontal'
+            else:
+                orientation = 'vertical'
+            self.figure.colorbar(self.p, ax=self.ax[0], orientation=orientation)
+
+    def set(self, U, vmin=None, vmax=None):
+        self.vmin = self.vmin if vmin is None else vmin
+        self.vmax = self.vmax if vmax is None else vmax
+        if self.codim == 2:
+            self.p.set_array(U)
+        elif self.reference_element is triangle:
+            self.p.set_array(U)
+        else:
+            self.p.set_array(np.tile(U, 2))
+        self.p.set_clim(self.vmin, self.vmax)
+        return (self.p,)
+
+
+class Matplotlib1DAxes(MatplotlibAxesBase):
+
+    def __init__(self, U, figure, grid, vmin=None, vmax=None, codim=1, separate_axes=False, sync_timer=None,
+                 columns=2, bounding_box=None):
+        assert isinstance(grid, OnedGrid)
+        assert codim in (0, 1)
+
+        if bounding_box is None:
+            bounding_box = grid.bounding_box()
+        aspect_ratio = (bounding_box[1] - bounding_box[0]) / (vmax - vmin)
+
+        super().__init__(U=U, figure=figure, grid=grid, vmin=vmin, vmax=vmax, codim=codim, columns=columns,
+                         sync_timer=sync_timer, separate_axes=separate_axes, aspect_ratio=aspect_ratio)
+
+    def _plot_init(self):
+        centers = self.grid.centers(1)
+        if self.grid.identify_left_right:
+            centers = np.concatenate((centers, [[self.grid.domain[1]]]), axis=0)
+            self.periodic = True
+        else:
+            self.periodic = False
+        if self.codim == 1:
+            xs = centers
+        else:
+            xs = np.repeat(centers, 2)[1:-1]
+        if self.separate_axes:
+            self.lines = [ax.plot(xs, np.zeros_like(xs))[0] for ax in self.ax]
+        else:
+            self.lines = [self.ax[0].plot(xs, np.zeros_like(xs))[0] for _ in range(self.count)]
+        pad = (self.vmax - self.vmin) * 0.1
+        for ax in self.ax:
+            ax.set_ylim(self.vmin - pad, self.vmax + pad)
+
+    def _set(self, u, i):
+        if self.codim == 1:
+            if self.periodic:
+                self.lines[i].set_ydata(np.concatenate((u, [self.U[0]])))
+            else:
+                self.lines[i].set_ydata(u)
+        else:
+            self.lines[i].set_ydata(np.repeat(u, 2))
+
+    def animate(self, u):
+        for i in range(len(self.ax)):
+            self._set(u, i)
+        return self.lines
+
+    def set(self, U, vmin=None, vmax=None):
+        self.vmin = self.vmin if vmin is None else vmin
+        self.vmax = self.vmax if vmax is None else vmax
+
+        if isinstance(U, tuple):
+            for i, u in enumerate(U):
+                self._set(u, i)
+        else:
+            for i, (u, _) in enumerate(zip(U, self.ax)):
+                self._set(u, i)
+        pad = (self.vmax - self.vmin) * 0.1
+        for ax in self.ax:
+            ax.set_ylim(self.vmin - pad, self.vmax + pad)

--- a/src/pymor/discretizers/builtin/gui/matplotlib_base.py
+++ b/src/pymor/discretizers/builtin/gui/matplotlib_base.py
@@ -8,8 +8,8 @@ This module provides widgets for displaying plots of
 scalar data assigned to one- and two-dimensional grids using
 :mod:`matplotlib`. These widgets are not intended to be used directly.
 """
-from pymor.core.config import require_dependency
-require_dependency('MATPLOTLIB')
+from pymor.core.config import config
+config.require('MATPLOTLIB')
 
 
 import numpy as np

--- a/src/pymor/discretizers/builtin/gui/qt.py
+++ b/src/pymor/discretizers/builtin/gui/qt.py
@@ -26,7 +26,6 @@ from pymor.core.defaults import defaults
 from pymor.core.logger import getLogger
 from pymor.core.pickle import dump
 from pymor.discretizers.builtin.grids.vtkio import write_vtk
-from pymor.discretizers.builtin.gui.matplotlib import Matplotlib1DWidget, MatplotlibPatchWidget
 from pymor.vectorarrays.interface import VectorArray
 from pymor.vectorarrays.numpy import NumpyVectorSpace
 
@@ -345,6 +344,7 @@ def visualize_patch(grid, U, bounding_box=([0, 0], [1, 1]), codim=2, title=None,
                 widget = GLPatchWidget
                 cbar_widget = ColorBarWidget
             else:
+                from pymor.discretizers.builtin.gui.matplotlib import MatplotlibPatchWidget
                 widget = MatplotlibPatchWidget
                 cbar_widget = None
                 if not separate_colorbars and len(U) > 1:
@@ -501,6 +501,7 @@ def visualize_matplotlib_1d(grid, U, codim=1, title=None, legend=None, separate_
                 legend = (legend,)
             assert legend is None or isinstance(legend, tuple) and len(legend) == len(U)
 
+            from pymor.discretizers.builtin.gui.matplotlib import Matplotlib1DWidget
             plot_widget = Matplotlib1DWidget(U, None, grid, len(U), vmin=[np.min(u) for u in U],
                                              vmax=[np.max(u) for u in U], legend=legend, codim=codim,
                                              separate_plots=separate_plots)

--- a/src/pymor/discretizers/builtin/gui/qt.py
+++ b/src/pymor/discretizers/builtin/gui/qt.py
@@ -21,7 +21,6 @@ from qtpy.QtWidgets import (QWidget, QVBoxLayout, QHBoxLayout, QGridLayout, QSli
                             QAction, QStyle, QToolBar, QLabel, QFileDialog, QMessageBox)
 from qtpy.QtCore import Qt, QTimer
 
-from pymor.core.config import config
 from pymor.core.defaults import defaults
 from pymor.core.logger import getLogger
 from pymor.core.pickle import dump

--- a/src/pymor/discretizers/builtin/gui/qt.py
+++ b/src/pymor/discretizers/builtin/gui/qt.py
@@ -8,8 +8,8 @@ This module provides a few methods and classes for visualizing data
 associated to grids. We use the `Qt <http://www.qt-project.org>`_ widget
 toolkit for the GUI.
 """
-from pymor.core.config import require_dependency
-require_dependency('QT')
+from pymor.core.config import config
+config.require('QT')
 
 import math as m
 from tempfile import NamedTemporaryFile

--- a/src/pymor/discretizers/builtin/gui/qt.py
+++ b/src/pymor/discretizers/builtin/gui/qt.py
@@ -429,7 +429,7 @@ def visualize_patch(grid, U, bounding_box=([0, 0], [1, 1]), codim=2, title=None,
             self.codim = codim
 
         def save(self):
-            if not config.HAVE_PYEVTK:
+            if not config.HAVE_VTKIO:
                 msg = QMessageBox(QMessageBox.Critical, 'Error', 'VTK output disabled. Please install pyvtk.')
                 msg.exec_()
                 return

--- a/src/pymor/discretizers/builtin/gui/qt.py
+++ b/src/pymor/discretizers/builtin/gui/qt.py
@@ -22,7 +22,6 @@ from pymor.core.logger import getLogger
 from pymor.core.exceptions import QtMissing
 from pymor.core.pickle import dump
 from pymor.discretizers.builtin.grids.vtkio import write_vtk
-from pymor.discretizers.builtin.gui.gl import GLPatchWidget, ColorBarWidget
 from pymor.discretizers.builtin.gui.matplotlib import Matplotlib1DWidget, MatplotlibPatchWidget
 from pymor.vectorarrays.interface import VectorArray
 from pymor.vectorarrays.numpy import NumpyVectorSpace
@@ -346,6 +345,7 @@ def visualize_patch(grid, U, bounding_box=([0, 0], [1, 1]), codim=2, title=None,
                 legend = (legend,)
             assert legend is None or isinstance(legend, tuple) and len(legend) == len(U)
             if backend == 'gl':
+                from pymor.discretizers.builtin.gui.gl import GLPatchWidget, ColorBarWidget
                 widget = GLPatchWidget
                 cbar_widget = ColorBarWidget
             else:

--- a/src/pymor/discretizers/builtin/gui/qt.py
+++ b/src/pymor/discretizers/builtin/gui/qt.py
@@ -25,7 +25,6 @@ from pymor.core.config import config
 from pymor.core.defaults import defaults
 from pymor.core.logger import getLogger
 from pymor.core.pickle import dump
-from pymor.discretizers.builtin.grids.vtkio import write_vtk
 from pymor.vectorarrays.interface import VectorArray
 from pymor.vectorarrays.numpy import NumpyVectorSpace
 
@@ -433,6 +432,7 @@ def visualize_patch(grid, U, bounding_box=([0, 0], [1, 1]), codim=2, title=None,
                 msg = QMessageBox(QMessageBox.Critical, 'Error', 'VTK output disabled. Please install pyvtk.')
                 msg.exec_()
                 return
+            from pymor.discretizers.builtin.grids.vtkio import write_vtk
             filename = QFileDialog.getSaveFileName(self, 'Save as vtk file')[0]
             base_name = filename.split('.vtu')[0].split('.vtk')[0].split('.pvd')[0]
             if base_name:

--- a/src/pymor/discretizers/builtin/gui/visualizers.py
+++ b/src/pymor/discretizers/builtin/gui/visualizers.py
@@ -8,7 +8,6 @@ from pymor.core.defaults import defaults
 from pymor.core.config import is_jupyter
 from pymor.discretizers.builtin.grids.oned import OnedGrid
 from pymor.discretizers.builtin.grids.referenceelements import triangle, square
-from pymor.discretizers.builtin.grids.vtkio import write_vtk
 from pymor.vectorarrays.interface import VectorArray
 
 
@@ -79,6 +78,7 @@ class PatchVisualizer(ImmutableObject):
                 and all(isinstance(u, VectorArray) for u in U)
                 and all(len(u) == len(U[0]) for u in U))
         if filename:
+            from pymor.discretizers.builtin.grids.vtkio import write_vtk
             if not isinstance(U, tuple):
                 write_vtk(self.grid, U, filename, codim=self.codim)
             else:

--- a/src/pymor/discretizers/skfem/cg.py
+++ b/src/pymor/discretizers/skfem/cg.py
@@ -2,8 +2,9 @@
 # Copyright 2013-2021 pyMOR developers and contributors. All rights reserved.
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
-from pymor.core.config import require_dependency
-require_dependency('SCIKIT_FEM')
+from pymor.core.config import config
+config.require('SCIKIT_FEM')
+
 
 import numpy as np
 from skfem import Basis, BoundaryFacetBasis, BilinearForm, LinearForm, asm, enforce, projection

--- a/src/pymor/discretizers/skfem/cg.py
+++ b/src/pymor/discretizers/skfem/cg.py
@@ -2,347 +2,330 @@
 # Copyright 2013-2021 pyMOR developers and contributors. All rights reserved.
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
-from pymor.core.config import config
+from pymor.core.config import require_dependency
+require_dependency('SCIKIT_FEM')
 
-if config.HAVE_SCIKIT_FEM:
+import numpy as np
+from skfem import Basis, BoundaryFacetBasis, BilinearForm, LinearForm, asm, enforce, projection
+from skfem.helpers import grad, dot
+from skfem.visuals.matplotlib import plot, show
 
-    import numpy as np
-    from skfem import Basis, BoundaryFacetBasis, BilinearForm, LinearForm, asm, enforce, projection
-    from skfem.helpers import grad, dot
-    from skfem.visuals.matplotlib import plot, show
-
-    from pymor.algorithms.preassemble import preassemble as preassemble_
-    from pymor.analyticalproblems.elliptic import StationaryProblem
-    from pymor.analyticalproblems.functions import ConstantFunction, LincombFunction
-    from pymor.core.base import ImmutableObject
-    from pymor.discretizers.skfem.domaindiscretizer import discretize_domain
-    from pymor.models.basic import StationaryModel
-    from pymor.operators.constructions import LincombOperator
-    from pymor.operators.numpy import NumpyMatrixBasedOperator
-    from pymor.vectorarrays.interface import VectorArray
-    from pymor.vectorarrays.numpy import NumpyVectorSpace
-
-
-if config.HAVE_SCIKIT_FEM:
-
-    class SKFemBilinearFormOperator(NumpyMatrixBasedOperator):
-
-        sparse = True
-
-        def __init__(self, basis, dirichlet_dofs=None, dirichlet_clear_diag=False, name=None):
-            self.source = self.range = NumpyVectorSpace(basis.N)
-            self.__auto_init(locals())
-
-        def build_form(mu):
-            pass
-
-        def _assemble(self, mu):
-            form = BilinearForm(self.build_form(mu))
-            A = asm(form, self.basis)
-            if self.dirichlet_dofs is not None:
-                A.setdiag(A.diagonal())
-                enforce(A, D=self.dirichlet_dofs, diag=0. if self.dirichlet_clear_diag else 1., overwrite=True)
-            return A
+from pymor.algorithms.preassemble import preassemble as preassemble_
+from pymor.analyticalproblems.elliptic import StationaryProblem
+from pymor.analyticalproblems.functions import ConstantFunction, LincombFunction
+from pymor.core.base import ImmutableObject
+from pymor.discretizers.skfem.domaindiscretizer import discretize_domain
+from pymor.models.basic import StationaryModel
+from pymor.operators.constructions import LincombOperator
+from pymor.operators.numpy import NumpyMatrixBasedOperator
+from pymor.vectorarrays.interface import VectorArray
+from pymor.vectorarrays.numpy import NumpyVectorSpace
 
 
-if config.HAVE_SCIKIT_FEM:
+class SKFemBilinearFormOperator(NumpyMatrixBasedOperator):
 
-    class SKFemLinearFormOperator(NumpyMatrixBasedOperator):
+    sparse = True
 
-        sparse = False
-        source = NumpyVectorSpace(1)
+    def __init__(self, basis, dirichlet_dofs=None, dirichlet_clear_diag=False, name=None):
+        self.source = self.range = NumpyVectorSpace(basis.N)
+        self.__auto_init(locals())
 
-        def __init__(self, basis, dirichlet_dofs=None, name=None):
-            self.range = NumpyVectorSpace(basis.N)
-            self.__auto_init(locals())
+    def build_form(mu):
+        pass
 
-        def _assemble(self, mu):
-            form = LinearForm(self.build_form(mu))
-            F = asm(form, self.basis)
-            if self.dirichlet_dofs is not None:
-                F[self.dirichlet_dofs] = 0
-            return F.reshape((-1, 1))
-
-
-if config.HAVE_SCIKIT_FEM:
-
-    class DiffusionOperator(SKFemBilinearFormOperator):
-
-        def __init__(self, basis, diffusion_function, dirichlet_dofs=None, dirichlet_clear_diag=False, name=None):
-            super().__init__(basis, dirichlet_dofs=dirichlet_dofs, dirichlet_clear_diag=dirichlet_clear_diag, name=name)
-            self.__auto_init(locals())
-
-        def build_form(self, mu):
-            def bf(u, v, w):
-                d = _eval_pymor_function(self.diffusion_function, w.x, mu)
-                return dot(grad(u), grad(v)) * d
-            return bf
+    def _assemble(self, mu):
+        form = BilinearForm(self.build_form(mu))
+        A = asm(form, self.basis)
+        if self.dirichlet_dofs is not None:
+            A.setdiag(A.diagonal())
+            enforce(A, D=self.dirichlet_dofs, diag=0. if self.dirichlet_clear_diag else 1., overwrite=True)
+        return A
 
 
-if config.HAVE_SCIKIT_FEM:
+class SKFemLinearFormOperator(NumpyMatrixBasedOperator):
 
-    class L2ProductOperator(SKFemBilinearFormOperator):
+    sparse = False
+    source = NumpyVectorSpace(1)
 
-        def __init__(self, basis, dirichlet_dofs=None, dirichlet_clear_diag=False, coefficient_function=None,
-                     name=None):
-            super().__init__(basis, dirichlet_dofs=dirichlet_dofs, dirichlet_clear_diag=dirichlet_clear_diag, name=name)
-            self.__auto_init(locals())
+    def __init__(self, basis, dirichlet_dofs=None, name=None):
+        self.range = NumpyVectorSpace(basis.N)
+        self.__auto_init(locals())
 
-        def build_form(self, mu):
-            def bf(u, v, w):
-                if self.coefficient_function is None:
-                    return u * v
-                else:
-                    c = _eval_pymor_function(self.coefficient_function, w.x, mu)
-                    return u * v * c
-            return bf
+    def _assemble(self, mu):
+        form = LinearForm(self.build_form(mu))
+        F = asm(form, self.basis)
+        if self.dirichlet_dofs is not None:
+            F[self.dirichlet_dofs] = 0
+        return F.reshape((-1, 1))
 
 
-if config.HAVE_SCIKIT_FEM:
+class DiffusionOperator(SKFemBilinearFormOperator):
 
-    class AdvectionOperator(SKFemBilinearFormOperator):
+    def __init__(self, basis, diffusion_function, dirichlet_dofs=None, dirichlet_clear_diag=False, name=None):
+        super().__init__(basis, dirichlet_dofs=dirichlet_dofs, dirichlet_clear_diag=dirichlet_clear_diag, name=name)
+        self.__auto_init(locals())
 
-        def __init__(self, basis, advection_function, dirichlet_dofs=None, dirichlet_clear_diag=False, name=None):
-            super().__init__(basis, dirichlet_dofs=dirichlet_dofs, dirichlet_clear_diag=dirichlet_clear_diag, name=name)
-            self.__auto_init(locals())
-
-        def build_form(self, mu):
-            def bf(u, v, w):
-                c = -_eval_pymor_function(self.advection_function, w.x, mu)
-                return u * dot(c, grad(v))
-            return bf
+    def build_form(self, mu):
+        def bf(u, v, w):
+            d = _eval_pymor_function(self.diffusion_function, w.x, mu)
+            return dot(grad(u), grad(v)) * d
+        return bf
 
 
-if config.HAVE_SCIKIT_FEM:
+class L2ProductOperator(SKFemBilinearFormOperator):
 
-    class L2Functional(SKFemLinearFormOperator):
+    def __init__(self, basis, dirichlet_dofs=None, dirichlet_clear_diag=False, coefficient_function=None,
+                 name=None):
+        super().__init__(basis, dirichlet_dofs=dirichlet_dofs, dirichlet_clear_diag=dirichlet_clear_diag, name=name)
+        self.__auto_init(locals())
 
-        def __init__(self, basis, function, dirichlet_dofs=None, dirichlet_data=None, name=None):
-            super().__init__(basis, dirichlet_dofs=dirichlet_dofs, name=name)
-            self.__auto_init(locals())
-
-        def build_form(self, mu):
-            def lf(u, w):
-                f = _eval_pymor_function(self.function, w.x, mu)
-                return u * f
-            return lf
-
-
-if config.HAVE_SCIKIT_FEM:
-
-    class BoundaryDirichletFunctional(NumpyMatrixBasedOperator):
-        sparse = False
-        source = NumpyVectorSpace(1)
-
-        def __init__(self, basis, dirichlet_data, dirichlet_dofs=None, name=None):
-            assert dirichlet_data.shape_range == ()
-            self.__auto_init(locals())
-            self.range = NumpyVectorSpace(basis.N)
-
-        def _assemble(self, mu=None):
-            D = projection(lambda x: _eval_pymor_function(self.dirichlet_data, x, mu=mu), self.basis,
-                           I=self.dirichlet_dofs)
-            F = np.zeros(self.range.dim)
-            F[self.dirichlet_dofs] = D
-            return F.reshape((-1, 1))
+    def build_form(self, mu):
+        def bf(u, v, w):
+            if self.coefficient_function is None:
+                return u * v
+            else:
+                c = _eval_pymor_function(self.coefficient_function, w.x, mu)
+                return u * v * c
+        return bf
 
 
-if config.HAVE_SCIKIT_FEM:
+class AdvectionOperator(SKFemBilinearFormOperator):
 
-    class SKFemVisualizer(ImmutableObject):
-        def __init__(self, space, basis):
-            self.__auto_init(locals())
+    def __init__(self, basis, advection_function, dirichlet_dofs=None, dirichlet_clear_diag=False, name=None):
+        super().__init__(basis, dirichlet_dofs=dirichlet_dofs, dirichlet_clear_diag=dirichlet_clear_diag, name=name)
+        self.__auto_init(locals())
 
-        def visualize(self, U, **kwargs):
-            if not isinstance(U, VectorArray):
-                raise NotImplementedError
-            if len(U) > 1:
-                raise NotImplementedError
-
-            plot(self.basis, U.to_numpy().ravel(), colorbar=True, **kwargs)
-            show()
+    def build_form(self, mu):
+        def bf(u, v, w):
+            c = -_eval_pymor_function(self.advection_function, w.x, mu)
+            return u * dot(c, grad(v))
+        return bf
 
 
-if config.HAVE_SCIKIT_FEM:
+class L2Functional(SKFemLinearFormOperator):
 
-    def discretize_stationary_cg(analytical_problem, diameter=None, mesh_type=None, element=None, preassemble=True):
-        """Discretizes a |StationaryProblem| with finite elements using scikit-fem.
+    def __init__(self, basis, function, dirichlet_dofs=None, dirichlet_data=None, name=None):
+        super().__init__(basis, dirichlet_dofs=dirichlet_dofs, name=name)
+        self.__auto_init(locals())
 
-        Parameters
-        ----------
-        analytical_problem
-            The |StationaryProblem| to discretize.
-        diameter
-            If not `None`, `diameter` is passed as an argument to the `domain_discretizer`.
-        mesh_type
-            If not `None`, a `skfem.Mesh` to be used for discretizing the domain of
-            `analytical_problem`.
-        element
-            If not `None`, the `skfem.Element` to be used for building the finite element space.
-            If `None`, `mesh.elem()` is used.
-        preassemble
-            If `True`, preassemble all operators in the resulting |Model|.
+    def build_form(self, mu):
+        def lf(u, w):
+            f = _eval_pymor_function(self.function, w.x, mu)
+            return u * f
+        return lf
 
-        Returns
-        -------
-        m
-            The |Model| that has been generated.
-        data
-            Dictionary with the following entries:
 
-                :mesh:             The generated `skfem.Mesh`.
-                :basis:            The generated `skfem.Basis`.
-                :boundary_facets:  Dict of `boundary_facets` of `mesh` per boundary type.
-                :dirichlet_dofs:   DOFs of the `skfem.Basis` associated with the Dirichlet boundary.
-                :unassembled_m:    In case `preassemble` is `True`, the generated |Model|
-                                   before preassembling operators.
-        """
-        assert isinstance(analytical_problem, StationaryProblem)
+class BoundaryDirichletFunctional(NumpyMatrixBasedOperator):
+    sparse = False
+    source = NumpyVectorSpace(1)
 
-        p = analytical_problem
+    def __init__(self, basis, dirichlet_data, dirichlet_dofs=None, name=None):
+        assert dirichlet_data.shape_range == ()
+        self.__auto_init(locals())
+        self.range = NumpyVectorSpace(basis.N)
 
-        if p.nonlinear_advection is not None:
+    def _assemble(self, mu=None):
+        D = projection(lambda x: _eval_pymor_function(self.dirichlet_data, x, mu=mu), self.basis,
+                       I=self.dirichlet_dofs)
+        F = np.zeros(self.range.dim)
+        F[self.dirichlet_dofs] = D
+        return F.reshape((-1, 1))
+
+
+class SKFemVisualizer(ImmutableObject):
+    def __init__(self, space, basis):
+        self.__auto_init(locals())
+
+    def visualize(self, U, **kwargs):
+        if not isinstance(U, VectorArray):
             raise NotImplementedError
-        if p.nonlinear_advection_derivative is not None:
-            raise NotImplementedError
-        if p.nonlinear_reaction is not None:
-            raise NotImplementedError
-        if p.nonlinear_reaction_derivative is not None:
-            raise NotImplementedError
-        if not p.domain.boundary_types <= {'dirichlet', 'neumann'}:
+        if len(U) > 1:
             raise NotImplementedError
 
-        mesh, boundary_facets = discretize_domain(p.domain, mesh_type=mesh_type, diameter=diameter)
-        element = element or mesh.elem()
-        basis = Basis(mesh, element)
-        dirichlet_dofs = basis.get_dofs(boundary_facets['dirichlet']) if p.domain.has_dirichlet else None
+        plot(self.basis, U.to_numpy().ravel(), colorbar=True, **kwargs)
+        show()
 
-        Li = [DiffusionOperator(basis, ConstantFunction(0., p.domain.dim), dirichlet_dofs=dirichlet_dofs,
-                                name='boundary_part')]
-        coefficients = [1.]
 
+def discretize_stationary_cg(analytical_problem, diameter=None, mesh_type=None, element=None, preassemble=True):
+    """Discretizes a |StationaryProblem| with finite elements using scikit-fem.
+
+    Parameters
+    ----------
+    analytical_problem
+        The |StationaryProblem| to discretize.
+    diameter
+        If not `None`, `diameter` is passed as an argument to the `domain_discretizer`.
+    mesh_type
+        If not `None`, a `skfem.Mesh` to be used for discretizing the domain of
+        `analytical_problem`.
+    element
+        If not `None`, the `skfem.Element` to be used for building the finite element space.
+        If `None`, `mesh.elem()` is used.
+    preassemble
+        If `True`, preassemble all operators in the resulting |Model|.
+
+    Returns
+    -------
+    m
+        The |Model| that has been generated.
+    data
+        Dictionary with the following entries:
+
+            :mesh:             The generated `skfem.Mesh`.
+            :basis:            The generated `skfem.Basis`.
+            :boundary_facets:  Dict of `boundary_facets` of `mesh` per boundary type.
+            :dirichlet_dofs:   DOFs of the `skfem.Basis` associated with the Dirichlet boundary.
+            :unassembled_m:    In case `preassemble` is `True`, the generated |Model|
+                               before preassembling operators.
+    """
+    assert isinstance(analytical_problem, StationaryProblem)
+
+    p = analytical_problem
+
+    if p.nonlinear_advection is not None:
+        raise NotImplementedError
+    if p.nonlinear_advection_derivative is not None:
+        raise NotImplementedError
+    if p.nonlinear_reaction is not None:
+        raise NotImplementedError
+    if p.nonlinear_reaction_derivative is not None:
+        raise NotImplementedError
+    if not p.domain.boundary_types <= {'dirichlet', 'neumann'}:
+        raise NotImplementedError
+
+    mesh, boundary_facets = discretize_domain(p.domain, mesh_type=mesh_type, diameter=diameter)
+    element = element or mesh.elem()
+    basis = Basis(mesh, element)
+    dirichlet_dofs = basis.get_dofs(boundary_facets['dirichlet']) if p.domain.has_dirichlet else None
+
+    Li = [DiffusionOperator(basis, ConstantFunction(0., p.domain.dim), dirichlet_dofs=dirichlet_dofs,
+                            name='boundary_part')]
+    coefficients = [1.]
+
+    _assemble_operator(
+        p.diffusion, 'diffusion',
+        lambda f, n: DiffusionOperator(basis, f, dirichlet_dofs=dirichlet_dofs, dirichlet_clear_diag=True, name=n),
+        Li, coefficients
+    )
+
+    _assemble_operator(
+        p.advection, 'advection',
+        lambda f, n: AdvectionOperator(basis, f, dirichlet_dofs=dirichlet_dofs, dirichlet_clear_diag=True, name=n),
+        Li, coefficients
+    )
+
+    _assemble_operator(
+        p.reaction, 'reaction',
+        lambda f, n: L2ProductOperator(basis, coefficient_function=f, dirichlet_dofs=dirichlet_dofs,
+                                       dirichlet_clear_diag=True, name=n),
+        Li, coefficients
+    )
+
+    L = LincombOperator(operators=Li, coefficients=coefficients, name='ellipticOperator')
+
+    # right-hand side
+    Fi = []
+    coefficients_F = []
+
+    _assemble_operator(
+        p.rhs, 'rhs',
+        lambda f, n: L2Functional(basis, f, dirichlet_dofs=dirichlet_dofs, name=n),
+        Fi, coefficients_F
+    )
+
+    if p.dirichlet_data is not None and dirichlet_dofs is not None:
+        dirichlet_basis = BoundaryFacetBasis(mesh, element, facets=boundary_facets['dirichlet'])
         _assemble_operator(
-            p.diffusion, 'diffusion',
-            lambda f, n: DiffusionOperator(basis, f, dirichlet_dofs=dirichlet_dofs, dirichlet_clear_diag=True, name=n),
-            Li, coefficients
-        )
-
-        _assemble_operator(
-            p.advection, 'advection',
-            lambda f, n: AdvectionOperator(basis, f, dirichlet_dofs=dirichlet_dofs, dirichlet_clear_diag=True, name=n),
-            Li, coefficients
-        )
-
-        _assemble_operator(
-            p.reaction, 'reaction',
-            lambda f, n: L2ProductOperator(basis, coefficient_function=f, dirichlet_dofs=dirichlet_dofs,
-                                           dirichlet_clear_diag=True, name=n),
-            Li, coefficients
-        )
-
-        L = LincombOperator(operators=Li, coefficients=coefficients, name='ellipticOperator')
-
-        # right-hand side
-        Fi = []
-        coefficients_F = []
-
-        _assemble_operator(
-            p.rhs, 'rhs',
-            lambda f, n: L2Functional(basis, f, dirichlet_dofs=dirichlet_dofs, name=n),
+            p.dirichlet_data, 'dirichlet',
+            lambda f, n: BoundaryDirichletFunctional(dirichlet_basis, f, dirichlet_dofs=dirichlet_dofs, name=n),
             Fi, coefficients_F
         )
 
-        if p.dirichlet_data is not None and dirichlet_dofs is not None:
-            dirichlet_basis = BoundaryFacetBasis(mesh, element, facets=boundary_facets['dirichlet'])
-            _assemble_operator(
-                p.dirichlet_data, 'dirichlet',
-                lambda f, n: BoundaryDirichletFunctional(dirichlet_basis, f, dirichlet_dofs=dirichlet_dofs, name=n),
-                Fi, coefficients_F
-            )
+    if p.neumann_data is not None and p.domain.has_neumann:
+        neumann_basis = BoundaryFacetBasis(mesh, element, facets=boundary_facets['neumann'])
+        _assemble_operator(
+            p.neumann_data, 'neumann',
+            lambda f, n: L2Functional(neumann_basis, f, name=n),
+            Fi, coefficients_F, negative=True
+        )
 
-        if p.neumann_data is not None and p.domain.has_neumann:
-            neumann_basis = BoundaryFacetBasis(mesh, element, facets=boundary_facets['neumann'])
-            _assemble_operator(
-                p.neumann_data, 'neumann',
-                lambda f, n: L2Functional(neumann_basis, f, name=n),
-                Fi, coefficients_F, negative=True
-            )
+    F = LincombOperator(operators=Fi, coefficients=coefficients_F, name='rhsOperator')
 
-        F = LincombOperator(operators=Fi, coefficients=coefficients_F, name='rhsOperator')
+    l2_product = L2ProductOperator(basis)
+    h1_semi_product = DiffusionOperator(basis, ConstantFunction(1, p.domain.dim))
 
-        l2_product = L2ProductOperator(basis)
-        h1_semi_product = DiffusionOperator(basis, ConstantFunction(1, p.domain.dim))
+    products = {
+        'l2': l2_product,
+        'h1_semi': h1_semi_product,
+        'h1': l2_product + h1_semi_product,
+    }
 
-        products = {
-            'l2': l2_product,
-            'h1_semi': h1_semi_product,
-            'h1': l2_product + h1_semi_product,
-        }
-
-        if p.outputs:
-            if any(v[0] not in ('l2', 'l2_boundary') for v in p.outputs):
-                raise NotImplementedError
-            outputs = []
-            boundary_basis = None
-            for v in p.outputs:
-                if v[0] == 'l2':
-                    outputs.append(
-                        _assemble_operator(v[1], 'l2_output', lambda f, n: L2Functional(basis, f, name=n).H)
-                    )
-                else:
-                    boundary_basis = boundary_basis or BoundaryFacetBasis(mesh, element)
-                    outputs.append(
-                        _assemble_operator(v[1], 'l2_boundary_output',
-                                           lambda f, n: L2Functional(boundary_basis, f, name=n).H)
-                    )
-            if len(outputs) > 1:
-                from pymor.operators.block import BlockColumnOperator
-                from pymor.operators.constructions import NumpyConversionOperator
-                output_functional = BlockColumnOperator(outputs)
-                output_functional = NumpyConversionOperator(output_functional.range) @ output_functional
-            else:
-                output_functional = outputs[0]
-        else:
-            output_functional = None
-
-        m  = StationaryModel(L, F, output_functional=output_functional, products=products,
-                             visualizer=SKFemVisualizer(L.source, basis),
-                             name=f'{p.name}_CG')
-
-        data = {
-            'mesh': mesh,
-            'basis': basis,
-            'boundary_facets': boundary_facets,
-            'dirichlet_dofs': dirichlet_dofs,
-        }
-
-        if preassemble:
-            data['unassembled_m'] = m
-            m = preassemble_(m)
-
-        return m, data
-
-    def _eval_pymor_function(f, x, mu):
-        if len(f.shape_range) > 1:
+    if p.outputs:
+        if any(v[0] not in ('l2', 'l2_boundary') for v in p.outputs):
             raise NotImplementedError
-        x = np.moveaxis(x, 0, -1)
-        fx = f(x, mu=mu)
-        if len(f.shape_range) == 1:
-            fx = np.moveaxis(fx, -1, 0)
-        return fx
+        outputs = []
+        boundary_basis = None
+        for v in p.outputs:
+            if v[0] == 'l2':
+                outputs.append(
+                    _assemble_operator(v[1], 'l2_output', lambda f, n: L2Functional(basis, f, name=n).H)
+                )
+            else:
+                boundary_basis = boundary_basis or BoundaryFacetBasis(mesh, element)
+                outputs.append(
+                    _assemble_operator(v[1], 'l2_boundary_output',
+                                       lambda f, n: L2Functional(boundary_basis, f, name=n).H)
+                )
+        if len(outputs) > 1:
+            from pymor.operators.block import BlockColumnOperator
+            from pymor.operators.constructions import NumpyConversionOperator
+            output_functional = BlockColumnOperator(outputs)
+            output_functional = NumpyConversionOperator(output_functional.range) @ output_functional
+        else:
+            output_functional = outputs[0]
+    else:
+        output_functional = None
 
-    def _assemble_operator(function, name, factory, ops=None, coeffs=None, negative=False):
-        if isinstance(function, LincombFunction):
-            operators = [factory(-f if negative else f, name=f'name_{i}') for i, f in enumerate(function)]
-            if ops is not None:
-                ops.extend(operators)
-                coeffs.extend(function.coefficients)
-            else:
-                return LincombOperator(operators, function.coefficients, name=name)
-        elif function is not None:
-            operator = factory(-function if negative else function, name)
-            if ops is not None:
-                ops.append(operator)
-                coeffs.append(1.)
-            else:
-                return operator
+    m  = StationaryModel(L, F, output_functional=output_functional, products=products,
+                         visualizer=SKFemVisualizer(L.source, basis),
+                         name=f'{p.name}_CG')
+
+    data = {
+        'mesh': mesh,
+        'basis': basis,
+        'boundary_facets': boundary_facets,
+        'dirichlet_dofs': dirichlet_dofs,
+    }
+
+    if preassemble:
+        data['unassembled_m'] = m
+        m = preassemble_(m)
+
+    return m, data
+
+
+def _eval_pymor_function(f, x, mu):
+    if len(f.shape_range) > 1:
+        raise NotImplementedError
+    x = np.moveaxis(x, 0, -1)
+    fx = f(x, mu=mu)
+    if len(f.shape_range) == 1:
+        fx = np.moveaxis(fx, -1, 0)
+    return fx
+
+
+def _assemble_operator(function, name, factory, ops=None, coeffs=None, negative=False):
+    if isinstance(function, LincombFunction):
+        operators = [factory(-f if negative else f, name=f'name_{i}') for i, f in enumerate(function)]
+        if ops is not None:
+            ops.extend(operators)
+            coeffs.extend(function.coefficients)
+        else:
+            return LincombOperator(operators, function.coefficients, name=name)
+    elif function is not None:
+        operator = factory(-function if negative else function, name)
+        if ops is not None:
+            ops.append(operator)
+            coeffs.append(1.)
+        else:
+            return operator

--- a/src/pymor/discretizers/skfem/domaindiscretizer.py
+++ b/src/pymor/discretizers/skfem/domaindiscretizer.py
@@ -2,73 +2,74 @@
 # Copyright 2013-2021 pyMOR developers and contributors. All rights reserved.
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
-from pymor.core.config import config
+from pymor.core.config import require_dependency
+require_dependency('SCIKIT_FEM')
 
-if config.HAVE_SCIKIT_FEM:
 
-    import numpy as np
-    import skfem
+import numpy as np
+import skfem
 
-    from pymor.analyticalproblems.domaindescriptions import (RectDomain, CylindricalDomain, TorusDomain, LineDomain,
-                                                             CircleDomain, PolygonalDomain)
+from pymor.analyticalproblems.domaindescriptions import (RectDomain, CylindricalDomain, TorusDomain, LineDomain,
+                                                         CircleDomain, PolygonalDomain)
 
-    def discretize_domain(domain_description, diameter=1 / 100, mesh_type=None):
 
-        def discretize_RectDomain():
-            mt = mesh_type or skfem.MeshQuad
-            x0i = int(np.ceil(domain_description.width * np.sqrt(2) / diameter))
-            x1i = int(np.ceil(domain_description.height * np.sqrt(2) / diameter))
-            mesh = mt.init_tensor(
-                np.linspace(domain_description.domain[0, 0], domain_description.domain[1, 0], x0i + 1),
-                np.linspace(domain_description.domain[0, 1], domain_description.domain[1, 1], x1i + 1)
-            ).with_boundaries({
-                'left': lambda x: x[0] == domain_description.domain[0, 0],
-                'right': lambda x: x[0] == domain_description.domain[1, 0],
-                'top': lambda x: x[1] == domain_description.domain[1, 1],
-                'bottom': lambda x: x[1] == domain_description.domain[0, 1],
-            })
+def discretize_domain(domain_description, diameter=1 / 100, mesh_type=None):
 
-            boundary_facets = {
-                bt: np.hstack([mesh.boundaries[edge]
-                              for edge in ['left', 'right', 'top', 'bottom']
-                              if getattr(domain_description, edge) == bt])
-                for bt in domain_description.boundary_types
-            }
+    def discretize_RectDomain():
+        mt = mesh_type or skfem.MeshQuad
+        x0i = int(np.ceil(domain_description.width * np.sqrt(2) / diameter))
+        x1i = int(np.ceil(domain_description.height * np.sqrt(2) / diameter))
+        mesh = mt.init_tensor(
+            np.linspace(domain_description.domain[0, 0], domain_description.domain[1, 0], x0i + 1),
+            np.linspace(domain_description.domain[0, 1], domain_description.domain[1, 1], x1i + 1)
+        ).with_boundaries({
+            'left': lambda x: x[0] == domain_description.domain[0, 0],
+            'right': lambda x: x[0] == domain_description.domain[1, 0],
+            'top': lambda x: x[1] == domain_description.domain[1, 1],
+            'bottom': lambda x: x[1] == domain_description.domain[0, 1],
+        })
 
-            return mesh, boundary_facets
+        boundary_facets = {
+            bt: np.hstack([mesh.boundaries[edge]
+                          for edge in ['left', 'right', 'top', 'bottom']
+                          if getattr(domain_description, edge) == bt])
+            for bt in domain_description.boundary_types
+        }
 
-        def discretize_LineDomain():
-            mt = mesh_type or skfem.MeshLine
-            mesh = mt(
-                np.linspace(domain_description.domain[0], domain_description.domain[1],
-                            int(np.ceil((domain_description.domain[1] - domain_description.domain[0]) / diameter)))
-            ).with_boundaries({
-                'left': lambda x: x[0] == domain_description.domain[0],
-                'right': lambda x: x[0] == domain_description.domain[1]
-            })
+        return mesh, boundary_facets
 
-            boundary_facets = {
-                bt: np.hstack([mesh.boundaries[edge]
-                              for edge in ['left', 'right']
-                              if getattr(domain_description, edge) == bt])
-                for bt in domain_description.boundary_types
-            }
+    def discretize_LineDomain():
+        mt = mesh_type or skfem.MeshLine
+        mesh = mt(
+            np.linspace(domain_description.domain[0], domain_description.domain[1],
+                        int(np.ceil((domain_description.domain[1] - domain_description.domain[0]) / diameter)))
+        ).with_boundaries({
+            'left': lambda x: x[0] == domain_description.domain[0],
+            'right': lambda x: x[0] == domain_description.domain[1]
+        })
 
-            return mesh, boundary_facets
+        boundary_facets = {
+            bt: np.hstack([mesh.boundaries[edge]
+                          for edge in ['left', 'right']
+                          if getattr(domain_description, edge) == bt])
+            for bt in domain_description.boundary_types
+        }
 
-        if isinstance(domain_description, RectDomain):
-            return discretize_RectDomain()
-        elif isinstance(domain_description, CylindricalDomain):
-            raise NotImplementedError
-        elif isinstance(domain_description, TorusDomain):
-            raise NotImplementedError
-        elif isinstance(domain_description, PolygonalDomain):
-            # from pymor.discretizers.builtin.domaindiscretizers.gmsh import discretize_gmsh
-            # return discretize_gmsh(domain_description, clscale=diameter)
-            raise NotImplementedError
-        elif isinstance(domain_description, LineDomain):
-            return discretize_LineDomain()
-        elif isinstance(domain_description, CircleDomain):
-            raise NotImplementedError
-        else:
-            raise NotImplementedError
+        return mesh, boundary_facets
+
+    if isinstance(domain_description, RectDomain):
+        return discretize_RectDomain()
+    elif isinstance(domain_description, CylindricalDomain):
+        raise NotImplementedError
+    elif isinstance(domain_description, TorusDomain):
+        raise NotImplementedError
+    elif isinstance(domain_description, PolygonalDomain):
+        # from pymor.discretizers.builtin.domaindiscretizers.gmsh import discretize_gmsh
+        # return discretize_gmsh(domain_description, clscale=diameter)
+        raise NotImplementedError
+    elif isinstance(domain_description, LineDomain):
+        return discretize_LineDomain()
+    elif isinstance(domain_description, CircleDomain):
+        raise NotImplementedError
+    else:
+        raise NotImplementedError

--- a/src/pymor/discretizers/skfem/domaindiscretizer.py
+++ b/src/pymor/discretizers/skfem/domaindiscretizer.py
@@ -2,8 +2,8 @@
 # Copyright 2013-2021 pyMOR developers and contributors. All rights reserved.
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
-from pymor.core.config import require_dependency
-require_dependency('SCIKIT_FEM')
+from pymor.core.config import config
+config.require('SCIKIT_FEM')
 
 
 import numpy as np

--- a/src/pymor/models/neural_network.py
+++ b/src/pymor/models/neural_network.py
@@ -10,297 +10,290 @@ and `FullyConnectedNN` do not appear in the documentation,
 see https://github.com/pymor/pymor/issues/1343.
 """
 
-from pymor.core.config import config
+from pymor.core.config import require_dependency
+require_dependency('TORCH')
 
 
-if config.HAVE_TORCH:
-    import numpy as np
+import numpy as np
 
-    import torch
-    import torch.nn as nn
+import torch
+import torch.nn as nn
 
-    from pymor.core.base import BasicObject
-    from pymor.models.interface import Model
-    from pymor.operators.constructions import ZeroOperator
-    from pymor.vectorarrays.numpy import NumpyVectorSpace
+from pymor.core.base import BasicObject
+from pymor.models.interface import Model
+from pymor.operators.constructions import ZeroOperator
+from pymor.vectorarrays.numpy import NumpyVectorSpace
 
-    class NeuralNetworkModel(Model):
-        """Class for models of stationary problems that use artificial neural networks.
 
-        This class implements a |Model| that uses a neural network for solving.
+class NeuralNetworkModel(Model):
+    """Class for models of stationary problems that use artificial neural networks.
 
-        Parameters
-        ----------
-        neural_network
-            The neural network that approximates the mapping from parameter space
-            to solution space. Should be an instance of
-            :class:`~pymor.models.neural_network.FullyConnectedNN` with input size that
-            matches the (total) number of parameters and output size equal to the
-            dimension of the reduced space.
-        parameters
-            |Parameters| of the reduced order model (the same as used in the full-order
-            model).
-        output_functional
-            |Operator| mapping a given solution to the model output. In many applications,
-            this will be a |Functional|, i.e. an |Operator| mapping to scalars.
-            This is not required, however.
-        products
-            A dict of inner product |Operators| defined on the discrete space the
-            problem is posed on. For each product with key `'x'` a corresponding
-            attribute `x_product`, as well as a norm method `x_norm` is added to
-            the model.
-        error_estimator
-            An error estimator for the problem. This can be any object with
-            an `estimate_error(U, mu, m)` method. If `error_estimator` is
-            not `None`, an `estimate_error(U, mu)` method is added to the
-            model which will call `error_estimator.estimate_error(U, mu, self)`.
-        visualizer
-            A visualizer for the problem. This can be any object with
-            a `visualize(U, m, ...)` method. If `visualizer`
-            is not `None`, a `visualize(U, *args, **kwargs)` method is added
-            to the model which forwards its arguments to the
-            visualizer's `visualize` method.
-        name
-            Name of the model.
-        """
+    This class implements a |Model| that uses a neural network for solving.
 
-        def __init__(self, neural_network, parameters={}, output_functional=None,
-                     products=None, error_estimator=None, visualizer=None, name=None):
+    Parameters
+    ----------
+    neural_network
+        The neural network that approximates the mapping from parameter space
+        to solution space. Should be an instance of
+        :class:`~pymor.models.neural_network.FullyConnectedNN` with input size that
+        matches the (total) number of parameters and output size equal to the
+        dimension of the reduced space.
+    parameters
+        |Parameters| of the reduced order model (the same as used in the full-order
+        model).
+    output_functional
+        |Operator| mapping a given solution to the model output. In many applications,
+        this will be a |Functional|, i.e. an |Operator| mapping to scalars.
+        This is not required, however.
+    products
+        A dict of inner product |Operators| defined on the discrete space the
+        problem is posed on. For each product with key `'x'` a corresponding
+        attribute `x_product`, as well as a norm method `x_norm` is added to
+        the model.
+    error_estimator
+        An error estimator for the problem. This can be any object with
+        an `estimate_error(U, mu, m)` method. If `error_estimator` is
+        not `None`, an `estimate_error(U, mu)` method is added to the
+        model which will call `error_estimator.estimate_error(U, mu, self)`.
+    visualizer
+        A visualizer for the problem. This can be any object with
+        a `visualize(U, m, ...)` method. If `visualizer`
+        is not `None`, a `visualize(U, *args, **kwargs)` method is added
+        to the model which forwards its arguments to the
+        visualizer's `visualize` method.
+    name
+        Name of the model.
+    """
 
-            super().__init__(products=products, error_estimator=error_estimator,
-                             visualizer=visualizer, name=name)
+    def __init__(self, neural_network, parameters={}, output_functional=None,
+                 products=None, error_estimator=None, visualizer=None, name=None):
 
-            self.__auto_init(locals())
-            self.solution_space = NumpyVectorSpace(neural_network.output_dimension)
-            output_functional = output_functional or ZeroOperator(NumpyVectorSpace(0), self.solution_space)
-            assert output_functional.source == self.solution_space
+        super().__init__(products=products, error_estimator=error_estimator,
+                         visualizer=visualizer, name=name)
+
+        self.__auto_init(locals())
+        self.solution_space = NumpyVectorSpace(neural_network.output_dimension)
+        output_functional = output_functional or ZeroOperator(NumpyVectorSpace(0), self.solution_space)
+        assert output_functional.source == self.solution_space
+        self.dim_output = output_functional.range.dim
+
+    def _compute_solution(self, mu=None, **kwargs):
+
+        # convert the parameter `mu` into a form that is usable in PyTorch
+        converted_input = torch.DoubleTensor(mu.to_numpy())
+        # obtain (reduced) coordinates by forward pass of the parameter values
+        # through the neural network
+        U = self.neural_network(converted_input).data.numpy()
+        # convert plain numpy array to element of the actual solution space
+        U = self.solution_space.make_array(U)
+
+        return U
+
+
+class NeuralNetworkStatefreeOutputModel(Model):
+    """Class for models of the output of stationary problems that use ANNs.
+
+    This class implements a |Model| that uses a neural network for solving for the output
+    quantity.
+
+    Parameters
+    ----------
+    neural_network
+        The neural network that approximates the mapping from parameter space
+        to output space. Should be an instance of
+        :class:`~pymor.models.neural_network.FullyConnectedNN` with input size that
+        matches the (total) number of parameters and output size equal to the
+        dimension of the output space.
+    parameters
+        |Parameters| of the reduced order model (the same as used in the full-order
+        model).
+    error_estimator
+        An error estimator for the problem. This can be any object with
+        an `estimate_error(U, mu, m)` method. If `error_estimator` is
+        not `None`, an `estimate_error(U, mu)` method is added to the
+        model which will call `error_estimator.estimate_error(U, mu, self)`.
+    name
+        Name of the model.
+    """
+
+    def __init__(self, neural_network, parameters={}, error_estimator=None, name=None):
+
+        super().__init__(error_estimator=error_estimator, name=name)
+
+        self.__auto_init(locals())
+
+    def _compute(self, solution=False, output=False, solution_d_mu=False, output_d_mu=False,
+                 solution_error_estimate=False, output_error_estimate=False,
+                 output_d_mu_return_array=False, mu=None, **kwargs):
+        if output:
+            converted_input = torch.from_numpy(mu.to_numpy()).double()
+            output = self.neural_network(converted_input).data.numpy()
+            return {'output': output, 'solution': None}
+        return {}
+
+
+class NeuralNetworkInstationaryModel(Model):
+    """Class for models of instationary problems that use artificial neural networks.
+
+    This class implements a |Model| that uses a neural network for solving.
+
+    Parameters
+    ----------
+    T
+        The final time T.
+    nt
+        The number of time steps.
+    neural_network
+        The neural network that approximates the mapping from parameter space
+        to solution space. Should be an instance of
+        :class:`~pymor.models.neural_network.FullyConnectedNN` with input size that
+        matches the (total) number of parameters and output size equal to the
+        dimension of the reduced space.
+    parameters
+        |Parameters| of the reduced order model (the same as used in the full-order
+        model).
+    output_functional
+        |Operator| mapping a given solution to the model output. In many applications,
+        this will be a |Functional|, i.e. an |Operator| mapping to scalars.
+        This is not required, however.
+    products
+        A dict of inner product |Operators| defined on the discrete space the
+        problem is posed on. For each product with key `'x'` a corresponding
+        attribute `x_product`, as well as a norm method `x_norm` is added to
+        the model.
+    error_estimator
+        An error estimator for the problem. This can be any object with
+        an `estimate_error(U, mu, m)` method. If `error_estimator` is
+        not `None`, an `estimate_error(U, mu)` method is added to the
+        model which will call `error_estimator.estimate_error(U, mu, self)`.
+    visualizer
+        A visualizer for the problem. This can be any object with
+        a `visualize(U, m, ...)` method. If `visualizer`
+        is not `None`, a `visualize(U, *args, **kwargs)` method is added
+        to the model which forwards its arguments to the
+        visualizer's `visualize` method.
+    name
+        Name of the model.
+    """
+
+    def __init__(self, T, nt, neural_network, parameters={}, output_functional=None,
+                 products=None, error_estimator=None, visualizer=None, name=None):
+
+        super().__init__(products=products, error_estimator=error_estimator,
+                         visualizer=visualizer, name=name)
+
+        self.__auto_init(locals())
+        self.solution_space = NumpyVectorSpace(neural_network.output_dimension)
+        if output_functional is not None:
             self.dim_output = output_functional.range.dim
 
-        def _compute_solution(self, mu=None, **kwargs):
-
-            # convert the parameter `mu` into a form that is usable in PyTorch
-            converted_input = torch.DoubleTensor(mu.to_numpy())
-            # obtain (reduced) coordinates by forward pass of the parameter values
-            # through the neural network
-            U = self.neural_network(converted_input).data.numpy()
-            # convert plain numpy array to element of the actual solution space
-            U = self.solution_space.make_array(U)
-
-            return U
+    def _compute_solution(self, mu=None, **kwargs):
+        # collect all inputs in a single tensor
+        inputs = torch.DoubleTensor([mu.with_(t=t).to_numpy() for t in np.linspace(0., self.T, self.nt)])
+        # pass batch of inputs to neural network
+        result = self.neural_network(inputs).data.numpy()
+        # convert result into element from solution space
+        return self.solution_space.make_array(result)
 
 
-if config.HAVE_TORCH:
+class NeuralNetworkInstationaryStatefreeOutputModel(Model):
+    """Class for models of the output of instationary problems that use ANNs.
 
-    class NeuralNetworkStatefreeOutputModel(Model):
-        """Class for models of the output of stationary problems that use ANNs.
+    This class implements a |Model| that uses a neural network for solving for the output
+    quantity in the instationary case.
 
-        This class implements a |Model| that uses a neural network for solving for the output
-        quantity.
+    Parameters
+    ----------
+    T
+        The final time T.
+    nt
+        The number of time steps.
+    neural_network
+        The neural network that approximates the mapping from parameter space
+        to output space. Should be an instance of
+        :class:`~pymor.models.neural_network.FullyConnectedNN` with input size that
+        matches the (total) number of parameters and output size equal to the
+        dimension of the output space.
+    parameters
+        |Parameters| of the reduced order model (the same as used in the full-order
+        model).
+    error_estimator
+        An error estimator for the problem. This can be any object with
+        an `estimate_error(U, mu, m)` method. If `error_estimator` is
+        not `None`, an `estimate_error(U, mu)` method is added to the
+        model which will call `error_estimator.estimate_error(U, mu, self)`.
+    name
+        Name of the model.
+    """
 
-        Parameters
-        ----------
-        neural_network
-            The neural network that approximates the mapping from parameter space
-            to output space. Should be an instance of
-            :class:`~pymor.models.neural_network.FullyConnectedNN` with input size that
-            matches the (total) number of parameters and output size equal to the
-            dimension of the output space.
-        parameters
-            |Parameters| of the reduced order model (the same as used in the full-order
-            model).
-        error_estimator
-            An error estimator for the problem. This can be any object with
-            an `estimate_error(U, mu, m)` method. If `error_estimator` is
-            not `None`, an `estimate_error(U, mu)` method is added to the
-            model which will call `error_estimator.estimate_error(U, mu, self)`.
-        name
-            Name of the model.
-        """
+    def __init__(self, T, nt, neural_network, parameters={}, error_estimator=None, name=None):
 
-        def __init__(self, neural_network, parameters={}, error_estimator=None, name=None):
+        super().__init__(error_estimator=error_estimator, name=name)
 
-            super().__init__(error_estimator=error_estimator, name=name)
+        self.__auto_init(locals())
 
-            self.__auto_init(locals())
+    def _compute(self, solution=False, output=False, solution_d_mu=False, output_d_mu=False,
+                 solution_error_estimate=False, output_error_estimate=False,
+                 output_d_mu_return_array=False, mu=None, **kwargs):
 
-        def _compute(self, solution=False, output=False, solution_d_mu=False, output_d_mu=False,
-                     solution_error_estimate=False, output_error_estimate=False,
-                     output_d_mu_return_array=False, mu=None, **kwargs):
-            if output:
-                converted_input = torch.from_numpy(mu.to_numpy()).double()
-                output = self.neural_network(converted_input).data.numpy()
-                return {'output': output, 'solution': None}
-            return {}
-
-
-if config.HAVE_TORCH:
-
-    class NeuralNetworkInstationaryModel(Model):
-        """Class for models of instationary problems that use artificial neural networks.
-
-        This class implements a |Model| that uses a neural network for solving.
-
-        Parameters
-        ----------
-        T
-            The final time T.
-        nt
-            The number of time steps.
-        neural_network
-            The neural network that approximates the mapping from parameter space
-            to solution space. Should be an instance of
-            :class:`~pymor.models.neural_network.FullyConnectedNN` with input size that
-            matches the (total) number of parameters and output size equal to the
-            dimension of the reduced space.
-        parameters
-            |Parameters| of the reduced order model (the same as used in the full-order
-            model).
-        output_functional
-            |Operator| mapping a given solution to the model output. In many applications,
-            this will be a |Functional|, i.e. an |Operator| mapping to scalars.
-            This is not required, however.
-        products
-            A dict of inner product |Operators| defined on the discrete space the
-            problem is posed on. For each product with key `'x'` a corresponding
-            attribute `x_product`, as well as a norm method `x_norm` is added to
-            the model.
-        error_estimator
-            An error estimator for the problem. This can be any object with
-            an `estimate_error(U, mu, m)` method. If `error_estimator` is
-            not `None`, an `estimate_error(U, mu)` method is added to the
-            model which will call `error_estimator.estimate_error(U, mu, self)`.
-        visualizer
-            A visualizer for the problem. This can be any object with
-            a `visualize(U, m, ...)` method. If `visualizer`
-            is not `None`, a `visualize(U, *args, **kwargs)` method is added
-            to the model which forwards its arguments to the
-            visualizer's `visualize` method.
-        name
-            Name of the model.
-        """
-
-        def __init__(self, T, nt, neural_network, parameters={}, output_functional=None,
-                     products=None, error_estimator=None, visualizer=None, name=None):
-
-            super().__init__(products=products, error_estimator=error_estimator,
-                             visualizer=visualizer, name=name)
-
-            self.__auto_init(locals())
-            self.solution_space = NumpyVectorSpace(neural_network.output_dimension)
-            if output_functional is not None:
-                self.dim_output = output_functional.range.dim
-
-        def _compute_solution(self, mu=None, **kwargs):
+        if output:
             # collect all inputs in a single tensor
             inputs = torch.DoubleTensor([mu.with_(t=t).to_numpy() for t in np.linspace(0., self.T, self.nt)])
             # pass batch of inputs to neural network
-            result = self.neural_network(inputs).data.numpy()
-            # convert result into element from solution space
-            return self.solution_space.make_array(result)
+            outputs = self.neural_network(inputs).data.numpy()
+
+            return {'output': outputs, 'solution': None}
+        return {}
 
 
-if config.HAVE_TORCH:
+class FullyConnectedNN(nn.Module, BasicObject):
+    """Class for neural networks with fully connected layers.
 
-    class NeuralNetworkInstationaryStatefreeOutputModel(Model):
-        """Class for models of the output of instationary problems that use ANNs.
+    This class implements neural networks consisting of linear and fully connected layers.
+    Furthermore, the same activation function is used between each layer, except for the
+    last one where no activation function is applied.
 
-        This class implements a |Model| that uses a neural network for solving for the output
-        quantity in the instationary case.
+    Parameters
+    ----------
+    layer_sizes
+        List of sizes (i.e. number of neurons) for the layers of the neural network.
+    activation_function
+        Function to use as activation function between the single layers.
+    """
 
-        Parameters
-        ----------
-        T
-            The final time T.
-        nt
-            The number of time steps.
-        neural_network
-            The neural network that approximates the mapping from parameter space
-            to output space. Should be an instance of
-            :class:`~pymor.models.neural_network.FullyConnectedNN` with input size that
-            matches the (total) number of parameters and output size equal to the
-            dimension of the output space.
-        parameters
-            |Parameters| of the reduced order model (the same as used in the full-order
-            model).
-        error_estimator
-            An error estimator for the problem. This can be any object with
-            an `estimate_error(U, mu, m)` method. If `error_estimator` is
-            not `None`, an `estimate_error(U, mu)` method is added to the
-            model which will call `error_estimator.estimate_error(U, mu, self)`.
-        name
-            Name of the model.
-        """
+    def __init__(self, layer_sizes, activation_function=torch.tanh):
+        super().__init__()
 
-        def __init__(self, T, nt, neural_network, parameters={}, error_estimator=None, name=None):
+        if layer_sizes is None or not len(layer_sizes) > 1 or not all(size >= 1 for size in layer_sizes):
+            raise ValueError
 
-            super().__init__(error_estimator=error_estimator, name=name)
+        self.input_dimension = layer_sizes[0]
+        self.output_dimension = layer_sizes[-1]
 
-            self.__auto_init(locals())
+        self.layers = nn.ModuleList()
+        self.layers.extend([nn.Linear(int(layer_sizes[i]), int(layer_sizes[i+1]))
+                            for i in range(len(layer_sizes) - 1)])
 
-        def _compute(self, solution=False, output=False, solution_d_mu=False, output_d_mu=False,
-                     solution_error_estimate=False, output_error_estimate=False,
-                     output_d_mu_return_array=False, mu=None, **kwargs):
+        self.activation_function = activation_function
 
-            if output:
-                # collect all inputs in a single tensor
-                inputs = torch.DoubleTensor([mu.with_(t=t).to_numpy() for t in np.linspace(0., self.T, self.nt)])
-                # pass batch of inputs to neural network
-                outputs = self.neural_network(inputs).data.numpy()
+        if not self.logging_disabled:
+            self.logger.info(f'Architecture of the neural network:\n{self}')
 
-                return {'output': outputs, 'solution': None}
-            return {}
+    def forward(self, x):
+        """Performs the forward pass through the neural network.
 
-
-if config.HAVE_TORCH:
-
-    class FullyConnectedNN(nn.Module, BasicObject):
-        """Class for neural networks with fully connected layers.
-
-        This class implements neural networks consisting of linear and fully connected layers.
-        Furthermore, the same activation function is used between each layer, except for the
-        last one where no activation function is applied.
+        Applies the weights in the linear layers and passes the outcomes to the
+        activation function.
 
         Parameters
         ----------
-        layer_sizes
-            List of sizes (i.e. number of neurons) for the layers of the neural network.
-        activation_function
-            Function to use as activation function between the single layers.
+        x
+            Input for the neural network.
+
+        Returns
+        -------
+        The output of the neural network for the input x.
         """
-
-        def __init__(self, layer_sizes, activation_function=torch.tanh):
-            super().__init__()
-
-            if layer_sizes is None or not len(layer_sizes) > 1 or not all(size >= 1 for size in layer_sizes):
-                raise ValueError
-
-            self.input_dimension = layer_sizes[0]
-            self.output_dimension = layer_sizes[-1]
-
-            self.layers = nn.ModuleList()
-            self.layers.extend([nn.Linear(int(layer_sizes[i]), int(layer_sizes[i+1]))
-                                for i in range(len(layer_sizes) - 1)])
-
-            self.activation_function = activation_function
-
-            if not self.logging_disabled:
-                self.logger.info(f'Architecture of the neural network:\n{self}')
-
-        def forward(self, x):
-            """Performs the forward pass through the neural network.
-
-            Applies the weights in the linear layers and passes the outcomes to the
-            activation function.
-
-            Parameters
-            ----------
-            x
-                Input for the neural network.
-
-            Returns
-            -------
-            The output of the neural network for the input x.
-            """
-            for i in range(len(self.layers) - 1):
-                x = self.activation_function(self.layers[i](x))
-            return self.layers[len(self.layers)-1](x)
+        for i in range(len(self.layers) - 1):
+            x = self.activation_function(self.layers[i](x))
+        return self.layers[len(self.layers)-1](x)

--- a/src/pymor/models/neural_network.py
+++ b/src/pymor/models/neural_network.py
@@ -10,8 +10,8 @@ and `FullyConnectedNN` do not appear in the documentation,
 see https://github.com/pymor/pymor/issues/1343.
 """
 
-from pymor.core.config import require_dependency
-require_dependency('TORCH')
+from pymor.core.config import config
+config.require('TORCH')
 
 
 import numpy as np

--- a/src/pymor/parallel/ipython.py
+++ b/src/pymor/parallel/ipython.py
@@ -2,23 +2,24 @@
 # Copyright 2013-2021 pyMOR developers and contributors. All rights reserved.
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
+from pymor.core.config import require_dependency
+require_dependency('IPYTHON')
+
+
 from itertools import chain
 import os
 import time
 
-
 from pymor.core.base import BasicObject
-from pymor.core.config import config
 from pymor.core import defaults
 from pymor.parallel.basic import WorkerPoolBase
 from pymor.tools.counter import Counter
 
 
-if config.HAVE_IPYTHON:
-    try:
-        from ipyparallel import Client, TimeoutError
-    except ImportError:
-        from IPython.parallel import Client, TimeoutError
+try:
+    from ipyparallel import Client, TimeoutError
+except ImportError:
+    from IPython.parallel import Client, TimeoutError
 
 
 class new_ipcluster_pool(BasicObject):
@@ -135,6 +136,7 @@ class IPythonPool(WorkerPoolBase):
     kwargs
         Keyword arguments used to instantiate the IPython cluster client.
     """
+
     _updated_defaults = 0
 
     def __init__(self, num_engines=None, **kwargs):

--- a/src/pymor/parallel/ipython.py
+++ b/src/pymor/parallel/ipython.py
@@ -2,8 +2,8 @@
 # Copyright 2013-2021 pyMOR developers and contributors. All rights reserved.
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
-from pymor.core.config import require_dependency
-require_dependency('IPYTHON')
+from pymor.core.config import config
+config.require('IPYTHON')
 
 
 from itertools import chain

--- a/src/pymor/reductors/neural_network.py
+++ b/src/pymor/reductors/neural_network.py
@@ -10,846 +10,833 @@ Due to an issue in autoapi, the classes `NeuralNetworkStatefreeOutputReductor`,
 see https://github.com/pymor/pymor/issues/1343.
 """
 
-from pymor.core.config import config
+from pymor.core.config import require_dependency
+require_dependency('TORCH')
 
 
-if config.HAVE_TORCH:
-    from numbers import Number
+from numbers import Number
 
-    import numpy as np
+import numpy as np
 
-    import torch
-    import torch.nn as nn
-    import torch.optim as optim
-    import torch.utils as utils
+import torch
+import torch.nn as nn
+import torch.optim as optim
+import torch.utils as utils
 
-    from pymor.algorithms.pod import pod
-    from pymor.algorithms.projection import project
-    from pymor.core.base import BasicObject
-    from pymor.core.exceptions import NeuralNetworkTrainingFailed
-    from pymor.core.logger import getLogger
-    from pymor.models.neural_network import (FullyConnectedNN, NeuralNetworkModel,
-                                             NeuralNetworkStatefreeOutputModel,
-                                             NeuralNetworkInstationaryModel,
-                                             NeuralNetworkInstationaryStatefreeOutputModel)
+from pymor.algorithms.pod import pod
+from pymor.algorithms.projection import project
+from pymor.core.base import BasicObject
+from pymor.core.exceptions import NeuralNetworkTrainingFailed
+from pymor.core.logger import getLogger
+from pymor.models.neural_network import (FullyConnectedNN, NeuralNetworkModel,
+                                         NeuralNetworkStatefreeOutputModel,
+                                         NeuralNetworkInstationaryModel,
+                                         NeuralNetworkInstationaryStatefreeOutputModel)
 
-    class NeuralNetworkReductor(BasicObject):
-        """Reduced Basis reductor relying on artificial neural networks.
 
-        This is a reductor that constructs a reduced basis using proper
-        orthogonal decomposition and trains a neural network that approximates
-        the mapping from parameter space to coefficients of the full-order
-        solution in the reduced basis.
-        The approach is described in :cite:`HU18`.
+class NeuralNetworkReductor(BasicObject):
+    """Reduced Basis reductor relying on artificial neural networks.
+
+    This is a reductor that constructs a reduced basis using proper
+    orthogonal decomposition and trains a neural network that approximates
+    the mapping from parameter space to coefficients of the full-order
+    solution in the reduced basis.
+    The approach is described in :cite:`HU18`.
+
+    Parameters
+    ----------
+    fom
+        The full-order |Model| to reduce.
+    training_set
+        Set of |parameter values| to use for POD and training of the
+        neural network.
+    validation_set
+        Set of |parameter values| to use for validation in the training
+        of the neural network.
+    validation_ratio
+        Fraction of the training set to use for validation in the training
+        of the neural network (only used if no validation set is provided).
+    basis_size
+        Desired size of the reduced basis. If `None`, rtol, atol or l2_err must
+        be provided.
+    rtol
+        Relative tolerance the basis should guarantee on the training set.
+    atol
+        Absolute tolerance the basis should guarantee on the training set.
+    l2_err
+        L2-approximation error the basis should not exceed on the training
+        set.
+    pod_params
+        Dict of additional parameters for the POD-method.
+    ann_mse
+        If `'like_basis'`, the mean squared error of the neural network on
+        the training set should not exceed the error of projecting onto the basis.
+        If `None`, the neural network with smallest validation error is
+        used to build the ROM.
+        If a tolerance is prescribed, the mean squared error of the neural
+        network on the training set should not exceed this threshold.
+        Training is interrupted if a neural network that undercuts the
+        error tolerance is found.
+    """
+
+    def __init__(self, fom, training_set, validation_set=None, validation_ratio=0.1,
+                 basis_size=None, rtol=0., atol=0., l2_err=0., pod_params=None,
+                 ann_mse='like_basis'):
+        assert 0 < validation_ratio < 1 or validation_set
+        self.__auto_init(locals())
+
+    def reduce(self, hidden_layers='[(N+P)*3, (N+P)*3]', activation_function=torch.tanh,
+               optimizer=optim.LBFGS, epochs=1000, batch_size=20, learning_rate=1.,
+               restarts=10, seed=0):
+        """Reduce by training artificial neural networks.
 
         Parameters
         ----------
-        fom
-            The full-order |Model| to reduce.
-        training_set
-            Set of |parameter values| to use for POD and training of the
-            neural network.
-        validation_set
-            Set of |parameter values| to use for validation in the training
-            of the neural network.
-        validation_ratio
-            Fraction of the training set to use for validation in the training
-            of the neural network (only used if no validation set is provided).
-        basis_size
-            Desired size of the reduced basis. If `None`, rtol, atol or l2_err must
-            be provided.
-        rtol
-            Relative tolerance the basis should guarantee on the training set.
-        atol
-            Absolute tolerance the basis should guarantee on the training set.
-        l2_err
-            L2-approximation error the basis should not exceed on the training
-            set.
-        pod_params
-            Dict of additional parameters for the POD-method.
-        ann_mse
-            If `'like_basis'`, the mean squared error of the neural network on
-            the training set should not exceed the error of projecting onto the basis.
-            If `None`, the neural network with smallest validation error is
-            used to build the ROM.
-            If a tolerance is prescribed, the mean squared error of the neural
-            network on the training set should not exceed this threshold.
-            Training is interrupted if a neural network that undercuts the
-            error tolerance is found.
+        hidden_layers
+            Number of neurons in the hidden layers. Can either be fixed or
+            a Python expression string depending on the reduced basis size
+            respectively output dimension `N` and the total dimension of
+            the |Parameters| `P`.
+        activation_function
+            Activation function to use between the hidden layers.
+        optimizer
+            Algorithm to use as optimizer during training.
+        epochs
+            Maximum number of epochs for training.
+        batch_size
+            Batch size to use if optimizer allows mini-batching.
+        learning_rate
+            Step size to use in each optimization step.
+        restarts
+            Number of restarts of the training algorithm. Since the training
+            results highly depend on the initial starting point, i.e. the
+            initial weights and biases, it is advisable to train multiple
+            neural networks by starting with different initial values and
+            choose that one performing best on the validation set.
+        seed
+            Seed to use for various functions in PyTorch. Using a fixed seed,
+            it is possible to reproduce former results.
+
+        Returns
+        -------
+        rom
+            Reduced-order |NeuralNetworkModel|.
         """
+        assert restarts > 0
+        assert epochs > 0
+        assert batch_size > 0
+        assert learning_rate > 0.
 
-        def __init__(self, fom, training_set, validation_set=None, validation_ratio=0.1,
-                     basis_size=None, rtol=0., atol=0., l2_err=0., pod_params=None,
-                     ann_mse='like_basis'):
-            assert 0 < validation_ratio < 1 or validation_set
-            self.__auto_init(locals())
+        # set a seed for the PyTorch initialization of weights and biases
+        # and further PyTorch methods
+        torch.manual_seed(seed)
 
-        def reduce(self, hidden_layers='[(N+P)*3, (N+P)*3]', activation_function=torch.tanh,
-                   optimizer=optim.LBFGS, epochs=1000, batch_size=20, learning_rate=1.,
-                   restarts=10, seed=0):
-            """Reduce by training artificial neural networks.
+        # build a reduced basis using POD and compute training data
+        if not hasattr(self, 'training_data'):
+            self.compute_training_data()
 
-            Parameters
-            ----------
-            hidden_layers
-                Number of neurons in the hidden layers. Can either be fixed or
-                a Python expression string depending on the reduced basis size
-                respectively output dimension `N` and the total dimension of
-                the |Parameters| `P`.
-            activation_function
-                Activation function to use between the hidden layers.
-            optimizer
-                Algorithm to use as optimizer during training.
-            epochs
-                Maximum number of epochs for training.
-            batch_size
-                Batch size to use if optimizer allows mini-batching.
-            learning_rate
-                Step size to use in each optimization step.
-            restarts
-                Number of restarts of the training algorithm. Since the training
-                results highly depend on the initial starting point, i.e. the
-                initial weights and biases, it is advisable to train multiple
-                neural networks by starting with different initial values and
-                choose that one performing best on the validation set.
-            seed
-                Seed to use for various functions in PyTorch. Using a fixed seed,
-                it is possible to reproduce former results.
+        layer_sizes = self._compute_layer_sizes(hidden_layers)
 
-            Returns
-            -------
-            rom
-                Reduced-order |NeuralNetworkModel|.
-            """
-            assert restarts > 0
-            assert epochs > 0
-            assert batch_size > 0
-            assert learning_rate > 0.
+        # compute validation data
+        if not hasattr(self, 'validation_data'):
+            with self.logger.block('Computing validation snapshots ...'):
 
-            # set a seed for the PyTorch initialization of weights and biases
-            # and further PyTorch methods
-            torch.manual_seed(seed)
-
-            # build a reduced basis using POD and compute training data
-            if not hasattr(self, 'training_data'):
-                self.compute_training_data()
-
-            layer_sizes = self._compute_layer_sizes(hidden_layers)
-
-            # compute validation data
-            if not hasattr(self, 'validation_data'):
-                with self.logger.block('Computing validation snapshots ...'):
-
-                    if self.validation_set:
-                        self.validation_data = []
-                        for mu in self.validation_set:
-                            sample = self._compute_sample(mu)
-                            self.validation_data.extend(sample)
-                    else:
-                        number_validation_snapshots = int(len(self.training_data)*self.validation_ratio)
-                        # randomly shuffle training data before splitting into two sets
-                        np.random.shuffle(self.training_data)
-                        # split training data into validation and training set
-                        self.validation_data = self.training_data[0:number_validation_snapshots]
-                        self.training_data = self.training_data[number_validation_snapshots+1:]
-
-            # run the actual training of the neural network
-            with self.logger.block('Training of neural network ...'):
-                target_loss = self._compute_target_loss()
-                # set parameters for neural network and training
-                neural_network_parameters = {'layer_sizes': layer_sizes,
-                                             'activation_function': activation_function}
-                training_parameters = {'optimizer': optimizer, 'epochs': epochs,
-                                       'batch_size': batch_size, 'learning_rate': learning_rate}
-
-                self.logger.info('Initializing neural network ...')
-                # initialize the neural network
-                neural_network = FullyConnectedNN(**neural_network_parameters).double()
-                # run training algorithm with multiple restarts
-                self.neural_network, self.losses = multiple_restarts_training(self.training_data, self.validation_data,
-                                                                              neural_network, target_loss, restarts,
-                                                                              training_parameters, seed)
-
-            self._check_tolerances()
-
-            return self._build_rom()
-
-        def compute_training_data(self):
-            """Compute a reduced basis using proper orthogonal decomposition."""
-            # compute snapshots for POD and training of neural networks
-            with self.logger.block('Computing training snapshots ...'):
-                U = self.fom.solution_space.empty()
-                for mu in self.training_set:
-                    U.append(self.fom.solve(mu))
-
-            # compute reduced basis via POD
-            with self.logger.block('Building reduced basis ...'):
-                self.reduced_basis, svals = pod(U, modes=self.basis_size, rtol=self.rtol / 2.,
-                                                atol=self.atol / 2., l2_err=self.l2_err / 2.,
-                                                **(self.pod_params or {}))
-
-            # compute training samples
-            with self.logger.block('Computing training samples ...'):
-                self.training_data = []
-                for mu, u in zip(self.training_set, U):
-                    sample = self._compute_sample(mu, u)
-                    self.training_data.extend(sample)
-
-            # compute mean square loss
-            self.mse_basis = (sum(U.norm2()) - sum(svals**2)) / len(U)
-
-        def _compute_sample(self, mu, u=None):
-            """Transform parameter and corresponding solution to |NumPy arrays|."""
-            # determine the coefficients of the full-order solutions in the reduced basis to obtain
-            # the training data
-            if u is None:
-                u = self.fom.solve(mu)
-            return [(mu, self.reduced_basis.inner(u)[:, 0])]
-
-        def _compute_layer_sizes(self, hidden_layers):
-            """Compute the number of neurons in the layers of the neural network."""
-            # determine the numbers of neurons in the hidden layers
-            if isinstance(hidden_layers, str):
-                hidden_layers = eval(hidden_layers, {'N': len(self.reduced_basis), 'P': self.fom.parameters.dim})
-            # input and output size of the neural network are prescribed by the
-            # dimension of the parameter space and the reduced basis size
-            assert isinstance(hidden_layers, list)
-            return [self.fom.parameters.dim, ] + hidden_layers + [len(self.reduced_basis), ]
-
-        def _compute_target_loss(self):
-            """Compute target loss depending on value of `ann_mse`."""
-            target_loss = None
-            if isinstance(self.ann_mse, Number):
-                target_loss = self.ann_mse
-            elif self.ann_mse == 'like_basis':
-                target_loss = self.mse_basis
-            return target_loss
-
-        def _check_tolerances(self):
-            """Check if trained neural network is sufficient to guarantee certain error bounds."""
-            with self.logger.block('Checking tolerances for error of neural network ...'):
-
-                if isinstance(self.ann_mse, Number):
-                    if self.losses['full'] > self.ann_mse:
-                        raise NeuralNetworkTrainingFailed('Could not train a neural network that '
-                                                          'guarantees prescribed tolerance!')
-                elif self.ann_mse == 'like_basis':
-                    if self.losses['full'] > self.mse_basis:
-                        raise NeuralNetworkTrainingFailed('Could not train a neural network with an error as small as '
-                                                          'the reduced basis error! Maybe you can try a different '
-                                                          'neural network architecture or change the value of '
-                                                          '`ann_mse`.')
-                elif self.ann_mse is None:
-                    self.logger.info('Using neural network with smallest validation error ...')
-                    self.logger.info(f'Finished training with a validation loss of {self.losses["val"]} ...')
+                if self.validation_set:
+                    self.validation_data = []
+                    for mu in self.validation_set:
+                        sample = self._compute_sample(mu)
+                        self.validation_data.extend(sample)
                 else:
-                    raise ValueError('Unknown value for mean squared error of neural network')
+                    number_validation_snapshots = int(len(self.training_data)*self.validation_ratio)
+                    # randomly shuffle training data before splitting into two sets
+                    np.random.shuffle(self.training_data)
+                    # split training data into validation and training set
+                    self.validation_data = self.training_data[0:number_validation_snapshots]
+                    self.training_data = self.training_data[number_validation_snapshots+1:]
 
-        def _build_rom(self):
-            """Construct the reduced order model."""
-            with self.logger.block('Building ROM ...'):
-                projected_output_functional = project(self.fom.output_functional, None, self.reduced_basis)
-                rom = NeuralNetworkModel(self.neural_network, parameters=self.fom.parameters,
-                                         output_functional=projected_output_functional,
-                                         name=f'{self.fom.name}_reduced')
+        # run the actual training of the neural network
+        with self.logger.block('Training of neural network ...'):
+            target_loss = self._compute_target_loss()
+            # set parameters for neural network and training
+            neural_network_parameters = {'layer_sizes': layer_sizes,
+                                         'activation_function': activation_function}
+            training_parameters = {'optimizer': optimizer, 'epochs': epochs,
+                                   'batch_size': batch_size, 'learning_rate': learning_rate}
 
-            return rom
+            self.logger.info('Initializing neural network ...')
+            # initialize the neural network
+            neural_network = FullyConnectedNN(**neural_network_parameters).double()
+            # run training algorithm with multiple restarts
+            self.neural_network, self.losses = multiple_restarts_training(self.training_data, self.validation_data,
+                                                                          neural_network, target_loss, restarts,
+                                                                          training_parameters, seed)
 
-        def reconstruct(self, u):
-            """Reconstruct high-dimensional vector from reduced vector `u`."""
-            assert hasattr(self, 'reduced_basis')
-            return self.reduced_basis.lincomb(u.to_numpy())
+        self._check_tolerances()
+
+        return self._build_rom()
+
+    def compute_training_data(self):
+        """Compute a reduced basis using proper orthogonal decomposition."""
+        # compute snapshots for POD and training of neural networks
+        with self.logger.block('Computing training snapshots ...'):
+            U = self.fom.solution_space.empty()
+            for mu in self.training_set:
+                U.append(self.fom.solve(mu))
+
+        # compute reduced basis via POD
+        with self.logger.block('Building reduced basis ...'):
+            self.reduced_basis, svals = pod(U, modes=self.basis_size, rtol=self.rtol / 2.,
+                                            atol=self.atol / 2., l2_err=self.l2_err / 2.,
+                                            **(self.pod_params or {}))
+
+        # compute training samples
+        with self.logger.block('Computing training samples ...'):
+            self.training_data = []
+            for mu, u in zip(self.training_set, U):
+                sample = self._compute_sample(mu, u)
+                self.training_data.extend(sample)
+
+        # compute mean square loss
+        self.mse_basis = (sum(U.norm2()) - sum(svals**2)) / len(U)
+
+    def _compute_sample(self, mu, u=None):
+        """Transform parameter and corresponding solution to |NumPy arrays|."""
+        # determine the coefficients of the full-order solutions in the reduced basis to obtain
+        # the training data
+        if u is None:
+            u = self.fom.solve(mu)
+        return [(mu, self.reduced_basis.inner(u)[:, 0])]
+
+    def _compute_layer_sizes(self, hidden_layers):
+        """Compute the number of neurons in the layers of the neural network."""
+        # determine the numbers of neurons in the hidden layers
+        if isinstance(hidden_layers, str):
+            hidden_layers = eval(hidden_layers, {'N': len(self.reduced_basis), 'P': self.fom.parameters.dim})
+        # input and output size of the neural network are prescribed by the
+        # dimension of the parameter space and the reduced basis size
+        assert isinstance(hidden_layers, list)
+        return [self.fom.parameters.dim, ] + hidden_layers + [len(self.reduced_basis), ]
+
+    def _compute_target_loss(self):
+        """Compute target loss depending on value of `ann_mse`."""
+        target_loss = None
+        if isinstance(self.ann_mse, Number):
+            target_loss = self.ann_mse
+        elif self.ann_mse == 'like_basis':
+            target_loss = self.mse_basis
+        return target_loss
+
+    def _check_tolerances(self):
+        """Check if trained neural network is sufficient to guarantee certain error bounds."""
+        with self.logger.block('Checking tolerances for error of neural network ...'):
+
+            if isinstance(self.ann_mse, Number):
+                if self.losses['full'] > self.ann_mse:
+                    raise NeuralNetworkTrainingFailed('Could not train a neural network that '
+                                                      'guarantees prescribed tolerance!')
+            elif self.ann_mse == 'like_basis':
+                if self.losses['full'] > self.mse_basis:
+                    raise NeuralNetworkTrainingFailed('Could not train a neural network with an error as small as '
+                                                      'the reduced basis error! Maybe you can try a different '
+                                                      'neural network architecture or change the value of '
+                                                      '`ann_mse`.')
+            elif self.ann_mse is None:
+                self.logger.info('Using neural network with smallest validation error ...')
+                self.logger.info(f'Finished training with a validation loss of {self.losses["val"]} ...')
+            else:
+                raise ValueError('Unknown value for mean squared error of neural network')
+
+    def _build_rom(self):
+        """Construct the reduced order model."""
+        with self.logger.block('Building ROM ...'):
+            projected_output_functional = project(self.fom.output_functional, None, self.reduced_basis)
+            rom = NeuralNetworkModel(self.neural_network, parameters=self.fom.parameters,
+                                     output_functional=projected_output_functional,
+                                     name=f'{self.fom.name}_reduced')
+
+        return rom
+
+    def reconstruct(self, u):
+        """Reconstruct high-dimensional vector from reduced vector `u`."""
+        assert hasattr(self, 'reduced_basis')
+        return self.reduced_basis.lincomb(u.to_numpy())
 
 
-if config.HAVE_TORCH:
+class NeuralNetworkStatefreeOutputReductor(NeuralNetworkReductor):
+    """Output reductor relying on artificial neural networks.
 
-    class NeuralNetworkStatefreeOutputReductor(NeuralNetworkReductor):
-        """Output reductor relying on artificial neural networks.
+    This is a reductor that trains a neural network that approximates
+    the mapping from parameter space to output space.
 
-        This is a reductor that trains a neural network that approximates
-        the mapping from parameter space to output space.
+    Parameters
+    ----------
+    fom
+        The full-order |Model| to reduce.
+    training_set
+        Set of |parameter values| to use for POD and training of the
+        neural network.
+    validation_set
+        Set of |parameter values| to use for validation in the training
+        of the neural network.
+    validation_ratio
+        Fraction of the training set to use for validation in the training
+        of the neural network (only used if no validation set is provided).
+    validation_loss
+        The validation loss to reach during training. If `None`, the neural
+        network with the smallest validation loss is returned.
+    """
 
-        Parameters
-        ----------
-        fom
-            The full-order |Model| to reduce.
-        training_set
-            Set of |parameter values| to use for POD and training of the
-            neural network.
-        validation_set
-            Set of |parameter values| to use for validation in the training
-            of the neural network.
-        validation_ratio
-            Fraction of the training set to use for validation in the training
-            of the neural network (only used if no validation set is provided).
-        validation_loss
-            The validation loss to reach during training. If `None`, the neural
-            network with the smallest validation loss is returned.
-        """
+    def __init__(self, fom, training_set, validation_set=None, validation_ratio=0.1,
+                 validation_loss=None):
+        assert 0 < validation_ratio < 1 or validation_set
+        self.__auto_init(locals())
 
-        def __init__(self, fom, training_set, validation_set=None, validation_ratio=0.1,
-                     validation_loss=None):
-            assert 0 < validation_ratio < 1 or validation_set
-            self.__auto_init(locals())
+    def compute_training_data(self):
+        """Compute the training samples (the outputs to the parameters of the training set)."""
+        with self.logger.block('Computing training samples ...'):
+            self.training_data = []
+            for mu in self.training_set:
+                sample = self._compute_sample(mu)
+                self.training_data.extend(sample)
 
-        def compute_training_data(self):
-            """Compute the training samples (the outputs to the parameters of the training set)."""
-            with self.logger.block('Computing training samples ...'):
-                self.training_data = []
-                for mu in self.training_set:
-                    sample = self._compute_sample(mu)
-                    self.training_data.extend(sample)
+    def _compute_sample(self, mu):
+        """Transform parameter and corresponding output to tensors."""
+        return [(mu, self.fom.output(mu).flatten())]
 
-        def _compute_sample(self, mu):
-            """Transform parameter and corresponding output to tensors."""
-            return [(mu, self.fom.output(mu).flatten())]
+    def _compute_layer_sizes(self, hidden_layers):
+        """Compute the number of neurons in the layers of the neural network."""
+        # determine the numbers of neurons in the hidden layers
+        if isinstance(hidden_layers, str):
+            hidden_layers = eval(hidden_layers, {'N': self.fom.dim_output, 'P': self.fom.parameters.dim})
+        # input and output size of the neural network are prescribed by the
+        # dimension of the parameter space and the output dimension
+        assert isinstance(hidden_layers, list)
+        return [self.fom.parameters.dim, ] + hidden_layers + [self.fom.dim_output, ]
 
-        def _compute_layer_sizes(self, hidden_layers):
-            """Compute the number of neurons in the layers of the neural network."""
-            # determine the numbers of neurons in the hidden layers
-            if isinstance(hidden_layers, str):
-                hidden_layers = eval(hidden_layers, {'N': self.fom.dim_output, 'P': self.fom.parameters.dim})
-            # input and output size of the neural network are prescribed by the
-            # dimension of the parameter space and the output dimension
-            assert isinstance(hidden_layers, list)
-            return [self.fom.parameters.dim, ] + hidden_layers + [self.fom.dim_output, ]
+    def _compute_target_loss(self):
+        """Compute target loss depending on value of `ann_mse`."""
+        return self.validation_loss
 
-        def _compute_target_loss(self):
-            """Compute target loss depending on value of `ann_mse`."""
-            return self.validation_loss
+    def _check_tolerances(self):
+        """Check if trained neural network is sufficient to guarantee certain error bounds."""
+        self.logger.info('Using neural network with smallest validation error ...')
+        self.logger.info(f'Finished training with a validation loss of {self.losses["val"]} ...')
 
-        def _check_tolerances(self):
-            """Check if trained neural network is sufficient to guarantee certain error bounds."""
-            self.logger.info('Using neural network with smallest validation error ...')
-            self.logger.info(f'Finished training with a validation loss of {self.losses["val"]} ...')
+    def _build_rom(self):
+        """Construct the reduced order model."""
+        with self.logger.block('Building ROM ...'):
+            rom = NeuralNetworkStatefreeOutputModel(self.neural_network, self.fom.parameters,
+                                                    name=f'{self.fom.name}_output_reduced')
 
-        def _build_rom(self):
-            """Construct the reduced order model."""
-            with self.logger.block('Building ROM ...'):
-                rom = NeuralNetworkStatefreeOutputModel(self.neural_network, self.fom.parameters,
-                                                        name=f'{self.fom.name}_output_reduced')
-
-            return rom
+        return rom
 
 
-if config.HAVE_TORCH:
+class NeuralNetworkInstationaryReductor(NeuralNetworkReductor):
+    """Reduced Basis reductor for instationary problems relying on artificial neural networks.
 
-    class NeuralNetworkInstationaryReductor(NeuralNetworkReductor):
-        """Reduced Basis reductor for instationary problems relying on artificial neural networks.
+    This is a reductor that constructs a reduced basis using proper
+    orthogonal decomposition and trains a neural network that approximates
+    the mapping from parameter and time space to coefficients of the
+    full-order solution in the reduced basis.
+    The approach is described in :cite:`WHR19`.
 
-        This is a reductor that constructs a reduced basis using proper
-        orthogonal decomposition and trains a neural network that approximates
-        the mapping from parameter and time space to coefficients of the
-        full-order solution in the reduced basis.
-        The approach is described in :cite:`WHR19`.
+    Parameters
+    ----------
+    fom
+        The full-order |Model| to reduce.
+    training_set
+        Set of |parameter values| to use for POD and training of the
+        neural network.
+    validation_set
+        Set of |parameter values| to use for validation in the training
+        of the neural network.
+    validation_ratio
+        Fraction of the training set to use for validation in the training
+        of the neural network (only used if no validation set is provided).
+    basis_size
+        Desired size of the reduced basis. If `None`, rtol, atol or l2_err must
+        be provided.
+    rtol
+        Relative tolerance the basis should guarantee on the training set.
+    atol
+        Absolute tolerance the basis should guarantee on the training set.
+    l2_err
+        L2-approximation error the basis should not exceed on the training
+        set.
+    pod_params
+        Dict of additional parameters for the POD-method.
+    ann_mse
+        If `'like_basis'`, the mean squared error of the neural network on
+        the training set should not exceed the error of projecting onto the basis.
+        If `None`, the neural network with smallest validation error is
+        used to build the ROM.
+        If a tolerance is prescribed, the mean squared error of the neural
+        network on the training set should not exceed this threshold.
+        Training is interrupted if a neural network that undercuts the
+        error tolerance is found.
+    """
 
-        Parameters
-        ----------
-        fom
-            The full-order |Model| to reduce.
-        training_set
-            Set of |parameter values| to use for POD and training of the
-            neural network.
-        validation_set
-            Set of |parameter values| to use for validation in the training
-            of the neural network.
-        validation_ratio
-            Fraction of the training set to use for validation in the training
-            of the neural network (only used if no validation set is provided).
-        basis_size
-            Desired size of the reduced basis. If `None`, rtol, atol or l2_err must
-            be provided.
-        rtol
-            Relative tolerance the basis should guarantee on the training set.
-        atol
-            Absolute tolerance the basis should guarantee on the training set.
-        l2_err
-            L2-approximation error the basis should not exceed on the training
-            set.
-        pod_params
-            Dict of additional parameters for the POD-method.
-        ann_mse
-            If `'like_basis'`, the mean squared error of the neural network on
-            the training set should not exceed the error of projecting onto the basis.
-            If `None`, the neural network with smallest validation error is
-            used to build the ROM.
-            If a tolerance is prescribed, the mean squared error of the neural
-            network on the training set should not exceed this threshold.
-            Training is interrupted if a neural network that undercuts the
-            error tolerance is found.
-        """
+    def __init__(self, fom, training_set, validation_set=None, validation_ratio=0.1,
+                 basis_size=None, rtol=0., atol=0., l2_err=0., pod_params=None,
+                 ann_mse='like_basis'):
+        assert 0 < validation_ratio < 1 or validation_set
+        self.__auto_init(locals())
 
-        def __init__(self, fom, training_set, validation_set=None, validation_ratio=0.1,
-                     basis_size=None, rtol=0., atol=0., l2_err=0., pod_params=None,
-                     ann_mse='like_basis'):
-            assert 0 < validation_ratio < 1 or validation_set
-            self.__auto_init(locals())
-
-        def compute_training_data(self):
-            """Compute a reduced basis using proper orthogonal decomposition."""
-            # compute snapshots for POD and training of neural networks
-            with self.logger.block('Computing training snapshots ...'):
-                U = self.fom.solution_space.empty()
-                for mu in self.training_set:
-                    u = self.fom.solve(mu)
-                    if hasattr(self, 'nt'):
-                        assert self.nt == len(u)
-                    else:
-                        self.nt = len(u)
-                    U.append(u)
-
-            # compute reduced basis via POD
-            with self.logger.block('Building reduced basis ...'):
-                self.reduced_basis, svals = pod(U, modes=self.basis_size, rtol=self.rtol / 2.,
-                                                atol=self.atol / 2., l2_err=self.l2_err / 2.,
-                                                **(self.pod_params or {}))
-
-            # compute training samples
-            with self.logger.block('Computing training samples ...'):
-                self.training_data = []
-                for i, mu in enumerate(self.training_set):
-                    sample = self._compute_sample(mu, U[i*self.nt:(i+1)*self.nt])
-                    self.training_data.extend(sample)
-
-            # compute mean square loss
-            self.mse_basis = (sum(U.norm2()) - sum(svals**2)) / len(U)
-
-        def _compute_sample(self, mu, u=None):
-            """Transform parameter and corresponding solution to |NumPy arrays|.
-
-            This function takes care of including the time instances in the inputs.
-            """
-            if u is None:
+    def compute_training_data(self):
+        """Compute a reduced basis using proper orthogonal decomposition."""
+        # compute snapshots for POD and training of neural networks
+        with self.logger.block('Computing training snapshots ...'):
+            U = self.fom.solution_space.empty()
+            for mu in self.training_set:
                 u = self.fom.solve(mu)
+                if hasattr(self, 'nt'):
+                    assert self.nt == len(u)
+                else:
+                    self.nt = len(u)
+                U.append(u)
 
-            parameters_with_time = [mu.with_(t=t) for t in np.linspace(0, self.fom.T, self.nt)]
+        # compute reduced basis via POD
+        with self.logger.block('Building reduced basis ...'):
+            self.reduced_basis, svals = pod(U, modes=self.basis_size, rtol=self.rtol / 2.,
+                                            atol=self.atol / 2., l2_err=self.l2_err / 2.,
+                                            **(self.pod_params or {}))
 
-            samples = [(mu, self.reduced_basis.inner(u_t)[:, 0])
-                       for mu, u_t in zip(parameters_with_time, u)]
+        # compute training samples
+        with self.logger.block('Computing training samples ...'):
+            self.training_data = []
+            for i, mu in enumerate(self.training_set):
+                sample = self._compute_sample(mu, U[i*self.nt:(i+1)*self.nt])
+                self.training_data.extend(sample)
 
-            return samples
+        # compute mean square loss
+        self.mse_basis = (sum(U.norm2()) - sum(svals**2)) / len(U)
 
-        def _compute_layer_sizes(self, hidden_layers):
-            """Compute the number of neurons in the layers of the neural network
-            (make sure to increase the input dimension to account for the time).
-            """
-            # determine the numbers of neurons in the hidden layers
-            if isinstance(hidden_layers, str):
-                hidden_layers = eval(hidden_layers, {'N': len(self.reduced_basis), 'P': self.fom.parameters.dim})
-            # input and output size of the neural network are prescribed by the
-            # dimension of the parameter space and the reduced basis size
-            assert isinstance(hidden_layers, list)
-            return [self.fom.parameters.dim + 1, ] + hidden_layers + [len(self.reduced_basis), ]
+    def _compute_sample(self, mu, u=None):
+        """Transform parameter and corresponding solution to |NumPy arrays|.
 
-        def _build_rom(self):
-            """Construct the reduced order model."""
-            with self.logger.block('Building ROM ...'):
-                projected_output_functional = project(self.fom.output_functional, None, self.reduced_basis)
-                rom = NeuralNetworkInstationaryModel(self.fom.T, self.nt, self.neural_network,
-                                                     parameters=self.fom.parameters,
-                                                     output_functional=projected_output_functional,
-                                                     name=f'{self.fom.name}_reduced')
+        This function takes care of including the time instances in the inputs.
+        """
+        if u is None:
+            u = self.fom.solve(mu)
 
-            return rom
+        parameters_with_time = [mu.with_(t=t) for t in np.linspace(0, self.fom.T, self.nt)]
+
+        samples = [(mu, self.reduced_basis.inner(u_t)[:, 0])
+                   for mu, u_t in zip(parameters_with_time, u)]
+
+        return samples
+
+    def _compute_layer_sizes(self, hidden_layers):
+        """Compute the number of neurons in the layers of the neural network
+        (make sure to increase the input dimension to account for the time).
+        """
+        # determine the numbers of neurons in the hidden layers
+        if isinstance(hidden_layers, str):
+            hidden_layers = eval(hidden_layers, {'N': len(self.reduced_basis), 'P': self.fom.parameters.dim})
+        # input and output size of the neural network are prescribed by the
+        # dimension of the parameter space and the reduced basis size
+        assert isinstance(hidden_layers, list)
+        return [self.fom.parameters.dim + 1, ] + hidden_layers + [len(self.reduced_basis), ]
+
+    def _build_rom(self):
+        """Construct the reduced order model."""
+        with self.logger.block('Building ROM ...'):
+            projected_output_functional = project(self.fom.output_functional, None, self.reduced_basis)
+            rom = NeuralNetworkInstationaryModel(self.fom.T, self.nt, self.neural_network,
+                                                 parameters=self.fom.parameters,
+                                                 output_functional=projected_output_functional,
+                                                 name=f'{self.fom.name}_reduced')
+
+        return rom
 
 
-if config.HAVE_TORCH:
+class NeuralNetworkInstationaryStatefreeOutputReductor(NeuralNetworkStatefreeOutputReductor):
+    """Output reductor relying on artificial neural networks.
 
-    class NeuralNetworkInstationaryStatefreeOutputReductor(NeuralNetworkStatefreeOutputReductor):
-        """Output reductor relying on artificial neural networks.
+    This is a reductor that trains a neural network that approximates
+    the mapping from parameter space to output space.
 
-        This is a reductor that trains a neural network that approximates
-        the mapping from parameter space to output space.
+    Parameters
+    ----------
+    fom
+        The full-order |Model| to reduce.
+    nt
+        Number of time steps in the reduced order model (does not have to
+        coincide with the number of time steps in the full order model).
+    training_set
+        Set of |parameter values| to use for POD and training of the
+        neural network.
+    validation_set
+        Set of |parameter values| to use for validation in the training
+        of the neural network.
+    validation_ratio
+        Fraction of the training set to use for validation in the training
+        of the neural network (only used if no validation set is provided).
+    validation_loss
+        The validation loss to reach during training. If `None`, the neural
+        network with the smallest validation loss is returned.
+    """
+
+    def __init__(self, fom, nt, training_set, validation_set=None, validation_ratio=0.1,
+                 validation_loss=None):
+        assert 0 < validation_ratio < 1 or validation_set
+        self.__auto_init(locals())
+
+    def _compute_sample(self, mu):
+        """Transform parameter and corresponding output to |NumPy arrays|.
+
+        This function takes care of including the time instances in the inputs.
+        """
+        output_trajectory = self.fom.output(mu)
+        output_size = output_trajectory.shape[0]
+        samples = [(mu.with_(t=t), output.flatten())
+                   for t, output in zip(np.linspace(0, self.fom.T, output_size), output_trajectory)]
+
+        return samples
+
+    def _compute_layer_sizes(self, hidden_layers):
+        """Compute the number of neurons in the layers of the neural network."""
+        # determine the numbers of neurons in the hidden layers
+        if isinstance(hidden_layers, str):
+            hidden_layers = eval(hidden_layers, {'N': self.fom.dim_output, 'P': self.fom.parameters.dim})
+        # input and output size of the neural network are prescribed by the
+        # dimension of the parameter space and the output dimension
+        assert isinstance(hidden_layers, list)
+        return [self.fom.parameters.dim + 1, ] + hidden_layers + [self.fom.dim_output, ]
+
+    def _build_rom(self):
+        """Construct the reduced order model."""
+        with self.logger.block('Building ROM ...'):
+            rom = NeuralNetworkInstationaryStatefreeOutputModel(self.fom.T, self.nt, self.neural_network,
+                                                                self.fom.parameters,
+                                                                name=f'{self.fom.name}_output_reduced')
+
+        return rom
+
+
+class EarlyStoppingScheduler(BasicObject):
+    """Class for performing early stopping in training of neural networks.
+
+    If the validation loss does not decrease over a certain amount of epochs, the
+    training should be aborted to avoid overfitting the training data.
+    This class implements an early stopping scheduler that recommends to stop the
+    training process if the validation loss did not decrease by at least `delta`
+    over `patience` epochs.
+
+    Parameters
+    ----------
+    size_training_validation_set
+        Size of both, training and validation set together.
+    patience
+        Number of epochs of non-decreasing validation loss allowed, before early
+        stopping the training process.
+    delta
+        Minimal amount of decrease in the validation loss that is required to reset
+        the counter of non-decreasing epochs.
+    """
+
+    def __init__(self, size_training_validation_set, patience=10, delta=0.):
+        self.__auto_init(locals())
+
+        self.best_losses = None
+        self.best_neural_network = None
+        self.counter = 0
+
+    def __call__(self, losses, neural_network=None):
+        """Returns `True` if early stopping of training is suggested.
 
         Parameters
         ----------
-        fom
-            The full-order |Model| to reduce.
-        nt
-            Number of time steps in the reduced order model (does not have to
-            coincide with the number of time steps in the full order model).
-        training_set
-            Set of |parameter values| to use for POD and training of the
-            neural network.
-        validation_set
-            Set of |parameter values| to use for validation in the training
-            of the neural network.
-        validation_ratio
-            Fraction of the training set to use for validation in the training
-            of the neural network (only used if no validation set is provided).
-        validation_loss
-            The validation loss to reach during training. If `None`, the neural
-            network with the smallest validation loss is returned.
+        losses
+            Dictionary of losses on the validation and the training set in
+            the current epoch.
+        neural_network
+            Neural network that produces the current validation loss.
+
+        Returns
+        -------
+        `True` if early stopping is suggested, `False` otherwise.
         """
-
-        def __init__(self, fom, nt, training_set, validation_set=None, validation_ratio=0.1,
-                     validation_loss=None):
-            assert 0 < validation_ratio < 1 or validation_set
-            self.__auto_init(locals())
-
-        def _compute_sample(self, mu):
-            """Transform parameter and corresponding output to |NumPy arrays|.
-
-            This function takes care of including the time instances in the inputs.
-            """
-            output_trajectory = self.fom.output(mu)
-            output_size = output_trajectory.shape[0]
-            samples = [(mu.with_(t=t), output.flatten())
-                       for t, output in zip(np.linspace(0, self.fom.T, output_size), output_trajectory)]
-
-            return samples
-
-        def _compute_layer_sizes(self, hidden_layers):
-            """Compute the number of neurons in the layers of the neural network."""
-            # determine the numbers of neurons in the hidden layers
-            if isinstance(hidden_layers, str):
-                hidden_layers = eval(hidden_layers, {'N': self.fom.dim_output, 'P': self.fom.parameters.dim})
-            # input and output size of the neural network are prescribed by the
-            # dimension of the parameter space and the output dimension
-            assert isinstance(hidden_layers, list)
-            return [self.fom.parameters.dim + 1, ] + hidden_layers + [self.fom.dim_output, ]
-
-        def _build_rom(self):
-            """Construct the reduced order model."""
-            with self.logger.block('Building ROM ...'):
-                rom = NeuralNetworkInstationaryStatefreeOutputModel(self.fom.T, self.nt, self.neural_network,
-                                                                    self.fom.parameters,
-                                                                    name=f'{self.fom.name}_output_reduced')
-
-            return rom
-
-
-if config.HAVE_TORCH:
-
-    class EarlyStoppingScheduler(BasicObject):
-        """Class for performing early stopping in training of neural networks.
-
-        If the validation loss does not decrease over a certain amount of epochs, the
-        training should be aborted to avoid overfitting the training data.
-        This class implements an early stopping scheduler that recommends to stop the
-        training process if the validation loss did not decrease by at least `delta`
-        over `patience` epochs.
-
-        Parameters
-        ----------
-        size_training_validation_set
-            Size of both, training and validation set together.
-        patience
-            Number of epochs of non-decreasing validation loss allowed, before early
-            stopping the training process.
-        delta
-            Minimal amount of decrease in the validation loss that is required to reset
-            the counter of non-decreasing epochs.
-        """
-
-        def __init__(self, size_training_validation_set, patience=10, delta=0.):
-            self.__auto_init(locals())
-
-            self.best_losses = None
-            self.best_neural_network = None
+        if self.best_losses is None:
+            self.best_losses = losses
+            self.best_losses['full'] /= self.size_training_validation_set
+            self.best_neural_network = neural_network
+        elif self.best_losses['val'] - self.delta <= losses['val']:
+            self.counter += 1
+            if self.counter >= self.patience:
+                return True
+        else:
+            self.best_losses = losses
+            self.best_losses['full'] /= self.size_training_validation_set
+            self.best_neural_network = neural_network
             self.counter = 0
 
-        def __call__(self, losses, neural_network=None):
-            """Returns `True` if early stopping of training is suggested.
+        return False
 
-            Parameters
-            ----------
-            losses
-                Dictionary of losses on the validation and the training set in
-                the current epoch.
-            neural_network
-                Neural network that produces the current validation loss.
 
-            Returns
-            -------
-            `True` if early stopping is suggested, `False` otherwise.
-            """
-            if self.best_losses is None:
-                self.best_losses = losses
-                self.best_losses['full'] /= self.size_training_validation_set
-                self.best_neural_network = neural_network
-            elif self.best_losses['val'] - self.delta <= losses['val']:
-                self.counter += 1
-                if self.counter >= self.patience:
-                    return True
+class CustomDataset(utils.data.Dataset):
+    """Class that represents the dataset to use in PyTorch.
+
+    Parameters
+    ----------
+    training_data
+        Set of training parameters and the respective coefficients of the
+        solution in the reduced basis.
+    """
+
+    def __init__(self, training_data):
+        self.training_data = training_data
+
+    def __len__(self):
+        return len(self.training_data)
+
+    def __getitem__(self, idx):
+        t = self.training_data[idx]
+        return t
+
+
+def train_neural_network(training_data, validation_data, neural_network,
+                         training_parameters={}):
+    """Training algorithm for artificial neural networks.
+
+    Trains a single neural network using the given training and validation data.
+
+    Parameters
+    ----------
+    training_data
+        Data to use during the training phase. Has to be a list of tuples,
+        where each tuple consists of two elements that are either
+        PyTorch-tensors (`torch.DoubleTensor`) or |NumPy arrays| or pyMOR data
+        structures that have `to_numpy()` implemented.
+        The first element contains the input data, the second element contains
+        the target values.
+    validation_data
+        Data to use during the validation phase. Has to be a list of tuples,
+        where each tuple consists of two elements that are either
+        PyTorch-tensors (`torch.DoubleTensor`) or |NumPy arrays| or pyMOR data
+        structures that have `to_numpy()` implemented.
+        The first element contains the input data, the second element contains
+        the target values.
+    neural_network
+        The neural network to train (can also be a pre-trained model).
+        Has to be a PyTorch-Module.
+    training_parameters
+        Dictionary with additional parameters for the training routine like
+        the type of the optimizer, the (maximum) number of epochs, the batch
+        size, the learning rate or the loss function to use.
+        Possible keys are `'optimizer'` (an optimizer from the PyTorch `optim`
+        package; if not provided, the LBFGS-optimizer is taken as default),
+        `'epochs'` (an integer that determines the number of epochs to use
+        for training the neural network (if training is not interrupted
+        prematurely due to early stopping); if not provided, 1000 is taken as
+        default value), `'batch_size'` (an integer that determines the number
+        of samples to pass to the optimizer at once; if not provided, 20 is
+        taken as default value; not used in the case of the LBFGS-optimizer
+        since LBFGS does not support mini-batching), `'learning_rate'` (a
+        positive real number used as the (initial) step size of the optimizer;
+        if not provided, 1 is taken as default value; thus far, no learning
+        rate schedulers are supported in this implementation), and
+        `'loss_function'` (a loss function from PyTorch; if not provided, the
+        MSE loss is taken as default).
+
+    Returns
+    -------
+    best_neural_network
+        The best trained neural network with respect to validation loss.
+    losses
+        The corresponding losses as a dictionary with keys `'full'` (for the
+        full loss containing the training and the validation average loss),
+        `'train'` (for the average loss on the training set), and `'val'`
+        (for the average loss on the validation set).
+    """
+    assert isinstance(neural_network, nn.Module)
+
+    for data in training_data, validation_data:
+        assert isinstance(data, list)
+        assert all(isinstance(datum, tuple) and len(datum) == 2 for datum in data)
+
+    def prepare_datum(datum):
+        if not (isinstance(datum, torch.DoubleTensor) or isinstance(datum, np.ndarray)):
+            return datum.to_numpy()
+        return datum
+
+    training_data = [(prepare_datum(datum[0]), prepare_datum(datum[1])) for datum in training_data]
+    validation_data = [(prepare_datum(datum[0]), prepare_datum(datum[1])) for datum in validation_data]
+
+    optimizer = optim.LBFGS if 'optimizer' not in training_parameters else training_parameters['optimizer']
+    epochs = 1000 if 'epochs' not in training_parameters else training_parameters['epochs']
+    assert isinstance(epochs, int) and epochs > 0
+    batch_size = 20 if 'batch_size' not in training_parameters else training_parameters['batch_size']
+    assert isinstance(batch_size, int) and batch_size > 0
+    learning_rate = 1. if 'learning_rate' not in training_parameters else training_parameters['learning_rate']
+    assert learning_rate > 0.
+    loss_function = (nn.MSELoss() if 'loss_function' not in training_parameters
+                     else training_parameters['loss_function'])
+
+    logger = getLogger('pymor.algorithms.neural_network.train_neural_network')
+
+    # LBFGS-optimizer does not support mini-batching, so the batch size needs to be adjusted
+    if optimizer == optim.LBFGS:
+        batch_size = max(len(training_data), len(validation_data))
+
+    # initialize optimizer and early stopping scheduler
+    optimizer = optimizer(neural_network.parameters(), lr=learning_rate)
+    early_stopping_scheduler = EarlyStoppingScheduler(len(training_data) + len(validation_data))
+
+    # create the training and validation sets as well as the respective data loaders
+    training_dataset = CustomDataset(training_data)
+    validation_dataset = CustomDataset(validation_data)
+    training_loader = utils.data.DataLoader(training_dataset, batch_size=batch_size)
+    validation_loader = utils.data.DataLoader(validation_dataset, batch_size=batch_size)
+    dataloaders = {'train':  training_loader, 'val': validation_loader}
+
+    phases = ['train', 'val']
+
+    logger.info('Starting optimization procedure ...')
+
+    # perform optimization procedure
+    for epoch in range(epochs):
+        losses = {'full': 0.}
+
+        # alternate between training and validation phase
+        for phase in phases:
+            if phase == 'train':
+                neural_network.train()
             else:
-                self.best_losses = losses
-                self.best_losses['full'] /= self.size_training_validation_set
-                self.best_neural_network = neural_network
-                self.counter = 0
+                neural_network.eval()
 
-            return False
+            running_loss = 0.0
 
+            # iterate over batches
+            for batch in dataloaders[phase]:
+                inputs = batch[0]
+                targets = batch[1]
 
-if config.HAVE_TORCH:
+                with torch.set_grad_enabled(phase == 'train'):
+                    def closure():
+                        if torch.is_grad_enabled():
+                            optimizer.zero_grad()
+                        outputs = neural_network(inputs)
+                        loss = loss_function(outputs, targets)
+                        if loss.requires_grad:
+                            loss.backward()
+                        return loss
 
-    class CustomDataset(utils.data.Dataset):
-        """Class that represents the dataset to use in PyTorch.
+                    # perform optimization step
+                    if phase == 'train':
+                        optimizer.step(closure)
 
-        Parameters
-        ----------
-        training_data
-            Set of training parameters and the respective coefficients of the
-            solution in the reduced basis.
-        """
+                    # compute loss of current batch
+                    loss = closure()
 
-        def __init__(self, training_data):
-            self.training_data = training_data
+                # update overall absolute loss
+                running_loss += loss.item() * len(batch[0])
 
-        def __len__(self):
-            return len(self.training_data)
+            # compute average loss
+            epoch_loss = running_loss / len(dataloaders[phase].dataset)
 
-        def __getitem__(self, idx):
-            t = self.training_data[idx]
-            return t
+            losses[phase] = epoch_loss
 
+            losses['full'] += running_loss
 
-if config.HAVE_TORCH:
+            # check for early stopping
+            if phase == 'val' and early_stopping_scheduler(losses, neural_network):
+                logger.info(f'Stopping training process early after {epoch + 1} epochs with validation loss '
+                            f'of {early_stopping_scheduler.best_losses["val"]:.3e} ...')
+                return early_stopping_scheduler.best_neural_network, early_stopping_scheduler.best_losses
 
-    def train_neural_network(training_data, validation_data, neural_network,
-                             training_parameters={}):
-        """Training algorithm for artificial neural networks.
-
-        Trains a single neural network using the given training and validation data.
-
-        Parameters
-        ----------
-        training_data
-            Data to use during the training phase. Has to be a list of tuples,
-            where each tuple consists of two elements that are either
-            PyTorch-tensors (`torch.DoubleTensor`) or |NumPy arrays| or pyMOR data
-            structures that have `to_numpy()` implemented.
-            The first element contains the input data, the second element contains
-            the target values.
-        validation_data
-            Data to use during the validation phase. Has to be a list of tuples,
-            where each tuple consists of two elements that are either
-            PyTorch-tensors (`torch.DoubleTensor`) or |NumPy arrays| or pyMOR data
-            structures that have `to_numpy()` implemented.
-            The first element contains the input data, the second element contains
-            the target values.
-        neural_network
-            The neural network to train (can also be a pre-trained model).
-            Has to be a PyTorch-Module.
-        training_parameters
-            Dictionary with additional parameters for the training routine like
-            the type of the optimizer, the (maximum) number of epochs, the batch
-            size, the learning rate or the loss function to use.
-            Possible keys are `'optimizer'` (an optimizer from the PyTorch `optim`
-            package; if not provided, the LBFGS-optimizer is taken as default),
-            `'epochs'` (an integer that determines the number of epochs to use
-            for training the neural network (if training is not interrupted
-            prematurely due to early stopping); if not provided, 1000 is taken as
-            default value), `'batch_size'` (an integer that determines the number
-            of samples to pass to the optimizer at once; if not provided, 20 is
-            taken as default value; not used in the case of the LBFGS-optimizer
-            since LBFGS does not support mini-batching), `'learning_rate'` (a
-            positive real number used as the (initial) step size of the optimizer;
-            if not provided, 1 is taken as default value; thus far, no learning
-            rate schedulers are supported in this implementation), and
-            `'loss_function'` (a loss function from PyTorch; if not provided, the
-            MSE loss is taken as default).
-
-        Returns
-        -------
-        best_neural_network
-            The best trained neural network with respect to validation loss.
-        losses
-            The corresponding losses as a dictionary with keys `'full'` (for the
-            full loss containing the training and the validation average loss),
-            `'train'` (for the average loss on the training set), and `'val'`
-            (for the average loss on the validation set).
-        """
-        assert isinstance(neural_network, nn.Module)
-
-        for data in training_data, validation_data:
-            assert isinstance(data, list)
-            assert all(isinstance(datum, tuple) and len(datum) == 2 for datum in data)
-
-        def prepare_datum(datum):
-            if not (isinstance(datum, torch.DoubleTensor) or isinstance(datum, np.ndarray)):
-                return datum.to_numpy()
-            return datum
-
-        training_data = [(prepare_datum(datum[0]), prepare_datum(datum[1])) for datum in training_data]
-        validation_data = [(prepare_datum(datum[0]), prepare_datum(datum[1])) for datum in validation_data]
-
-        optimizer = optim.LBFGS if 'optimizer' not in training_parameters else training_parameters['optimizer']
-        epochs = 1000 if 'epochs' not in training_parameters else training_parameters['epochs']
-        assert isinstance(epochs, int) and epochs > 0
-        batch_size = 20 if 'batch_size' not in training_parameters else training_parameters['batch_size']
-        assert isinstance(batch_size, int) and batch_size > 0
-        learning_rate = 1. if 'learning_rate' not in training_parameters else training_parameters['learning_rate']
-        assert learning_rate > 0.
-        loss_function = (nn.MSELoss() if 'loss_function' not in training_parameters
-                         else training_parameters['loss_function'])
-
-        logger = getLogger('pymor.algorithms.neural_network.train_neural_network')
-
-        # LBFGS-optimizer does not support mini-batching, so the batch size needs to be adjusted
-        if optimizer == optim.LBFGS:
-            batch_size = max(len(training_data), len(validation_data))
-
-        # initialize optimizer and early stopping scheduler
-        optimizer = optimizer(neural_network.parameters(), lr=learning_rate)
-        early_stopping_scheduler = EarlyStoppingScheduler(len(training_data) + len(validation_data))
-
-        # create the training and validation sets as well as the respective data loaders
-        training_dataset = CustomDataset(training_data)
-        validation_dataset = CustomDataset(validation_data)
-        training_loader = utils.data.DataLoader(training_dataset, batch_size=batch_size)
-        validation_loader = utils.data.DataLoader(validation_dataset, batch_size=batch_size)
-        dataloaders = {'train':  training_loader, 'val': validation_loader}
-
-        phases = ['train', 'val']
-
-        logger.info('Starting optimization procedure ...')
-
-        # perform optimization procedure
-        for epoch in range(epochs):
-            losses = {'full': 0.}
-
-            # alternate between training and validation phase
-            for phase in phases:
-                if phase == 'train':
-                    neural_network.train()
-                else:
-                    neural_network.eval()
-
-                running_loss = 0.0
-
-                # iterate over batches
-                for batch in dataloaders[phase]:
-                    inputs = batch[0]
-                    targets = batch[1]
-
-                    with torch.set_grad_enabled(phase == 'train'):
-                        def closure():
-                            if torch.is_grad_enabled():
-                                optimizer.zero_grad()
-                            outputs = neural_network(inputs)
-                            loss = loss_function(outputs, targets)
-                            if loss.requires_grad:
-                                loss.backward()
-                            return loss
-
-                        # perform optimization step
-                        if phase == 'train':
-                            optimizer.step(closure)
-
-                        # compute loss of current batch
-                        loss = closure()
-
-                    # update overall absolute loss
-                    running_loss += loss.item() * len(batch[0])
-
-                # compute average loss
-                epoch_loss = running_loss / len(dataloaders[phase].dataset)
-
-                losses[phase] = epoch_loss
-
-                losses['full'] += running_loss
-
-                # check for early stopping
-                if phase == 'val' and early_stopping_scheduler(losses, neural_network):
-                    logger.info(f'Stopping training process early after {epoch + 1} epochs with validation loss '
-                                f'of {early_stopping_scheduler.best_losses["val"]:.3e} ...')
-                    return early_stopping_scheduler.best_neural_network, early_stopping_scheduler.best_losses
-
-        return early_stopping_scheduler.best_neural_network, early_stopping_scheduler.best_losses
+    return early_stopping_scheduler.best_neural_network, early_stopping_scheduler.best_losses
 
 
-if config.HAVE_TORCH:
+def multiple_restarts_training(training_data, validation_data, neural_network,
+                               target_loss=None, max_restarts=10,
+                               training_parameters={}, seed=None):
+    """Algorithm that performs multiple restarts of neural network training.
 
-    def multiple_restarts_training(training_data, validation_data, neural_network,
-                                   target_loss=None, max_restarts=10,
-                                   training_parameters={}, seed=None):
-        """Algorithm that performs multiple restarts of neural network training.
+    This method either performs a predefined number of restarts and returns
+    the best trained network or tries to reach a given target loss and
+    stops training when the target loss is reached.
 
-        This method either performs a predefined number of restarts and returns
-        the best trained network or tries to reach a given target loss and
-        stops training when the target loss is reached.
+    See :func:`train_neural_network` for more information on the parameters.
 
-        See :func:`train_neural_network` for more information on the parameters.
+    Parameters
+    ----------
+    training_data
+        Data to use during the training phase.
+    validation_data
+        Data to use during the validation phase.
+    target_loss
+        Loss to reach during training (if `None`, the network with the
+        smallest loss is returned).
+    max_restarts
+        Maximum number of restarts to perform.
+    neural_network
+        The neural network to train (parameters will be reset after each
+        restart).
 
-        Parameters
-        ----------
-        training_data
-            Data to use during the training phase.
-        validation_data
-            Data to use during the validation phase.
-        target_loss
-            Loss to reach during training (if `None`, the network with the
-            smallest loss is returned).
-        max_restarts
-            Maximum number of restarts to perform.
-        neural_network
-            The neural network to train (parameters will be reset after each
-            restart).
+    Returns
+    -------
+    best_neural_network
+        The best trained neural network.
+    losses
+        The corresponding losses.
 
-        Returns
-        -------
-        best_neural_network
-            The best trained neural network.
-        losses
-            The corresponding losses.
+    Raises
+    ------
+    NeuralNetworkTrainingFailed
+        Raised if prescribed loss can not be reached within the given number
+        of restarts.
+    """
+    assert isinstance(training_parameters, dict)
+    assert isinstance(max_restarts, int) and max_restarts > 0
 
-        Raises
-        ------
-        NeuralNetworkTrainingFailed
-            Raised if prescribed loss can not be reached within the given number
-            of restarts.
-        """
-        assert isinstance(training_parameters, dict)
-        assert isinstance(max_restarts, int) and max_restarts > 0
+    logger = getLogger('pymor.algorithms.neural_network.multiple_restarts_training')
 
-        logger = getLogger('pymor.algorithms.neural_network.multiple_restarts_training')
+    # if applicable, set a common seed for the PyTorch initialization
+    # of weights and biases and further PyTorch methods for all training runs
+    if seed:
+        torch.manual_seed(seed)
 
-        # if applicable, set a common seed for the PyTorch initialization
-        # of weights and biases and further PyTorch methods for all training runs
-        if seed:
-            torch.manual_seed(seed)
+    if target_loss:
+        logger.info(f'Performing up to {max_restarts} restart{"s" if max_restarts > 1 else ""} '
+                    f'to train a neural network with a loss below {target_loss:.3e} ...')
+    else:
+        logger.info(f'Performing up to {max_restarts} restart{"s" if max_restarts > 1 else ""} '
+                    'to find the neural network with the lowest loss ...')
 
-        if target_loss:
-            logger.info(f'Performing up to {max_restarts} restart{"s" if max_restarts > 1 else ""} '
-                        f'to train a neural network with a loss below {target_loss:.3e} ...')
+    with logger.block('Training neural network #0 ...'):
+        best_neural_network, losses = train_neural_network(training_data, validation_data,
+                                                           neural_network, training_parameters)
+
+    # perform multiple restarts
+    for run in range(1, max_restarts + 1):
+
+        if target_loss and losses['full'] <= target_loss:
+            logger.info(f'Finished training after {run - 1} restart{"s" if run - 1 != 1 else ""}, '
+                        f'found neural network with loss of {losses["full"]:.3e} ...')
+            return neural_network, losses
+
+        with logger.block(f'Training neural network #{run} ...'):
+            # reset parameters of layers to start training with a new and untrained network
+            for layers in neural_network.children():
+                for layer in layers:
+                    if hasattr(layer, 'reset_parameters'):
+                        layer.reset_parameters()
+            # perform training
+            current_nn, current_losses = train_neural_network(training_data, validation_data,
+                                                              neural_network, training_parameters)
+
+        if current_losses['full'] < losses['full']:
+            logger.info(f'Found better neural network (loss of {current_losses["full"]:.3e} '
+                        f'instead of {losses["full"]:.3e}) ...')
+            best_neural_network = current_nn
+            losses = current_losses
         else:
-            logger.info(f'Performing up to {max_restarts} restart{"s" if max_restarts > 1 else ""} '
-                        'to find the neural network with the lowest loss ...')
+            logger.info(f'Rejecting neural network with loss of {current_losses["full"]:.3e} '
+                        f'(instead of {losses["full"]:.3e}) ...')
 
-        with logger.block('Training neural network #0 ...'):
-            best_neural_network, losses = train_neural_network(training_data, validation_data,
-                                                               neural_network, training_parameters)
-
-        # perform multiple restarts
-        for run in range(1, max_restarts + 1):
-
-            if target_loss and losses['full'] <= target_loss:
-                logger.info(f'Finished training after {run - 1} restart{"s" if run - 1 != 1 else ""}, '
-                            f'found neural network with loss of {losses["full"]:.3e} ...')
-                return neural_network, losses
-
-            with logger.block(f'Training neural network #{run} ...'):
-                # reset parameters of layers to start training with a new and untrained network
-                for layers in neural_network.children():
-                    for layer in layers:
-                        if hasattr(layer, 'reset_parameters'):
-                            layer.reset_parameters()
-                # perform training
-                current_nn, current_losses = train_neural_network(training_data, validation_data,
-                                                                  neural_network, training_parameters)
-
-            if current_losses['full'] < losses['full']:
-                logger.info(f'Found better neural network (loss of {current_losses["full"]:.3e} '
-                            f'instead of {losses["full"]:.3e}) ...')
-                best_neural_network = current_nn
-                losses = current_losses
-            else:
-                logger.info(f'Rejecting neural network with loss of {current_losses["full"]:.3e} '
-                            f'(instead of {losses["full"]:.3e}) ...')
-
-        if target_loss:
-            raise NeuralNetworkTrainingFailed(f'Could not find neural network with prescribed loss of '
-                                              f'{target_loss:.3e} (best one found was {losses["full"]:.3e})!')
-        logger.info(f'Found neural network with error of {losses["full"]:.3e} ...')
-        return best_neural_network, losses
+    if target_loss:
+        raise NeuralNetworkTrainingFailed(f'Could not find neural network with prescribed loss of '
+                                          f'{target_loss:.3e} (best one found was {losses["full"]:.3e})!')
+    logger.info(f'Found neural network with error of {losses["full"]:.3e} ...')
+    return best_neural_network, losses

--- a/src/pymor/reductors/neural_network.py
+++ b/src/pymor/reductors/neural_network.py
@@ -428,6 +428,7 @@ class NeuralNetworkInstationaryReductor(NeuralNetworkReductor):
 
     def _compute_layer_sizes(self, hidden_layers):
         """Compute the number of neurons in the layers of the neural network
+
         (make sure to increase the input dimension to account for the time).
         """
         # determine the numbers of neurons in the hidden layers

--- a/src/pymor/reductors/neural_network.py
+++ b/src/pymor/reductors/neural_network.py
@@ -10,8 +10,8 @@ Due to an issue in autoapi, the classes `NeuralNetworkStatefreeOutputReductor`,
 see https://github.com/pymor/pymor/issues/1343.
 """
 
-from pymor.core.config import require_dependency
-require_dependency('TORCH')
+from pymor.core.config import config
+config.require('TORCH')
 
 
 from numbers import Number

--- a/src/pymor/tools/io/__init__.py
+++ b/src/pymor/tools/io/__init__.py
@@ -8,16 +8,19 @@ import tempfile
 from contextlib import contextmanager
 
 from .matrices import load_matrix, save_matrix
-from pymor.core.config import config
-from ...core.exceptions import IOLibsMissing
+from pymor.tools.deprecated import Deprecated
 
-if config.HAVE_VTKIO:
-    from .vtk import read_vtkfile, write_vtk_collection
-else:
-    def read_vtkfile(*args, **kwargs):
-        raise IOLibsMissing()
 
-    write_vtk_collection = read_vtkfile
+@Deprecated('pymor.tools.io.vtk.read_vtkfile')
+def read_vtkfile(*args, **kwargs):
+    from .vtk import read_vtkfile
+    return read_vtkfile(*args, **kwargs)
+
+
+@Deprecated('pymor.tools.io.vtk.write_vtk_collection')
+def write_vtk_collection(*args, **kwargs):
+    from .vtk import write_vtk_collection
+    return write_vtk_collection(*args, **kwargs)
 
 
 @contextmanager

--- a/src/pymor/tools/io/vtk.py
+++ b/src/pymor/tools/io/vtk.py
@@ -2,6 +2,10 @@
 # Copyright 2013-2021 pyMOR developers and contributors. All rights reserved.
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
+from pymor.core.config import require_dependency
+require_dependency('VTKIO')
+
+
 from pathlib import Path
 
 import meshio

--- a/src/pymor/tools/io/vtk.py
+++ b/src/pymor/tools/io/vtk.py
@@ -2,8 +2,8 @@
 # Copyright 2013-2021 pyMOR developers and contributors. All rights reserved.
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
-from pymor.core.config import require_dependency
-require_dependency('VTKIO')
+from pymor.core.config import config
+config.require('VTKIO')
 
 
 from pathlib import Path

--- a/src/pymor/tools/io/vtk.py
+++ b/src/pymor/tools/io/vtk.py
@@ -14,7 +14,6 @@ from collections import OrderedDict
 from xmljson import BadgerFish
 from lxml import etree
 
-from pymor.core.config import config
 from pymor.core.exceptions import IOLibsMissing
 
 

--- a/src/pymortests/core/config.py
+++ b/src/pymortests/core/config.py
@@ -2,6 +2,7 @@
 # Copyright 2013-2021 pyMOR developers and contributors. All rights reserved.
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
+import pytest
 
 from pymor.core.config import config, _PACKAGES
 
@@ -22,3 +23,13 @@ def test_dir():
     for p in _PACKAGES:
         assert 'HAVE_' + p in d
         assert p + '_VERSION' in d
+
+
+def test_require_numpy():
+    config.require('numpy')
+    config.require('NUMPY')
+
+
+def test_require_fail_foo():
+    with pytest.raises(AttributeError):
+        config.require('FOO')

--- a/src/pymortests/core/config.py
+++ b/src/pymortests/core/config.py
@@ -5,6 +5,7 @@
 import pytest
 
 from pymor.core.config import config, _PACKAGES
+from pymor.core.exceptions import DependencyMissing
 
 
 def test_repr():
@@ -33,3 +34,9 @@ def test_require_numpy():
 def test_require_fail_foo():
     with pytest.raises(AttributeError):
         config.require('FOO')
+
+
+def test_require_fail_missing_dependency(monkeypatch):
+    monkeypatch.setitem(_PACKAGES, 'THISISNOTAPACKAGENAMETHATEXISTS', lambda: False)
+    with pytest.raises(DependencyMissing):
+        config.require('THISISNOTAPACKAGENAMETHATEXISTS')

--- a/src/pymortests/gui.py
+++ b/src/pymortests/gui.py
@@ -3,7 +3,6 @@
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
 from pymor.discretizers.builtin.grids.oned import OnedGrid
-from pymor.discretizers.builtin.gui.qt import visualize_patch
 
 import pytest
 import numpy as np
@@ -34,6 +33,7 @@ def test_visualize_patch(backend_gridtype):
     m, data = discretize_stationary_cg(analytical_problem=problem, grid=grid, boundary_info=bi)
     U = m.solve()
     try:
+        from pymor.discretizers.builtin.gui.qt import visualize_patch
         visualize_patch(data['grid'], U=U, backend=backend)
     except QtMissing:
         pytest.xfail("Qt missing")

--- a/src/pymortests/tools.py
+++ b/src/pymortests/tools.py
@@ -19,7 +19,7 @@ from pymor.tools import formatsrc, timing
 from pymor.tools.deprecated import Deprecated
 from pymor.tools.floatcmp import almost_less, float_cmp, float_cmp_all
 from pymor.tools.formatsrc import print_source
-from pymor.tools.io import safe_temporary_filename, change_to_directory, read_vtkfile
+from pymor.tools.io import safe_temporary_filename, change_to_directory
 from pymor.vectorarrays.numpy import NumpyVectorSpace
 from pymortests.base import runmodule
 from pymortests.fixtures.grid import hy_rect_or_tria_grid
@@ -125,6 +125,7 @@ def test_almost_less():
 @given(hy_rect_or_tria_grid)
 def test_vtkio(grid):
     from pymor.discretizers.builtin.grids.vtkio import write_vtk
+    from pymor.tools.io.vtk import read_vtkfile
     steps = 4
     for codim, data in enumerate((NumpyVectorSpace.from_numpy(np.ones((steps, grid.size(c))))
                                   for c in range(grid.dim+1))):

--- a/src/pymortests/tools.py
+++ b/src/pymortests/tools.py
@@ -14,7 +14,6 @@ from hypothesis import given
 
 from pymor.core.config import config
 from pymor.core.logger import getLogger
-from pymor.discretizers.builtin.grids.vtkio import write_vtk
 from pymor.discretizers.builtin.quadratures import GaussQuadratures
 from pymor.tools import formatsrc, timing
 from pymor.tools.deprecated import Deprecated
@@ -125,6 +124,7 @@ def test_almost_less():
 @pytest.mark.skipif(not config.HAVE_VTKIO, reason='VTKIO support libraries missing')
 @given(hy_rect_or_tria_grid)
 def test_vtkio(grid):
+    from pymor.discretizers.builtin.grids.vtkio import write_vtk
     steps = 4
     for codim, data in enumerate((NumpyVectorSpace.from_numpy(np.ones((steps, grid.size(c))))
                                   for c in range(grid.dim+1))):


### PR DESCRIPTION
This pr adds ~`require_dependency` to `pymor.core.config`~ a `require` method to `pymor.core.config.config`, which will raise an `DependencyMissing` error when the provided config item is not available. I refactored all relevant modules to use this mechanism instead of the current `if config.HAVE_FOO` checks, which lead to unnecessary indents and leads to the surprising behavior that an imported module is empty. As a consequence, importing e.g. `pymor.bindings.fenics` will raise an error, when fenics is unavailable. To avoid an exception one, thus, has to check first for fenics availability and then conditionally import the bindings. In practice this should be only necessary in very few places.

Also see discussion in #1343.