### PR TITLE
[deps] restrict DUNE suggestion to systems

### DIFF
--- a/.ci/conda-env.yml
+++ b/.ci/conda-env.yml
@@ -22,6 +22,7 @@ dependencies:
   - meshio>=4.4
   - mpi4py>=3.0
   - mpi4py>=3.0.3
+  - myst-nb>=0.14
   - nbconvert
   - nbresuse
   - numpy>=1.17.5

--- a/dependencies.py
+++ b/dependencies.py
@@ -55,8 +55,8 @@ install_suggests = {
     'torch': 'PyTorch open source machine learning framework',
     'jupyter_contrib_nbextensions': 'modular collection of jupyter extensions',
     'pillow': 'image library used for bitmap data functions',
-    'dune-gdt>=2021.1.3': 'generic discretization toolbox',
-    'dune-xt>=2021.1.3': 'DUNE extensions for dune-gdt',
+    'dune-gdt>=2021.1.3; platform_system=="Linux" and platform_machine=="x86_64"': 'generic discretization toolbox',
+    'dune-xt>=2021.1.3; platform_system=="Linux" and platform_machine=="x86_64"': 'DUNE extensions for dune-gdt',
 }
 io_requires = ['pyevtk', 'xmljson', 'meshio>=4.4', 'lxml', 'gmsh']
 install_suggests.update({p: 'optional File I/O support libraries' for p in io_requires})

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -62,7 +62,7 @@ myst_heading_anchors = 2
 import substitutions # noqa
 myst_substitutions = substitutions.myst_substitutions
 nb_execute_notebooks = "cache"
-nb_execution_timeout = 120
+nb_execution_timeout = 180
 # print tracebacks to stdout
 nb_execution_show_tb = True
 

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -5,8 +5,8 @@ PySide2>=5.15.2.1
 bash_kernel
 click
 diskcache
-dune-gdt>=2021.1.3
-dune-xt>=2021.1.3
+dune-gdt>=2021.1.3; platform_system=="Linux" and platform_machine=="x86_64"
+dune-xt>=2021.1.3; platform_system=="Linux" and platform_machine=="x86_64"
 gmsh
 ipyparallel>=6.2.5
 ipython>=5.0


### PR DESCRIPTION
 where wheels are available for it. 
 This allows `pip install pymor[full]` to succeed on those system where no DUNE wheels are available.