### PR TITLE
Improve config checks for FEniCS and dealii

### DIFF
--- a/src/pymor/core/config.py
+++ b/src/pymor/core/config.py
@@ -142,7 +142,7 @@ _PACKAGES = {
     'MESHIO': lambda: _can_import('meshio'),
     'IPYWIDGETS': lambda: import_module('ipywidgets').__version__,
     'MPI': lambda: import_module('mpi4py.MPI') and import_module('mpi4py').__version__,
-    'NGSOLVE': lambda: bool(import_module('ngsolve')),
+    'NGSOLVE': lambda: import_module('ngsolve').__version__,
     'NUMPY': lambda: import_module('numpy').__version__,
     'PYMESS': lambda: bool(import_module('pymess')),
     'PYTEST': lambda: import_module('pytest').__version__,

--- a/src/pymor/core/config.py
+++ b/src/pymor/core/config.py
@@ -139,7 +139,7 @@ _PACKAGES = {
     'IPYTHON': _get_ipython_version,
     'MATPLOTLIB': _get_matplotib_version,
     'VTKIO': lambda: _can_import(('meshio', 'pyevtk', 'lxml', 'xmljson')),
-    'MESHIO': lambda: _can_import('meshio'),
+    'MESHIO': lambda: import_module('meshio').__version__,
     'IPYWIDGETS': lambda: import_module('ipywidgets').__version__,
     'MPI': lambda: import_module('mpi4py.MPI') and import_module('mpi4py').__version__,
     'NGSOLVE': lambda: import_module('ngsolve').__version__,

--- a/src/pymor/core/config.py
+++ b/src/pymor/core/config.py
@@ -132,7 +132,7 @@ def is_nbconvert():
 
 
 _PACKAGES = {
-    'DEALII': lambda: import_module('pymor_dealii'),
+    'DEALII': lambda: import_module('pymor_dealii').__version__,
     'DUNEGDT': _get_dunegdt_version,
     'FENICS': _get_fenics_version,
     'GL': lambda: import_module('OpenGL.GL') and import_module('OpenGL').__version__,

--- a/src/pymor/core/config.py
+++ b/src/pymor/core/config.py
@@ -33,8 +33,9 @@ def _get_fenics_version():
         pass
 
     import dolfin as df
-    if df.__version__ != '2019.1.0':
-        warnings.warn(f'FEniCS bindings have been tested for version 2019.1.0 (installed: {df.__version__}).')
+    if parse(df.__version__) < parse('2019.1.0'):
+        warnings.warn(f'FEniCS bindings have been tested for version 2019.1.0 and greater '
+                      f'(installed: {df.__version__}).')
     return df.__version__
 
 


### PR DESCRIPTION
- Only warn when dolfin version is too old. (Since development of dolfin has ceased in favor of dolfinx, it is safe to only check for old versions.)
- Properly report version of dealii bindings.
- Report ngsolve version.
- Report meshio version.