### PR TITLE
preset values for `LTIModel`

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -19,6 +19,7 @@
   * several additional features for neural networks
 
 * Art Pelling, a.pelling@tu-berlin.de
+  * functionality to instantiate non-parametric LTIModels with preset attributes
   * support for discrete-time LTI systems, Lyapunov equations and balanced truncation
   * dedicated Hankel operator class
 

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -593,9 +593,9 @@ class LTIModel(Model):
         elif typ == 'o_lrcf' and 'o_dense' in self.presets:
             return self.A.source.from_numpy(_chol(self.presets['o_dense']).T)
         elif typ == 'c_dense' and 'c_lrcf' in self.presets:
-            return self.presets['c_lrcf'].to_numpy().T @ self.presets['c_lrcf']
+            return self.presets['c_lrcf'].to_numpy().T @ self.presets['c_lrcf'].to_numpy()
         elif typ == 'o_dense' and 'o_lrcf' in self.presets:
-            return self.presets['o_lrcf'].to_numpy().T @ self.presets['o_lrcf']
+            return self.presets['o_lrcf'].to_numpy().T @ self.presets['o_lrcf'].to_numpy()
         else:
             A = self.A.assemble(mu)
             B = self.B

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -582,7 +582,7 @@ class LTIModel(Model):
         One-dimensional |NumPy array| of system poles.
         """
         poles = self.presets['poles'] if 'poles' in self.presets else self._poles(mu=mu)
-        assert isinstance(poles, np.ndarray) and len(poles) == (self.A.source.dim)
+        assert isinstance(poles, np.ndarray) and poles.shape == (self.A.source.dim,)
 
         return poles
 
@@ -872,7 +872,7 @@ class LTIModel(Model):
     @cached
     def _linf_norm(self, mu=None, ab13dd_equilibrate=False):
         if 'fpeak' in self.presets:
-            return self.transfer_function.eval_tf(self.presets['fpeak']), self.presets['fpeak']
+            return spla.norm(self.transfer_function.eval_tf(self.presets['fpeak']), ord=2), self.presets['fpeak']
         elif not config.HAVE_SLYCOT:
             raise NotImplementedError
 

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -549,9 +549,6 @@ class LTIModel(Model):
 
     @cached
     def _poles(self, mu=None):
-        if not isinstance(mu, Mu):
-            mu = self.parameters.parse(mu)
-        assert self.parameters.assert_compatible(mu)
         A = self.A.assemble(mu=mu)
         E = self.E.assemble(mu=mu)
 
@@ -581,6 +578,9 @@ class LTIModel(Model):
         -------
         One-dimensional |NumPy array| of system poles.
         """
+        if not isinstance(mu, Mu):
+            mu = self.parameters.parse(mu)
+        assert self.parameters.assert_compatible(mu)
         poles = self.presets['poles'] if 'poles' in self.presets else self._poles(mu=mu)
         assert isinstance(poles, np.ndarray) and poles.shape == (self.A.source.dim,)
 
@@ -712,8 +712,6 @@ class LTIModel(Model):
 
     @cached
     def _h2_norm(self, mu=None):
-        if not isinstance(mu, Mu):
-            mu = self.parameters.parse(mu)
         D_norm2 = np.sum(self.D.as_range_array(mu=mu).norm2())
         if D_norm2 != 0 and self.sampling_time == 0:
             self.logger.warning('The D operator is not exactly zero '
@@ -743,6 +741,8 @@ class LTIModel(Model):
         norm
             :math:`\mathcal{H}_2`-norm.
         """
+        if not isinstance(mu, Mu):
+            mu = self.parameters.parse(mu)
         h2_norm = self.presets['h2_norm'] if 'h2_norm' in self.presets else self._h2_norm(mu=mu)
         assert h2_norm >= 0
 
@@ -800,8 +800,6 @@ class LTIModel(Model):
 
     @cached
     def _l2_norm(self, ast_pole_data=None, mu=None):
-        if not isinstance(mu, Mu):
-            mu = self.parameters.parse(mu)
         assert self.parameters.assert_compatible(mu)
 
         A, B, C, D, E = (op.assemble(mu=mu) for op in [self.A, self.B, self.C, self.D, self.E])
@@ -863,6 +861,8 @@ class LTIModel(Model):
         norm
             :math:`\mathcal{L}_2`-norm.
         """
+        if not isinstance(mu, Mu):
+            mu = self.parameters.parse(mu)
         l2_norm = self.presets['l2_norm'] if 'l2_norm' in self.presets else self._l2_norm(ast_pole_data=ast_pole_data,
                                                                                           mu=mu)
         assert l2_norm >= 0

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -136,7 +136,7 @@ class LTIModel(Model):
 
         assert presets is None or presets.keys() <= {'poles', 'c_lrcf', 'o_lrcf', 'c_dense', 'o_dense', 'hsv',
                                                      'h2_norm', 'hinf_norm', 'l2_norm', 'linf_norm', 'fpeak'}
-        if isinstance(presets, dict) and presets:
+        if presets:
             assert all(not obj.parametric for obj in [A, B, C, D, E])
         else:
             presets = {}

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -743,7 +743,7 @@ class LTIModel(Model):
         norm
             :math:`\mathcal{H}_2`-norm.
         """
-        h2_norm = self.presets['h2_norm'] if 'h2_norm' in self.presets else self._h2_norm()
+        h2_norm = self.presets['h2_norm'] if 'h2_norm' in self.presets else self._h2_norm(mu=mu)
         assert h2_norm >= 0
 
         return h2_norm

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -711,7 +711,7 @@ class LTIModel(Model):
             One-dimensional |NumPy array| of singular values.
         """
         hsv = self.presets['hsv'] if 'hsv' in self.presets else self._hsv_U_V(mu=mu)[0]
-        assert isinstance(hsv, np.ndarray) and hsv.shape == (self.A.source.dim,)
+        assert isinstance(hsv, np.ndarray) and hsv.ndim == 1
 
         return hsv
 

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -706,7 +706,7 @@ class LTIModel(Model):
             One-dimensional |NumPy array| of singular values.
         """
         hsv = self.presets['hsv'] if 'hsv' in self.presets else self._hsv_U_V(mu=mu)[0]
-        assert isinstance(hsv, np.ndarray) and hsv.shape == (self.A.source.dim)
+        assert isinstance(hsv, np.ndarray) and hsv.shape == (self.A.source.dim,)
 
         return hsv
 


### PR DESCRIPTION
Following the discussion in #1570, this PR adds the ability to supply preset values for nearly all attributes of `LTIModel` as a dict of `presets` that can be passed to the constructor as keyword argument. If an attribute is preset this way, no computations are performed and the preset value is returned instead.

The following attributes can be set:
`poles`, `c_lrcf`, `o_lrcf`, `c_dense`, `o_dense`, `hsv`, `h2_norm`, `hinf_norm`, `l2_norm` ,`linf_norm` as well as `fpeak` (the frequency at which `linf` is attained).

Todos:
- [x] Merge #1525 