### PR TITLE
Fix Issue #1661

### DIFF
--- a/src/pymor/algorithms/genericsolvers.py
+++ b/src/pymor/algorithms/genericsolvers.py
@@ -218,7 +218,7 @@ def lgmres(A, b, x0=None, tol=1e-5, maxiter=1000, M=None, callback=None,
            inner_m=30, outer_k=3, outer_v=None, store_outer_Av=True):
     if A.source != A.range:
         raise InversionError
-    from scipy.linalg.basic import lstsq
+    from scipy.linalg import lstsq
     x = A.source.zeros() if x0 is None else x0.copy()
 
     # psolve = M.matvec

--- a/src/pymor/algorithms/symplectic.py
+++ b/src/pymor/algorithms/symplectic.py
@@ -306,8 +306,8 @@ def psd_cotengent_lift(U, modes):
         U.space.subspaces[0] == U.space.subspaces[1]
     assert modes % 2 == 0
 
-    X = U.block(0).copy()
-    X.append(U.block(1).copy())
+    X = U.blocks[0].copy()
+    X.append(U.blocks[1].copy())
     V, svals = pod(X, modes=modes // 2)
 
     return SymplecticBasis(
@@ -337,7 +337,7 @@ def psd_complex_svd(U, modes):
         U.space.subspaces[0] == U.space.subspaces[1]
     assert modes % 2 == 0
 
-    X = U.block(0) + U.block(1) * 1j
+    X = U.blocks[0] + U.blocks[1] * 1j
 
     V, _ = pod(X, modes=modes // 2)
 

--- a/src/pymor/bindings/scipy.py
+++ b/src/pymor/bindings/scipy.py
@@ -197,7 +197,7 @@ def apply_inverse(op, V, initial_guess=None, options=None, least_squares=False, 
     if options['type'] == 'scipy_bicgstab':
         for i, VV in enumerate(V):
             R[i], info = bicgstab(matrix, VV, initial_guess[i] if initial_guess is not None else None,
-                                  tol=options['tol'], maxiter=options['maxiter'])
+                                  tol=options['tol'], maxiter=options['maxiter'], atol='legacy')
             if info != 0:
                 if info > 0:
                     raise InversionError(f'bicgstab failed to converge after {info} iterations')
@@ -210,7 +210,7 @@ def apply_inverse(op, V, initial_guess=None, options=None, least_squares=False, 
         precond = LinearOperator(matrix.shape, ilu.solve)
         for i, VV in enumerate(V):
             R[i], info = bicgstab(matrix, VV, initial_guess[i] if initial_guess is not None else None,
-                                  tol=options['tol'], maxiter=options['maxiter'], M=precond)
+                                  tol=options['tol'], maxiter=options['maxiter'], M=precond, atol='legacy')
             if info != 0:
                 if info > 0:
                     raise InversionError(f'bicgstab failed to converge after {info} iterations')

--- a/src/pymor/discretizers/builtin/gui/gl.py
+++ b/src/pymor/discretizers/builtin/gui/gl.py
@@ -312,7 +312,7 @@ class ColorBarWidget(QOpenGLWidget):
             gl.glVertex(0.5, (bar_height*y + bar_start), y)
         gl.glEnd()
         p.endNativePainting()
-        p.drawText(round((self.width() - self.vmax_width)/2), self.text_ascent, self.vmax_str)
-        p.drawText(round((self.width() - self.vmin_width)/2), self.height() - self.text_height + self.text_ascent,
+        p.drawText(int(round((self.width() - self.vmax_width)/2)), self.text_ascent, self.vmax_str)
+        p.drawText(int(round((self.width() - self.vmin_width)/2)), self.height() - self.text_height + self.text_ascent,
                    self.vmin_str)
         p.end()

--- a/src/pymordemos/parametric_heat.py
+++ b/src/pymordemos/parametric_heat.py
@@ -88,6 +88,8 @@ def main(
 ):
     """Parametric 1D heat equation example."""
     set_log_levels({'pymor.algorithms.gram_schmidt.gram_schmidt': 'WARNING'})
+    # This demo opens more than 20 figures and matplotlib wants to warn us about that
+    plt.rcParams['figure.max_open_warning'] = 0
 
     # Model
     p = InstationaryProblem(

--- a/src/pymordemos/thermalblock_simple.py
+++ b/src/pymordemos/thermalblock_simple.py
@@ -262,7 +262,7 @@ def discretize_ngsolve():
     h1_0_op = op.assemble(Mu(diffusion=[1] * len(coeffs))).with_(name='h1_0_semi')
 
     F = space.zeros()
-    F._list[0].real_part.impl.vec.data = f.vec
+    F.vectors[0].real_part.impl.vec.data = f.vec
     F = VectorOperator(F)
 
     fom = StationaryModel(op, F, visualizer=NGSolveVisualizer(mesh, V),


### PR DESCRIPTION
- [gui] fix non-int input for text width draw
- [demos] fix deprecated `ListVectorArray._list` usage
- [demos] silence "too many open figures" warning
- [algorithms] `scipy.linalg.basic` is deprecated, now private namespace
- [scipy] explicitly set `atol='legacy'` for bicgstab
- [symplectic] fix deprecated usage of `BlockVectorArray.block`
