### PR TITLE
Moebius Transform Operator and Tustin's method for LTI-Systems

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -20,6 +20,7 @@
 
 * Art Pelling, a.pelling@tu-berlin.de
   * support for discrete-time LTI systems, Lyapunov equations and balanced truncation
+  * Moebius transformations and continuous/discrete-time conversion of LTI models
   * dedicated Hankel operator class
 
 * Sven Ullmann, ullmannsven@gmx.de

--- a/docs/source/bibliography.bib
+++ b/docs/source/bibliography.bib
@@ -150,6 +150,17 @@
   publisher={SIAM}
 }
 
+@article{CCA96,
+  author={Clapperton, B. and Crusca, F. and Aldeen, M.},
+  journal={IEEE Transactions on Automatic Control},
+  title={Bilinear transformation and generalized singular perturbation model reduction},
+  year={1996},
+  volume={41},
+  number={4},
+  pages={589-593},
+  doi={10.1109/9.489281}
+}
+
 @Article{CLVV06,
   author =       {Chahlaoui, Y. and Lemonnier, D. and Vandendorpe, A.  and
                   Van~Dooren, P.},

--- a/docs/source/substitutions.py
+++ b/docs/source/substitutions.py
@@ -113,6 +113,11 @@ common = '''
 .. |LinearDelayModels| replace:: :class:`LinearDelayModels <pymor.models.iosys.LinearDelayModel>`
 .. |NeuralNetworkModel| replace:: :class:`~pymor.models.neural_network.NeuralNetworkModel`
 
+.. |MoebiusTransformation| replace:: :class:`~pymor.models.transforms.MoebiusTransformation`
+.. |MoebiusTransformations| replace:: :class:`~pymor.models.transforms.MoebiusTransformation`
+.. |BilinearTransformation| replace:: :class:`~pymor.models.transforms.BilinearTransformation
+.. |CayleyTransformation| replace:: :class:`~pymor.models.transforms.CayleyTransformation`
+
 .. |Parameter| replace:: :class:`Parameter <pymor.parameters.base.Parameters>`
 .. |Parameters| replace:: :class:`~pymor.parameters.base.Parameters`
 .. |Parameter values| replace:: :class:`Parameter values <pymor.parameters.base.Mu>`

--- a/docs/source/substitutions.py
+++ b/docs/source/substitutions.py
@@ -114,8 +114,8 @@ common = '''
 .. |NeuralNetworkModel| replace:: :class:`~pymor.models.neural_network.NeuralNetworkModel`
 
 .. |MoebiusTransformation| replace:: :class:`~pymor.models.transforms.MoebiusTransformation`
-.. |MoebiusTransformations| replace:: :class:`~pymor.models.transforms.MoebiusTransformation`
-.. |BilinearTransformation| replace:: :class:`~pymor.models.transforms.BilinearTransformation
+.. |MoebiusTransformations| replace:: :class:`MoebiusTransformations <pymor.models.transforms.MoebiusTransformation>`
+.. |BilinearTransformation| replace:: :class:`~pymor.models.transforms.BilinearTransformation`
 .. |CayleyTransformation| replace:: :class:`~pymor.models.transforms.CayleyTransformation`
 
 .. |Parameter| replace:: :class:`Parameter <pymor.parameters.base.Parameters>`

--- a/src/pymor/algorithms/to_matrix.py
+++ b/src/pymor/algorithms/to_matrix.py
@@ -10,7 +10,6 @@ import scipy.sparse.linalg as spsla
 from pymor.algorithms.rules import RuleTable, match_class
 from pymor.core.config import config
 from pymor.core.exceptions import NoMatchingRuleError
-from pymor.models.transforms import MoebiusTransformation
 from pymor.operators.block import BlockOperatorBase
 from pymor.operators.constructions import (AdjointOperator, ComponentProjectionOperator, ConcatenationOperator,
                                            IdentityOperator, LincombOperator, LowRankOperator, LowRankUpdatedOperator,
@@ -48,10 +47,6 @@ class ToMatrixRules(RuleTable):
     def __init__(self, format, mu):
         super().__init__()
         self.__auto_init(locals())
-
-    @match_class(MoebiusTransformation)
-    def action_MoebiusTransformation(self, op):
-        return op.coefficients.reshape(2, 2)
 
     @match_class(NumpyHankelOperator)
     def action_NumpyHankelOperator(self, op):

--- a/src/pymor/algorithms/to_matrix.py
+++ b/src/pymor/algorithms/to_matrix.py
@@ -10,7 +10,7 @@ import scipy.sparse.linalg as spsla
 from pymor.algorithms.rules import RuleTable, match_class
 from pymor.core.config import config
 from pymor.core.exceptions import NoMatchingRuleError
-from pymor.models.transforms import MoebiusTransform
+from pymor.models.transforms import MoebiusTransformation
 from pymor.operators.block import BlockOperatorBase
 from pymor.operators.constructions import (AdjointOperator, ComponentProjectionOperator, ConcatenationOperator,
                                            IdentityOperator, LincombOperator, LowRankOperator, LowRankUpdatedOperator,
@@ -49,8 +49,8 @@ class ToMatrixRules(RuleTable):
         super().__init__()
         self.__auto_init(locals())
 
-    @match_class(MoebiusTransform)
-    def action_MoebiusTransform(self, op):
+    @match_class(MoebiusTransformation)
+    def action_MoebiusTransformation(self, op):
         return op.coefficients.reshape(2, 2)
 
     @match_class(NumpyHankelOperator)

--- a/src/pymor/algorithms/to_matrix.py
+++ b/src/pymor/algorithms/to_matrix.py
@@ -9,7 +9,6 @@ import scipy.sparse.linalg as spsla
 
 from pymor.algorithms.rules import RuleTable, match_class
 from pymor.core.config import config
-from pymor.core.exceptions import NoMatchingRuleError
 from pymor.operators.block import BlockOperatorBase
 from pymor.operators.constructions import (AdjointOperator, ComponentProjectionOperator, ConcatenationOperator,
                                            IdentityOperator, LincombOperator, LowRankOperator, LowRankUpdatedOperator,
@@ -134,13 +133,13 @@ class ToMatrixRules(RuleTable):
 
     @match_class(ConcatenationOperator)
     def action_ConcatenationOperator(self, op):
-        try:
-            mats = [self.apply(o) for o in op.operators]
-            from functools import reduce
-            from operator import matmul
-            return reduce(matmul, mats)
-        except NoMatchingRuleError:
-            return op.as_range_array(mu=self.mu).to_numpy().T
+        mats = [self.apply(o) for o in op.operators]
+        while len(mats) > 1:
+            if self.format is None and not sps.issparse(mats[-2]) and sps.issparse(mats[-1]):
+                mats = mats[:-2] + [mats[-1].T.dot(mats[-2].T).T]
+            else:
+                mats = mats[:-2] + [mats[-2].dot(mats[-1])]
+        return mats[0]
 
     @match_class(IdentityOperator)
     def action_IdentityOperator(self, op):

--- a/src/pymor/algorithms/to_matrix.py
+++ b/src/pymor/algorithms/to_matrix.py
@@ -9,6 +9,7 @@ import scipy.sparse.linalg as spsla
 
 from pymor.algorithms.rules import RuleTable, match_class
 from pymor.core.config import config
+from pymor.models.transforms import MoebiusTransform
 from pymor.operators.block import BlockOperatorBase
 from pymor.operators.constructions import (AdjointOperator, ComponentProjectionOperator, ConcatenationOperator,
                                            IdentityOperator, LincombOperator, LowRankOperator, LowRankUpdatedOperator,
@@ -46,6 +47,10 @@ class ToMatrixRules(RuleTable):
     def __init__(self, format, mu):
         super().__init__()
         self.__auto_init(locals())
+
+    @match_class(MoebiusTransform)
+    def action_MoebiusTransform(self, op):
+        return op.coefficients.reshape(2, 2)
 
     @match_class(NumpyHankelOperator)
     def action_NumpyHankelOperator(self, op):

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -961,7 +961,7 @@ class LTIModel(Model):
         Parameters
         ----------
         M
-            The |MoebiusTransformation| that defines the frequency mapping.
+            The :class:`MoebiusTransformation` that defines the frequency mapping.
         sampling_time
             The sampling time of the transformed system (in seconds). `0` if the system is
             continuous-time, otherwise a positive number. Defaults to zero.

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -1009,7 +1009,7 @@ class LTIModel(Model):
         assert self.sampling_time == 0
         assert sampling_time > 0
         assert isinstance(w0, Number)
-        x = 2/sampling_time if w0 == 0 else w0 / np.tan(w0*sampling_time/2)
+        x = 2 / sampling_time if w0 == 0 else w0 / np.tan(w0 * sampling_time / 2)
         c2d = BilinearTransform(x, dim=self.A.source.dim).inverse()
         return self.moebius_substitution(c2d, sampling_time=sampling_time)
 
@@ -1034,7 +1034,7 @@ class LTIModel(Model):
             return NotImplemented
         assert self.sampling_time > 0
         assert isinstance(w0, Number)
-        x = 2 / self.sampling_time if w0 == 0 else w0 / np.tan(w0*self.sampling_time/2)
+        x = 2 / self.sampling_time if w0 == 0 else w0 / np.tan(w0 * self.sampling_time / 2)
         d2c = BilinearTransform(x, dim=self.A.source.dim)
         return self.moebius_substitution(d2c, sampling_time=0)
 

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -961,7 +961,7 @@ class LTIModel(Model):
         Parameters
         ----------
         M
-            The :class:`MoebiusTransformation` that defines the frequency mapping.
+            The |MoebiusTransformation| that defines the frequency mapping.
         sampling_time
             The sampling time of the transformed system (in seconds). `0` if the system is
             continuous-time, otherwise a positive number. Defaults to zero.

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -943,6 +943,34 @@ class LTIModel(Model):
             return ast_lev, ast_ews[idx], ast_rev
 
     def moebius_substitution(self, M, sampling_time=0):
+        r"""Create a transformed |LTIModel| by applying an arbitrary Moebius transformation.
+
+        This method returns a transformed |LTIModel| such that the transfer function of the original
+        and transformed |LTIModel| are related by a Moebius substitution of the frequency argument:
+
+        .. math::
+            H(s)=\tilde{H}(M(s)),
+
+        where
+
+        .. math::
+            M(s) = \frac{as+b}{cs+d}
+
+        is a Moebius transformation. See :cite:`CCA96` for details.
+
+        Parameters
+        ----------
+        M
+            The |MoebiusTransformation| that defines the frequency mapping.
+        sampling_time
+            The sampling time of the transformed system (in seconds). `0` if the system is
+            continuous-time, otherwise a positive number. Defaults to zero.
+
+        Returns
+        -------
+        sys
+            The transformed |LTIModel|.
+        """
         assert isinstance(M, MoebiusTransformation)
 
         a, b, c, d = M.coefficients
@@ -958,6 +986,24 @@ class LTIModel(Model):
         return LTIModel(At, Bt, Ct, D=Dt, E=Et, sampling_time=sampling_time)
 
     def to_discrete(self, sampling_time, method='Tustin', w0=0):
+        """Converts a continuous-time |LTIModel| to a discrete-time |LTIModel|.
+
+        Parameters
+        ----------
+        sampling_time
+            A positive number that denotes the sampling time of the resulting system (in seconds).
+        method
+            A string that defines the transformation method. At the moment only Tustin's method is
+            supported.
+        w0
+            If `method=='Tustin'`, this parameter can be used to specify the prewarping-frequency.
+            Defaults to zero.
+
+        Returns
+        -------
+        sys
+            Discrete-time |LTIModel|.
+        """
         if method != 'Tustin':
             return NotImplemented
         assert self.sampling_time == 0
@@ -968,6 +1014,22 @@ class LTIModel(Model):
         return self.moebius_substitution(c2d, sampling_time=sampling_time)
 
     def to_continuous(self, method='Tustin', w0=0):
+        """Converts a discrete-time |LTIModel| to a continuous-time |LTIModel|.
+
+        Parameters
+        ----------
+        method
+            A string that defines the transformation method. At the moment only Tustin's method is
+            supported.
+        w0
+            If `method=='Tustin'`, this parameter can be used to specify the prewarping-frequency.
+            Defaults to zero.
+
+        Returns
+        -------
+        sys
+            Continuous-time |LTIModel|.
+        """
         if method != 'Tustin':
             return NotImplemented
         assert self.sampling_time > 0

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -17,7 +17,7 @@ from pymor.core.config import config
 from pymor.core.defaults import defaults
 from pymor.models.interface import Model
 from pymor.models.transfer_function import FactorizedTransferFunction
-from pymor.models.transforms import BilinearTransform, MoebiusTransform
+from pymor.models.transforms import BilinearTransform, MoebiusTransformation
 from pymor.operators.block import (BlockOperator, BlockRowOperator, BlockColumnOperator, BlockDiagonalOperator,
                                    SecondOrderModelOperator)
 from pymor.operators.constructions import (IdentityOperator, InverseOperator, LincombOperator, LowRankOperator,
@@ -943,7 +943,7 @@ class LTIModel(Model):
             return ast_lev, ast_ews[idx], ast_rev
 
     def moebius_substitution(self, M, sampling_time=0):
-        assert isinstance(M, MoebiusTransform)
+        assert isinstance(M, MoebiusTransformation)
 
         a, b, c, d = M.coefficients
         s = a * d - b * c

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -1005,7 +1005,7 @@ class LTIModel(Model):
             Discrete-time |LTIModel|.
         """
         if method != 'Tustin':
-            return NotImplemented
+            return NotImplementedError
         assert self.sampling_time == 0
         assert sampling_time > 0
         assert isinstance(w0, Number)
@@ -1031,7 +1031,7 @@ class LTIModel(Model):
             Continuous-time |LTIModel|.
         """
         if method != 'Tustin':
-            return NotImplemented
+            return NotImplementedError
         assert self.sampling_time > 0
         assert isinstance(w0, Number)
         x = 2 / self.sampling_time if w0 == 0 else w0 / np.tan(w0 * self.sampling_time / 2)

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -1010,7 +1010,7 @@ class LTIModel(Model):
         assert sampling_time > 0
         assert isinstance(w0, Number)
         x = 2 / sampling_time if w0 == 0 else w0 / np.tan(w0 * sampling_time / 2)
-        c2d = BilinearTransform(x, dim=self.A.source.dim).inverse()
+        c2d = BilinearTransform(x).inverse()
         return self.moebius_substitution(c2d, sampling_time=sampling_time)
 
     def to_continuous(self, method='Tustin', w0=0):
@@ -1035,7 +1035,7 @@ class LTIModel(Model):
         assert self.sampling_time > 0
         assert isinstance(w0, Number)
         x = 2 / self.sampling_time if w0 == 0 else w0 / np.tan(w0 * self.sampling_time / 2)
-        d2c = BilinearTransform(x, dim=self.A.source.dim)
+        d2c = BilinearTransform(x)
         return self.moebius_substitution(d2c, sampling_time=0)
 
 

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -17,7 +17,7 @@ from pymor.core.config import config
 from pymor.core.defaults import defaults
 from pymor.models.interface import Model
 from pymor.models.transfer_function import FactorizedTransferFunction
-from pymor.models.transforms import BilinearTransform, MoebiusTransformation
+from pymor.models.transforms import BilinearTransformation, MoebiusTransformation
 from pymor.operators.block import (BlockOperator, BlockRowOperator, BlockColumnOperator, BlockDiagonalOperator,
                                    SecondOrderModelOperator)
 from pymor.operators.constructions import (IdentityOperator, InverseOperator, LincombOperator, LowRankOperator,
@@ -1010,7 +1010,7 @@ class LTIModel(Model):
         assert sampling_time > 0
         assert isinstance(w0, Number)
         x = 2 / sampling_time if w0 == 0 else w0 / np.tan(w0 * sampling_time / 2)
-        c2d = BilinearTransform(x).inverse()
+        c2d = BilinearTransformation(x).inverse()
         return self.moebius_substitution(c2d, sampling_time=sampling_time)
 
     def to_continuous(self, method='Tustin', w0=0):
@@ -1035,7 +1035,7 @@ class LTIModel(Model):
         assert self.sampling_time > 0
         assert isinstance(w0, Number)
         x = 2 / self.sampling_time if w0 == 0 else w0 / np.tan(w0 * self.sampling_time / 2)
-        d2c = BilinearTransform(x)
+        d2c = BilinearTransformation(x)
         return self.moebius_substitution(d2c, sampling_time=0)
 
 

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -1007,6 +1007,7 @@ class LTIModel(Model):
         if method != 'Tustin':
             return NotImplementedError
         assert self.sampling_time == 0
+        sampling_time = float(sampling_time)
         assert sampling_time > 0
         assert isinstance(w0, Number)
         x = 2 / sampling_time if w0 == 0 else w0 / np.tan(w0 * sampling_time / 2)

--- a/src/pymor/models/transforms.py
+++ b/src/pymor/models/transforms.py
@@ -36,7 +36,8 @@ class MoebiusTransformation(ImmutableObject):
         assert coefficients[0]*coefficients[3] != coefficients[1]*coefficients[2]
 
         if normalize:
-            coefficients /= np.sqrt(coefficients[0]*coefficients[3]-coefficients[2]*coefficients[3])
+            coefficients = coefficients / np.sqrt(coefficients[0]*coefficients[3]-coefficients[1]*coefficients[2])
+            coefficients *= np.sign(coefficients[0])
 
         self.__auto_init(locals())
 
@@ -65,7 +66,7 @@ class MoebiusTransformation(ImmutableObject):
         assert len(z) == 3
         assert len(w) == 3
 
-        A = np.zeros([3, 4])
+        A = np.zeros([3, 4], dtype=complex)
         for i in range(3):
             if np.isinf(w[i]) and np.isinf(z[i]):
                 A[i] = [0, 0, -1, 0]

--- a/src/pymor/models/transforms.py
+++ b/src/pymor/models/transforms.py
@@ -122,10 +122,11 @@ class MoebiusTransformation(ImmutableObject):
         return MoebiusTransformation(M.ravel())
 
     def __str__(self):
-        numerator = 8*' ' + f'({self.coefficients[0]:.1f})*z + ({self.coefficients[1]:.1f})\n'.center(29)
-        line = 'f(z) = ' + 29*'-' + '\n'
-        denominator = 8*' ' + f'({self.coefficients[2]:.1f})*z + ({self.coefficients[3]:.1f})'.center(29)
-        return f'{self.name}: ℂ --> ℂ\n' + numerator + line + denominator
+        numerator = f'({self.coefficients[0]:.1f})*z + ({self.coefficients[1]:.1f})'
+        denominator = f'({self.coefficients[2]:.1f})*z + ({self.coefficients[3]:.1f})'
+        n = max(len(numerator), len(denominator))
+        line = '\nf(z) = ' + n*'-' + '\n'
+        return f'{self.name}: ℂ --> ℂ\n' + 7*' ' + numerator.center(n) + line + 7*' ' + denominator.center(n)
 
 
 class BilinearTransformation(MoebiusTransformation):

--- a/src/pymor/models/transforms.py
+++ b/src/pymor/models/transforms.py
@@ -18,7 +18,7 @@ class MoebiusTransformation(ImmutableObject):
 
     is determined by the coefficients :math:`a,b,c,d\in\mathbb{C}`. The Moebius transformations form
     a group under composition, therefore the `__matmul__` operator is defined to yield a
-    :class:`MoebiusTransformation` if both factors are :class:`MoebiusTransformation`\s.
+    |MoebiusTransformation| if both factors are |MoebiusTransformations|.
 
     Parameters
     ----------
@@ -65,7 +65,7 @@ class MoebiusTransformation(ImmutableObject):
         Returns
         -------
         M
-            The corresponding :class:`MoebiusTransformation`.
+            The corresponding |MoebiusTransformation|.
         """
         assert len(z) == 3
         assert len(w) == 3
@@ -94,7 +94,7 @@ class MoebiusTransformation(ImmutableObject):
         Returns
         -------
         M
-            The inverse :class:`MoebiusTransformation`.
+            The inverse |MoebiusTransformation|.
         """
         a, b, c, d = self.coefficients
         coefficients = np.array([d, -b, -c, a])
@@ -144,7 +144,7 @@ class BilinearTransformation(MoebiusTransformation):
     Parameters
     ----------
     x
-        An arbitrary number that defines the :class:`BilinearTransformation`.
+        An arbitrary number that defines the |BilinearTransformation|.
     name
         Name of the transform.
     """

--- a/src/pymor/models/transforms.py
+++ b/src/pymor/models/transforms.py
@@ -2,6 +2,8 @@
 # Copyright pyMOR developers and contributors. All rights reserved.
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
+from numbers import Number
+
 import numpy as np
 from scipy.linalg import null_space
 
@@ -150,6 +152,7 @@ class BilinearTransformation(MoebiusTransformation):
     """
 
     def __init__(self, x, name=None):
+        assert isinstance(x, Number)
         assert x > 0
         super().__init__([x, -x, 1, 1], name=name)
         self.__auto_init(locals())

--- a/src/pymor/models/transforms.py
+++ b/src/pymor/models/transforms.py
@@ -36,7 +36,7 @@ class MoebiusTransformation(ImmutableObject):
         assert coefficients[0]*coefficients[3] != coefficients[1]*coefficients[2]
 
         if normalize:
-            coefficients = coefficients / np.sqrt(coefficients[0]*coefficients[3]-coefficients[1]*coefficients[2])
+            coefficients /= np.sqrt(np.abs(coefficients[0]*coefficients[3]-coefficients[1]*coefficients[2]))
             coefficients *= np.sign(coefficients[0])
 
         self.__auto_init(locals())

--- a/src/pymor/models/transforms.py
+++ b/src/pymor/models/transforms.py
@@ -52,6 +52,11 @@ class MoebiusTransformation(ImmutableObject):
             Defaults to `(0, 1, np.inf)`.
         name
             Name of the transformation.
+
+        Returns
+        -------
+        M
+            The corresponding |MoebiusTransformation|.
         """
         assert len(z) == 3
         assert len(w) == 3
@@ -76,6 +81,11 @@ class MoebiusTransformation(ImmutableObject):
         ----------
         normalize
             If `True`, the coefficients are normalized, i.e. :math:`ad-bc=1`. Defaults to `False`.
+
+        Returns
+        -------
+        M
+            The inverse |MoebiusTransformation|.
         """
         a, b, c, d = self.coefficients
         coefficients = np.array([d, -b, -c, a])

--- a/src/pymor/models/transforms.py
+++ b/src/pymor/models/transforms.py
@@ -1,0 +1,90 @@
+import numpy as np
+from scipy.linalg import null_space
+
+from pymor.core.base import ImmutableObject
+
+
+class MoebiusTransform(ImmutableObject):
+    """A Moebius transform operator.
+
+    Maps complex numbers to complex numbers.
+    The transform coefficients can be normalized.
+    Contains a method for constructing an inverse mapping, as well as a constructor that takes three
+    points and their images. The Moebius transforms form a group under composition, so __matmul__ is
+    defined to yield Moebius Transforms if both factors are Moebius Transforms.
+    """
+
+    def __init__(self, coefficients, normalize=False, name=None):
+        assert len(coefficients) == 4
+        coefficients = np.array(coefficients, dtype=complex)
+        assert coefficients[0]*coefficients[3] != coefficients[1]*coefficients[2]
+
+        if normalize:
+            coefficients /= np.sqrt(coefficients[0]*coefficients[3]-coefficients[2]*coefficients[3])
+
+        self.__auto_init(locals())
+
+    @classmethod
+    def from_points(cls, w, z=(0, 1, np.inf), name=None):
+        assert len(z) == 3
+        assert len(w) == 3
+
+        A = np.zeros([3, 4])
+        for i in range(3):
+            if np.isinf(w[i]) and np.isinf(z[i]):
+                A[i] = [0, 0, -1, 0]
+            elif np.isinf(w[i]):
+                A[i] = [0, 0, -z[i], -1]
+            elif np.isinf(z[i]):
+                A[i] = [1, 0, -w[i], 0]
+            else:
+                A[i] = [z[i], 1, -w[i]*z[i], -w[i]]
+
+        return cls(null_space(A).ravel(), name=name)
+
+    def inverse(self, normalize=False):
+        a, b, c, d = self.coefficients
+        coefficients = np.array([d, -b, -c, a])
+        return MoebiusTransform(coefficients, normalize=normalize, name=self.name + '_inverse')
+
+    def _mapping(self, x):
+        a, b, c, d = self.coefficients
+        if c != 0 and np.allclose(x, -d / c):
+            return np.inf
+        elif c != 0 and np.isinf(x):
+            return a / c
+        elif c == 0 and np.isinf(x):
+            return np.inf
+        else:
+            return (a * x + b) / (c * x + d)
+
+    def __call__(self, x):
+        x = np.squeeze(np.array(x, dtype=complex))
+        assert x.ndim <= 1
+        return np.vectorize(self._mapping)(x)
+
+    def __matmul__(self, other):
+        assert isinstance(other, MoebiusTransform)
+        M = self.coefficients.reshape(2, 2) @ other.coefficients.reshape(2, 2)
+        return MoebiusTransform(M.ravel())
+
+    def __str__(self):
+        return (
+            f'{self.name}: C^1 --> C^1\n'
+            f'       ({self.coefficients[0]:.1f})*z + ({self.coefficients[1]:.1f})\n'
+            'f(z) = --------------------------------\n'
+            f'       ({self.coefficients[2]:.1f})*z + ({self.coefficients[3]:.1f})'
+        )
+
+
+class BilinearTransform(MoebiusTransform):
+    def __init__(self, x, normalize=False, name=None):
+        assert x > 0
+        super().__init__([x, -x, 1, 1], normalize=normalize, name=name)
+        self.__auto_init(locals())
+
+
+class CayleyTransform(MoebiusTransform):
+    def __init__(self, normalize=False, name=None):
+        super().__init__([1, -1j, 1, 1j], normalize=normalize, name=name)
+        self.__auto_init(locals())

--- a/src/pymor/models/transforms.py
+++ b/src/pymor/models/transforms.py
@@ -121,7 +121,7 @@ class MoebiusTransformation(ImmutableObject):
         )
 
 
-class BilinearTransform(MoebiusTransformation):
+class BilinearTransformation(MoebiusTransformation):
     r"""The bilinear transform also known as Tustin's method.
 
     The bilinear transform can be seen as the first order approximation of the natural logarithm
@@ -136,7 +136,7 @@ class BilinearTransform(MoebiusTransformation):
     Parameters
     ----------
     x
-        An arbitrary number that defines the |BilinearTransform|.
+        An arbitrary number that defines the |BilinearTransformation|.
     name
         Name of the transform.
     """
@@ -147,7 +147,7 @@ class BilinearTransform(MoebiusTransformation):
         self.__auto_init(locals())
 
 
-class CayleyTransform(MoebiusTransformation):
+class CayleyTransformation(MoebiusTransformation):
     r"""Maps the upper complex half-plane to the unit disk.
 
     The Cayley transform is defined as

--- a/src/pymor/models/transforms.py
+++ b/src/pymor/models/transforms.py
@@ -36,7 +36,11 @@ class MoebiusTransformation(ImmutableObject):
         assert coefficients[0]*coefficients[3] != coefficients[1]*coefficients[2]
 
         if normalize:
-            coefficients /= np.sqrt(np.abs(coefficients[0]*coefficients[3]-coefficients[1]*coefficients[2]))
+            factor = coefficients[0]*coefficients[3]-coefficients[1]*coefficients[2]
+            if np.isrealobj(coefficients):
+                coefficients, factor = np.asarray(coefficients, dtype=float), np.abs(factor)
+
+            coefficients /= np.sqrt(factor)
             coefficients *= np.sign(coefficients[0])
 
         self.__auto_init(locals())

--- a/src/pymor/models/transforms.py
+++ b/src/pymor/models/transforms.py
@@ -1,3 +1,7 @@
+# This file is part of the pyMOR project (http://www.pymor.org).
+# Copyright pyMOR developers and contributors. All rights reserved.
+# License: BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+
 import numpy as np
 from scipy.linalg import null_space
 

--- a/src/pymor/models/transforms.py
+++ b/src/pymor/models/transforms.py
@@ -18,7 +18,7 @@ class MoebiusTransformation(ImmutableObject):
 
     is determined by the coefficients :math:`a,b,c,d\in\mathbb{C}`. The Moebius transformations form
     a group under composition, therefore the `__matmul__` operator is defined to yield a
-    |MoebiusTransformation| if both factors are |MoebiusTransformation|s.
+    :class:`MoebiusTransformation` if both factors are :class:`MoebiusTransformation`\s.
 
     Parameters
     ----------
@@ -61,7 +61,7 @@ class MoebiusTransformation(ImmutableObject):
         Returns
         -------
         M
-            The corresponding |MoebiusTransformation|.
+            The corresponding :class:`MoebiusTransformation`.
         """
         assert len(z) == 3
         assert len(w) == 3
@@ -90,7 +90,7 @@ class MoebiusTransformation(ImmutableObject):
         Returns
         -------
         M
-            The inverse |MoebiusTransformation|.
+            The inverse :class:`MoebiusTransformation`.
         """
         a, b, c, d = self.coefficients
         coefficients = np.array([d, -b, -c, a])
@@ -139,7 +139,7 @@ class BilinearTransformation(MoebiusTransformation):
     Parameters
     ----------
     x
-        An arbitrary number that defines the |BilinearTransformation|.
+        An arbitrary number that defines the :class:`BilinearTransformation`.
     name
         Name of the transform.
     """

--- a/src/pymor/models/transforms.py
+++ b/src/pymor/models/transforms.py
@@ -118,12 +118,10 @@ class MoebiusTransformation(ImmutableObject):
         return MoebiusTransformation(M.ravel())
 
     def __str__(self):
-        return (
-            f'{self.name}: ℂ --> ℂ\n'
-            f'       ({self.coefficients[0]:.1f})*z + ({self.coefficients[1]:.1f})\n'
-            'f(z) = --------------------------------\n'
-            f'       ({self.coefficients[2]:.1f})*z + ({self.coefficients[3]:.1f})'
-        )
+        numerator = 8*' ' + f'({self.coefficients[0]:.1f})*z + ({self.coefficients[1]:.1f})\n'.center(29)
+        line = 'f(z) = ' + 29*'-' + '\n'
+        denominator = 8*' ' + f'({self.coefficients[2]:.1f})*z + ({self.coefficients[3]:.1f})'.center(29)
+        return f'{self.name}: ℂ --> ℂ\n' + numerator + line + denominator
 
 
 class BilinearTransformation(MoebiusTransformation):

--- a/src/pymor/models/transforms.py
+++ b/src/pymor/models/transforms.py
@@ -1,6 +1,6 @@
-# This file is part of the pyMOR project (http://www.pymor.org).
+# This file is part of the pyMOR project (https://www.pymor.org).
 # Copyright pyMOR developers and contributors. All rights reserved.
-# License: BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+# License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
 import numpy as np
 from scipy.linalg import null_space
@@ -25,14 +25,14 @@ class MoebiusTransformation(ImmutableObject):
     coefficients
         A tuple, list or |NumPy array| containing the four coefficients `a,b,c,d`.
     normalize
-        If `True`, the coefficients are normalized, i.e. :math:`ad-bc=1`. Defaults to `False`.
+        If `True`, the coefficients are normalized, i.e., :math:`ad-bc=1`. Defaults to `False`.
     name
         Name of the transformation.
     """
 
     def __init__(self, coefficients, normalize=False, name=None):
-        assert len(coefficients) == 4
         coefficients = np.array(coefficients)
+        assert coefficients.shape == (4,)
         assert coefficients[0]*coefficients[3] != coefficients[1]*coefficients[2]
 
         if normalize:
@@ -85,7 +85,7 @@ class MoebiusTransformation(ImmutableObject):
         Parameters
         ----------
         normalize
-            If `True`, the coefficients are normalized, i.e. :math:`ad-bc=1`. Defaults to `False`.
+            If `True`, the coefficients are normalized, i.e., :math:`ad-bc=1`. Defaults to `False`.
 
         Returns
         -------
@@ -119,7 +119,7 @@ class MoebiusTransformation(ImmutableObject):
 
     def __str__(self):
         return (
-            f'{self.name}: C^1 --> C^1\n'
+            f'{self.name}: ℂ --> ℂ\n'
             f'       ({self.coefficients[0]:.1f})*z + ({self.coefficients[1]:.1f})\n'
             'f(z) = --------------------------------\n'
             f'       ({self.coefficients[2]:.1f})*z + ({self.coefficients[3]:.1f})'

--- a/src/pymor/models/transforms.py
+++ b/src/pymor/models/transforms.py
@@ -4,7 +4,7 @@ from scipy.linalg import null_space
 from pymor.core.base import ImmutableObject
 
 
-class MoebiusTransform(ImmutableObject):
+class MoebiusTransformation(ImmutableObject):
     """A Moebius transform operator.
 
     Maps complex numbers to complex numbers.
@@ -45,7 +45,7 @@ class MoebiusTransform(ImmutableObject):
     def inverse(self, normalize=False):
         a, b, c, d = self.coefficients
         coefficients = np.array([d, -b, -c, a])
-        return MoebiusTransform(coefficients, normalize=normalize, name=self.name + '_inverse')
+        return MoebiusTransformation(coefficients, normalize=normalize, name=self.name + '_inverse')
 
     def _mapping(self, x):
         a, b, c, d = self.coefficients
@@ -64,9 +64,9 @@ class MoebiusTransform(ImmutableObject):
         return np.vectorize(self._mapping)(x)
 
     def __matmul__(self, other):
-        assert isinstance(other, MoebiusTransform)
+        assert isinstance(other, MoebiusTransformation)
         M = self.coefficients.reshape(2, 2) @ other.coefficients.reshape(2, 2)
-        return MoebiusTransform(M.ravel())
+        return MoebiusTransformation(M.ravel())
 
     def __str__(self):
         return (
@@ -77,14 +77,33 @@ class MoebiusTransform(ImmutableObject):
         )
 
 
-class BilinearTransform(MoebiusTransform):
+class BilinearTransform(MoebiusTransformation):
+    r"""The bilinear transform.
+
+    A bilinear transformation is defined as
+
+    .. math::
+        M(s) = \frac{as+b}{cs+b}
+
+    is determined by the coefficients :math:`a,b,c,d\in\mathbb{C}`. The Moebius transformations form
+    a group under composition, therefore the `__matmul__` operator is defined to yield a
+    |MoebiusTransform| if both factors are |MoebiusTransformation|s.
+
+    Parameters
+    ----------
+    coefficients
+        A tuple, list or |NumPy array| containing the four coefficients `a,b,c,d`.
+    normalize
+        If `True`, the coefficients are normalized, i.e. :math:`ad-bc=1`. Defaults to `False`.
+    """
+
     def __init__(self, x, normalize=False, name=None):
         assert x > 0
         super().__init__([x, -x, 1, 1], normalize=normalize, name=name)
         self.__auto_init(locals())
 
 
-class CayleyTransform(MoebiusTransform):
+class CayleyTransform(MoebiusTransformation):
     def __init__(self, normalize=False, name=None):
         super().__init__([1, -1j, 1, 1j], normalize=normalize, name=name)
         self.__auto_init(locals())

--- a/src/pymor/models/transforms.py
+++ b/src/pymor/models/transforms.py
@@ -14,7 +14,7 @@ class MoebiusTransformation(ImmutableObject):
 
     is determined by the coefficients :math:`a,b,c,d\in\mathbb{C}`. The Moebius transformations form
     a group under composition, therefore the `__matmul__` operator is defined to yield a
-    |MoebiusTransform| if both factors are |MoebiusTransformation|s.
+    |MoebiusTransformation| if both factors are |MoebiusTransformation|s.
 
     Parameters
     ----------

--- a/src/pymor/models/transforms.py
+++ b/src/pymor/models/transforms.py
@@ -28,7 +28,7 @@ class MoebiusTransformation(ImmutableObject):
 
     def __init__(self, coefficients, normalize=False, name=None):
         assert len(coefficients) == 4
-        coefficients = np.array(coefficients, dtype=complex)
+        coefficients = np.array(coefficients)
         assert coefficients[0]*coefficients[3] != coefficients[1]*coefficients[2]
 
         if normalize:
@@ -103,7 +103,7 @@ class MoebiusTransformation(ImmutableObject):
             return (a * x + b) / (c * x + d)
 
     def __call__(self, x):
-        x = np.squeeze(np.array(x, dtype=complex))
+        x = np.squeeze(np.array(x))
         assert x.ndim <= 1
         return np.vectorize(self._mapping)(x)
 

--- a/src/pymor/models/transforms.py
+++ b/src/pymor/models/transforms.py
@@ -131,9 +131,9 @@ class BilinearTransform(MoebiusTransformation):
         Name of the transform.
     """
 
-    def __init__(self, x, normalize=False, name=None):
+    def __init__(self, x, name=None):
         assert x > 0
-        super().__init__([x, -x, 1, 1], normalize=normalize, name=name)
+        super().__init__([x, -x, 1, 1], name=name)
         self.__auto_init(locals())
 
 
@@ -151,6 +151,6 @@ class CayleyTransform(MoebiusTransformation):
         Name of the transform.
     """
 
-    def __init__(self, normalize=False, name=None):
-        super().__init__([1, -1j, 1, 1j], normalize=normalize, name=name)
+    def __init__(self, name=None):
+        super().__init__([1, -1j, 1, 1j], name=name)
         self.__auto_init(locals())

--- a/src/pymortests/transforms.py
+++ b/src/pymortests/transforms.py
@@ -1,0 +1,59 @@
+# This file is part of the pyMOR project (http://www.pymor.org).
+# Copyright pyMOR developers and contributors. All rights reserved.
+# License: BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+
+import numpy as np
+import pytest
+from itertools import combinations
+
+from pymor.models.transforms import BilinearTransformation, CayleyTransformation, MoebiusTransformation
+
+
+type_list = ['BilinearTransformation', 'CayleyTransformation', 'MoebiusTransformation']
+points_list = list(combinations([0, 1, -1, 1j, -1j, np.inf], 3))
+
+
+def get_transformation(name):
+    if name == 'BilinearTransformation':
+        return BilinearTransformation(2)
+    elif name == 'CayleyTransformation':
+        return CayleyTransformation()
+    elif name == 'MoebiusTransformation':
+        return MoebiusTransformation([1+2j, 2+3j, 4+5j, 6+7j])
+    else:
+        raise KeyError
+
+
+@pytest.mark.parametrize('m', type_list)
+def test_inv(m):
+    m = get_transformation(m)
+    m_inv = m.inverse()
+    mm_inv = MoebiusTransformation((m @ m_inv).coefficients, normalize=True)
+    m_invm = MoebiusTransformation((m_inv @ m).coefficients, normalize=True)
+    assert np.allclose(np.eye(2).ravel(), mm_inv.coefficients)
+    assert np.allclose(np.eye(2).ravel(), m_invm.coefficients)
+
+
+@pytest.mark.parametrize('m1', type_list)
+@pytest.mark.parametrize('m2', type_list)
+def test_matmul(m1, m2):
+    m1 = get_transformation(m1)
+    m2 = get_transformation(m2)
+    m = m1 @ m2
+    assert np.allclose(m.coefficients.reshape(2, 2), m1.coefficients.reshape(2, 2) @ m2.coefficients.reshape(2, 2))
+
+
+@pytest.mark.parametrize('p1', points_list)
+@pytest.mark.parametrize('p2', points_list)
+def test_from_points(p1, p2):
+    p1, p2 = np.asarray(p1), np.asarray(p2)
+    M1 = MoebiusTransformation.from_points(p1, z=p2)
+    m1 = M1(p2)
+
+    for i in range(3):
+        if np.isinf(p1[i]):
+            assert np.isinf(m1[i]) or np.abs(m1[i]) >= 1e+15 or np.allclose(p1[i], m1[i])
+        elif np.isinf(m1[i]):
+            assert np.abs(p1[i]) >= 1e+15 or np.allclose(p1[i], m1[i])
+        else:
+            assert np.allclose(p1[i], m1[i])

--- a/src/pymortests/transforms.py
+++ b/src/pymortests/transforms.py
@@ -6,11 +6,13 @@ import numpy as np
 import pytest
 from itertools import combinations
 
+from pymor.models.iosys import LTIModel
 from pymor.models.transforms import BilinearTransformation, CayleyTransformation, MoebiusTransformation
 
 
 type_list = ['BilinearTransformation', 'CayleyTransformation', 'MoebiusTransformation']
 points_list = list(combinations([0, 1, -1, 1j, -1j, np.inf], 3))
+sampling_time_list = [0, 1/100, 2]
 
 
 def get_transformation(name):
@@ -57,3 +59,16 @@ def test_from_points(p1, p2):
             assert np.abs(p1[i]) >= 1e+15 or np.allclose(p1[i], m1[i])
         else:
             assert np.allclose(p1[i], m1[i])
+
+
+@pytest.mark.parametrize('sampling_time', sampling_time_list)
+def test_substitution(sampling_time):
+    sys1 = LTIModel.from_matrices(np.array([-1]), np.array([[1]]), np.array([[1]]), sampling_time=sampling_time)
+    if sampling_time:
+        sys2 = sys1.to_continuous()
+        assert isinstance(sys2, LTIModel)
+        assert sys2.sampling_time == 0
+    else:
+        sys2 = sys1.to_discrete(1)
+        assert isinstance(sys2, LTIModel)
+        assert sys2.sampling_time == 1


### PR DESCRIPTION
I have this code here that I would like to integrate in order to have Bilinear Transformations of LTI-systems similarly to Matlabs `c2d` and `d2c` commands. So far I have implemented Tustin's method and I am looking to extend this to higher order approximations in the future. 

I am particularly interested in arbitrary Moebius substitutions of the frequency argument (not only the bilinear transformation) which is why I chose a more functional approach and implemented a `MoebiusTransform` operator directly. Maybe this can be used elsewhere in the future (I have added the CayleyTransform as an inspiration).

I would love to get some feedback, IMO the method `LTIModel.moebius_substitution` could use some improvement in both naming and the code. The method substitutes the frequency argument `omega` by a MoebiusTransform (please see https://ieeexplore.ieee.org/document/489281/ for reference). I feel like I am not using pyMORs structure optimally in the current implementation.

The docstrings are sparse and sketchy, I will obviously add proper ones and tests at a later stage.
