### PR TITLE
Assembly of `ConcatenationOperator`

### DIFF
--- a/src/pymor/algorithms/concat.py
+++ b/src/pymor/algorithms/concat.py
@@ -1,0 +1,37 @@
+from pymor.algorithms.rules import RuleTable, match_always, match_class_any
+from pymor.core.exceptions import RuleNotMatchingError
+from pymor.operators.constructions import ConcatenationOperator, IdentityOperator, ZeroOperator
+
+
+def assemble_concat(operators, solver_options=None, name=None):
+    return AssembleConcatRules(solver_options, name).apply(tuple(operators))
+
+
+class AssembleConcatRules(RuleTable):
+    def __init__(self, solver_options, name):
+        super().__init__(use_caching=False)
+        self.__auto_init(locals())
+
+    @match_class_any(ZeroOperator)
+    def action_ZeroOperator(self, ops):
+        return ZeroOperator(ops[0].range, ops[-1].source, name=self.name)
+
+    @match_class_any(IdentityOperator)
+    def action_IdentityOperator(self, ops):
+        without_identity = [op for op in ops if not isinstance(op, IdentityOperator)]
+        if len(without_identity) == 0:
+            return IdentityOperator(ops[0].range, name=self.name)
+        else:
+            return assemble_concat(without_identity, solver_options=self.solver_options, name=self.name)
+
+    @match_always
+    def action_call_assemble_concat_method(self, ops):
+        op = ops[0]._assemble_concat(ops, solver_options=self.solver_options, name=self.name)
+        if not op:
+            raise RuleNotMatchingError
+        else:
+            return op
+
+    @match_always
+    def action_return_concat(self, ops):
+        return ConcatenationOperator(ops, name=self.name)

--- a/src/pymor/operators/constructions.py
+++ b/src/pymor/operators/constructions.py
@@ -269,6 +269,12 @@ class ConcatenationOperator(Operator):
             V = op.apply_adjoint(V, mu=mu)
         return V
 
+    def assemble(self, mu=None):
+        from pymor.algorithms.concat import assemble_concat
+        operators = tuple(op.assemble(mu) for op in self.operators)
+        op = assemble_concat(operators, solver_options=self.solver_options, name=self.name + '_assembled')
+        return op
+
     def jacobian(self, U, mu=None):
         assert len(U) == 1
         Us = [U]

--- a/src/pymor/operators/interface.py
+++ b/src/pymor/operators/interface.py
@@ -453,6 +453,9 @@ class Operator(ParametricObject):
         else:
             return self
 
+    def _assemble_concat(self, operators, solver_options=None, name=None):
+        return None
+
     def _assemble_lincomb(self, operators, coefficients, identity_shift=0., solver_options=None, name=None):
         """Try to assemble a linear combination of the given operators.
 

--- a/src/pymor/operators/numpy.py
+++ b/src/pymor/operators/numpy.py
@@ -365,7 +365,7 @@ class NumpyMatrixOperator(NumpyMatrixBasedOperator):
         else:
             matrix = matrices[0]
         return NumpyMatrixOperator(matrix,
-                                   source_id=self.source.id,
+                                   source_id=operators[-1].source.id,
                                    range_id=self.range.id,
                                    solver_options=solver_options)
 


### PR DESCRIPTION
This PR will add `MatchingRules` for the assembly of `ConcatenationOperator` similar to `assemble_lincomb`.
At the moment it is mainly aimed at the concatenation of `NumpyMatrixOperator`. It checks for sparsity and then leverages `np.linalg.multi_dot` for the multiplication of the dense matrices.

## Todos:
- [ ] docstrings
- [ ] tests
- [ ] add more classes
- [ ] maybe add a default up to which matrix size the assembly is done