### PR TITLE
add `random_state` and `seed` arguments to `rrf` and `adaptive_rrf`

### DIFF
--- a/src/pymor/algorithms/randrangefinder.py
+++ b/src/pymor/algorithms/randrangefinder.py
@@ -9,6 +9,7 @@ from scipy.special import erfinv
 from pymor.algorithms.gram_schmidt import gram_schmidt
 from pymor.core.defaults import defaults
 from pymor.operators.interface import Operator
+from pymor.tools.random import get_random_state
 
 
 @defaults('tol', 'failure_tolerance', 'num_testvecs')
@@ -94,7 +95,7 @@ def adaptive_rrf(A, source_product=None, range_product=None, tol=1e-4,
 
 
 @defaults('q', 'l')
-def rrf(A, source_product=None, range_product=None, q=2, l=8, iscomplex=False, seed=None):
+def rrf(A, source_product=None, range_product=None, q=2, l=8, iscomplex=False, random_state=None, seed=None):
     """Randomized range approximation of `A`.
 
     This is an implementation of Algorithm 4.4 in :cite:`HMT11`.
@@ -128,11 +129,14 @@ def rrf(A, source_product=None, range_product=None, q=2, l=8, iscomplex=False, s
     assert range_product is None or isinstance(range_product, Operator)
     assert isinstance(A, Operator)
 
+    assert random_state is None or seed is None
+    random_state = get_random_state(random_state, seed)
+
     if iscomplex:
-        R = A.source.random(2*l, distribution='normal', seed=seed)
+        R = A.source.random(2*l, distribution='normal', random_state=random_state)
         R = R[:l] + 1j * R[l:]
     else:
-        R = A.source.random(l, distribution='normal', seed=seed)
+        R = A.source.random(l, distribution='normal', random_state=random_state)
     Q = A.apply(R)
     gram_schmidt(Q, range_product, atol=0, rtol=0, copy=False)
 

--- a/src/pymor/algorithms/randrangefinder.py
+++ b/src/pymor/algorithms/randrangefinder.py
@@ -13,8 +13,8 @@ from pymor.tools.random import get_random_state
 
 
 @defaults('tol', 'failure_tolerance', 'num_testvecs')
-def adaptive_rrf(A, source_product=None, range_product=None, tol=1e-4,
-                 failure_tolerance=1e-15, num_testvecs=20, lambda_min=None, iscomplex=False):
+def adaptive_rrf(A, source_product=None, range_product=None, tol=1e-4, failure_tolerance=1e-15, num_testvecs=20,
+                 lambda_min=None, iscomplex=False, random_state=None, seed=None):
     r"""Adaptive randomized range approximation of `A`.
 
     This is an implementation of Algorithm 1 in :cite:`BS18`.
@@ -48,6 +48,13 @@ def adaptive_rrf(A, source_product=None, range_product=None, tol=1e-4,
         If `None`, the smallest eigenvalue is computed using scipy.
     iscomplex
         If `True`, the random vectors are chosen complex.
+    random_state
+        :class:`~numpy.random.RandomState` to use for sampling.
+        If `None`, a new random state is generated using `seed`
+        as random seed, or the :func:`default <pymor.tools.random.default_random_state>`
+        random state is used.
+    seed
+        If not `None`, a new random state with this seed is used.
 
     Returns
     -------
@@ -58,11 +65,16 @@ def adaptive_rrf(A, source_product=None, range_product=None, tol=1e-4,
     assert range_product is None or isinstance(range_product, Operator)
     assert isinstance(A, Operator)
 
+    assert random_state is None or seed is None
+    random_state = get_random_state(random_state, seed)
+
     B = A.range.empty()
 
-    R = A.source.random(num_testvecs, distribution='normal')
     if iscomplex:
-        R += 1j*A.source.random(num_testvecs, distribution='normal')
+        R = A.source.random(2*num_testvecs, distribution='normal', random_state=random_state)
+        R = R[:num_testvecs] + 1j * R[num_testvecs:]
+    else:
+        R = A.source.random(num_testvecs, distribution='normal', random_state=random_state)
 
     if source_product is None:
         lambda_min = 1
@@ -83,9 +95,11 @@ def adaptive_rrf(A, source_product=None, range_product=None, tol=1e-4,
 
     while(maxnorm > testlimit):
         basis_length = len(B)
-        v = A.source.random(distribution='normal')
         if iscomplex:
-            v += 1j*A.source.random(distribution='normal')
+            v = A.source.random(2, distribution='normal', random_state=random_state)
+            v = v[0] + 1j * v[1]
+        else:
+            v = A.source.random(distribution='normal', random_state=random_state)
         B.append(A.apply(v))
         gram_schmidt(B, range_product, atol=0, rtol=0, offset=basis_length, copy=False)
         M -= B.lincomb(B.inner(M, range_product).T)
@@ -117,8 +131,13 @@ def rrf(A, source_product=None, range_product=None, q=2, l=8, iscomplex=False, r
         The block size of the normalized power iterations.
     iscomplex
         If `True`, the random vectors are chosen complex.
+    random_state
+        :class:`~numpy.random.RandomState` to use for sampling.
+        If `None`, a new random state is generated using `seed`
+        as random seed, or the :func:`default <pymor.tools.random.default_random_state>`
+        random state is used.
     seed
-        The seed to use for the random samples, defaults to `None`.
+        If not `None`, a new random state with this seed is used.
 
     Returns
     -------

--- a/src/pymor/algorithms/randrangefinder.py
+++ b/src/pymor/algorithms/randrangefinder.py
@@ -94,7 +94,7 @@ def adaptive_rrf(A, source_product=None, range_product=None, tol=1e-4,
 
 
 @defaults('q', 'l')
-def rrf(A, source_product=None, range_product=None, q=2, l=8, iscomplex=False):
+def rrf(A, source_product=None, range_product=None, q=2, l=8, iscomplex=False, seed=None):
     """Randomized range approximation of `A`.
 
     This is an implementation of Algorithm 4.4 in :cite:`HMT11`.
@@ -116,6 +116,8 @@ def rrf(A, source_product=None, range_product=None, q=2, l=8, iscomplex=False):
         The block size of the normalized power iterations.
     iscomplex
         If `True`, the random vectors are chosen complex.
+    seed
+     The seed to use for the random samples, defaults to `None`.
 
     Returns
     -------
@@ -126,9 +128,11 @@ def rrf(A, source_product=None, range_product=None, q=2, l=8, iscomplex=False):
     assert range_product is None or isinstance(range_product, Operator)
     assert isinstance(A, Operator)
 
-    R = A.source.random(l, distribution='normal')
     if iscomplex:
-        R += 1j*A.source.random(l, distribution='normal')
+        R = A.source.random(2*l, distribution='normal', seed=seed)
+        R = R[:l] + 1j * R[l:]
+    else:
+        R = A.source.random(l, distribution='normal', seed=seed)
     Q = A.apply(R)
     gram_schmidt(Q, range_product, atol=0, rtol=0, copy=False)
 

--- a/src/pymor/algorithms/randrangefinder.py
+++ b/src/pymor/algorithms/randrangefinder.py
@@ -117,7 +117,7 @@ def rrf(A, source_product=None, range_product=None, q=2, l=8, iscomplex=False, s
     iscomplex
         If `True`, the random vectors are chosen complex.
     seed
-     The seed to use for the random samples, defaults to `None`.
+        The seed to use for the random samples, defaults to `None`.
 
     Returns
     -------

--- a/src/pymor/vectorarrays/interface.py
+++ b/src/pymor/vectorarrays/interface.py
@@ -153,7 +153,7 @@ class VectorArray(BasicObject):
             as random seed, or the :func:`default <pymor.tools.random.default_random_state>`
             random state is used.
         seed
-            If not `None`, a new radom state with this seed is used.
+            If not `None`, a new random state with this seed is used.
         reserve
             Hint for the backend to which length the array will grow.
         """


### PR DESCRIPTION
This PR adds `random_state=None` and `seed=None` to the arguments of `rrf` and `adaptive_rrf` in order to enable reproducible computations and fixes a typo in the docstring of `VectorArray.random`.