### PR TITLE
Removes deprecated complex Hypothesis strategy

### DIFF
--- a/.ci/conda-env.yml
+++ b/.ci/conda-env.yml
@@ -11,11 +11,13 @@ dependencies:
   - bash_kernel
   - check-manifest==0.49
   - click
+  - codecov==2.1.12
   - diskcache
   - docutils==0.18
   - flake8-docstrings==1.6.0
   - flake8-rst-docstrings==0.3.0
   - gmsh
+  - hypothesis==6.56.3
   - ipyparallel>=6.2.5
   - ipython>=5.0
   - ipywidgets<8,>7

--- a/.ci/conda-env.yml
+++ b/.ci/conda-env.yml
@@ -11,7 +11,6 @@ dependencies:
   - bash_kernel
   - check-manifest==0.49
   - click
-  - codecov==2.1.12
   - diskcache
   - docutils==0.18
   - flake8-docstrings==1.6.0

--- a/.github/workflows/conda_tests.yml
+++ b/.github/workflows/conda_tests.yml
@@ -168,7 +168,7 @@ jobs:
         id: cache
         env:
           # Increase this value to reset cache if .ci/conda-env.yml have not changed
-          CACHE_NUMBER: 2
+          CACHE_NUMBER: 3
         with:
           path: ${{ matrix.prefix }}
           key:

--- a/dependencies.py
+++ b/dependencies.py
@@ -71,6 +71,8 @@ doc_requires = ['sphinx>=5.0,<5.2', 'matplotlib', _PYSIDE, 'ipyparallel>=6.2.5',
                 'sphinxcontrib-applehelp<1.0.3',
                 'ipywidgets<8,>7', 'sphinx-qt-documentation', 'bash_kernel', 'sphinx-material',
                 'sphinxcontrib-bibtex', 'sphinx-autoapi>=1.8,<2', 'myst-nb>=0.16'] + install_requires
+# Note the hypothesis duplication makes the conda env creation script work
+# and is harmless for pip installs
 ci_requires = ['check-manifest==0.49',
                'check_reqs==1.0.0',
                # only update in lockstep with sphinx
@@ -78,6 +80,7 @@ ci_requires = ['check-manifest==0.49',
                'flake8-docstrings==1.6.0',
                'flake8-rst-docstrings==0.3.0',
                'hypothesis[numpy,pytest]==6.56.3',
+               'hypothesis==6.56.3',
                'pybind11==2.9.2',
                'pypi-oldest-requirements==2022.1.0',
                'pyqt5-qt5==5.15.2',

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -5,6 +5,7 @@ check_reqs==1.0.0
 docutils==0.18
 flake8-docstrings==1.6.0
 flake8-rst-docstrings==0.3.0
+hypothesis==6.56.3
 hypothesis[numpy,pytest]==6.56.3
 pybind11==2.9.2
 pypi-oldest-requirements==2022.1.0

--- a/src/pymortests/strategies.py
+++ b/src/pymortests/strategies.py
@@ -13,7 +13,6 @@ from scipy.stats._multivariate import random_correlation_gen
 from pymor.analyticalproblems.functions import Function, ExpressionFunction, ConstantFunction
 from pymor.core.config import config
 from pymor.parameters.base import Mu
-from pymor.tools.deprecated import Deprecated
 from pymor.vectorarrays.list import NumpyListVectorSpace
 from pymor.vectorarrays.block import BlockVectorSpace
 from pymor.vectorarrays.numpy import NumpyVectorSpace
@@ -45,15 +44,9 @@ MIN_ARRAY_ELEMENT_ABSVALUE = 1e-34
 hy_dtypes = hyst.sampled_from([np.float64, np.complex128])
 hy_float_array_elements = hyst.floats(allow_nan=False, allow_infinity=False, allow_subnormal=False,
                                       min_value=-MAX_ARRAY_ELEMENT_ABSVALUE, max_value=MAX_ARRAY_ELEMENT_ABSVALUE)
-
-
-@Deprecated("hypothesis.strategies.complex_numbers(allow_subnormal=False)")
-@hyst.composite
-def hy_complex_array_elements(draw):
-    # This is a crutch in place for https://github.com/HypothesisWorks/hypothesis/issues/3390
-    parts = hyst.floats(allow_nan=False, allow_infinity=False, allow_subnormal=False,
-                        min_value=-MAX_ARRAY_ELEMENT_ABSVALUE, max_value=MAX_ARRAY_ELEMENT_ABSVALUE)
-    return complex(draw(parts), draw(parts))
+hy_complex_array_elements = hyst.complex_numbers(allow_subnormal=False, min_magnitude=MIN_ARRAY_ELEMENT_ABSVALUE,
+                                                 max_magnitude=MAX_ARRAY_ELEMENT_ABSVALUE,
+                                                 allow_nan=False, allow_infinity=False)
 
 
 @hyst.composite
@@ -74,9 +67,9 @@ def nothing(*args, **kwargs):
 def _np_arrays(length, dim, dtype=None):
     if dtype is None:
         return hynp.arrays(dtype=np.float64, shape=(length, dim), elements=hy_float_array_elements) | \
-            hynp.arrays(dtype=np.complex128, shape=(length, dim), elements=hy_complex_array_elements())
+            hynp.arrays(dtype=np.complex128, shape=(length, dim), elements=hy_complex_array_elements)
     if dtype is np.complex128:
-        return hynp.arrays(dtype=dtype, shape=(length, dim), elements=hy_complex_array_elements())
+        return hynp.arrays(dtype=dtype, shape=(length, dim), elements=hy_complex_array_elements)
     if dtype is np.float64:
         return hynp.arrays(dtype=dtype, shape=(length, dim), elements=hy_float_array_elements)
     raise RuntimeError(f'unsupported dtype={dtype}')


### PR DESCRIPTION
This is blocked until https://github.com/conda-forge/hypothesis-feedstock/issues/730 is resolved, which most likely means until after https://github.com/agronholm/exceptiongroup had its first non-RC release

This will need a rebase after #1701 is merged. 