### PR TITLE
branch off new slycot version

### DIFF
--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -35,7 +35,7 @@ qtpy>2.0
 scipy>=1.3.3;python_version == "3.8"
 scipy>=1.3;python_version < "3.8"
 scipy>=1.5.4;python_version >= "3.9"
-slycot>=0.5.0
+slycot>=0.4.0
 sphinx-autoapi>=1.8
 sphinx-material
 sphinx-qt-documentation

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -35,7 +35,7 @@ qtpy>2.0
 scipy>=1.3.3;python_version == "3.8"
 scipy>=1.3;python_version < "3.8"
 scipy>=1.5.4;python_version >= "3.9"
-slycot>=0.4.0
+slycot>=0.5.0
 sphinx-autoapi>=1.8
 sphinx-material
 sphinx-qt-documentation

--- a/src/pymor/bindings/slycot.py
+++ b/src/pymor/bindings/slycot.py
@@ -131,11 +131,8 @@ def solve_lyap_dense(A, E, B, trans=False, cont_time=True, options=None):
         dico = 'C' if cont_time else 'D'
         job = 'B'
         if E is None:
-            ldwork = max(2*n*n, 3*n) if cont_time else 2*n*n+2*n
-            # slycot v. 0.4.0 does not set ldwork correctly for dico='D'
-            # should be fixed in the next release
             U = np.zeros((n, n))
-            X, scale, sep, ferr, _ = slycot.sb03md(n, C, A, U, dico, job=job, trana=trana, ldwork=ldwork)
+            X, scale, sep, ferr, _ = slycot.sb03md(n, C, A, U, dico, job=job, trana=trana)
             _solve_check(A.dtype, 'slycot.sb03md', sep, ferr)
         else:
             fact = 'N'


### PR DESCRIPTION
I saw that a new slycot version was released last week. It includes my bugfix PR for an incorrectly set `ldwork` variable in the discrete-time case. If we update our requirements to version 0.5.0 or higher, we can remove the workaround bugfix from our bindings.

The new release does not seem to contain drastic changes, although they have switched to a different license and version of SLICOT and there seems to be an issue with NumPy 1.23.0 (but not 1.23.1 and greater).

https://github.com/python-control/Slycot/releases/tag/v0.5.0