### PR TITLE
Make RuleTable.get_children more restrictive

### DIFF
--- a/src/pymor/algorithms/rules.py
+++ b/src/pymor/algorithms/rules.py
@@ -343,9 +343,9 @@ class RuleTable(BasicObject, metaclass=RuleTableMeta):
         result = {}
         for child in children:
             c = getattr(obj, child)
-            if isinstance(c, Mapping):
+            if isinstance(c, dict):
                 result[child] = {k: self.apply(v) if v is not None else v for k, v in c.items()}
-            elif isinstance(c, Iterable):
+            elif isinstance(c, (list, tuple)):
                 result[child] = tuple(self.apply(v) if v is not None else v for v in c)
             else:
                 result[child] = self.apply(c) if c is not None else c
@@ -368,18 +368,17 @@ class RuleTable(BasicObject, metaclass=RuleTableMeta):
         attributes `a`, for which one of the folling is true:
 
             1. `a` is an |Operator|.
-            2. `a` is a `mapping` and each of its values is either an |Operator| or `None`.
-            3. `a` is an `iterable` and each of its elements is either an |Operator| or `None`.
+            2. `a` is a dict` and each of its values is either an |Operator| or `None`.
+            3. `a` is a `list` or `tuple` and each of its elements is either an |Operator|
+               or `None`.
         """
         children = set()
         for k in obj._init_arguments:
             try:
                 v = getattr(obj, k)
                 if (isinstance(v, Operator)
-                    or isinstance(v, Mapping) and all(isinstance(vv, Operator)
-                                                      or vv is None for vv in v.values())
-                    or isinstance(v, Iterable) and type(v) is not str and all(isinstance(vv, Operator)
-                                                                              or vv is None for vv in v)):
+                        or isinstance(v, dict) and all(isinstance(vv, Operator) or vv is None for vv in v.values())
+                        or isinstance(v, (list, tuple)) and all(isinstance(vv, Operator) or vv is None for vv in v)):
                     children.add(k)
             except AttributeError:
                 pass

--- a/src/pymortests/algorithms/simplify.py
+++ b/src/pymortests/algorithms/simplify.py
@@ -34,6 +34,12 @@ def test_expand():
             == {frozenset([i0, i1, i2]) for i0, i1, i2 in product([0, 1, 2], [3, 4, 5], [6, 7])})
 
 
+def test_expand_matrix_operator():
+    # MWE from #1656
+    op = expand(NumpyMatrixOperator(np.zeros((0, 0))))
+    assert isinstance(op, NumpyMatrixOperator)
+
+
 def test_contract():
     ops = [NumpyMatrixOperator(np.eye(1) * i) for i in range(1, 6)]
     pf = ProjectionParameterFunctional('p', 1, 0)


### PR DESCRIPTION
Instead of allowing arbitrary Mappings or Iterables, only dicts, tuples and list are allowed as containers.
This avoids unwanted side-effects like iterating over a numpy array.

Fixes #1656.