### PR TITLE
add `NumpyLoewnerOperator`

### DIFF
--- a/src/pymor/algorithms/to_matrix.py
+++ b/src/pymor/algorithms/to_matrix.py
@@ -55,13 +55,18 @@ class ToMatrixRules(RuleTable):
     def action_NumpyLoewnerOperator(self, op):
         format = self.format
         if format in (None, 'dense'):
-            if op.shifted:
-                op_matrix = (np.expand_dims(op.si, axis=(1, 2)) * op.Hsi)[:, np.newaxis] \
-                    - (np.expand_dims(op.sj, axis=(1, 2)) * op.Hsj)[np.newaxis]
+            si, sj = op.s[op.i], op.s[op.j]
+            Hsi, Hsj = op.Hs[op.i], op.Hs[op.j]
+            if np.any(np.isin(si, sj)):
+                raise NotImplementedError
             else:
-                op_matrix = op.Hsi[:, np.newaxis] - op.Hsj[np.newaxis]
-            op_matrix /= np.expand_dims(np.subtract.outer(op.si, op.sj), axis=(2, 3))
-            return np.concatenate(np.concatenate(op_matrix, axis=1), axis=1)
+                if op.shifted:
+                    op_matrix = (np.expand_dims(si, axis=(1, 2)) * Hsi)[:, np.newaxis] \
+                        - (np.expand_dims(sj, axis=(1, 2)) * Hsj)[np.newaxis]
+                else:
+                    op_matrix = Hsi[:, np.newaxis] - Hsj[np.newaxis]
+                op_matrix /= np.expand_dims(np.subtract.outer(si, sj), axis=(2, 3))
+                return np.concatenate(np.concatenate(op_matrix, axis=1), axis=1)
         else:
             raise NotImplementedError
 

--- a/src/pymor/algorithms/to_matrix.py
+++ b/src/pymor/algorithms/to_matrix.py
@@ -56,11 +56,11 @@ class ToMatrixRules(RuleTable):
         format = self.format
         if format in (None, 'dense'):
             if op.shifted:
-                op_matrix = (np.expand_dims(op.x, axis=(1, 2)) * op.Hx)[:, np.newaxis] \
-                    - (np.expand_dims(op.y, axis=(1, 2)) * op.Hy)[np.newaxis]
+                op_matrix = (np.expand_dims(op.si, axis=(1, 2)) * op.Hsi)[:, np.newaxis] \
+                    - (np.expand_dims(op.sj, axis=(1, 2)) * op.Hsj)[np.newaxis]
             else:
-                op_matrix = op.Hx[:, np.newaxis] - op.Hy[np.newaxis]
-            op_matrix /= np.expand_dims(np.subtract.outer(op.x, op.y), axis=(2, 3))
+                op_matrix = op.Hsi[:, np.newaxis] - op.Hsj[np.newaxis]
+            op_matrix /= np.expand_dims(np.subtract.outer(op.si, op.sj), axis=(2, 3))
             return np.concatenate(np.concatenate(op_matrix, axis=1), axis=1)
         else:
             raise NotImplementedError

--- a/src/pymor/models/transfer_function.py
+++ b/src/pymor/models/transfer_function.py
@@ -5,7 +5,6 @@
 import numpy as np
 import scipy.linalg as spla
 
-from pymor.algorithms.to_matrix import to_matrix
 from pymor.core.cache import CacheableObject
 from pymor.core.cache import cached
 from pymor.operators.block import BlockOperator, BlockRowOperator, BlockColumnOperator, BlockDiagonalOperator
@@ -455,6 +454,7 @@ class FactorizedTransferFunction(TransferFunction):
     def __init__(self, dim_input, dim_output, K, B, C, D, dK=None, dB=None, dC=None, dD=None,
                  parameters={}, sampling_time=0, name=None):
         def tf(s, mu=None):
+            from pymor.algorithms.to_matrix import to_matrix
             if dim_input <= dim_output:
                 B_vec = B(s).as_range_array(mu=mu)
                 Kinv_B = K(s).apply_inverse(B_vec, mu=mu)
@@ -470,6 +470,7 @@ class FactorizedTransferFunction(TransferFunction):
             dtf = None
         else:
             def dtf(s, mu=None):
+                from pymor.algorithms.to_matrix import to_matrix
                 if dim_input <= dim_output:
                     B_vec = B(s).as_range_array(mu=mu)
                     Ki_B = K(s).apply_inverse(B_vec, mu=mu)

--- a/src/pymor/operators/numpy.py
+++ b/src/pymor/operators/numpy.py
@@ -538,14 +538,16 @@ class NumpyLoewnerOperator(NumpyGenericOperator):
 
     Parameters
     ----------
-    x
+    si
         |Numpy Array| of length k containing the left frequencies.
-    y
+    sj
         |Numpy Array| of length l containing the right frequencies.
-    Hx
+    Hsi
         |Numpy Array| of shape (k, p, m) containing the left data.
-    Hy
+    Hsj
         |Numpy Array| of shape (l, p, m) containing the right data.
+    shifted
+        If `True` the shifted Loewner matrix is constructed.
     source_id
         The id of the operator's `source` |VectorSpace|.
     range_id
@@ -554,51 +556,51 @@ class NumpyLoewnerOperator(NumpyGenericOperator):
         Name of the operator.
     """
 
-    def __init__(self, x, y, Hx, Hy, shifted=False, source_id=None, range_id=None, name=None):
-        assert all(isinstance(arg, np.ndarray) for arg in (x, y, Hx, Hy))
+    def __init__(self, si, sj, Hsi, Hsj, shifted=False, source_id=None, range_id=None, name=None):
+        assert all(isinstance(arg, np.ndarray) for arg in (si, sj, Hsi, Hsj))
         assert isinstance(shifted, bool)
 
-        assert x.ndim == 1 and y.ndim == 1
-        if Hx.ndim == 1:
-            Hx = Hx.reshape(-1, 1, 1)
+        assert si.ndim == 1 and sj.ndim == 1
+        if Hsi.ndim == 1:
+            Hsi = Hsi.reshape(-1, 1, 1)
         else:
-            assert Hx.ndim == 3
-        if Hy.ndim == 1:
-            Hy = Hy.reshape(-1, 1, 1)
+            assert Hsi.ndim == 3
+        if Hsj.ndim == 1:
+            Hsj = Hsj.reshape(-1, 1, 1)
         else:
-            assert Hy.ndim == 3
+            assert Hsj.ndim == 3
 
-        assert x.shape[0] == Hx.shape[0]
-        assert y.shape[0] == Hy.shape[0]
-        assert Hx.shape[1:] == Hy.shape[1:]
+        assert si.shape[0] == Hsi.shape[0]
+        assert sj.shape[0] == Hsj.shape[0]
+        assert Hsi.shape[1:] == Hsj.shape[1:]
 
         self.__auto_init(locals())
-        self.range = NumpyVectorSpace(x.shape[0], range_id)
-        self.source = NumpyVectorSpace(y.shape[0], source_id)
+        self.range = NumpyVectorSpace(si.shape[0], range_id)
+        self.source = NumpyVectorSpace(sj.shape[0], source_id)
         self.linear = True
 
     @classmethod
-    def from_partitioning(cls, w, H, split="even-odd", shifted=False, source_id=None, range_id=None, name=None):
+    def from_partitioning(cls, s, Hs, split="even-odd", shifted=False, source_id=None, range_id=None, name=None):
         assert isinstance(shifted, bool)
-        assert isinstance(w, np.ndarray) and isinstance(H, np.ndarray)
+        assert isinstance(s, np.ndarray) and isinstance(Hs, np.ndarray)
         assert split in ("even-odd", "half-half", "random")
 
-        assert w.ndim == 1
-        if H.ndim == 1:
-            H = H.reshape(-1, 1, 1)
+        assert s.ndim == 1
+        if Hs.ndim == 1:
+            Hs = Hs.reshape(-1, 1, 1)
         else:
-            assert H.ndim == 3
-        assert H.shape[0] == w.shape[0]
+            assert Hs.ndim == 3
+        assert Hs.shape[0] == s.shape[0]
 
         if split == "random":
-            idx = np.random.permutation(w.shape[0])
+            idx = np.random.permutation(s.shape[0])
             split = "even-odd"
         else:
-            idx = np.arange(w.shape[0])
+            idx = np.arange(s.shape[0])
 
         if split == "even-odd":
             i, j = idx[::2], idx[1::2]
         elif split == "half-half":
             i, j = np.array_split(idx, 2)
 
-        return cls(w[i], w[j], H[i], H[j], shifted=shifted, source_id=source_id, range_id=range_id, name=name)
+        return cls(s[i], s[j], Hs[i], Hs[j], shifted=shifted, source_id=source_id, range_id=range_id, name=name)


### PR DESCRIPTION
Hi guys, I have had this Loewner operator code for a while. I have polished it a little bit and would like to discuss about it. I have not added an `apply` method, yet.

My idea is to use this as a handy and unified interface for constructing Loewner matrices in pyMOR for the dense methods. Something like

<strike>

```python
L = to_matrix(NumpyLoewnerOperator.from_partitioning(x, H, split="even-odd"))
```

</strike>

```python
L = to_matrix(NumpyLoewnerOperator(s, Hs, partitioning="half-half", ordering="magnitude")
```
or

<strike>

```python
L = to_matrix(NumpyLoewnerOperator(x, y, Hx, Hy, shifted=True))
```

</strike>

```python
partitioning = ([1, 2, 4, 5], [1, 3, 6, 7, 5])
L = to_matrix(NumpyLoewnerOperator(s, Hs, shifted=True, partitioning=partitioning)
```

The construction procedure in `to_matrix` could maybe be done more efficiently. For now, thats the best I could come up with.

Let me know what you think! @aaborghi @lbalicki @gioconno

## Todo
- [ ] add tangential directions
- [ ] add derivative
- [ ] write tests
