### PR TITLE
Reset random state for each test

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -9,6 +9,8 @@ from hypothesis import settings, Verbosity, HealthCheck
 import pytest
 import numpy as np
 
+from pymor.tools.random import new_rng
+
 _common_settings = {
     "print_blob": True,
     "suppress_health_check": (HealthCheck.data_too_large, HealthCheck.too_slow,
@@ -55,3 +57,9 @@ def monkey_np_testing(monkeypatch):
         return real_all_close(a, b, rtol=rtol, atol=atol)
 
     monkeypatch.setattr(np.testing, 'assert_allclose', monkey_allclose)
+
+
+@pytest.fixture(autouse=True)
+def reset_rng():
+    new_rng(42).install()
+    np.random.seed(42)

--- a/src/pymortests/algorithms/basic.py
+++ b/src/pymortests/algorithms/basic.py
@@ -182,7 +182,6 @@ def test_project_array(arrays):
 
 
 def test_project_array_with_product():
-    np.random.seed(123)
     U = NumpyVectorSpace.from_numpy(np.random.random((1, 10)))
     basis = NumpyVectorSpace.from_numpy(np.random.random((3, 10)))
     product = np.random.random((10, 10))

--- a/src/pymortests/algorithms/bernoulli.py
+++ b/src/pymortests/algorithms/bernoulli.py
@@ -22,7 +22,6 @@ n_list = [10, 20, 30]
 @pytest.mark.parametrize('with_E', [False, True])
 @pytest.mark.parametrize('trans', [False, True])
 def test_bernoulli(n, with_E, trans):
-    np.random.seed(0)
     E = -ortho_group.rvs(dim=n)
     A = np.diag(np.concatenate((np.arange(-n + 4, 0), np.arange(1, 5)))) @ E
     A = A + 1.j * A
@@ -45,7 +44,6 @@ def test_bernoulli(n, with_E, trans):
 @pytest.mark.parametrize('n', n_list)
 @pytest.mark.parametrize('trans', [False, True])
 def test_bernoulli_stabilize(n, trans):
-    np.random.seed(0)
     A = sps.random(n, n, density=0.3)
     Aop = NumpyMatrixOperator(A)
 

--- a/src/pymortests/algorithms/ei.py
+++ b/src/pymortests/algorithms/ei.py
@@ -7,7 +7,6 @@ import numpy as np
 from pymor.algorithms.pod import pod
 from pymor.operators.ei import EmpiricalInterpolatedOperator
 from pymor.reductors.basic import StationaryRBReductor
-from pymor.tools.random import new_rng
 from pymortests.base import runmodule, assert_all_almost_equal
 
 
@@ -19,8 +18,7 @@ def test_ei_restricted_to_full(stationary_models):
     ei_op = EmpiricalInterpolatedOperator(op, collateral_basis=cb, interpolation_dofs=dofs, triangular=True)
     ei_model = model.with_(operator=ei_op)
 
-    with new_rng(234):
-        mus = model.parameters.space(1, 2).sample_randomly(3)
+    mus = model.parameters.space(1, 2).sample_randomly(3)
     for mu in mus:
         a = model.solve(mu)
         b = ei_model.solve(mu)
@@ -44,8 +42,7 @@ def test_ei_rom(stationary_models):
 
     U = fom.solution_space.empty()
     base_mus = []
-    with new_rng(234):
-        mus = fom.parameters.space(1, 2).sample_randomly(3)
+    mus = fom.parameters.space(1, 2).sample_randomly(3)
     for mu in mus:
         a = fom.solve(mu)
         U.append(a)

--- a/src/pymortests/algorithms/eigs.py
+++ b/src/pymortests/algorithms/eigs.py
@@ -18,7 +18,6 @@ sigma_list = [None, 0]
 @pytest.mark.parametrize('k', k_list)
 @pytest.mark.parametrize('sigma', sigma_list)
 def test_eigs(n, k, sigma):
-    np.random.seed(0)
     A = sps.random(n, n, density=0.1)
     Aop = NumpyMatrixOperator(A)
     ew, ev = eigs(Aop, k=k, sigma=sigma)

--- a/src/pymortests/algorithms/lyapunov.py
+++ b/src/pymortests/algorithms/lyapunov.py
@@ -130,7 +130,6 @@ def test_cont_lrcf(n, m, with_E, trans, lyap_solver):
         E = None
     else:
         A, E = conv_diff_1d_fem(n, 1, 0.1, cont_time=True)
-    np.random.seed(0)
     B = np.random.randn(n, m)
     if trans:
         B = B.T
@@ -160,7 +159,6 @@ def test_disc_lrcf(n, m, with_E, trans, lyap_solver):
     else:
         A, E = conv_diff_1d_fem(n, 1, 0.1, cont_time=False)
 
-    np.random.seed(0)
     B = np.random.randn(n, m)
     if trans:
         B = B.T
@@ -184,7 +182,6 @@ def test_disc_lrcf(n, m, with_E, trans, lyap_solver):
 @skip_if_missing('SLYCOT')
 @skip_if_missing('PYMESS')
 def test_cont_dense(n, m, with_E, trans, lyap_solver):
-    np.random.seed(0)
     A = np.random.randn(n, n)
     E = np.eye(n) + np.random.randn(n, n) / n if with_E else None
     B = np.random.randn(n, m)
@@ -205,7 +202,6 @@ def test_cont_dense(n, m, with_E, trans, lyap_solver):
 @skip_if_missing('SLYCOT')
 @skip_if_missing('PYMESS')
 def test_disc_dense(n, m, with_E, trans, lyap_solver):
-    np.random.seed(0)
     A = np.random.randn(n, n)
     E = np.eye(n) + np.random.randn(n, n) / n if with_E else None
     B = np.random.randn(n, m)

--- a/src/pymortests/algorithms/projection.py
+++ b/src/pymortests/algorithms/projection.py
@@ -11,7 +11,6 @@ from pymor.algorithms.projection import project, project_to_subbasis
 def test_project(operator_with_arrays):
     op, mu, U, V = operator_with_arrays
     op_UV = project(op, V, U)
-    np.random.seed(4711 + U.dim + len(V))
     coeffs = np.random.random(len(U))
     X = op_UV.apply(op_UV.source.make_array(coeffs), mu=mu)
     Y = op_UV.range.make_array(V.inner(op.apply(U.lincomb(coeffs), mu=mu)).T)
@@ -25,7 +24,6 @@ def test_project_2(operator_with_arrays):
     op_U_V = project(op_U, V, None)
     op_V_U = project(op_V, None, U)
     op_UV = project(op, V, U)
-    np.random.seed(4711 + U.dim + len(V))
     W = op_UV.source.make_array(np.random.random(len(U)))
     Y0 = op_UV.apply(W, mu=mu)
     Y1 = op_U_V.apply(W, mu=mu)
@@ -37,7 +35,6 @@ def test_project_2(operator_with_arrays):
 def test_project_with_product(operator_with_arrays_and_products):
     op, mu, U, V, sp, rp = operator_with_arrays_and_products
     op_UV = project(op, V, U, product=rp)
-    np.random.seed(4711 + U.dim + len(V))
     coeffs = np.random.random(len(U))
     X = op_UV.apply(op_UV.source.make_array(coeffs), mu=mu)
     Y = op_UV.range.make_array(rp.apply2(op.apply(U.lincomb(coeffs), mu=mu), V))
@@ -51,7 +48,6 @@ def test_project_with_product_2(operator_with_arrays_and_products):
     op_U_V = project(op_U, V, None, product=rp)
     op_V_U = project(op_V, None, U)
     op_UV = project(op, V, U, product=rp)
-    np.random.seed(4711 + U.dim + len(V))
     W = op_UV.source.make_array(np.random.random(len(U)))
     Y0 = op_UV.apply(W, mu=mu)
     Y1 = op_U_V.apply(W, mu=mu)
@@ -63,7 +59,6 @@ def test_project_with_product_2(operator_with_arrays_and_products):
 def test_project_to_subbasis(operator_with_arrays):
     op, mu, U, V = operator_with_arrays
     op_UV = project(op, V, U)
-    np.random.seed(4711 + U.dim + len(V))
 
     for dim_range in {None, 0, len(V)//2, len(V)}:
         for dim_source in {None, 0, len(U)//2, len(U)}:
@@ -86,7 +81,6 @@ def test_project_to_subbasis(operator_with_arrays):
 def test_project_to_subbasis_no_range_basis(operator_with_arrays):
     op, mu, U, V = operator_with_arrays
     op_U = project(op, None, U)
-    np.random.seed(4711 + U.dim + len(V))
 
     for dim_source in {None, 0, len(U)//2, len(U)}:
         op_U_sb = project_to_subbasis(op_U, None, dim_source)
@@ -107,7 +101,6 @@ def test_project_to_subbasis_no_range_basis(operator_with_arrays):
 def test_project_to_subbasis_no_source_basis(operator_with_arrays):
     op, mu, U, V = operator_with_arrays
     op_V = project(op, V, None)
-    np.random.seed(4711 + U.dim + len(V))
 
     for dim_range in {None, 0, len(V)//2, len(V)}:
         op_V_sb = project_to_subbasis(op_V, dim_range, None)

--- a/src/pymortests/algorithms/rand_la.py
+++ b/src/pymortests/algorithms/rand_la.py
@@ -9,28 +9,22 @@ from numpy.random import uniform
 from pymor.algorithms.rand_la import rrf, adaptive_rrf, random_ghep, random_generalized_svd
 from pymor.operators.numpy import NumpyMatrixOperator
 from pymor.operators.constructions import VectorArrayOperator
-from pymor.tools.random import new_rng
 
 
 def test_adaptive_rrf():
-    np.random.seed(0)
     A = uniform(low=-1.0, high=1.0, size=(100, 100))
     A = A @ A.T
     range_product = NumpyMatrixOperator(A)
 
-    np.random.seed(1)
     B = uniform(low=-1.0, high=1.0, size=(10, 10))
     B = B.dot(B.T)
     source_product = NumpyMatrixOperator(B)
 
-    with new_rng(10):
-        C = range_product.range.random(10)
+    C = range_product.range.random(10)
     op = VectorArrayOperator(C)
 
-    with new_rng(11):
-        D = range_product.range.random(10)
-    with new_rng(12):
-        D += 1j*range_product.range.random(10)
+    D = range_product.range.random(10)
+    D += 1j*range_product.range.random(10)
     op_complex = VectorArrayOperator(D)
 
     Q1 = adaptive_rrf(op, source_product, range_product)
@@ -42,24 +36,19 @@ def test_adaptive_rrf():
 
 
 def test_rrf():
-    np.random.seed(2)
     A = uniform(low=-1.0, high=1.0, size=(100, 100))
     A = A @ A.T
     range_product = NumpyMatrixOperator(A)
 
-    np.random.seed(3)
     B = uniform(low=-1.0, high=1.0, size=(10, 10))
     B = B @ B.T
     source_product = NumpyMatrixOperator(B)
 
-    with new_rng(10):
-        C = range_product.range.random(10)
+    C = range_product.range.random(10)
     op = VectorArrayOperator(C)
 
-    with new_rng(11):
-        D = range_product.range.random(10)
-    with new_rng(12):
-        D += 1j*range_product.range.random(10)
+    D = range_product.range.random(10)
+    D += 1j*range_product.range.random(10)
     op_complex = VectorArrayOperator(D)
 
     Q1 = rrf(op, source_product, range_product)
@@ -73,7 +62,6 @@ def test_rrf():
 
 
 def test_random_generalized_svd():
-    np.random.seed(4)
     E = uniform(low=-1.0, high=1.0, size=(5, 5))
     E_op = NumpyMatrixOperator(E)
 
@@ -90,7 +78,6 @@ def test_random_generalized_svd():
 
 
 def test_random_ghep():
-    np.random.seed(5)
     D = uniform(low=-1.0, high=1.0, size=(5, 5))
     D = D @ D.T
     D_op = NumpyMatrixOperator(D)

--- a/src/pymortests/algorithms/riccati.py
+++ b/src/pymortests/algorithms/riccati.py
@@ -80,7 +80,6 @@ def test_ricc_dense(n, m, p, with_E, with_R, trans, solver):
         A, E = conv_diff_1d_fem(n, 1, 1)
         A = A.todense()
         E = E.todense()
-    np.random.seed(0)
     B = np.random.randn(n, m)
     C = np.random.randn(p, n)
     D = np.random.randn(p, m)
@@ -111,7 +110,6 @@ def test_ricc_lrcf(n, m, p, with_E, with_R, trans, solver):
         E = None
     else:
         A, E = conv_diff_1d_fem(n, 1, 1)
-    np.random.seed(0)
     B = np.random.randn(n, m)
     C = np.random.randn(p, n)
     D = np.random.randn(p, m)
@@ -153,7 +151,6 @@ def test_pos_ricc_lrcf(n, m, p, with_E, with_R, trans, solver):
         E = None
     else:
         A, E = conv_diff_1d_fem(n, 1, 1)
-    np.random.seed(0)
     B = np.random.randn(n, m)
     C = np.random.randn(p, n)
     D = np.random.randn(p, m)

--- a/src/pymortests/algorithms/samdp.py
+++ b/src/pymortests/algorithms/samdp.py
@@ -52,7 +52,6 @@ def test_samdp(n, m, k, wanted, with_E, which):
         A, E = conv_diff_1d_fem(n, 1, 1)
         Eop = NumpyMatrixOperator(E)
 
-    np.random.seed(0)
     B = np.random.randn(n, m)
     C = np.random.randn(k, n)
 

--- a/src/pymortests/algorithms/sylvester.py
+++ b/src/pymortests/algorithms/sylvester.py
@@ -49,7 +49,6 @@ def diff_conv_1d_fem(n, a, b):
 @pytest.mark.parametrize('r', r_list)
 @pytest.mark.parametrize('m', m_list)
 def test_sylv_schur_V(n, r, m):
-    np.random.seed(0)
 
     A = diff_conv_1d_fd(n, 1, 1)
     B = np.random.randn(n, m)
@@ -77,7 +76,6 @@ def test_sylv_schur_V(n, r, m):
 @pytest.mark.parametrize('r', r_list)
 @pytest.mark.parametrize('m', m_list)
 def test_sylv_schur_V_E(n, r, m):
-    np.random.seed(0)
 
     A, E = diff_conv_1d_fem(n, 1, 1)
     B = np.random.randn(n, m)
@@ -110,7 +108,6 @@ def test_sylv_schur_V_E(n, r, m):
 @pytest.mark.parametrize('r', r_list)
 @pytest.mark.parametrize('p', p_list)
 def test_sylv_schur_W(n, r, p):
-    np.random.seed(0)
 
     A = diff_conv_1d_fd(n, 1, 1)
     C = np.random.randn(p, n)
@@ -138,7 +135,6 @@ def test_sylv_schur_W(n, r, p):
 @pytest.mark.parametrize('r', r_list)
 @pytest.mark.parametrize('p', p_list)
 def test_sylv_schur_W_E(n, r, p):
-    np.random.seed(0)
 
     A, E = diff_conv_1d_fem(n, 1, 1)
     C = np.random.randn(p, n)

--- a/src/pymortests/algorithms/symplectic.py
+++ b/src/pymortests/algorithms/symplectic.py
@@ -5,7 +5,6 @@ from pymor.algorithms.symplectic import (psd_complex_svd, psd_cotengent_lift,
                                          psd_svd_like_decomp,
                                          symplectic_gram_schmidt)
 from pymor.operators.symplectic import CanonicalSymplecticFormOperator
-from pymor.tools.random import new_rng
 from pymor.vectorarrays.block import BlockVectorSpace
 from pymor.vectorarrays.numpy import NumpyVectorSpace
 
@@ -24,8 +23,7 @@ def test_symplecticity(key_method):
     half_space = NumpyVectorSpace(half_dim)
     phase_space = BlockVectorSpace([half_space] * 2)
     n_data = 100
-    with new_rng(42):
-        U = phase_space.random(n_data)
+    U = phase_space.random(n_data)
     modes = 10
     basis = METHODS_DICT[key_method](U, modes)
     tis_basis = basis.transposed_symplectic_inverse()
@@ -39,8 +37,7 @@ def test_orthonormality(key_orthosympl_method):
     half_space = NumpyVectorSpace(half_dim)
     phase_space = BlockVectorSpace([half_space] * 2)
     n_data = 100
-    with new_rng(42):
-        U = phase_space.random(n_data)
+    U = phase_space.random(n_data)
     modes = 10
     basis = METHODS_DICT[key_orthosympl_method](U, modes).to_array()
     assert np.allclose(basis.inner(basis), np.eye(modes))
@@ -56,15 +53,13 @@ def test_symplectic_gram_schmidt(test_orthonormality, reiterate):
     J = CanonicalSymplecticFormOperator(phase_space)
     half_red_dim = 10
 
-    with new_rng(42):
-        E = phase_space.random(half_red_dim)
+    E = phase_space.random(half_red_dim)
     if test_orthonormality:
         # special choice, such that result is orthosymplectic
         F = J.apply(E)
     else:
         # less structure in snapshots, no orthogonality
-        with new_rng(43):
-            F = phase_space.random(half_red_dim)
+        F = phase_space.random(half_red_dim)
 
     S, Lambda = symplectic_gram_schmidt(E, F, return_Lambda=True, reiterate=reiterate)
     tsi_S = S.transposed_symplectic_inverse()

--- a/src/pymortests/algorithms/to_matrix.py
+++ b/src/pymortests/algorithms/to_matrix.py
@@ -34,7 +34,6 @@ def assert_type_and_allclose(A, Aop, default_format):
 
 
 def test_to_matrix_NumpyMatrixOperator():
-    np.random.seed(0)
     A = np.random.randn(2, 2)
 
     Aop = NumpyMatrixOperator(A)
@@ -45,7 +44,6 @@ def test_to_matrix_NumpyMatrixOperator():
 
 
 def test_to_matrix_BlockOperator():
-    np.random.seed(0)
     A11 = np.random.randn(2, 2)
     A12 = np.random.randn(2, 3)
     A21 = np.random.randn(3, 2)
@@ -68,7 +66,6 @@ def test_to_matrix_BlockOperator():
 
 
 def test_to_matrix_BlockDiagonalOperator():
-    np.random.seed(0)
     A1 = np.random.randn(2, 2)
     A2 = np.random.randn(3, 3)
     B = np.block([[A1, np.zeros((2, 3))],
@@ -86,7 +83,6 @@ def test_to_matrix_BlockDiagonalOperator():
 
 
 def test_to_matrix_AdjointOperator():
-    np.random.seed(0)
     A = np.random.randn(2, 2)
     S = np.random.randn(2, 2)
     S = S.dot(S.T)
@@ -138,7 +134,6 @@ def test_to_matrix_ComponentProjectionOperator():
 
 
 def test_to_matrix_ConcatenationOperator():
-    np.random.seed(0)
     A = np.random.randn(2, 3)
     B = np.random.randn(3, 4)
     C = A.dot(B)
@@ -173,7 +168,6 @@ def test_to_matrix_IdentityOperator():
 
 
 def test_to_matrix_LincombOperator():
-    np.random.seed(0)
     A = np.random.randn(3, 3)
     B = np.random.randn(3, 2)
     a = np.random.randn()
@@ -202,7 +196,6 @@ def test_to_matrix_LincombOperator():
 
 
 def test_to_matrix_LowRankOperator():
-    np.random.seed(0)
     m = 6
     n = 5
     r = 2
@@ -220,7 +213,6 @@ def test_to_matrix_LowRankOperator():
 
 
 def test_to_matrix_LowRankUpdatedOperator():
-    np.random.seed(0)
     m = 6
     n = 5
     r = 2
@@ -238,7 +230,6 @@ def test_to_matrix_LowRankUpdatedOperator():
 
 
 def test_to_matrix_VectorArrayOperator():
-    np.random.seed(0)
     V = np.random.randn(10, 2)
 
     Vva = NumpyVectorSpace.make_array(V.T)
@@ -263,7 +254,6 @@ if config.HAVE_DUNEGDT:
     from pymor.bindings.dunegdt import DuneXTMatrixOperator
 
     def test_to_matrix_DuneXTMatrixOperator():
-        np.random.seed(0)
         A = np.random.randn(2, 2)
 
         pattern = SparsityPatternDefault(2)

--- a/src/pymortests/analyticalproblems/function.py
+++ b/src/pymortests/analyticalproblems/function.py
@@ -14,9 +14,9 @@ from pymortests.core.pickling import assert_picklable, assert_picklable_without_
 
 def test_evaluate(function):
     f = function
-    mus = mu_of_type(f.parameters, 4711)
+    mus = mu_of_type(f.parameters)
     for count in [0, 1, 5, (0, 1), (2, 2, 2)]:
-        arg = function_argument(f, count, 454)
+        arg = function_argument(f, count)
         result = f.evaluate(arg, next(mus))
         assert result.shape == arg.shape[:-1] + f.shape_range
 
@@ -59,8 +59,8 @@ def test_pickle_without_dumps_function(picklable_function):
 def test_pickle_by_evaluation(function):
     f = function
     f2 = loads(dumps(f))
-    mus = mu_of_type(f.parameters, 47)
-    for arg in function_argument(f, 10, 42):
+    mus = mu_of_type(f.parameters)
+    for arg in function_argument(f, 10):
         mu = next(mus)
         assert np.all(f.evaluate(arg, mu) == f2.evaluate(arg, mu))
 

--- a/src/pymortests/complex_values.py
+++ b/src/pymortests/complex_values.py
@@ -9,7 +9,6 @@ from pymor.vectorarrays.numpy import NumpyVectorSpace
 
 
 def test_complex():
-    np.random.seed(0)
     I = np.eye(5)
     A = np.random.randn(5, 5)
     B = np.random.randn(5, 5)

--- a/src/pymortests/demos.py
+++ b/src/pymortests/demos.py
@@ -230,10 +230,6 @@ def _test_demo(demo):
     except ImportError:
         pass
 
-    # reset default RandomState
-    import pymor.tools.random
-    pymor.tools.random.new_rng().install()
-
     result = None
     try:
         result = demo()

--- a/src/pymortests/fixtures/function.py
+++ b/src/pymortests/fixtures/function.py
@@ -65,8 +65,7 @@ def picklable_function(request):
     return request.param
 
 
-def function_argument(f, count, seed):
-    np.random.seed(seed)
+def function_argument(f, count):
     if isinstance(count, tuple):
         return np.random.random(count + (f.dim_domain,))
     else:

--- a/src/pymortests/fixtures/parameter.py
+++ b/src/pymortests/fixtures/parameter.py
@@ -7,8 +7,7 @@ import numpy as np
 from pymor.parameters.base import Mu
 
 
-def mu_of_type(parameters, seed):
-    np.random.seed(seed)
+def mu_of_type(parameters):
     while True:
         if parameters is None:
             yield None

--- a/src/pymortests/models/model.py
+++ b/src/pymortests/models/model.py
@@ -14,7 +14,6 @@ from pymor.core.pickle import dumps, loads
 from pymor.models.symplectic import QuadraticHamiltonianModel
 from pymor.operators.block import BlockDiagonalOperator
 from pymor.operators.constructions import IdentityOperator
-from pymor.tools.random import new_rng
 from pymor.vectorarrays.numpy import NumpyVectorSpace
 from pymortests.base import runmodule
 from pymortests.core.pickling import assert_picklable, assert_picklable_without_dumps_function
@@ -33,8 +32,7 @@ def test_pickle_by_solving(model):
     m2 = loads(dumps(m))
     m.disable_caching()
     m2.disable_caching()
-    with new_rng(234):
-        mus = m.parameters.space(1, 2).sample_randomly(3)
+    mus = m.parameters.space(1, 2).sample_randomly(3)
     for mu in mus:
         assert np.all(almost_equal(m.solve(mu), m2.solve(mu)))
 

--- a/src/pymortests/operators/block.py
+++ b/src/pymortests/operators/block.py
@@ -12,8 +12,6 @@ from pymor.vectorarrays.numpy import NumpyVectorSpace
 
 
 def test_apply():
-    np.random.seed(0)
-
     A11 = np.random.randn(2, 3)
     A12 = np.random.randn(2, 4)
     A21 = np.zeros((5, 3))
@@ -38,8 +36,6 @@ def test_apply():
 
 
 def test_apply_adjoint():
-    np.random.seed(0)
-
     A11 = np.random.randn(2, 3)
     A12 = np.random.randn(2, 4)
     A21 = np.zeros((5, 3))
@@ -64,7 +60,6 @@ def test_apply_adjoint():
 
 
 def test_block_diagonal():
-    np.random.seed(0)
     A = np.random.randn(2, 3)
     B = np.random.randn(4, 5)
     Aop = NumpyMatrixOperator(A)
@@ -75,8 +70,6 @@ def test_block_diagonal():
 
 
 def test_blk_diag_apply_inverse():
-    np.random.seed(0)
-
     A = np.random.randn(2, 2)
     B = np.random.randn(3, 3)
     C = spla.block_diag(A, B)
@@ -97,8 +90,6 @@ def test_blk_diag_apply_inverse():
 
 
 def test_blk_diag_apply_inverse_adjoint():
-    np.random.seed(0)
-
     A = np.random.randn(2, 2)
     B = np.random.randn(3, 3)
     C = spla.block_diag(A, B)

--- a/src/pymortests/operators/low_rank_op.py
+++ b/src/pymortests/operators/low_rank_op.py
@@ -8,20 +8,19 @@ import scipy.linalg as spla
 from pymor.algorithms.lincomb import assemble_lincomb
 from pymor.operators.constructions import LowRankOperator, LowRankUpdatedOperator
 from pymor.operators.numpy import NumpyMatrixOperator
-from pymor.tools.random import new_rng
+from pymor.tools.random import get_rng
 from pymor.vectorarrays.numpy import NumpyVectorSpace
 
 
-def construct_operators_and_vectorarrays(m, n, r, k, seed=0):
+def construct_operators_and_vectorarrays(m, n, r, k):
     space_m = NumpyVectorSpace(m)
     space_n = NumpyVectorSpace(n)
-    with new_rng(seed) as rng:
-        A = NumpyMatrixOperator(rng.normal(size=(m, n)))
-        L = space_m.random(r, distribution='normal')
-        C = rng.normal(size=(r, r))
-        R = space_n.random(r, distribution='normal')
-        U = space_n.random(k, distribution='normal')
-        V = space_m.random(k, distribution='normal')
+    A = NumpyMatrixOperator(get_rng().normal(size=(m, n)))
+    L = space_m.random(r, distribution='normal')
+    C = get_rng().normal(size=(r, r))
+    R = space_n.random(r, distribution='normal')
+    U = space_n.random(k, distribution='normal')
+    V = space_m.random(k, distribution='normal')
     return A, L, C, R, U, V
 
 
@@ -86,7 +85,7 @@ def test_low_rank_updated_apply_inverse_adjoint():
 def test_low_rank_assemble():
     r1, r2 = 2, 3
     _, L1, C1, R1, _, _ = construct_operators_and_vectorarrays(5, 5, r1, 0)
-    _, L2, C2, R2, _, _ = construct_operators_and_vectorarrays(5, 5, r2, 0, seed=1)
+    _, L2, C2, R2, _, _ = construct_operators_and_vectorarrays(5, 5, r2, 0)
 
     LR1 = LowRankOperator(L1, C1, R1)
     LR2 = LowRankOperator(L2, C2, R2)

--- a/src/pymortests/operators/operators.py
+++ b/src/pymortests/operators/operators.py
@@ -340,7 +340,6 @@ def test_restricted(operator_with_arrays):
     op, mu, U, _, = operator_with_arrays
     if op.range.dim == 0:
         return
-    np.random.seed(4711 + U.dim)
     for num in [0, 1, 3, 7]:
         dofs = np.random.randint(0, op.range.dim, num)
         try:
@@ -356,7 +355,6 @@ def test_restricted_jacobian(operator_with_arrays):
     op, mu, U, _, = operator_with_arrays
     if op.range.dim == 0:
         return
-    np.random.seed(4711 + U.dim)
     for num in [0, 1, 3, 7]:
         dofs = np.random.randint(0, op.range.dim, num)
         try:
@@ -427,18 +425,16 @@ def test_InverseAdjointOperator(operator_with_arrays):
 
 
 def test_vectorarray_op_apply_inverse():
-    np.random.seed(1234)
     O = np.random.random((5, 5))
     op = VectorArrayOperator(NumpyVectorSpace.make_array(O))
     V = op.range.random()
     U = op.apply_inverse(V)
     v = V.to_numpy()
     u = np.linalg.solve(O.T, v.ravel())
-    assert np.all(almost_equal(U, U.space.from_numpy(u)))
+    assert np.all(almost_equal(U, U.space.from_numpy(u), rtol=1e-10))
 
 
 def test_vectorarray_op_apply_inverse_lstsq():
-    np.random.seed(1234)
     O = np.random.random((3, 5))
     op = VectorArrayOperator(NumpyVectorSpace.make_array(O))
     V = op.range.random()
@@ -449,7 +445,6 @@ def test_vectorarray_op_apply_inverse_lstsq():
 
 
 def test_adjoint_vectorarray_op_apply_inverse_lstsq():
-    np.random.seed(1234)
     O = np.random.random((3, 5))
     op = VectorArrayOperator(NumpyVectorSpace.make_array(O), adjoint=True)
     V = op.range.random()

--- a/src/pymortests/strategies.py
+++ b/src/pymortests/strategies.py
@@ -242,7 +242,7 @@ def given_vector_arrays(which='all', count=1, dtype=None, length=None, compatibl
 
 
 # TODO match st_valid_inds results to this
-def valid_inds(v, length=None, random_module=None):
+def valid_inds(v, length=None):
     if length is None:
         yield []
         yield slice(None)
@@ -267,10 +267,6 @@ def valid_inds(v, length=None, random_module=None):
             yield ind
         if len(v) == length:
             yield slice(None)
-        # this avoids managing random state "against" hypothesis when this function is used in a
-        # strategy
-        if random_module is None:
-            np.random.seed(len(v) * length)
         yield list(np.random.randint(-len(v), len(v), size=length))
     else:
         if len(v) == 0:
@@ -301,7 +297,7 @@ def valid_indices(draw, array_strategy, length=None):
 
 
 # TODO match st_valid_inds_of_same_length results to this
-def valid_inds_of_same_length(v1, v2, random_module=None):
+def valid_inds_of_same_length(v1, v2):
     if len(v1) == len(v2):
         yield slice(None), slice(None)
         yield list(range(len(v1))), list(range(len(v1)))
@@ -317,10 +313,6 @@ def valid_inds_of_same_length(v1, v2, random_module=None):
         yield -len(v1), -len(v2)
         yield [0], 0
         yield (list(range(min(len(v1), len(v2))//2)),) * 2
-        # this avoids managing random state "against" hypothesis when this function is used in a
-        # strategy
-        if random_module is None:
-            np.random.seed(len(v1) * len(v2))
         for count in np.linspace(0, min(len(v1), len(v2)), 3).astype(int):
             yield (list(np.random.randint(-len(v1), len(v1), size=count)),
                    list(np.random.randint(-len(v2), len(v2), size=count)))
@@ -360,7 +352,7 @@ def st_scaling_value(draw, v1, v2=None):
 
 
 # TODO match st_valid_inds_of_different_length results to this
-def valid_inds_of_different_length(v1, v2, random_module):
+def valid_inds_of_different_length(v1, v2):
     # note this potentially yields no result at all for dual 0 length inputs
     if len(v1) != len(v2):
         yield slice(None), slice(None)
@@ -374,10 +366,6 @@ def valid_inds_of_different_length(v1, v2, random_module):
         if len(v2) > 1:
             yield 0, [0, 1]
             yield [0], [0, 1]
-        # this avoids managing random state "against" hypothesis when this function is used in a
-        # strategy
-        if random_module is None:
-            np.random.seed(len(v1) * len(v2))
         for count1 in np.linspace(0, len(v1), 3).astype(int):
             count2 = np.random.randint(0, len(v2))
             if count2 == count1:

--- a/src/pymortests/tools.py
+++ b/src/pymortests/tools.py
@@ -20,6 +20,7 @@ from pymor.tools.deprecated import Deprecated
 from pymor.tools.floatcmp import almost_less, float_cmp, float_cmp_all
 from pymor.tools.formatsrc import print_source
 from pymor.tools.io import safe_temporary_filename, change_to_directory
+from pymor.tools.random import get_rng
 from pymor.vectorarrays.numpy import NumpyVectorSpace
 from pymortests.base import runmodule
 from pymortests.fixtures.grid import hy_rect_or_tria_grid
@@ -43,6 +44,15 @@ def polynomials(max_order):
 
         integral = (1 / (n + 1))
         yield (n, f, deri, integral)
+
+
+def test_rng_state_deterministic_a():
+    get_rng().integers(0, 10**10)
+    assert True
+
+
+def test_rng_state_deterministic_b():
+    assert get_rng().integers(0, 10**10) == 7739560485
 
 
 def test_quadrature_polynomials():

--- a/src/pymortests/tools.py
+++ b/src/pymortests/tools.py
@@ -47,11 +47,19 @@ def polynomials(max_order):
 
 
 def test_rng_state_deterministic_a():
+    # Just draw some random number to modify the RNG state.
+    # If the RNG state isn't properly reset before each test
+    # function execution, `py.test -k deterministic tools.py`
+    # will fail in test_rng_state_deterministic_b
     get_rng().integers(0, 10**10)
-    assert True
 
 
 def test_rng_state_deterministic_b():
+    # Ensure that pyMOR's RNG is in its initial state when
+    # a new test function is executed.
+    # By fixing a number here, we ensure that we are also
+    # made aware of changes in the initial state or the RNG
+    # algorithm.
     assert get_rng().integers(0, 10**10) == 7739560485
 
 

--- a/src/pymortests/vectorarray.py
+++ b/src/pymortests/vectorarray.py
@@ -14,7 +14,6 @@ from pymor.core.config import config
 from pymor.vectorarrays.interface import VectorSpace
 from pymor.vectorarrays.numpy import NumpyVectorSpace
 from pymor.tools.floatcmp import float_cmp, bounded
-from pymor.tools.random import new_rng
 from pymortests.base import might_exceed_deadline
 from pymortests.core.pickling import assert_picklable_without_dumps_function
 import pymortests.strategies as pyst
@@ -165,10 +164,8 @@ def _test_random_uniform(vector_array, realizations, low, high):
         with pytest.raises(ValueError):
             vector_array.random(c, low=low, high=high)
         return
-    seed = 123
     try:
-        with new_rng(seed):
-            v = vector_array.random(c, low=low, high=high)
+        v = vector_array.random(c, low=low, high=high)
     except ValueError as e:
         if high <= low:
             return
@@ -184,9 +181,6 @@ def _test_random_uniform(vector_array, realizations, low, high):
         assert np.all(x >= low)
     except NotImplementedError:
         pass
-    with new_rng(seed):
-        vv = vector_array.random(c, distribution='uniform', low=low, high=high)
-    assert np.allclose((v - vv).sup_norm(), 0.)
 
 
 @pyst.given_vector_arrays(realizations=hyst.integers(min_value=0, max_value=30),
@@ -200,10 +194,8 @@ def test_random_normal(vector_array, realizations, loc, scale):
         with pytest.raises(ValueError):
             vector_array.random(c, 'normal', loc=loc, scale=scale)
         return
-    seed = 123
     try:
-        with new_rng(seed):
-            v = vector_array.random(c, 'normal', loc=loc, scale=scale)
+        v = vector_array.random(c, 'normal', loc=loc, scale=scale)
     except ValueError as e:
         if scale <= 0:
             return
@@ -226,13 +218,6 @@ def test_random_normal(vector_array, realizations, loc, scale):
         bounded(lower, upper, loc)
     except NotImplementedError:
         pass
-    with new_rng(seed):
-        vv = vector_array.random(c, 'normal', loc=loc, scale=scale)
-    data = vv.to_numpy()
-    # due to scaling data might actually now include nan or inf
-    assume(not np.isnan(data).any())
-    assume(not np.isinf(data).any())
-    assert np.allclose((v - vv).sup_norm(), 0.)
 
 
 @pyst.given_vector_arrays()
@@ -270,7 +255,7 @@ def test_getitem_repeated(vectors_and_indices):
     v_ind = v[ind]
     v_ind_copy = v_ind.copy()
     assert not v_ind_copy.is_view
-    for ind_ind in pyst.valid_inds(v_ind, random_module=False):
+    for ind_ind in pyst.valid_inds(v_ind):
         v_ind_ind = v_ind[ind_ind]
         assert np.all(almost_equal(v_ind_ind, v_ind_copy[ind_ind]))
 
@@ -493,7 +478,7 @@ def test_axpy(vectors_and_indices, scalar):
                           scalar=hyst.floats(min_value=1, max_value=pyst.MAX_VECTORARRAY_LENGTH))
 def test_axpy_one_x(vectors_and_indices, scalar):
     (v1, v2), (ind1, _) = vectors_and_indices
-    for ind2 in pyst.valid_inds(v2, 1, random_module=False):
+    for ind2 in pyst.valid_inds(v2, 1):
         assert v1.check_ind(ind1)
         assert v2.check_ind(ind2)
         if v1.len_ind(ind1) != v1.len_ind_unique(ind1):
@@ -961,7 +946,7 @@ def test_append_incompatible(vector_arrays):
 @pyst.given_vector_arrays(count=2, compatible=False)
 def test_axpy_incompatible(vector_arrays):
     v1, v2 = vector_arrays
-    for ind1, ind2 in pyst.valid_inds_of_same_length(v1, v2, random_module=False):
+    for ind1, ind2 in pyst.valid_inds_of_same_length(v1, v2):
         c1, c2 = v1.copy(), v2.copy()
         with pytest.raises(Exception):
             c1[ind1].axpy(0., c2[ind2])
@@ -979,7 +964,7 @@ def test_axpy_incompatible(vector_arrays):
 @pyst.given_vector_arrays(count=2, compatible=False)
 def test_inner_incompatible(vector_arrays):
     v1, v2 = vector_arrays
-    for ind1, ind2 in pyst.valid_inds_of_same_length(v1, v2, random_module=False):
+    for ind1, ind2 in pyst.valid_inds_of_same_length(v1, v2):
         c1, c2 = v1.copy(), v2.copy()
         with pytest.raises(Exception):
             c1[ind1].inner(c2[ind2])
@@ -988,7 +973,7 @@ def test_inner_incompatible(vector_arrays):
 @pyst.given_vector_arrays(count=2, compatible=False)
 def test_pairwise_inner_incompatible(vector_arrays):
     v1, v2 = vector_arrays
-    for ind1, ind2 in pyst.valid_inds_of_same_length(v1, v2, random_module=False):
+    for ind1, ind2 in pyst.valid_inds_of_same_length(v1, v2):
         c1, c2 = v1.copy(), v2.copy()
         with pytest.raises(Exception):
             c1[ind1].pairwise_inner(c2[ind2])


### PR DESCRIPTION
While we use the `derandomize=True` setting of hypothesis for all test runs except for the `ci_large` profile, no care is taken of pyMOR's or numpy's global random state. This PR introduces an autouse fixture which resets both random states before executing a new test function.

Further I did some cleanup and removed all manual seeding in the test functions/fixtures.

I hope this finally puts an end to suddenly appearing CI test failures when new test are added.