### PR TITLE
Remark on requirements-ci.txt in developer_docs.md

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,8 +49,8 @@ README.html: README.md
 
 README: README.html
 
-pep8:
-	pep8 ./src
+pycodestyle:
+	pycodestyle ./src
 
 flake8:
 	flake8 ./src

--- a/Makefile
+++ b/Makefile
@@ -49,9 +49,6 @@ README.html: README.md
 
 README: README.html
 
-pycodestyle:
-	pycodestyle ./src
-
 flake8:
 	flake8 ./src
 

--- a/docs/source/developer_docs.md
+++ b/docs/source/developer_docs.md
@@ -65,8 +65,8 @@ be sufficiently well documented.
 #### How to check code style
 
 Firstly, make sure that you installed the `requirements-ci.txt` with `pip install -r requirements-ci.txt`.
-Afterwards use the Makefile to check for flake8 and pep8 warnings with `make flake8` and `make pycodestyle`
-or directly use the tools on the `src` folder.
+Afterwards use the Makefile to check for flake8 warnings with `make flake8`
+or directly use `flake8` on the `src` folder.
 
 ### GitHub project
 

--- a/docs/source/developer_docs.md
+++ b/docs/source/developer_docs.md
@@ -62,6 +62,12 @@ function is extended.
 All functions and classes called or instantiated by users should
 be sufficiently well documented.
 
+#### How to check code style
+
+Firstly, make sure that you installed the `requirements-ci.txt` with `pip install -r requirements-ci.txt`.
+Afterwards use the Makefile to check for flake8 and pep8 warnings with `make flake8` and `make pep8`
+or directly use the tools on the `src` folder.
+
 ### GitHub project
 
 All new code enters pyMOR by means of a pull request. Pull requests (PR) trigger [automatic tests](#continuous-testing--integration-setup)

--- a/docs/source/developer_docs.md
+++ b/docs/source/developer_docs.md
@@ -65,7 +65,7 @@ be sufficiently well documented.
 #### How to check code style
 
 Firstly, make sure that you installed the `requirements-ci.txt` with `pip install -r requirements-ci.txt`.
-Afterwards use the Makefile to check for flake8 and pep8 warnings with `make flake8` and `make pep8`
+Afterwards use the Makefile to check for flake8 and pep8 warnings with `make flake8` and `make pycodestyle`
 or directly use the tools on the `src` folder.
 
 ### GitHub project

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -21,4 +21,3 @@ readme_renderer[md]
 rstcheck
 scikit-fem
 twine
-pep8

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -21,3 +21,4 @@ readme_renderer[md]
 rstcheck
 scikit-fem
 twine
+pep8


### PR DESCRIPTION
I inserted a hint on installing the `requirements-ci.txt` for checking the code style in `developer_docs.md`. I tried to be brief not to uselessly extend the document. If you have an idea how to shorten it, feel free to alter it. If I'm not mistaken, `pep8` was missing in the requirements list?