### PR TITLE
[demos.linear_optimization] use floats for objective functions

### DIFF
--- a/docs/source/tutorial_optimization.md
+++ b/docs/source/tutorial_optimization.md
@@ -178,7 +178,7 @@ We now define the first function for the output of the model that will be used b
 
 ```{code-cell}
 def fom_objective_functional(mu):
-    return fom.output(mu)[0]
+    return fom.output(mu)[0, 0]
 ```
 
 We also pick a starting parameter for the optimization method,
@@ -287,7 +287,7 @@ def record_results(function, data, adaptive_enrichment=False, opt_dict=None, mu=
         QoI = function(mu)
     data['num_evals'] += 1
     data['evaluation_points'].append(mu)
-    data['evaluations'].append(QoI[0])
+    data['evaluations'].append(QoI)
     return QoI
 
 def report(result, data, reference_mu=None):
@@ -296,7 +296,7 @@ def report(result, data, reference_mu=None):
     else:
         print('\n succeeded!')
         print(f'  mu_min:    {fom.parameters.parse(result.x)}')
-        print(f'  J(mu_min): {result.fun[0]}')
+        print(f'  J(mu_min): {result.fun}')
         if reference_mu is not None:
             print(f'  absolute error w.r.t. reference solution: {np.linalg.norm(result.x-reference_mu):.2e}')
         print(f'  num iterations:     {result.nit}')
@@ -433,7 +433,7 @@ the resulting ROM objective functional.
 
 ```{code-cell}
 def rom_objective_functional(mu):
-    return rom.output(mu)[0]
+    return rom.output(mu)[0, 0]
 
 RB_minimization_data = prepare_data(offline_time=RB_greedy_data['time'])
 
@@ -717,7 +717,7 @@ def enrich_adaptively_and_compute_objective_function(mu, data, opt_dict):
     else:
         print('Do NOT enrich the space because primal estimate is {} ...'.format(primal_estimate))
     opt_rom = pdeopt_reductor.reduce()
-    QoI = opt_rom.output(mu)
+    QoI = opt_rom.output(mu)[0, 0]
     return QoI, data, opt_rom
 ```
 

--- a/src/pymordemos/linear_optimization.py
+++ b/src/pymordemos/linear_optimization.py
@@ -23,7 +23,7 @@ def main(
     initial_guess = fom.parameters.parse([0.25, 0.5])
 
     def fom_objective_functional(mu):
-        return fom.output(mu)
+        return fom.output(mu)[0, 0]
 
     def fom_gradient_of_functional(mu):
         return fom.output_d_mu(fom.parameters.parse(mu), return_array=True, use_adjoint=True)
@@ -61,7 +61,7 @@ def main(
     rom = RB_greedy_data['rom']
 
     def rom_objective_functional(mu):
-        return rom.output(mu)
+        return rom.output(mu)[0, 0]
 
     def rom_gradient_of_functional(mu):
         return rom.output_d_mu(fom.parameters.parse(mu), return_array=True, use_adjoint=True)
@@ -132,7 +132,7 @@ def record_results(function, parse, data, mu):
     QoI = function(mu)
     data['num_evals'] += 1
     data['evaluation_points'].append(parse(mu).to_numpy())
-    data['evaluations'].append(QoI[0])
+    data['evaluations'].append(QoI)
     print('.', end='')
     return QoI
 
@@ -143,7 +143,7 @@ def report(result, parse, data, reference_mu):
     else:
         print('\n succeeded!')
         print('  mu_min:    {}'.format(parse(result.x)))
-        print('  J(mu_min): {}'.format(result.fun[0]))
+        print('  J(mu_min): {}'.format(result.fun))
         print('  absolute error w.r.t. reference solution: {:.2e}'.format(np.linalg.norm(result.x-reference_mu)))
         print('  num iterations:        {}'.format(result.nit))
         print('  num function calls:    {}'.format(data['num_evals']))


### PR DESCRIPTION
This is cherry-picked from #1562, where it was needed to make the Azure pipeline pass. I guess the issue is that SciPy's `minimize` handles array-valued objective functions differently in different SciPy versions.

Indeed, I tried testing it, and it seems that at least L-BFGS-B changed from SciPy 1.7 to 1.8.

```python
import numpy as np
from scipy.optimize import minimize, rosen, rosen_der


def fun(x):
    return np.array([rosen(x)])


x0 = [1.3, 0.7, 0.8, 1.9, 1.2]
res = minimize(fun, x0, method='L-BFGS-B', jac=rosen_der)
print(res.fun)
```

Output with SciPy 1.7.0:
```python
[1.3003449e-12]
```

Output with SciPy 1.8.0 (needs at least Python 3.8):
```python
1.3003448967631297e-12
```