### PR TITLE
Fix setting of logger filename via defaults

### DIFF
--- a/src/pymor/core/logger.py
+++ b/src/pymor/core/logger.py
@@ -173,7 +173,7 @@ class ColoredFormatter(logging.Formatter):
 
 
 @defaults('filename')
-def default_handler(filename=''):
+def default_handler(filename=None):
     streamhandler = logging.StreamHandler()
     streamformatter = ColoredFormatter()
     streamhandler.setFormatter(streamformatter)
@@ -187,7 +187,7 @@ def default_handler(filename=''):
 
 
 @defaults('filename')
-def getLogger(module, level=None, filename=''):
+def getLogger(module, level=None, filename=None):
     """Get the logger of the respective module for pyMOR's logging facility.
 
     In addition to the logging methods inherited from :class:`~logging.Logger`


### PR DESCRIPTION
Fixes the default value of the `filename` argument of `getLogger`, to allow specification using our defaults.

Reasoning: `@default` values are only inserted if the function is called with `None` as argument. Since the signature of `getlogger` was `getLogger(module, ...filename='')`, any call to `getLogger('foo')` translates to `filename=''`. This results in a scenario, where a user calls
```python
set_defaults({'pymor.core.logger.getLogger.filename': 'bar.txt'})
```
without getting output in `bar.txt`. Defaulting `filename=None` fixes this.