### PR TITLE
Allow ParameterSpace to project parameters into its ranges

### DIFF
--- a/src/pymor/parameters/base.py
+++ b/src/pymor/parameters/base.py
@@ -582,3 +582,25 @@ class ParameterSpace(ParametricObject):
             return False
         return all(np.all(self.ranges[k][0] <= mu[k]) and np.all(mu[k] <= self.ranges[k][1])
                    for k in self.parameters)
+
+    def clip(self, mu):
+        """Clip (limit) |parameter values| to the space's parameter ranges.
+
+        Parameters
+        ----------
+        mu
+            |Parameter value| to clip.
+
+        Returns
+        -------
+        The clipped |parameter values|.
+        """
+        if not isinstance(mu, Mu):
+            mu = self.parameters.parse(mu)
+        if not self.parameters.is_compatible(mu):
+            raise NotImplementedError
+        mu_dict = {key: np.array([v for v in mu[key]], dtype=float) for key in mu}
+        for key in self.parameters:
+            range_ = self.ranges[key]
+            mu_dict[key] = np.clip(mu_dict[key], range_[0], range_[1])
+        return Mu(((key, mu_dict[key]) for key in self.parameters))

--- a/src/pymor/parameters/base.py
+++ b/src/pymor/parameters/base.py
@@ -591,7 +591,7 @@ class ParameterSpace(ParametricObject):
         mu
             |Parameter value| to clip.
         keep_additional
-            Boolean to keep additional values in the `Mu` instance which are
+            If `True`, keep additional values in the `Mu` instance which are
             not contained in the parameters, e.g. time parameters.
 
         Returns

--- a/src/pymor/parameters/base.py
+++ b/src/pymor/parameters/base.py
@@ -537,7 +537,7 @@ class ParameterSpace(ParametricObject):
         counts
             Number of samples to take per parameter and component
             of the parameter. Either a dict of counts per |Parameter|
-            or a single count that is taken for all |Parameters|
+            or a single count that is taken for each parameter in |Parameters|.
 
         Returns
         -------

--- a/src/pymortests/parameters/parameters.py
+++ b/src/pymortests/parameters/parameters.py
@@ -39,6 +39,17 @@ def test_randomly_without_count(space):
     assert isinstance(mu, Mu)
 
 
+def test_clip(space):
+    large_mu = [10e4]
+    large_mu = space.clip(large_mu)
+    small_mu = [-1]
+    small_mu = space.clip(small_mu)
+    max_mu = space.parameters.parse([1])
+    min_mu = space.parameters.parse([0.1])
+    assert large_mu == max_mu
+    assert small_mu == min_mu
+
+
 def test_parse_parameter():
     parameters = Parameters(b=2, a=1)
     mu_as_list = [1, 2, 3]

--- a/src/pymortests/parameters/parameters.py
+++ b/src/pymortests/parameters/parameters.py
@@ -15,9 +15,11 @@ import pymortests.strategies as pyst
 num_samples = 100
 
 
-@pytest.fixture(scope='module')
-def space():
-    return Parameters({'diffusionl': 1}).space(0.1, 1)
+@pytest.fixture(scope='module', params=([1], [2], [1, 1]))
+def space(request):
+    parameter_sizes = request.param
+    param_dict = {'diffusion_' + str(ind): size for ind, size in enumerate(parameter_sizes)}
+    return Parameters(param_dict).space(0.1, 1)
 
 
 def test_uniform(space):

--- a/src/pymortests/parameters/parameters.py
+++ b/src/pymortests/parameters/parameters.py
@@ -22,7 +22,8 @@ def space():
 
 def test_uniform(space):
     values = space.sample_uniformly(num_samples)
-    assert len(values) == num_samples
+    total_num_parameters = sum([space.parameters[k] for k in space.parameters])
+    assert len(values) == num_samples**total_num_parameters
     for value in values:
         assert space.contains(value)
 

--- a/src/pymortests/parameters/parameters.py
+++ b/src/pymortests/parameters/parameters.py
@@ -40,22 +40,26 @@ def test_randomly_without_count(space):
 
 
 def test_clip(space):
-    large_mu = [1e4]
-    large_mu = space.clip(large_mu)
-    small_mu = [-1]
-    small_mu = space.clip(small_mu)
-    max_mu = space.parameters.parse([1])
-    min_mu = space.parameters.parse([0.1])
-    assert large_mu == max_mu
-    assert small_mu == min_mu
+    keys = space.parameters.keys()
+    upper_mu = {k: space.ranges[k][1] for k in keys}
+    lower_mu = {k: space.ranges[k][0] for k in keys}
+    large_mu = upper_mu.copy()
+    large_mu[next(iter(large_mu))] += 1
+    small_mu = lower_mu.copy()
+    small_mu[next(iter(small_mu))] -= 1
+    clipped_large_mu = space.clip(Mu(large_mu))
+    clipped_small_mu = space.clip(Mu(small_mu))
+    assert clipped_large_mu == Mu(upper_mu)
+    assert clipped_small_mu == Mu(lower_mu)
 
-    additional_mu = Mu({'diffusionl': [1e4], 'test': [2.]})
-    additional_mu = space.clip(additional_mu, keep_additional=True)
-    no_additional_mu = space.clip(additional_mu, keep_additional=False)
-    add_clipped_mu = Mu({'diffusionl': [1.], 'test': [2.]})
-    clipped_mu = Mu({'diffusionl': [1.]})
-    assert additional_mu == add_clipped_mu
-    assert no_additional_mu == clipped_mu
+    additional_upper_mu = upper_mu.copy()
+    additional_upper_mu[next(iter(upper_mu)) + '_test'] = 2
+    additional_large_mu = large_mu.copy()
+    additional_large_mu[next(iter(large_mu)) + '_test'] = 2
+    additional_mu = space.clip(Mu(additional_large_mu), keep_additional=True)
+    no_additional_mu = space.clip(Mu(additional_large_mu), keep_additional=False)
+    assert additional_mu == Mu(additional_upper_mu)
+    assert no_additional_mu == Mu(upper_mu)
 
 
 def test_parse_parameter():

--- a/src/pymortests/parameters/parameters.py
+++ b/src/pymortests/parameters/parameters.py
@@ -40,7 +40,7 @@ def test_randomly_without_count(space):
 
 
 def test_clip(space):
-    large_mu = [10e4]
+    large_mu = [1e4]
     large_mu = space.clip(large_mu)
     small_mu = [-1]
     small_mu = space.clip(small_mu)
@@ -48,6 +48,14 @@ def test_clip(space):
     min_mu = space.parameters.parse([0.1])
     assert large_mu == max_mu
     assert small_mu == min_mu
+
+    additional_mu = Mu({'diffusionl': [1e4], 'test': [2.]})
+    additional_mu = space.clip(additional_mu, keep_additional=True)
+    no_additional_mu = space.clip(additional_mu, keep_additional=False)
+    add_clipped_mu = Mu({'diffusionl': [1.], 'test': [2.]})
+    clipped_mu = Mu({'diffusionl': [1.]})
+    assert additional_mu == add_clipped_mu
+    assert no_additional_mu == clipped_mu
 
 
 def test_parse_parameter():

--- a/src/pymortests/parameters/parameters.py
+++ b/src/pymortests/parameters/parameters.py
@@ -40,13 +40,14 @@ def test_randomly_without_count(space):
 
 
 def test_clip(space):
-    keys = space.parameters.keys()
-    upper_mu = {k: space.ranges[k][1] for k in keys}
-    lower_mu = {k: space.ranges[k][0] for k in keys}
-    large_mu = upper_mu.copy()
-    large_mu[next(iter(large_mu))] += 1
-    small_mu = lower_mu.copy()
-    small_mu[next(iter(small_mu))] -= 1
+    from copy import deepcopy
+    params = space.parameters
+    upper_mu = {k: [space.ranges[k][1]] * params[k] for k in params}
+    lower_mu = {k: [space.ranges[k][0]] * params[k] for k in params}
+    large_mu = deepcopy(upper_mu)
+    large_mu[next(iter(large_mu))][0] += 1.
+    small_mu = deepcopy(lower_mu)
+    small_mu[next(iter(small_mu))][0] -= 1.
     clipped_large_mu = space.clip(Mu(large_mu))
     clipped_small_mu = space.clip(Mu(small_mu))
     assert clipped_large_mu == Mu(upper_mu)


### PR DESCRIPTION
The method implemented here will allow any `ParameterSpace` to project any given parameter of suitable dimensions into its respective parameter ranges. This feature will in particular come in handy when trying to implement optimization algorithms such as TR-RB because of the often imposed rectangular parameter bounds.

One small problem that needs to be addressed is the nomenclature of the method: usually `project` methods call upon generalizable `ProjectionRules` as these methods refer to the projection of operators, etc. onto subbases and the like. Here however no such behaviour is intended because of the simple use case (we only ever want to "project" a parameter when in use with a `ParameterSpace`). If you've got any better suggestions for naming the method, please let me know or amend it directly in the code.