### PR TITLE
Avoid division by zero in gram_schmidt

### DIFF
--- a/src/pymor/algorithms/gram_schmidt.py
+++ b/src/pymor/algorithms/gram_schmidt.py
@@ -64,7 +64,7 @@ def gram_schmidt(A, product=None, return_R=False, atol=1e-13, rtol=1e-13, offset
         # first calculate norm
         initial_norm = A[i].norm(product)[0]
 
-        if initial_norm < atol:
+        if initial_norm <= atol:
             logger.info(f"Removing vector {i} of norm {initial_norm}")
             remove.append(i)
             continue
@@ -91,7 +91,7 @@ def gram_schmidt(A, product=None, return_R=False, atol=1e-13, rtol=1e-13, offset
                 old_norm, norm = norm, A[i].norm(product)[0]
 
                 # remove vector if it got too small
-                if norm < rtol * initial_norm:
+                if norm <= rtol * initial_norm:
                     logger.info(f"Removing linearly dependent vector {i}")
                     remove.append(i)
                     break

--- a/src/pymor/discretizers/builtin/grids/interfaces.py
+++ b/src/pymor/discretizers/builtin/grids/interfaces.py
@@ -147,6 +147,7 @@ class Grid(CacheableObject):
     # reference mapping etc numerics fail due to limited precision
     MAX_DOMAIN_WIDTH = 1e12
     MIN_DOMAIN_WIDTH = 1e-12
+    MAX_DOMAIN_RATIO = 1e6
 
     @abstractmethod
     def size(self, codim):
@@ -504,7 +505,11 @@ class Grid(CacheableObject):
     @classmethod
     def _check_domain(cls, domain):
         ll, rr = np.array(domain[0]), np.array(domain[1])
-        too_large = np.linalg.norm(ll - rr) > cls.MAX_DOMAIN_WIDTH
+        sizes = rr - ll
+        too_large = (
+            np.linalg.norm(sizes) > cls.MAX_DOMAIN_WIDTH
+            or np.max(sizes) / np.min(sizes) > cls.MAX_DOMAIN_RATIO
+        )
         if too_large:
             logger = getLogger('pymor.discretizers.builtin.grid')
             logger.warning(f'Domain {domain} for {cls} exceeds width limit. Results may be inaccurate')


### PR DESCRIPTION
By throwing out vectors whose norm exactly equals the tolerance, we avoid division by zero when `atol = 0`.