### PR TITLE
Improve MPI related interpreter shutdown issues

### DIFF
--- a/docs/source/environment.rst
+++ b/docs/source/environment.rst
@@ -32,7 +32,7 @@ PYMOR_HYPOTHESIS_PROFILE
 PYMOR_MPI_FINALIZE
     If set controls the value for `mpi4py.rc.finalize`. If `PYMOR_MPI_FINALIZE` is unset the value
     of `mpi4py.rc.finalize` remains unchanged, unless `mpi4py.rc.finalize is None` in which
-    case it is defaulted to `False`.
+    case it is defaulted to `True`.
 
 PYMOR_ALLOW_DEADLINE_EXCESS
     If set, test functions decorated with :func:`~pymortests.base.might_exceed_deadline` are allowed

--- a/src/pymor/__init__.py
+++ b/src/pymor/__init__.py
@@ -24,12 +24,13 @@ def _init_mpi():
 
 
     """
+
     try:
         import mpi4py
     except ImportError:
         return
 
-    finalize = os.environ.get('PYMOR_MPI_FINALIZE', mpi4py.rc.finalize if mpi4py.rc.finalize is not None else False)
+    finalize = os.environ.get('PYMOR_MPI_FINALIZE', mpi4py.rc.finalize if mpi4py.rc.finalize is not None else True)
     mpi4py.rc(initialize=False, finalize=finalize)
     from mpi4py import MPI
     if not MPI.Is_initialized():
@@ -37,13 +38,13 @@ def _init_mpi():
         supported_lvl = MPI.Init_thread(required_level)
         if supported_lvl < required_level:
             print(f'MPI does support threading level {required_level}, running with {supported_lvl} instead', flush=True)
+
     try:
         # this solves sporadic mpi calls happening after finalize
         import petsc4py
         petsc4py.init()
     except ImportError:
         return
-
 
 _init_mpi()
 


### PR DESCRIPTION
- In `mpi_wrap_model` ensure proper cleanup of objects managed by pyMOR's MPI event loop.
- Issue a warning when there are still managed objects when the event loop is shut down.
- Switch import order for petsc4py and mpi4py.

The last commit locally fixes petsc trying to communicate after MPI_Finalize during interpreter shutdown. @renefritze, was there any reason for the prior import oder?