### PR TITLE
Adaptive frequency response

### DIFF
--- a/docs/source/tutorial_bt.md
+++ b/docs/source/tutorial_bt.md
@@ -193,7 +193,7 @@ We can compare the magnitude plots between the full-order and reduced-order
 models
 
 ```{code-cell}
-w = np.logspace(-2, 8, 300)
+w = (1e-2, 1e3)
 fig, ax = plt.subplots()
 fom.transfer_function.mag_plot(w, ax=ax, label='FOM')
 rom.transfer_function.mag_plot(w, ax=ax, linestyle='--', label='ROM')

--- a/docs/source/tutorial_lti_systems.md
+++ b/docs/source/tutorial_lti_systems.md
@@ -234,7 +234,7 @@ using the {meth}`~pymor.models.transfer_function.TransferFunction.mag_plot`
 method.
 
 ```{code-cell}
-w = np.logspace(-2, 8, 300)
+w = (1e-2, 1e3)
 _ = fom.transfer_function.mag_plot(w)
 ```
 

--- a/src/pymor/models/transfer_function.py
+++ b/src/pymor/models/transfer_function.py
@@ -122,7 +122,7 @@ class TransferFunction(CacheableObject, ParametricObject):
             return self.dtf(s, mu=mu)
 
     @cached
-    def freq_resp(self, w=None, mu=None, adaptive_type='bode', adaptive_opts=None):
+    def freq_resp(self, w, mu=None, adaptive_type='bode', adaptive_opts=None):
         """Evaluate the transfer function on the imaginary axis.
 
         Parameters
@@ -285,7 +285,7 @@ class TransferFunction(CacheableObject, ParametricObject):
 
         return artists
 
-    def mag_plot(self, w=None, mu=None, ax=None, ord=None, Hz=False, dB=False, adaptive_opts=None, **mpl_kwargs):
+    def mag_plot(self, w, mu=None, ax=None, ord=None, Hz=False, dB=False, adaptive_opts=None, **mpl_kwargs):
         """Draw the magnitude plot.
 
         Parameters

--- a/src/pymor/models/transfer_function.py
+++ b/src/pymor/models/transfer_function.py
@@ -137,7 +137,7 @@ class TransferFunction(CacheableObject, ParametricObject):
             (`'bode'`, `'mag'`).
             Ignored if `len(w) != 2`.
         adaptive_opts
-            Optional arguments for `pymor.tools.plot.adaptive` (ignored if `len(w) != 2`).
+            Optional arguments for :func:`~pymor.tools.plot.adaptive` (ignored if `len(w) != 2`).
             If `xscale` and `yscale` are not set, `'log'` is used.
 
         Returns
@@ -196,7 +196,7 @@ class TransferFunction(CacheableObject, ParametricObject):
         mu
             |Parameter values| for which to evaluate the transfer function.
         adaptive_opts
-            Optional arguments for `pymor.tools.plot.adaptive` (ignored if `len(w) != 2`).
+            Optional arguments for :func:`~pymor.tools.plot.adaptive` (ignored if `len(w) != 2`).
 
         Returns
         -------
@@ -240,7 +240,7 @@ class TransferFunction(CacheableObject, ParametricObject):
         deg
             Should the phase be in degrees (otherwise in radians).
         adaptive_opts
-            Optional arguments for `pymor.tools.plot.adaptive` (ignored if `len(w) != 2`).
+            Optional arguments for :func:`~pymor.tools.plot.adaptive` (ignored if `len(w) != 2`).
         mpl_kwargs
             Keyword arguments used in the matplotlib plot function.
 
@@ -315,7 +315,7 @@ class TransferFunction(CacheableObject, ParametricObject):
         dB
             Should the magnitude be in dB on the plot.
         adaptive_opts
-            Optional arguments for `pymor.tools.plot.adaptive` (ignored if `len(w) != 2`).
+            Optional arguments for :func:`~pymor.tools.plot.adaptive` (ignored if `len(w) != 2`).
         mpl_kwargs
             Keyword arguments used in the matplotlib plot function.
 

--- a/src/pymor/models/transfer_function.py
+++ b/src/pymor/models/transfer_function.py
@@ -138,6 +138,7 @@ class TransferFunction(CacheableObject, ParametricObject):
             Ignored if `len(w) != 2`.
         adaptive_opts
             Optional arguments for `pymor.tools.plot.adaptive` (ignored if `len(w) != 2`).
+            If `xscale` and `yscale` are not set, `'log'` is used.
 
         Returns
         -------
@@ -169,8 +170,11 @@ class TransferFunction(CacheableObject, ParametricObject):
 
             if adaptive_opts is None:
                 adaptive_opts = {}
-
-            w_new, _ = adaptive(f, w[0], w[1], xscale='log', yscale='log', **adaptive_opts)
+            else:
+                adaptive_opts = adaptive_opts.copy()
+            adaptive_opts.setdefault('xscale', 'log')
+            adaptive_opts.setdefault('yscale', 'log')
+            w_new, _ = adaptive(f, w[0], w[1], **adaptive_opts)
         else:
             w_new = w
 

--- a/src/pymor/models/transfer_function.py
+++ b/src/pymor/models/transfer_function.py
@@ -166,9 +166,9 @@ class TransferFunction(CacheableObject, ParametricObject):
                 f = lambda w: self.eval_tf(np.exp(1j * w))
         else:
             if self.sampling_time == 0:
-                f = lambda w: np.abs(self.eval_tf(1j * w))
+                f = lambda w: spla.norm(self.eval_tf(1j * w))
             else:
-                f = lambda w: np.abs(self.eval_tf(np.exp(1j * w)))
+                f = lambda w: spla.norm(self.eval_tf(np.exp(1j * w)))
 
         if adaptive_opts is None:
             adaptive_opts = {}

--- a/src/pymor/models/transfer_function.py
+++ b/src/pymor/models/transfer_function.py
@@ -137,7 +137,7 @@ class TransferFunction(CacheableObject, ParametricObject):
             (`'bode'`, `'mag'`).
             Ignored if `len(w) != 2`.
         adaptive_opts
-            Optional arguments for `pymor.algorithms.plot.adaptive` (ignored if `len(w) != 2`).
+            Optional arguments for `pymor.tools.plot.adaptive` (ignored if `len(w) != 2`).
 
         Returns
         -------
@@ -192,7 +192,7 @@ class TransferFunction(CacheableObject, ParametricObject):
         mu
             |Parameter values| for which to evaluate the transfer function.
         adaptive_opts
-            Optional arguments for `pymor.algorithms.plot.adaptive` (ignored if `len(w) != 2`).
+            Optional arguments for `pymor.tools.plot.adaptive` (ignored if `len(w) != 2`).
 
         Returns
         -------
@@ -236,7 +236,7 @@ class TransferFunction(CacheableObject, ParametricObject):
         deg
             Should the phase be in degrees (otherwise in radians).
         adaptive_opts
-            Optional arguments for `pymor.algorithms.plot.adaptive` (ignored if `len(w) != 2`).
+            Optional arguments for `pymor.tools.plot.adaptive` (ignored if `len(w) != 2`).
         mpl_kwargs
             Keyword arguments used in the matplotlib plot function.
 
@@ -311,7 +311,7 @@ class TransferFunction(CacheableObject, ParametricObject):
         dB
             Should the magnitude be in dB on the plot.
         adaptive_opts
-            Optional arguments for `pymor.algorithms.plot.adaptive` (ignored if `len(w) != 2`).
+            Optional arguments for `pymor.tools.plot.adaptive` (ignored if `len(w) != 2`).
         mpl_kwargs
             Keyword arguments used in the matplotlib plot function.
 

--- a/src/pymor/models/transfer_function.py
+++ b/src/pymor/models/transfer_function.py
@@ -158,14 +158,14 @@ class TransferFunction(CacheableObject, ParametricObject):
         if len(w) == 2:
             if adaptive_type == 'bode':
                 if self.sampling_time == 0:
-                    f = lambda w: self.eval_tf(1j * w)
+                    f = lambda w: self.eval_tf(1j * w, mu=mu)
                 else:
-                    f = lambda w: self.eval_tf(np.exp(1j * w))
+                    f = lambda w: self.eval_tf(np.exp(1j * w), mu=mu)
             else:
                 if self.sampling_time == 0:
-                    f = lambda w: spla.norm(self.eval_tf(1j * w))
+                    f = lambda w: spla.norm(self.eval_tf(1j * w, mu=mu))
                 else:
-                    f = lambda w: spla.norm(self.eval_tf(np.exp(1j * w)))
+                    f = lambda w: spla.norm(self.eval_tf(np.exp(1j * w), mu=mu))
 
             if adaptive_opts is None:
                 adaptive_opts = {}

--- a/src/pymor/tools/plot.py
+++ b/src/pymor/tools/plot.py
@@ -1,0 +1,78 @@
+# This file is part of the pyMOR project (https://www.pymor.org).
+# Copyright pyMOR developers and contributors. All rights reserved.
+# License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
+
+import numpy as np
+
+
+def adaptive(f, a, b, initial_num=10, max_num=2000, tol=2, min_rel_dist=1e-3,
+             aspect_ratio=4/3):
+    """Adaptive sampling of a |NumPy array|-valued function.
+
+    Samples the function such that the piecewise linear interpolation looks
+    "smooth".
+
+    Parameters
+    ----------
+    f
+        The function to sample.
+    a
+        The left bound.
+    b
+        The right bound.
+    initial_num
+        Initial number of linearly spaced sampling points.
+    max_num
+        Maximum number of sampling points.
+    tol
+        Tolerance for the maximum pointwise angle in degrees away from 180°.
+    min_rel_dist
+        Minimum distance between two neighboring points relative to the width
+        of the plot.
+    aspect_ratio
+        Ratio between width and height of the plot, used in calculating
+        angles and distances.
+
+    Returns
+    -------
+    points
+        A 1D |NumPy array| of sampled points.
+    fvals
+        A |NumPy array| of function values.
+    """
+    tol *= np.pi / 180
+    points = list(np.linspace(a, b, initial_num))
+    fvals = [f(p) for p in points]
+    while len(points) < max_num:
+        angles, dists = _angles_and_dists(points, fvals, aspect_ratio)
+        dists_pair_max = np.max(np.stack((dists[:-1], dists[1:])), axis=0)
+        angles[dists_pair_max <= min_rel_dist] = np.pi
+        idx = np.unravel_index(np.argmin(angles), angles.shape)
+        if np.pi - angles[idx] <= tol:
+            break
+        idx_1 = (idx[0] + 1,) + idx[1:]
+        if dists[idx_1] > min_rel_dist:
+            p2 = (points[idx[0] + 1] + points[idx[0] + 2]) / 2
+            points.insert(idx[0] + 2, p2)
+            fvals.insert(idx[0] + 2, f(p2))
+        if dists[idx] > min_rel_dist and len(points) < max_num:
+            p1 = (points[idx[0]] + points[idx[0] + 1]) / 2
+            points.insert(idx[0] + 1, p1)
+            fvals.insert(idx[0] + 1, f(p1))
+    return np.array(points), np.array(fvals)
+
+
+def _angles_and_dists(x, y, aspect_ratio):
+    x_range = x[-1] - x[0]
+    y_range = np.max(y, axis=0, keepdims=True) - np.min(y, axis=0, keepdims=True)
+    y_range[y_range == 0] = 1
+    x = np.array(x) / x_range * aspect_ratio
+    y = np.array(y) / y_range
+    dx = x[:-1] - x[1:]
+    dy = y[:-1] - y[1:]
+    dx = dx.reshape(dx.shape + (dy.ndim - 1) * (1,))
+    dists = np.sqrt(dx**2 + dy**2)
+    inner_products = -(dx[:-1] * dx[1:] + dy[:-1] * dy[1:])
+    ip_norm = inner_products / (dists[:-1] * dists[1:])
+    angles = np.arccos(np.clip(ip_norm, -1, 1))
+    return angles, dists

--- a/src/pymor/tools/plot.py
+++ b/src/pymor/tools/plot.py
@@ -70,7 +70,7 @@ class Adaptive(BasicObject):
         assert xscale in ('linear', 'log')
         assert yscale in ('linear', 'log')
 
-        angle_tol *= np.pi/180
+        angle_tol *= np.pi / 180
         self.__auto_init(locals())
 
         if xscale == 'linear':

--- a/src/pymor/tools/plot.py
+++ b/src/pymor/tools/plot.py
@@ -62,6 +62,7 @@ class Adaptive(BasicObject):
 
     def __init__(self, f, a, b, initial_num, max_num, angle_tol, min_rel_dist,
                  aspect_ratio, xscale, yscale):
+        assert a < b
         assert initial_num >= 2
         assert max_num > initial_num
         assert 0 < angle_tol < 90
@@ -135,14 +136,18 @@ class Adaptive(BasicObject):
                 self.y.insert(index, np.log2(self.fvals[index]))
         else:
             if self.yscale == 'linear':
-                self.y.insert(index, np.stack((np.abs(self.fvals[index]),
-                                               np.angle(self.fvals[index]))))
+                self.y.insert(index, np.stack(
+                    (np.abs(self.fvals[index]), np.angle(self.fvals[index])),
+                    axis=-1,
+                ))
             else:
-                self.y.insert(index, np.stack((np.log2(np.abs(self.fvals[index])),
-                                               np.angle(self.fvals[index]))))
-            unwrapped_angle = np.unwrap([y[1] for y in self.y], axis=0)
+                self.y.insert(index, np.stack(
+                    (np.log2(np.abs(self.fvals[index])), np.angle(self.fvals[index])),
+                    axis=-1,
+                ))
+            unwrapped_angle = np.unwrap([y[..., 1] for y in self.y], axis=0)
             for y, new_angle in zip(self.y, unwrapped_angle):
-                y[1] = new_angle
+                y[..., 1] = new_angle
         self.y_min = np.min(self.y, axis=0, keepdims=True)
         self.y_max = np.max(self.y, axis=0, keepdims=True)
 

--- a/src/pymor/tools/plot.py
+++ b/src/pymor/tools/plot.py
@@ -7,8 +7,10 @@ import math
 import numpy as np
 
 from pymor.core.base import BasicObject
+from pymor.core.defaults import defaults
 
 
+@defaults('initial_num', 'max_num', 'angle_tol', 'min_rel_dist', 'aspect_ratio', 'xscale', 'yscale')
 def adaptive(f, a, b, initial_num=10, max_num=2000, angle_tol=2, min_rel_dist=1e-2,
              aspect_ratio=4/3, xscale='linear', yscale='linear'):
     """Adaptive sampling of a |NumPy array|-valued function.

--- a/src/pymor/tools/plot.py
+++ b/src/pymor/tools/plot.py
@@ -54,8 +54,7 @@ def adaptive(f, a, b, initial_num=10, max_num=2000, angle_tol=2, min_rel_dist=1e
     plot = Adaptive(f, a, b, initial_num=initial_num, max_num=max_num,
                     angle_tol=angle_tol, min_rel_dist=min_rel_dist,
                     aspect_ratio=aspect_ratio, xscale=xscale, yscale=yscale)
-    plot.run()
-    return np.array(plot.points), np.array(plot.fvals)
+    return plot.compute()
 
 
 class Adaptive(BasicObject):
@@ -151,7 +150,7 @@ class Adaptive(BasicObject):
         self.y_min = np.min(self.y, axis=0, keepdims=True)
         self.y_max = np.max(self.y, axis=0, keepdims=True)
 
-    def run(self):
+    def _loop(self):
         while len(self.points) < self.max_num:
             angles, dists = self._angles_and_dists()
 
@@ -170,3 +169,7 @@ class Adaptive(BasicObject):
                 self._insert(idx[0] + 2)
             else:
                 self._insert(idx[0] + 1)
+
+    def compute(self):
+        self._loop()
+        return np.array(self.points), np.array(self.fvals)

--- a/src/pymor/tools/plot.py
+++ b/src/pymor/tools/plot.py
@@ -2,15 +2,20 @@
 # Copyright pyMOR developers and contributors. All rights reserved.
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
+import math
+
 import numpy as np
 
+from pymor.core.base import BasicObject
 
-def adaptive(f, a, b, initial_num=10, max_num=2000, tol=2, min_rel_dist=1e-3,
-             aspect_ratio=4/3):
+
+def adaptive(f, a, b, initial_num=10, max_num=2000, angle_tol=2, min_rel_dist=1e-2,
+             aspect_ratio=4/3, xscale='linear', yscale='linear'):
     """Adaptive sampling of a |NumPy array|-valued function.
 
-    Samples the function such that the piecewise linear interpolation looks
-    "smooth".
+    Samples the function such that the piecewise linear interpolation looks "smooth".
+
+    It the function is complex-valued, it is assumed that the magnitude and phase should be plotted.
 
     Parameters
     ----------
@@ -24,14 +29,18 @@ def adaptive(f, a, b, initial_num=10, max_num=2000, tol=2, min_rel_dist=1e-3,
         Initial number of linearly spaced sampling points.
     max_num
         Maximum number of sampling points.
-    tol
+    angle_tol
         Tolerance for the maximum pointwise angle in degrees away from 180°.
     min_rel_dist
-        Minimum distance between two neighboring points relative to the width
-        of the plot.
+        Minimum distance between two neighboring points relative to the width of the plot.
     aspect_ratio
-        Ratio between width and height of the plot, used in calculating
-        angles and distances.
+        Ratio between width and height of the plot, used in calculating angles and distances.
+    xscale
+        Whether to use linear (`'linear'`) or logarithmic (`'log'`) scale in the x-axis.
+    yscale
+        Whether to use linear (`'linear'`) or logarithmic (`'log'`) scale in the y-axis.
+        If the function is complex-valued, yscale only refers to the magnitude
+        (phase is always assumed to be in a linear scale).
 
     Returns
     -------
@@ -40,39 +49,117 @@ def adaptive(f, a, b, initial_num=10, max_num=2000, tol=2, min_rel_dist=1e-3,
     fvals
         A |NumPy array| of function values.
     """
-    tol *= np.pi / 180
-    points = list(np.linspace(a, b, initial_num))
-    fvals = [f(p) for p in points]
-    while len(points) < max_num:
-        angles, dists = _angles_and_dists(points, fvals, aspect_ratio)
-        dists_pair_max = np.max(np.stack((dists[:-1], dists[1:])), axis=0)
-        angles[dists_pair_max <= min_rel_dist] = np.pi
-        idx = np.unravel_index(np.argmin(angles), angles.shape)
-        if np.pi - angles[idx] <= tol:
-            break
-        idx_1 = (idx[0] + 1,) + idx[1:]
-        if dists[idx_1] > min_rel_dist:
-            p2 = (points[idx[0] + 1] + points[idx[0] + 2]) / 2
-            points.insert(idx[0] + 2, p2)
-            fvals.insert(idx[0] + 2, f(p2))
-        if dists[idx] > min_rel_dist and len(points) < max_num:
-            p1 = (points[idx[0]] + points[idx[0] + 1]) / 2
-            points.insert(idx[0] + 1, p1)
-            fvals.insert(idx[0] + 1, f(p1))
-    return np.array(points), np.array(fvals)
+    plot = Adaptive(f, a, b, initial_num=initial_num, max_num=max_num,
+                    angle_tol=angle_tol, min_rel_dist=min_rel_dist,
+                    aspect_ratio=aspect_ratio, xscale=xscale, yscale=yscale)
+    plot.run()
+    return np.array(plot.points), np.array(plot.fvals)
 
 
-def _angles_and_dists(x, y, aspect_ratio):
-    x_range = x[-1] - x[0]
-    y_range = np.max(y, axis=0, keepdims=True) - np.min(y, axis=0, keepdims=True)
-    y_range[y_range == 0] = 1
-    x = np.array(x) / x_range * aspect_ratio
-    y = np.array(y) / y_range
-    dx = x[:-1] - x[1:]
-    dy = y[:-1] - y[1:]
-    dx = dx.reshape(dx.shape + (dy.ndim - 1) * (1,))
-    dists = np.sqrt(dx**2 + dy**2)
-    inner_products = -(dx[:-1] * dx[1:] + dy[:-1] * dy[1:])
-    ip_norm = inner_products / (dists[:-1] * dists[1:])
-    angles = np.arccos(np.clip(ip_norm, -1, 1))
-    return angles, dists
+class Adaptive(BasicObject):
+
+    def __init__(self, f, a, b, initial_num, max_num, angle_tol, min_rel_dist,
+                 aspect_ratio, xscale, yscale):
+        assert initial_num >= 2
+        assert max_num > initial_num
+        assert 0 < angle_tol < 90
+        assert 0 < min_rel_dist < 1
+        assert aspect_ratio > 0
+        assert xscale in ('linear', 'log')
+        assert yscale in ('linear', 'log')
+
+        angle_tol *= np.pi/180
+        self.__auto_init(locals())
+
+        if xscale == 'linear':
+            self.points = list(np.linspace(a, b, initial_num))
+            self.x = self.points
+            self.x_range = b - a
+        else:
+            points_array = np.geomspace(a, b, initial_num)
+            self.points = list(points_array)
+            self.x = list(np.log2(points_array))
+            self.x_range = self.x[-1] - self.x[0]
+        self.fvals = [f(p) for p in self.points]
+        self.is_complex = any(np.iscomplexobj(fval) for fval in self.fvals)
+        if not self.is_complex:
+            if yscale == 'linear':
+                self.y = self.fvals
+            else:
+                self.y = [np.log2(fval) for fval in self.fvals]
+        else:
+            if yscale == 'linear':
+                self.y = list(np.stack(
+                    (np.abs(self.fvals), np.unwrap(np.angle(self.fvals), axis=0)),
+                    axis=-1,
+                ))
+            else:
+                self.y = list(np.stack(
+                    (np.log2(np.abs(self.fvals)), np.unwrap(np.angle(self.fvals), axis=0)),
+                    axis=-1,
+                ))
+        self.y_min = np.min(self.y, axis=0, keepdims=True)
+        self.y_max = np.max(self.y, axis=0, keepdims=True)
+
+    def _p_mean(self, p1, p2):
+        if self.xscale == 'linear':
+            return (p1 + p2) / 2
+        else:
+            # geometric mean, but trying to avoid overflow or underflow
+            return 2**((math.log2(p1) + math.log2(p2)) / 2)
+
+    def _angles_and_dists(self):
+        y_range = self.y_max - self.y_min
+        y_range[y_range == 0] = 1
+        x = np.array(self.x) / self.x_range
+        y = np.array(self.y) / (y_range * self.aspect_ratio)
+        dx = x[:-1] - x[1:]
+        dy = y[:-1] - y[1:]
+        dx = dx.reshape(dx.shape + (dy.ndim - 1) * (1,))
+        dists = np.sqrt(dx**2 + dy**2)
+        inner_products = -(dx[:-1] * dx[1:] + dy[:-1] * dy[1:])
+        inner_products_normed = inner_products / (dists[:-1] * dists[1:])
+        angles = np.arccos(np.clip(inner_products_normed, -1, 1))
+        return angles, dists
+
+    def _insert(self, index):
+        p = self._p_mean(self.points[index - 1], self.points[index])
+        self.points.insert(index, p)
+        self.fvals.insert(index, self.f(p))
+        if self.xscale == 'log':
+            self.x.insert(index, math.log2(p))
+        if not self.is_complex:
+            if self.yscale == 'log':
+                self.y.insert(index, np.log2(self.fvals[index]))
+        else:
+            if self.yscale == 'linear':
+                self.y.insert(index, np.stack((np.abs(self.fvals[index]),
+                                               np.angle(self.fvals[index]))))
+            else:
+                self.y.insert(index, np.stack((np.log2(np.abs(self.fvals[index])),
+                                               np.angle(self.fvals[index]))))
+            unwrapped_angle = np.unwrap([y[1] for y in self.y], axis=0)
+            for y, new_angle in zip(self.y, unwrapped_angle):
+                y[1] = new_angle
+        self.y_min = np.min(self.y, axis=0, keepdims=True)
+        self.y_max = np.max(self.y, axis=0, keepdims=True)
+
+    def run(self):
+        while len(self.points) < self.max_num:
+            angles, dists = self._angles_and_dists()
+
+            # ignore points where both incident segments are short
+            dists_pair_max = np.max(np.stack((dists[:-1], dists[1:])), axis=0)
+            angles[dists_pair_max <= self.min_rel_dist] = np.pi
+
+            # find the point with the sharpest angle
+            idx = np.unravel_index(np.argmin(angles), angles.shape)
+            if np.pi - angles[idx] <= self.angle_tol:
+                break
+
+            # sample at the longer segment
+            idx_1 = (idx[0] + 1,) + idx[1:]
+            if dists[idx] < dists[idx_1]:
+                self._insert(idx[0] + 2)
+            else:
+                self._insert(idx[0] + 1)

--- a/src/pymor/tools/plot.py
+++ b/src/pymor/tools/plot.py
@@ -17,7 +17,7 @@ def adaptive(f, a, b, initial_num=10, max_num=2000, angle_tol=2, min_rel_dist=1e
 
     Samples the function such that the piecewise linear interpolation looks "smooth".
 
-    It the function is complex-valued, it is assumed that the magnitude and phase should be plotted.
+    If the function is complex-valued, it is assumed that the magnitude and phase should be plotted.
 
     Parameters
     ----------
@@ -62,7 +62,7 @@ class Adaptive(BasicObject):
     def __init__(self, f, a, b, initial_num, max_num, angle_tol, min_rel_dist,
                  aspect_ratio, xscale, yscale):
         assert a < b
-        assert initial_num >= 2
+        assert initial_num >= 3
         assert max_num > initial_num
         assert 0 < angle_tol < 90
         assert 0 < min_rel_dist < 1

--- a/src/pymordemos/delay.py
+++ b/src/pymordemos/delay.py
@@ -33,7 +33,7 @@ def main(
 
     # Bode plot
     fig = plt.figure(constrained_layout=True)
-    w = np.logspace(-1, 3, 500)
+    w = (1e-1, 1e3)
     fom_properties(tf, w, fig_bode=fig)
     plt.show()
 

--- a/src/pymordemos/heat.py
+++ b/src/pymordemos/heat.py
@@ -221,7 +221,7 @@ def main(
     fig.suptitle('Full-order model')
 
     # System properties
-    w = np.logspace(-1, 3, 100)
+    w = (1e-1, 1e3)
     fom_properties(lti, w, fig_poles=subfigs1[0], fig_bode=subfigs[0])
 
     # Hankel singular values

--- a/src/pymordemos/parametric_delay.py
+++ b/src/pymordemos/parametric_delay.py
@@ -36,7 +36,7 @@ def main(r: int = Argument(10, help='Order of the TF-IRKA ROM.')):
                            parameters={'tau': 1})
 
     mus = [0.01, 0.1, 1]
-    w = np.logspace(-2, 4, 300)
+    w = (1e-2, 1e4)
     fom_properties_param(fom, w, mus)
 
     # TF-IRKA

--- a/src/pymordemos/parametric_heat.py
+++ b/src/pymordemos/parametric_heat.py
@@ -3,7 +3,6 @@
 # Copyright pyMOR developers and contributors. All rights reserved.
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
-import numpy as np
 import matplotlib.pyplot as plt
 from typer import Argument, run
 
@@ -223,7 +222,7 @@ def main(
     lti = fom.to_lti()
 
     mus = [0.1, 1, 10]
-    w = np.logspace(-1, 3, 100)
+    w = (1e-1, 1e3)
     fom_properties_param(lti, w, mus)
 
     # Model order reduction

--- a/src/pymordemos/parametric_string.py
+++ b/src/pymordemos/parametric_string.py
@@ -62,7 +62,7 @@ def main(
     so_sys = SecondOrderModel(Mop, Eop, Kop, Bop, Cpop)
 
     mus = [1, 5, 10]
-    w = np.logspace(-3, 2, 200)
+    w = (1e-3, 1e2)
     fom_properties_param(so_sys, w, mus)
 
     # Model order reduction

--- a/src/pymordemos/parametric_synthetic.py
+++ b/src/pymordemos/parametric_synthetic.py
@@ -66,7 +66,7 @@ def main(
     lti = LTIModel(A, B, C)
 
     mus = [1/50, 1/20, 1/10, 1/5, 1/2, 1]
-    w = np.logspace(0.5, 3.5, 200)
+    w = (10**0.5, 10**3.5)
     fom_properties_param(lti, w, mus)
 
     # Model order reduction

--- a/src/pymordemos/phlti.py
+++ b/src/pymordemos/phlti.py
@@ -131,7 +131,7 @@ def main(
     print(phlti)
 
     # Magnitude plot
-    w = np.logspace(-2, 8, 300)
+    w = (1e-2, 1e8)
     fig, ax = plt.subplots()
     _ = lti.transfer_function.mag_plot(w, ax=ax, label='LTI')
     _ = phlti.transfer_function.mag_plot(w, ax=ax, ls='--', label='PH')
@@ -151,7 +151,7 @@ def main(
     plt.show()
 
     e = phlti - lti
-    e.transfer_function.mag_plot(w)
+    e.transfer_function.mag_plot(np.geomspace(*w, 300))
     plt.show()
 
 

--- a/src/pymordemos/string_equation.py
+++ b/src/pymordemos/string_equation.py
@@ -62,7 +62,7 @@ def main(
     fig.suptitle('Full-order model')
 
     # System properties
-    w = np.logspace(-4, 2, 200)
+    w = (1e-4, 1e2)
     fom_properties(so_sys, w, fig_poles=subfigs1[0], fig_bode=subfigs[0])
 
     # Singular values

--- a/src/pymordemos/unstable_heat.py
+++ b/src/pymordemos/unstable_heat.py
@@ -74,6 +74,7 @@ def main(
 
     # System properties
     w = np.logspace(-1, 3, 100)
+    w = (1e-1, 1e3)
     fom_properties(lti, w, stable=False, fig_bode=subfigs[0], fig_poles=subfigs[1])
     plt.show()
 


### PR DESCRIPTION
The goal here is to add functionality to adaptively sample the transfer function given the boundaries of the frequency interval of interest (see #389):

- adds an `adaptive` method to `pymor.tools.plot`,
- extends `freq_resp` to support adaptive sampling for `bode_plot` and `mag_plot`,
- updates `bode`, `bode_plot`, and `mag_plot` to use adaptive `freq_resp`,
- updates sys-mor demos and tutorials to use adaptive plots.

Adaptive sampling seems to be working well on Penzl's three-peak example:

```python
import matplotlib.pyplot as plt
import numpy as np
import scipy.sparse as sps

from pymor.models.iosys import LTIModel

A1 = np.array([[-1, 100], [-100, -1]])
A2 = np.array([[-1, 200], [-200, -1]])
A3 = np.array([[-1, 400], [-400, -1]])
A4 = sps.diags(np.arange(-1, -1001, -1))
A = sps.block_diag((A1, A2, A3, A4), format='csc')
B = np.ones((1006, 1))
B[:6, :] = 10
C = B.T

m = LTIModel.from_matrices(A, B, C)
a, b = 1e-2, 1e6

w, tfw = m.transfer_function.freq_resp((a, b), adaptive_type='mag')
w_log = np.geomspace(a, b, len(w))
print(len(w))

fig, axs = plt.subplots(1, 2, dpi=150, figsize=(10, 5), constrained_layout=True)

m.transfer_function.mag_plot(
    (a, b),
    ax=axs[0],
    marker='.',
)
axs[0].set_title('Adaptive mesh')

m.transfer_function.mag_plot(
    w_log,
    ax=axs[1],
    marker='.',
)
axs[1].set_title('Uniform mesh')

w, tfw = m.transfer_function.freq_resp((a, b), adaptive_type='bode')
w_log = np.geomspace(a, b, len(w))
print(len(w))

fig, axs = plt.subplots(2, 2, dpi=150, figsize=(10, 10), constrained_layout=True)

m.transfer_function.bode_plot(
    (a, b),
    ax=axs[:, :1],
    marker='.',
)
axs[0, 0].set_title('Adaptive mesh')

m.transfer_function.bode_plot(
    w_log,
    ax=axs[:, 1:],
    marker='.',
)
axs[0, 1].set_title('Uniform mesh')

plt.show()
```

If others are happy with this approach, extending `bode_plot`, `bode`, and `freq_resp` would be the next steps.

### Considered alternatives

- [`adaptive`](https://github.com/python-adaptive/adaptive): in my testing, it uses more points and is non-deterministic.
- [SymPy plot](https://docs.sympy.org/latest/modules/plotting.html#sympy.plotting.plot.plot): it can adaptively plot SymPy expressions, but I'm not sure if it works with arbitrary functions. Also, there is some non-determinism and the function does not return the sampled points.
- [mpmath plot](https://mpmath.org/doc/current/plotting.html): It accepts arbitrary functions (only that mpmath feeds its own multiple-precision numbers, which needs to be taken care of). As SymPy, it only plots and does not return sampled points.