### PR TITLE
add spmatrix to docstring of `NumpyMatrixOperator`

### DIFF
--- a/src/pymor/operators/numpy.py
+++ b/src/pymor/operators/numpy.py
@@ -164,7 +164,7 @@ class NumpyMatrixBasedOperator(Operator):
 
 
 class NumpyMatrixOperator(NumpyMatrixBasedOperator):
-    """Wraps a 2D |NumPy Array| as an |Operator|.
+    """Wraps a 2D |NumPy Array| or |SciPy spmatrix| as an |Operator|.
 
     Parameters
     ----------

--- a/src/pymor/operators/numpy.py
+++ b/src/pymor/operators/numpy.py
@@ -169,7 +169,7 @@ class NumpyMatrixOperator(NumpyMatrixBasedOperator):
     Parameters
     ----------
     matrix
-        The |NumPy array| which is to be wrapped.
+        The |NumPy array| or |SciPy spmatrix| which is to be wrapped.
     source_id
         The id of the operator's `source` |VectorSpace|.
     range_id


### PR DESCRIPTION
fixes #1560.
I could not test whether the doc-link works due to #1557 but I don't see a reason that it shouldn't.