### PR TITLE
[ci] allow numpy to pull in unfrozen dependencies

### DIFF
--- a/.ci/gitlab/test_numpy_git.bash
+++ b/.ci/gitlab/test_numpy_git.bash
@@ -3,6 +3,9 @@
 THIS_DIR="$(cd "$(dirname ${BASH_SOURCE[0]})" ; pwd -P )"
 source ${THIS_DIR}/common_test_setup.bash
 
+# allow numpy main to pull in requirements not yet in our docker images
+# to be reverted after https://github.com/pymor/pymor/pull/1555
+unset PIP_CONFIG_FILE
 pip install git+https://github.com/numpy/numpy@main
 # there seems to be no way of really overwriting -p no:warnings from setup.cfg
 sed -i -e 's/\-p\ no\:warnings//g' setup.cfg

--- a/.github/workflows/process_linter_results.yml
+++ b/.github/workflows/process_linter_results.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/setup-python@v2
       # pinned to lintly 0.5.0 due to https://github.com/grantmcconnaughey/Lintly/issues/41
       - name: Install dependencies
-        run: pip install lintly==0.5.0
+        run: pip install lintly==0.5.0 markupsafe==2.0.1
       - name: 'Comment on PR'
         run: |
           cat ./flake8.out | lintly --use-checks \


### PR DESCRIPTION
Numpy git has bumped its dependencies, but due to https://github.com/pymor/pymor/pull/1555
we currently cannot update docker images. So we'll allow unfrozen dependencies in the numpy job for now
