### PR TITLE
fix pickling to respect specified protocol

### DIFF
--- a/src/pymor/core/pickle.py
+++ b/src/pymor/core/pickle.py
@@ -61,7 +61,7 @@ else:
         pickle.dump(obj, file, protocol=protocol or PROTOCOL)
 
     def dumps(obj, protocol=None):
-        dumps(obj, protocol=protocol or PROTOCOL)
+        pickle.dumps(obj, protocol=protocol or PROTOCOL)
 
     load = pickle.load
     loads = pickle.loads

--- a/src/pymor/core/pickle.py
+++ b/src/pymor/core/pickle.py
@@ -57,9 +57,12 @@ if platform.python_implementation() == 'CPython':
         return unpickler.load()
 
 else:
-    from functools import partial
-    dump = partial(pickle.dump, protocol=protocol or PROTOCOL)
-    dumps = partial(pickle.dumps, protocol=protocol or PROTOCOL)
+    def dump(obj, file, protocol=None):
+        pickle.dump(obj, file, protocol=protocol or PROTOCOL)
+
+    def dumps(obj, protocol=None):
+        dumps(obj, protocol=protocol or PROTOCOL)
+
     load = pickle.load
     loads = pickle.loads
 

--- a/src/pymor/core/pickle.py
+++ b/src/pymor/core/pickle.py
@@ -34,13 +34,13 @@ PROTOCOL = pickle.HIGHEST_PROTOCOL
 if platform.python_implementation() == 'CPython':
 
     def dump(obj, file, protocol=None):
-        pickler = pickle.Pickler(file, protocol=PROTOCOL)
+        pickler = pickle.Pickler(file, protocol=protocol or PROTOCOL)
         pickler.persistent_id = _function_pickling_handler
         pickler.dump(obj)
 
     def dumps(obj, protocol=None):
         file = IOtype()
-        pickler = pickle.Pickler(file, protocol=PROTOCOL)
+        pickler = pickle.Pickler(file, protocol=protocol or PROTOCOL)
         pickler.persistent_id = _function_pickling_handler
         pickler.dump(obj)
         return file.getvalue()
@@ -58,8 +58,8 @@ if platform.python_implementation() == 'CPython':
 
 else:
     from functools import partial
-    dump = partial(pickle.dump, protocol=PROTOCOL)
-    dumps = partial(pickle.dumps, protocol=PROTOCOL)
+    dump = partial(pickle.dump, protocol=protocol or PROTOCOL)
+    dumps = partial(pickle.dumps, protocol=protocol or PROTOCOL)
     load = pickle.load
     loads = pickle.loads
 


### PR DESCRIPTION
This actually passes the `protocol` variable to the respective pickler.