### PR TITLE
change URLs to https (and more)

### DIFF
--- a/docs/source/getting_started.md
+++ b/docs/source/getting_started.md
@@ -102,13 +102,13 @@ parameter values which maximises reduction error.
 In the following we will walk through the thermal block demo step by
 step in an interactive Python shell. We assume that you are familiar
 with the reduced basis method and that you know the basics of
-[Python](<http://www.python.org>) programming as well as working
+[Python](<https://www.python.org>) programming as well as working
 with {{ NumPy }}. (Note that our code will differ a bit from
 `thermalblock.py` as we will hardcode the various options the script
 offers and leave out some features.)
 
 First, start a Python shell. We recommend using
-[IPython](<http://ipython.org>)
+[IPython](<https://ipython.org>)
 
 ```
 ipython

--- a/docs/source/release_notes/0.4.rst
+++ b/docs/source/release_notes/0.4.rst
@@ -26,7 +26,7 @@ FEniCS and deal.II support
 pyMOR now includes wrapper classes for integrating PDE solvers
 written with the `dolfin` library of the `FEniCS <https://fenicsproject.org>`_
 project. For a usage example, see :meth:`pymordemos.thermalblock_simple.discretize_fenics`.
-Experimental support for `deal.II <http://dealii.org>`_ can be
+Experimental support for `deal.II <https://dealii.org>`_ can be
 found in the `pymor-deal.II <https://github.com/pymor/pymor-deal.II>`_
 repository of the pyMOR GitHub organization.
 

--- a/docs/source/release_notes/0.4.rst
+++ b/docs/source/release_notes/0.4.rst
@@ -115,7 +115,7 @@ Improvements to pyMOR's discretizaion tookit
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 - An unstructured triangular |Grid| is now provided by :class:`~pymor.grids.unstructured.UnstructuredTriangleGrid`.
   Such a |Grid| can be obtained using the :meth:`~pymor.domaindiscretizers.gmsh.discretize_gmsh`
-  method, which can parse `Gmsh <http://gmsh.info/>`_ output files. Moreover, this
+  method, which can parse `Gmsh <https://gmsh.info/>`_ output files. Moreover, this
   method can generate `Gmsh` input files to create unstructured meshes for
   an arbitrary :class:`~pymor.domaindescriptions.polygonal.PolygonalDomain`
   `[#9] <https://github.com/pymor/pymor/issues/9>`_.

--- a/docs/source/technical_overview.rst
+++ b/docs/source/technical_overview.rst
@@ -203,7 +203,7 @@ Creating Models
 
 pyMOR ships a small (and still quite incomplete) framework for creating finite
 element or finite volume discretizations based on the `NumPy/Scipy
-<http://scipy.org>`_ software stack. To end up with an appropriate
+<https://scipy.org>`_ software stack. To end up with an appropriate
 |Model|, one starts by instantiating an |analytical problem| which
 describes the problem we want to discretize. |analytical problems| contain
 |Functions| which define the analytical data functions associated with the

--- a/docs/source/tutorial_external_solver.md
+++ b/docs/source/tutorial_external_solver.md
@@ -163,7 +163,7 @@ construct the right-hand side vector for our problem.
 This completes the {download}`model.cc <minimal_cpp_demo/model.cc>`.
 
 This extension module needs to be compiled to a shared object that the Python interpreter can import.
-We use a minimal [CMake](<http://cmake.org/>) project that generates makefiles for us to achieve this.
+We use a minimal [CMake](<https://cmake.org/>) project that generates makefiles for us to achieve this.
 
 First we make sure pybind11 can be used:
 

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ def setup_package():
                 'pymor-vis = pymor.scripts.pymor_vis:run',
             ],
         },
-        url='http://pymor.org',
+        url='https://pymor.org',
         description=' ',
         python_requires='>=3.8',
         long_description=open('README.md').read(),

--- a/src/pymor/algorithms/bernoulli.py
+++ b/src/pymor/algorithms/bernoulli.py
@@ -1,4 +1,4 @@
-# This file is part of the pyMOR project (http://www.pymor.org).
+# This file is part of the pyMOR project (https://www.pymor.org).
 # Copyright pyMOR developers and contributors. All rights reserved.
 # License: BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
 

--- a/src/pymor/algorithms/bernoulli.py
+++ b/src/pymor/algorithms/bernoulli.py
@@ -1,6 +1,6 @@
 # This file is part of the pyMOR project (https://www.pymor.org).
 # Copyright pyMOR developers and contributors. All rights reserved.
-# License: BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+# License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
 import numpy as np
 import scipy.linalg as spla

--- a/src/pymor/analyticalproblems/expressions.py
+++ b/src/pymor/analyticalproblems/expressions.py
@@ -1,4 +1,4 @@
-# This file is part of the pyMOR project (http://www.pymor.org).
+# This file is part of the pyMOR project (https://www.pymor.org).
 # Copyright pyMOR developers and contributors. All rights reserved.
 # License: BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
 

--- a/src/pymor/analyticalproblems/expressions.py
+++ b/src/pymor/analyticalproblems/expressions.py
@@ -1,6 +1,6 @@
 # This file is part of the pyMOR project (https://www.pymor.org).
 # Copyright pyMOR developers and contributors. All rights reserved.
-# License: BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+# License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
 """This module contains a basic symbolic expression library.
 

--- a/src/pymor/bindings/dunegdt.py
+++ b/src/pymor/bindings/dunegdt.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # This file is part of the pyMOR project (https://www.pymor.org).
 # Copyright pyMOR developers and contributors. All rights reserved.
-# License: BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+# License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
 from pymor.core.config import config
 config.require('DUNEGDT')

--- a/src/pymor/bindings/dunegdt.py
+++ b/src/pymor/bindings/dunegdt.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is part of the pyMOR project (http://www.pymor.org).
+# This file is part of the pyMOR project (https://www.pymor.org).
 # Copyright pyMOR developers and contributors. All rights reserved.
 # License: BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
 

--- a/src/pymor/discretizers/builtin/domaindiscretizers/gmsh.py
+++ b/src/pymor/discretizers/builtin/domaindiscretizers/gmsh.py
@@ -38,7 +38,7 @@ def discretize_gmsh(domain_description=None, geo_file=None, geo_file_path=None, 
         Mesh element size scaling factor.
     options
         Other options to control the meshing procedure of Gmsh. See
-        http://geuz.org/gmsh/doc/texinfo/gmsh.html#Command_002dline-options for all available
+        https://gmsh.info/doc/texinfo/gmsh.html#Command_002dline-options for all available
         options.
     refinement_steps
         Number of refinement steps to do after the initial meshing.
@@ -64,7 +64,7 @@ def discretize_gmsh(domain_description=None, geo_file=None, geo_file_path=None, 
         version = subprocess.check_output(['gmsh', '--version'], stderr=subprocess.STDOUT, env=env).decode()
     except (subprocess.CalledProcessError, OSError):
         raise GmshMissing('Could not find Gmsh.'
-                          ' Please ensure that the gmsh binary (http://geuz.org/gmsh/) is in your PATH.')
+                          ' Please ensure that the gmsh binary (https://gmsh.info/) is in your PATH.')
 
     logger.info('Found version ' + version.strip())
 

--- a/src/pymor/discretizers/builtin/gui/qt.py
+++ b/src/pymor/discretizers/builtin/gui/qt.py
@@ -5,7 +5,7 @@
 """Visualization of grid data using Qt.
 
 This module provides a few methods and classes for visualizing data
-associated to grids. We use the `Qt <http://www.qt-project.org>`_ widget
+associated to grids. We use the `Qt <https://www.qt-project.org>`_ widget
 toolkit for the GUI.
 """
 from pymor.core.config import config

--- a/src/pymor/models/symplectic.py
+++ b/src/pymor/models/symplectic.py
@@ -1,4 +1,4 @@
-# This file is part of the pyMOR project (http://www.pymor.org).
+# This file is part of the pyMOR project (https://www.pymor.org).
 # Copyright pyMOR developers and contributors. All rights reserved.
 # License: BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
 

--- a/src/pymor/models/symplectic.py
+++ b/src/pymor/models/symplectic.py
@@ -1,6 +1,6 @@
 # This file is part of the pyMOR project (https://www.pymor.org).
 # Copyright pyMOR developers and contributors. All rights reserved.
-# License: BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+# License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
 import numpy as np
 from pymor.algorithms.timestepping import ImplicitMidpointTimeStepper

--- a/src/pymor/operators/numpy.py
+++ b/src/pymor/operators/numpy.py
@@ -60,7 +60,7 @@ class NumpyGenericOperator(Operator):
     linear
         Set to `True` if the provided `mapping` and `adjoint_mapping` are linear.
     parameters
-        The |Parameters| the depends on.
+        The |Parameters| the operator depends on.
     solver_options
         The |solver_options| for the operator.
     name

--- a/src/pymor/tools/frozendict.py
+++ b/src/pymor/tools/frozendict.py
@@ -3,7 +3,7 @@
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
 # The following implementation is based on
-# http://code.activestate.com/recipes/414283-frozen-dictionaries/
+# https://code.activestate.com/recipes/414283-frozen-dictionaries/
 
 
 class FrozenDict(dict):

--- a/src/pymordemos/elliptic_unstructured.py
+++ b/src/pymordemos/elliptic_unstructured.py
@@ -17,10 +17,9 @@ def main(
     num_points: int = Argument(..., help='The number of points that form the arc of the circular sector.'),
     clscale: float = Argument(..., help='Mesh element size scaling factor.'),
 ):
-    """Solves the Poisson equation in 2D on a circular sector domain of radius 1
-    using an unstructured mesh.
+    """Solves the 2D-Poisson equation on a circular sector of radius 1 with an unstructured mesh.
 
-    Note that Gmsh (http://geuz.org/gmsh/) is required for meshing.
+    Note that Gmsh (https://gmsh.info/) is required for meshing.
     """
     problem = StationaryProblem(
         domain=CircularSectorDomain(angle, radius=1, num_points=num_points),

--- a/src/pymordemos/unstable_heat.py
+++ b/src/pymordemos/unstable_heat.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# This file is part of the pyMOR project (http://www.pymor.org).
+# This file is part of the pyMOR project (https://www.pymor.org).
 # Copyright pyMOR developers and contributors. All rights reserved.
 # License: BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
 

--- a/src/pymordemos/unstable_heat.py
+++ b/src/pymordemos/unstable_heat.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # This file is part of the pyMOR project (https://www.pymor.org).
 # Copyright pyMOR developers and contributors. All rights reserved.
-# License: BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+# License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
 import numpy as np
 import scipy.sparse as sps

--- a/src/pymortests/algorithms/bernoulli.py
+++ b/src/pymortests/algorithms/bernoulli.py
@@ -1,4 +1,4 @@
-# This file is part of the pyMOR project (http://www.pymor.org).
+# This file is part of the pyMOR project (https://www.pymor.org).
 # Copyright pyMOR developers and contributors. All rights reserved.
 # License: BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
 

--- a/src/pymortests/algorithms/bernoulli.py
+++ b/src/pymortests/algorithms/bernoulli.py
@@ -1,6 +1,6 @@
 # This file is part of the pyMOR project (https://www.pymor.org).
 # Copyright pyMOR developers and contributors. All rights reserved.
-# License: BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+# License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
 import numpy as np
 import scipy.linalg as spla

--- a/src/pymortests/iosys_add_sub_mul.py
+++ b/src/pymortests/iosys_add_sub_mul.py
@@ -1,4 +1,4 @@
-# This file is part of the pyMOR project (http://www.pymor.org).
+# This file is part of the pyMOR project (https://www.pymor.org).
 # Copyright pyMOR developers and contributors. All rights reserved.
 # License: BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
 

--- a/src/pymortests/iosys_add_sub_mul.py
+++ b/src/pymortests/iosys_add_sub_mul.py
@@ -1,6 +1,6 @@
 # This file is part of the pyMOR project (https://www.pymor.org).
 # Copyright pyMOR developers and contributors. All rights reserved.
-# License: BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+# License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
 import numpy as np
 import pytest

--- a/versioneer.py
+++ b/versioneer.py
@@ -1815,7 +1815,7 @@ def do_setup():
     except EnvironmentError:
         pass
     # That doesn't cover everything MANIFEST.in can do
-    # (http://docs.python.org/2/distutils/sourcedist.html#commands), so
+    # (https://docs.python.org/2/distutils/sourcedist.html#commands), so
     # it might give some false negatives. Appending redundant 'include'
     # lines is safe, though.
     if "versioneer.py" not in simple_includes:


### PR DESCRIPTION
I went ahead and replaced most `http://` URLs with `https://`.

Eight instances of `http://` remain.
 - MORWiki and SLICOT do not seem to use TLS
 - Four instances are in the bib file which I left untouched
 - which leaves pyamg.org and the link to NA-digest which both didn't work when I tested them

I also added a missing word while I was at it.