### PR TITLE
`NumpyHankelOperator` class

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -14,6 +14,7 @@
 
 * Art Pelling, a.pelling@tu-berlin.de
   * support for discrete-time LTI systems
+  * dedicated Hankel operator class
 
 ### pyMOR 2021.2
 

--- a/docs/source/bibliography.bib
+++ b/docs/source/bibliography.bib
@@ -307,7 +307,7 @@
   title = {Efficient Algorithms for Eigensystem Realization Using Randomized SVD},
   author = {Minster, Rachel and Saibaba, Arvind K. and Kar, Jishnudeep and Chakrabortty, Aranya},
   year = 2021,
-  journaltitle = {SIAM Journal on Matrix Analysis and Applications},
+  journal = {SIAM Journal on Matrix Analysis and Applications},
   volume = {42},
   number = {2},
   pages = {1045--1072},

--- a/docs/source/bibliography.bib
+++ b/docs/source/bibliography.bib
@@ -303,6 +303,18 @@
   doi =          {10.1109/9.86941}
 }
 
+@Article{MSKC21,
+  title = {Efficient Algorithms for Eigensystem Realization Using Randomized SVD},
+  author = {Minster, Rachel and Saibaba, Arvind K. and Kar, Jishnudeep and Chakrabortty, Aranya},
+  year = 2021,
+  journaltitle = {SIAM Journal on Matrix Analysis and Applications},
+  volume = {42},
+  number = {2},
+  pages = {1045--1072},
+  doi = {10.1137/20M1327616},
+  url = {https://epubs.siam.org/doi/10.1137/20M1327616},
+}
+
 @book{NW06,
   title={Numerical optimization},
   author={Nocedal, Jorge and Wright, Stephen},

--- a/src/pymor/algorithms/to_matrix.py
+++ b/src/pymor/algorithms/to_matrix.py
@@ -55,7 +55,7 @@ class ToMatrixRules(RuleTable):
             n = s // 2 + 1
             op_mp = np.concatenate([op.markov_parameters, np.zeros([1 - s % 2, p, m])])
             r, c = op_mp[:n], op_mp[n - 1:]
-            op_matrix = np.zeros([p * n, m * n])
+            op_matrix = np.zeros([p * n, m * n], dtype=op_mp.dtype)
             for (i, j) in np.ndindex((p, m)):
                 op_matrix[i::p, j::m] = spla.hankel(r[:, i, j], c[:, i, j])
 

--- a/src/pymor/algorithms/to_matrix.py
+++ b/src/pymor/algorithms/to_matrix.py
@@ -13,7 +13,7 @@ from pymor.operators.block import BlockOperatorBase
 from pymor.operators.constructions import (AdjointOperator, ComponentProjectionOperator, ConcatenationOperator,
                                            IdentityOperator, LincombOperator, LowRankOperator, LowRankUpdatedOperator,
                                            VectorArrayOperator, ZeroOperator)
-from pymor.operators.numpy import NumpyMatrixOperator
+from pymor.operators.numpy import NumpyHankelOperator, NumpyMatrixOperator
 
 
 def to_matrix(op, format=None, mu=None):
@@ -46,6 +46,23 @@ class ToMatrixRules(RuleTable):
     def __init__(self, format, mu):
         super().__init__()
         self.__auto_init(locals())
+
+    @match_class(NumpyHankelOperator)
+    def action_NumpyHankelOperator(self, op):
+        format = self.format
+        p, m, s = op.markov_parameters.shape
+        n = s // 2 + 1
+        op_mp = np.concatenate([op.markov_parameters, np.zeros([p, m, 1 - s % 2])], axis=-1)
+        r, c = op_mp[..., :n], op_mp[..., n - 1:]
+        op_matrix = np.zeros([p * n, m * n])
+        for (i, j) in np.ndindex((p, m)):
+            op_matrix[i::p, j::m] = spla.hankel(r[i, j], c[i, j])
+        if format is None:
+            return op_matrix
+        elif format == 'dense':
+            return op_matrix
+        else:
+            raise NotImplementedError
 
     @match_class(NumpyMatrixOperator)
     def action_NumpyMatrixOperator(self, op):

--- a/src/pymor/algorithms/to_matrix.py
+++ b/src/pymor/algorithms/to_matrix.py
@@ -50,13 +50,13 @@ class ToMatrixRules(RuleTable):
     @match_class(NumpyHankelOperator)
     def action_NumpyHankelOperator(self, op):
         format = self.format
-        p, m, s = op.markov_parameters.shape
+        s, p, m = op.markov_parameters.shape
         n = s // 2 + 1
-        op_mp = np.concatenate([op.markov_parameters, np.zeros([p, m, 1 - s % 2])], axis=-1)
-        r, c = op_mp[..., :n], op_mp[..., n - 1:]
+        op_mp = np.concatenate([op.markov_parameters, np.zeros([1 - s % 2, p, m])])
+        r, c = op_mp[:n], op_mp[n - 1:]
         op_matrix = np.zeros([p * n, m * n])
         for (i, j) in np.ndindex((p, m)):
-            op_matrix[i::p, j::m] = spla.hankel(r[i, j], c[i, j])
+            op_matrix[i::p, j::m] = spla.hankel(r[:, i, j], c[:, i, j])
         if format is None:
             return op_matrix
         elif format == 'dense':

--- a/src/pymor/algorithms/to_matrix.py
+++ b/src/pymor/algorithms/to_matrix.py
@@ -50,16 +50,15 @@ class ToMatrixRules(RuleTable):
     @match_class(NumpyHankelOperator)
     def action_NumpyHankelOperator(self, op):
         format = self.format
-        s, p, m = op.markov_parameters.shape
-        n = s // 2 + 1
-        op_mp = np.concatenate([op.markov_parameters, np.zeros([1 - s % 2, p, m])])
-        r, c = op_mp[:n], op_mp[n - 1:]
-        op_matrix = np.zeros([p * n, m * n])
-        for (i, j) in np.ndindex((p, m)):
-            op_matrix[i::p, j::m] = spla.hankel(r[:, i, j], c[:, i, j])
-        if format is None:
-            return op_matrix
-        elif format == 'dense':
+        if format in (None, 'dense'):
+            s, p, m = op.markov_parameters.shape
+            n = s // 2 + 1
+            op_mp = np.concatenate([op.markov_parameters, np.zeros([1 - s % 2, p, m])])
+            r, c = op_mp[:n], op_mp[n - 1:]
+            op_matrix = np.zeros([p * n, m * n])
+            for (i, j) in np.ndindex((p, m)):
+                op_matrix[i::p, j::m] = spla.hankel(r[:, i, j], c[:, i, j])
+
             return op_matrix
         else:
             raise NotImplementedError

--- a/src/pymor/operators/numpy.py
+++ b/src/pymor/operators/numpy.py
@@ -490,7 +490,7 @@ class NumpyHankelOperator(NumpyGenericOperator):
                 FFT, iFFT = rfft, irfft
                 dtype = float
             else:
-                c = np.concatenate([c, np.flip(c[1:-1]).conj()])
+                c = np.concatenate([c, np.flip(c[1:-1], axis=0).conj()])
 
         y = np.zeros([self.range.dim, k], dtype=dtype)
         for (i, j) in np.ndindex((p, m)):

--- a/src/pymor/operators/numpy.py
+++ b/src/pymor/operators/numpy.py
@@ -6,13 +6,13 @@
 
 This module provides the following |NumPy|-based |Operators|:
 
-- |NumpyHankelOperator| implicitly constructs a Hankel operator from a |NumPy array| of Markov
-  parameters.
 - |NumpyMatrixOperator| wraps a 2D |NumPy array| as an |Operator|.
 - |NumpyMatrixBasedOperator| should be used as base class for all |Operators|
   which assemble into a |NumpyMatrixOperator|.
 - |NumpyGenericOperator| wraps an arbitrary Python function between
   |NumPy arrays| as an |Operator|.
+- |NumpyHankelOperator| implicitly constructs a Hankel operator from a |NumPy array| of Markov
+  parameters.
 """
 
 from functools import reduce

--- a/src/pymor/operators/numpy.py
+++ b/src/pymor/operators/numpy.py
@@ -6,6 +6,8 @@
 
 This module provides the following |NumPy|-based |Operators|:
 
+- |NumpyHankelOperator| implicitly constructs a Hankel operator from a |NumPy array| of Markov
+  parameters.
 - |NumpyMatrixOperator| wraps a 2D |NumPy array| as an |Operator|.
 - |NumpyMatrixBasedOperator| should be used as base class for all |Operators|
   which assemble into a |NumpyMatrixOperator|.

--- a/src/pymor/operators/numpy.py
+++ b/src/pymor/operators/numpy.py
@@ -463,13 +463,8 @@ class NumpyHankelOperator(NumpyGenericOperator):
     def __init__(self, markov_parameters, source_id=None, range_id=None, name=None):
         if markov_parameters.ndim == 1:
             markov_parameters = markov_parameters.reshape(-1, 1, 1)
-
         assert markov_parameters.ndim == 3
-        try:
-            markov_parameters.setflags(write=False)  # make numpy arrays read-only
-        except AttributeError:
-            pass
-
+        markov_parameters.setflags(write=False)  # make numpy arrays read-only
         self.__auto_init(locals())
         s, p, m = markov_parameters.shape
         n = s // 2 + 1

--- a/src/pymor/operators/numpy.py
+++ b/src/pymor/operators/numpy.py
@@ -411,7 +411,7 @@ class NumpyHankelOperator(NumpyGenericOperator):
             h_1 & h_2 & \dots & h_n
         \end{pmatrix},\quad h_i\in\mathbb{R}^{p\times m},\,i=1,\,\dots,\,n,\quad n,m,p\in\mathbb{N}
 
-    be a finite sequence of (matrix-valued) Markov parameters. For an uneven number :math:`n=2s-1`
+    be a finite sequence of (matrix-valued) Markov parameters. For an odd number :math:`n=2s-1`
     Markov parameters, the corresponding Hankel operator can be represented by the matrix
 
     .. math::

--- a/src/pymor/operators/numpy.py
+++ b/src/pymor/operators/numpy.py
@@ -11,7 +11,7 @@ This module provides the following |NumPy|-based |Operators|:
   which assemble into a |NumpyMatrixOperator|.
 - |NumpyGenericOperator| wraps an arbitrary Python function between
   |NumPy arrays| as an |Operator|.
-- |NumpyHankelOperator| implicitly constructs a Hankel operator from a |NumPy array| of Markov
+- :class:`NumpyHankelOperator` implicitly constructs a Hankel operator from a |NumPy array| of Markov
   parameters.
 """
 

--- a/src/pymor/operators/numpy.py
+++ b/src/pymor/operators/numpy.py
@@ -399,6 +399,67 @@ class NumpyMatrixOperator(NumpyMatrixBasedOperator):
 
 
 class NumpyHankelOperator(NumpyGenericOperator):
+    r"""Implicit representation of a Hankel operator by a |NumPy Array| of Markov parameters.
+
+    Let
+
+    .. math::
+        h =
+        \begin{pmatrix}
+            h_1 & h_2 & \dots & h_n
+        \end{pmatrix},\quad h_i\in\mathbb{R}^{p\times m},\,i=1,\,\dots,\,n,\quad n,m,p\in\mathbb{N}
+
+    be a finite sequence of (matrix-valued) Markov parameters. For an uneven number :math:`n=2s-1`
+    Markov parameters, the corresponding Hankel operator can be represented by the matrix
+
+    .. math::
+        H =
+        \begin{bmatrix}
+            h_1 & h_2 & \dots & h_s \\
+            h_2 & h_3 & \dots & h_{s+1}\\
+            \vdots & \vdots && \vdots\\
+            h_s & h_{s+1} & \dots & h_{2s-1}
+        \end{bmatrix}\in\mathbb{R}^{ms\times ps}.
+
+    For an even number of :math:`n=2s` Markov parameters, the corresponding matrix
+    representation is given by
+
+    .. math::
+        H =
+        \begin{bmatrix}
+            h_1 & h_2 & \dots & h_s & h_{s+1}\\
+            h_2 & h_3 & \dots & h_{s+1} & h_{s+2}\\
+            \vdots & \vdots && \vdots & \vdots\\
+            h_s & h_{s+1} & \dots & h_{2s-1} & h_{2s}\\
+            h_{s+1} & h_{s+2} & \dots & h_{2s} & 0
+        \end{bmatrix}\in\mathbb{R}^{m(s+1)\times p(s+1)}.
+
+    The matrix :math:`H` as seen above is not explicitly constructed, only the sequence of Markov
+    parameters is stored. Efficient matrix-vector multiplications are realized via circulant
+    matrices with DFT in the class' `apply` method
+    (see :cite:`MSKC21` Algorithm 3.1. for details).
+
+    Parameters
+    ----------
+    markov_parameters
+        The |NumPy array| that contains the first :math:`n` Markov parameters that define the Hankel
+        operator. Has to be one- or three-dimensional with either::
+
+            markov_parameters.shape = (n,)
+
+        for scalar-valued Markov parameters or::
+
+            markov_parameters.shape = (p, m, n)
+
+        for matrix-valued Markov parameters of dimension :math:`p\times m`.
+    source_id
+        The id of the operator's `source` |VectorSpace|.
+    range_id
+        The id of the operator's `range` |VectorSpace|.
+    name
+        Name of the operator.
+    """
+
     def __init__(self, markov_parameters, source_id=None, range_id=None, name=None):
         if markov_parameters.ndim == 1:
             markov_parameters = markov_parameters.reshape(1, 1, -1)

--- a/src/pymor/operators/numpy.py
+++ b/src/pymor/operators/numpy.py
@@ -409,7 +409,7 @@ class NumpyHankelOperator(NumpyGenericOperator):
         h =
         \begin{pmatrix}
             h_1 & h_2 & \dots & h_n
-        \end{pmatrix},\quad h_i\in\mathbb{R}^{p\times m},\,i=1,\,\dots,\,n,\quad n,m,p\in\mathbb{N}
+        \end{pmatrix},\quad h_i\in\mathbb{C}^{p\times m},\,i=1,\,\dots,\,n,\quad n,m,p\in\mathbb{N}
 
     be a finite sequence of (matrix-valued) Markov parameters. For an odd number :math:`n=2s-1`
     of Markov parameters, the corresponding Hankel operator can be represented by the matrix
@@ -421,7 +421,7 @@ class NumpyHankelOperator(NumpyGenericOperator):
             h_2 & h_3 & \dots & h_{s+1}\\
             \vdots & \vdots && \vdots\\
             h_s & h_{s+1} & \dots & h_{2s-1}
-        \end{bmatrix}\in\mathbb{R}^{ms\times ps}.
+        \end{bmatrix}\in\mathbb{C}^{ms\times ps}.
 
     For an even number :math:`n=2s` of Markov parameters, the corresponding matrix
     representation is given by
@@ -434,7 +434,7 @@ class NumpyHankelOperator(NumpyGenericOperator):
             \vdots & \vdots && \vdots & \vdots\\
             h_s & h_{s+1} & \dots & h_{2s-1} & h_{2s}\\
             h_{s+1} & h_{s+2} & \dots & h_{2s} & 0
-        \end{bmatrix}\in\mathbb{R}^{m(s+1)\times p(s+1)}.
+        \end{bmatrix}\in\mathbb{C}^{m(s+1)\times p(s+1)}.
 
     The matrix :math:`H` as seen above is not explicitly constructed, only the sequence of Markov
     parameters is stored. Efficient matrix-vector multiplications are realized via circulant

--- a/src/pymor/operators/numpy.py
+++ b/src/pymor/operators/numpy.py
@@ -11,8 +11,8 @@ This module provides the following |NumPy|-based |Operators|:
   which assemble into a |NumpyMatrixOperator|.
 - |NumpyGenericOperator| wraps an arbitrary Python function between
   |NumPy arrays| as an |Operator|.
-- :class:`NumpyHankelOperator` implicitly constructs a Hankel operator from a |NumPy array| of Markov
-  parameters.
+- :class:`NumpyHankelOperator` implicitly constructs a Hankel operator from a |NumPy array| of
+  Markov parameters.
 """
 
 from functools import reduce

--- a/src/pymor/operators/numpy.py
+++ b/src/pymor/operators/numpy.py
@@ -412,7 +412,7 @@ class NumpyHankelOperator(NumpyGenericOperator):
         \end{pmatrix},\quad h_i\in\mathbb{R}^{p\times m},\,i=1,\,\dots,\,n,\quad n,m,p\in\mathbb{N}
 
     be a finite sequence of (matrix-valued) Markov parameters. For an odd number :math:`n=2s-1`
-    Markov parameters, the corresponding Hankel operator can be represented by the matrix
+    of Markov parameters, the corresponding Hankel operator can be represented by the matrix
 
     .. math::
         H =
@@ -423,7 +423,7 @@ class NumpyHankelOperator(NumpyGenericOperator):
             h_s & h_{s+1} & \dots & h_{2s-1}
         \end{bmatrix}\in\mathbb{R}^{ms\times ps}.
 
-    For an even number of :math:`n=2s` Markov parameters, the corresponding matrix
+    For an even number :math:`n=2s` of Markov parameters, the corresponding matrix
     representation is given by
 
     .. math::

--- a/src/pymortests/fixtures/operator.py
+++ b/src/pymortests/fixtures/operator.py
@@ -452,7 +452,7 @@ def misc_operator_with_arrays_and_products_factory(n):
     elif n == 13:
         from pymor.operators.numpy import NumpyHankelOperator
         s, p, m = 4, 2, 3
-        mp = np.arange(s * p * m).reshape(s, p, m) + 1
+        mp = np.random.rand(s, p, m)
         op = NumpyHankelOperator(mp)
         return op, None, op.source.random(), op.range.random(), IdentityOperator(op.source), IdentityOperator(op.range)
     else:

--- a/src/pymortests/fixtures/operator.py
+++ b/src/pymortests/fixtures/operator.py
@@ -341,7 +341,7 @@ thermalblock_fixedparam_operator_with_arrays_and_products_generators = \
     [lambda args=args: thermalblock_fixedparam_factory(*args) for args in thermalblock_factory_arguments]
 
 
-num_misc_operators = 13
+num_misc_operators = 14
 
 
 def misc_operator_with_arrays_and_products_factory(n):
@@ -448,6 +448,12 @@ def misc_operator_with_arrays_and_products_factory(n):
         from pymor.vectorarrays.block import BlockVectorSpace
         space = BlockVectorSpace([NumpyVectorSpace(1), NumpyVectorSpace(2)])
         op = NumpyConversionOperator(space)
+        return op, None, op.source.random(), op.range.random(), IdentityOperator(op.source), IdentityOperator(op.range)
+    elif n == 13:
+        from pymor.operators.numpy import NumpyHankelOperator
+        s, p, m = 4, 2, 3
+        mp = np.arange(s * p * m).reshape(s, p, m) + 1
+        op = NumpyHankelOperator(mp)
         return op, None, op.source.random(), op.range.random(), IdentityOperator(op.source), IdentityOperator(op.range)
     else:
         assert False

--- a/src/pymortests/operators.py
+++ b/src/pymortests/operators.py
@@ -487,6 +487,8 @@ def test_hankel_operator():
     op = NumpyHankelOperator(mp)
     U = op.source.random(1)
     np.testing.assert_almost_equal(op.apply(U).to_numpy().T, to_matrix(op) @ U.to_numpy().T)
+    V = op.range.random(1)
+    np.testing.assert_almost_equal(op.apply_adjoint(V).to_numpy().T, to_matrix(op).T @ V.to_numpy().T)
 
 
 if config.HAVE_DUNEGDT:

--- a/src/pymortests/operators.py
+++ b/src/pymortests/operators.py
@@ -13,7 +13,7 @@ from pymor.core.config import config
 from pymor.operators.block import BlockDiagonalOperator
 from pymor.operators.constructions import (SelectionOperator, InverseOperator, InverseAdjointOperator, IdentityOperator,
                                            LincombOperator, VectorArrayOperator)
-from pymor.operators.numpy import NumpyMatrixOperator
+from pymor.operators.numpy import NumpyHankelOperator, NumpyMatrixOperator
 from pymor.operators.interface import as_array_max_length
 from pymor.parameters.functionals import GenericParameterFunctional, ExpressionParameterFunctional
 from pymor.vectorarrays.block import BlockVectorSpace
@@ -479,6 +479,14 @@ def test_issue_1276():
     v = B.source.ones()
 
     B.apply_inverse(v)
+
+
+def test_hankel_operator():
+    s, p, m = 4, 2, 3
+    mp = np.arange(s * p * m).reshape(s, p, m) + 1
+    op = NumpyHankelOperator(mp)
+    U = op.source.random(1)
+    np.testing.assert_almost_equal(op.apply(U).to_numpy().T, to_matrix(op) @ U.to_numpy().T)
 
 
 if config.HAVE_DUNEGDT:

--- a/src/pymortests/operators.py
+++ b/src/pymortests/operators.py
@@ -489,12 +489,14 @@ def test_hankel_operator(iscomplex):
     else:
         mp = np.random.rand(s, p, m)
     op = NumpyHankelOperator(mp)
-    if iscomplex:
-        U = op.source.random(1) + 1j * op.source.random(1)
-        V = op.range.random(1) + 1j * op.range.random(1)
-    else:
-        U = op.source.random(1)
-        V = op.range.random(1)
+
+    U = op.source.random(1)
+    V = op.range.random(1)
+    np.testing.assert_array_almost_equal(op.apply(U).to_numpy().T, to_matrix(op) @ U.to_numpy().T)
+    np.testing.assert_array_almost_equal(op.apply_adjoint(V).to_numpy().T, to_matrix(op).conj().T @ V.to_numpy().T)
+
+    U += 1j * op.source.random(1)
+    V += 1j * op.range.random(1)
     np.testing.assert_array_almost_equal(op.apply(U).to_numpy().T, to_matrix(op) @ U.to_numpy().T)
     np.testing.assert_array_almost_equal(op.apply_adjoint(V).to_numpy().T, to_matrix(op).conj().T @ V.to_numpy().T)
 

--- a/src/pymortests/operators.py
+++ b/src/pymortests/operators.py
@@ -481,14 +481,22 @@ def test_issue_1276():
     B.apply_inverse(v)
 
 
-def test_hankel_operator():
+@pytest.mark.parametrize('iscomplex', [False, True])
+def test_hankel_operator(iscomplex):
     s, p, m = 4, 2, 3
-    mp = np.arange(s * p * m).reshape(s, p, m) + 1
+    if iscomplex:
+        mp = np.random.rand(s, p, m) + 1j * np.random.rand(s, p, m)
+    else:
+        mp = np.random.rand(s, p, m)
     op = NumpyHankelOperator(mp)
-    U = op.source.random(1)
-    np.testing.assert_almost_equal(op.apply(U).to_numpy().T, to_matrix(op) @ U.to_numpy().T)
-    V = op.range.random(1)
-    np.testing.assert_almost_equal(op.apply_adjoint(V).to_numpy().T, to_matrix(op).T @ V.to_numpy().T)
+    if iscomplex:
+        U = op.source.random(1) + 1j * op.source.random(1)
+        V = op.range.random(1) + 1j * op.range.random(1)
+    else:
+        U = op.source.random(1)
+        V = op.range.random(1)
+    np.testing.assert_array_almost_equal(op.apply(U).to_numpy().T, to_matrix(op) @ U.to_numpy().T)
+    np.testing.assert_array_almost_equal(op.apply_adjoint(V).to_numpy().T, to_matrix(op).conj().T @ V.to_numpy().T)
 
 
 if config.HAVE_DUNEGDT:


### PR DESCRIPTION
Following the discussion #1535 and #1537, this PR introduced a new `NumpyHankelOperator` class that implements FFT-accelerated `apply` methods.
Please refer to #1537 for the math and some basic benchmarks.

The idea behind this is to use it together with a randomized range finder to enable the Eigensystem Realization Algorithm with high-dimensional data. This class could maybe be useful for other MOR-methods that work with the Hankel matrix as well.

## The construction process
The `__init__` method takes an `array` of Markov parameters that represent the Hankel matrix.
For an uneven number of Markov parameters, i.e. <img src=
"https://render.githubusercontent.com/render/math?math=%5Cdisplaystyle+%5Cbegin%7Balign%2A%7D%0Ah%5Cin%5Cmathbb%7BR%7D%5E%7B2s-1%7D%0A%5Cend%7Balign%2A%7D">, this is the matrix

<img src=
"https://render.githubusercontent.com/render/math?math=%5Cdisplaystyle+%5Cbegin%7Balign%2A%7D%0A++H%3D%0A++%5Cbegin%7Bbmatrix%7D%0A++++h_1+%26+h_2+%26+%5Ccdots+%26+h_s+%5C%5C%0A++++h_2+%26+h_3+%26+%5Ccdots+%26+h_%7Bs%2B1%7D+%5C%5C%0A++++%5Cvdots+%26+%5Cvdots+%26+%26+%5Cvdots+%5C%5C%0A++++h_s+%26h_%7Bs%2B1%7D+%26+%5Ccdots+%26+h_%7B2s-1%7D%0A++%5Cend%7Bbmatrix%7D%5Cin%5Cmathbb%7BR%7D%5E%7Bs%5Ctimes+s%7D%0A%5Cend%7Balign%2A%7D">.

The question is what to do if an even number of Markov parameters are supplied. The last one could be neglected such that the above holds. I personally went for appending a zero, because this ensures that "nothing gets lost".

So for even inputs, i.e. <img src=
"https://render.githubusercontent.com/render/math?math=%5Cdisplaystyle+%5Cbegin%7Balign%2A%7D%0A++h%3D%5Cin%5Cmathbb%7BR%7D%5E%7B2s%7D%0A%5Cend%7Balign%2A%7D">, this yields:

<img src=
"https://render.githubusercontent.com/render/math?math=%5Cdisplaystyle+%5Cbegin%7Balign%2A%7D%0A++H%3D%0A++%5Cbegin%7Bbmatrix%7D%0A++++h_1+%26+h_2+%26+%5Ccdots+%26+h_s+%26+h_%7Bs%2B1%7D%5C%5C%0A++++h_2+%26+h_3+%26+%5Ccdots+%26+h_%7Bs%2B1%7D+%26+h_%7Bs%2B2%7D+%5C%5C%0A++++%5Cvdots+%26+%5Cvdots+%26+%26+%5Cvdots+%5C%5C%0A++++h_s+%26h_%7Bs%2B1%7D+%26+%5Ccdots+%26+h_%7B2s-1%7D+%26+h_%7B2s%7D%5C%5C%0Ah_%7Bs%2B1%7D+%26+h_%7Bs%2B2%7D+%26+%5Ccdots+%26+h_%7B2s%7D+%26+0%0A++%5Cend%7Bbmatrix%7D%5Cin%5Cmathbb%7BR%7D%5E%7Bs%2B1%5Ctimes+s%2B1%7D%0A%5Cend%7Balign%2A%7D">

My first implementation in #1537 zero-padded in the `__init__` before the class attributes where assigned but this could be confusing to the user.
I think it is better to zero-pad implictly when constructing `self._circulant`, because then `self.markov_parameters` will always match the input array.


## Todos
- [x] write test
- [x] create docstrings