### PR TITLE
2022.1.x dune versions

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -16,11 +16,11 @@ _common_settings = {
     "verbosity": Verbosity.normal,
 }
 settings.register_profile("ci_large", max_examples=400, **_common_settings)
-settings.register_profile("ci_pr", max_examples=80, **_common_settings)
-settings.register_profile("ci", max_examples=25, **_common_settings)
-settings.register_profile("dev", max_examples=10, **_common_settings)
+settings.register_profile("ci_pr", derandomize=True, max_examples=80, **_common_settings)
+settings.register_profile("ci", derandomize=True, max_examples=25, **_common_settings)
+settings.register_profile("dev", derandomize=True, max_examples=10, **_common_settings)
 _common_settings["verbosity"] = Verbosity.verbose
-settings.register_profile("debug", max_examples=10, **_common_settings)
+settings.register_profile("debug", derandomize=True, max_examples=10, **_common_settings)
 settings.load_profile(os.getenv(u'PYMOR_HYPOTHESIS_PROFILE', 'dev'))
 
 """ This makes sure all our fixtures are available to all tests

--- a/src/pymor/core/config.py
+++ b/src/pymor/core/config.py
@@ -45,20 +45,20 @@ def _get_dunegdt_version():
     version = 'outdated'
     try:
         version = dune.gdt.__version__
-        if parse(version) < parse('2021.1.2') or parse(version) >= parse('2021.2'):
-            warnings.warn('dune-gdt bindings have been tested for version 2021.1.x (x >= 2) '
+        if parse(version) < parse('2021.1.2') or parse(version) >= parse('2022.2'):
+            warnings.warn('dune-gdt bindings have been tested for version 2022.1.x (x >= 1) '
                           f'(installed: {dune.gdt.__version__}).')
     except AttributeError:
-        warnings.warn('dune-gdt bindings have been tested for version 2021.1.x (x >= 2) '
-                      '(installed: unknown older than 2021.1.2).')
+        warnings.warn('dune-gdt bindings have been tested for version 2022.1.x (x >= 1) '
+                      '(installed: unknown older than 2022.1.1).')
     try:
         xt_version = dune.xt.__version__
-        if parse(xt_version) < parse('2021.1.2') or parse(xt_version) >= parse('2021.2'):
-            warnings.warn('dune-gdt bindings have been tested for dune-xt 2021.1.x (x >= 2) '
+        if parse(xt_version) < parse('2021.1.2') or parse(xt_version) >= parse('2022.2'):
+            warnings.warn('dune-gdt bindings have been tested for dune-xt 2022.1.x (x >= 4) '
                           f'(installed: {dune.xt.__version__}).')
     except AttributeError:
-        warnings.warn('dune-gdt bindings have been tested for dune-xt version 2021.1.x (x >= 2) '
-                      '(installed: unknown older than 2021.1.2).')
+        warnings.warn('dune-gdt bindings have been tested for dune-xt version 2022.1.x (x >= 4) '
+                      '(installed: unknown older than 2022.1.4).')
     return version
 
 

--- a/src/pymor/core/config.py
+++ b/src/pymor/core/config.py
@@ -40,26 +40,25 @@ def _get_fenics_version():
 
 
 def _get_dunegdt_version():
-    import dune.xt
-    import dune.gdt
-    version = 'outdated'
-    try:
-        version = dune.gdt.__version__
-        if parse(version) < parse('2021.1.2') or parse(version) >= parse('2022.2'):
-            warnings.warn('dune-gdt bindings have been tested for version 2022.1.x (x >= 1) '
-                          f'(installed: {dune.gdt.__version__}).')
-    except AttributeError:
-        warnings.warn('dune-gdt bindings have been tested for version 2022.1.x (x >= 1) '
-                      '(installed: unknown older than 2022.1.1).')
-    try:
-        xt_version = dune.xt.__version__
-        if parse(xt_version) < parse('2021.1.2') or parse(xt_version) >= parse('2022.2'):
-            warnings.warn('dune-gdt bindings have been tested for dune-xt 2022.1.x (x >= 4) '
-                          f'(installed: {dune.xt.__version__}).')
-    except AttributeError:
-        warnings.warn('dune-gdt bindings have been tested for dune-xt version 2022.1.x (x >= 4) '
-                      '(installed: unknown older than 2022.1.4).')
-    return version
+    import importlib
+    version_ranges = {"dune-gdt": ('2021.1.2', '2022.2'), "dune-xt": ('2021.1.2', '2022.2')}
+
+    def _get_version(dep_name):
+        min_version, max_version = version_ranges[dep_name]
+        module = importlib.import_module(dep_name.replace("-", "."))
+        try:
+            version = module.__version__
+            if parse(version) < parse(min_version) or parse(version) >= parse(max_version):
+                warnings.warn(f'{dep_name} bindings have been tested for versions between '
+                              '{min_version} and {max_version} (installed: {version}).')
+        except AttributeError:
+            warnings.warn(f'{dep_name} bindings have been tested for versions between '
+                          '{min_version} and {max_version} (installed unknown version).')
+            version = None
+        return version
+
+    _get_version("dune-xt")
+    return _get_version("dune-gdt")
 
 
 def is_windows_platform():

--- a/src/pymortests/docker_ci_smoketest.py
+++ b/src/pymortests/docker_ci_smoketest.py
@@ -2,6 +2,8 @@
 # Copyright pyMOR developers and contributors. All rights reserved.
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 import os
+import warnings
+
 import pytest
 
 from pymor.core.config import config, _PACKAGES
@@ -12,3 +14,27 @@ from pymor.core.config import config, _PACKAGES
                     reason='Guarantee only valid in the docker container')
 def test_config(pkg):
     assert getattr(config, f'HAVE_{pkg}')
+
+
+@pytest.mark.skipif(condition=not os.environ.get('DOCKER_PYMOR', False),
+                    reason='Guarantee only valid in the docker container')
+def test_no_dune_warnings():
+    _test_dune_import_warn()
+
+
+@pytest.mark.skipif(condition=not os.environ.get('DOCKER_PYMOR', False),
+                    reason='Guarantee only valid in the docker container')
+def test_dune_warnings(monkeypatch):
+    from dune import xt, gdt
+    monkeypatch.setattr(gdt, "__version__", "2020.0.0")
+    monkeypatch.setattr(xt, "__version__", "2020.0.0")
+    with pytest.xfail(""):
+        _test_dune_import_warn()
+
+
+def _test_dune_import_warn():
+    with warnings.catch_warnings():
+        from pymor.core.config import _get_dunegdt_version
+        # this will result in an error if a warning is caught
+        warnings.simplefilter("error")
+        _get_dunegdt_version()


### PR DESCRIPTION
- [tests] ensure we get no dune import warnings in our CI
- [config] bump supported dune versions
