### PR TITLE
[discretizers.builtin] Eliminate zeros of sparse matrices

### DIFF
--- a/src/pymor/discretizers/builtin/cg.py
+++ b/src/pymor/discretizers/builtin/cg.py
@@ -332,6 +332,7 @@ class L2ProductP1(NumpyMatrixBasedOperator):
         self.logger.info('Assemble system matrix ...')
         A = coo_matrix((SF_INTS, (SF_I0, SF_I1)), shape=(g.size(g.dim), g.size(g.dim)))
         del SF_INTS, SF_I0, SF_I1
+        A.eliminate_zeros()
         A = csc_matrix(A).copy()  # See DiffusionOperatorP1 for why copy() is necessary
 
         return A
@@ -411,6 +412,7 @@ class L2ProductQ1(NumpyMatrixBasedOperator):
         self.logger.info('Assemble system matrix ...')
         A = coo_matrix((SF_INTS, (SF_I0, SF_I1)), shape=(g.size(g.dim), g.size(g.dim)))
         del SF_INTS, SF_I0, SF_I1
+        A.eliminate_zeros()
         A = csc_matrix(A).copy()  # See DiffusionOperatorP1 for why copy() is necessary
 
         return A
@@ -509,6 +511,7 @@ class DiffusionOperatorP1(NumpyMatrixBasedOperator):
         self.logger.info('Assemble system matrix ...')
         A = coo_matrix((SF_INTS, (SF_I0, SF_I1)), shape=(g.size(g.dim), g.size(g.dim)))
         del SF_INTS, SF_I0, SF_I1
+        A.eliminate_zeros()
         A = csc_matrix(A).copy()
 
         # The call to copy() is necessary to resize the data arrays of the sparse matrix:
@@ -616,6 +619,7 @@ class DiffusionOperatorQ1(NumpyMatrixBasedOperator):
         self.logger.info('Assemble system matrix ...')
         A = coo_matrix((SF_INTS, (SF_I0, SF_I1)), shape=(g.size(g.dim), g.size(g.dim)))
         del SF_INTS, SF_I0, SF_I1
+        A.eliminate_zeros()
         A = csc_matrix(A).copy()
 
         # The call to copy() is necessary to resize the data arrays of the sparse matrix:
@@ -716,6 +720,7 @@ class AdvectionOperatorP1(NumpyMatrixBasedOperator):
         self.logger.info('Assemble system matrix ...')
         A = coo_matrix((SF_INTS, (SF_I0, SF_I1)), shape=(g.size(g.dim), g.size(g.dim)))
         del SF_INTS, SF_I0, SF_I1
+        A.eliminate_zeros()
         A = csc_matrix(A).copy()
 
         # The call to copy() is necessary to resize the data arrays of the sparse matrix:
@@ -816,6 +821,7 @@ class AdvectionOperatorQ1(NumpyMatrixBasedOperator):
         self.logger.info('Assemble system matrix ...')
         A = coo_matrix((SF_INTS, (SF_I0, SF_I1)), shape=(g.size(g.dim), g.size(g.dim)))
         del SF_INTS, SF_I0, SF_I1
+        A.eliminate_zeros()
         A = csc_matrix(A).copy()
 
         # The call to copy() is necessary to resize the data arrays of the sparse matrix:
@@ -881,6 +887,7 @@ class RobinBoundaryOperator(NumpyMatrixBasedOperator):
         if g.dim == 1:
             robin_c = self.robin_data[0](g.centers(1)[RI], mu=mu)
             I = coo_matrix((robin_c, (RI, RI)), shape=(g.size(g.dim), g.size(g.dim)))
+            I.eliminate_zeros()
             return csc_matrix(I).copy()
         else:
             xref = g.centers(1)[RI]
@@ -903,6 +910,7 @@ class RobinBoundaryOperator(NumpyMatrixBasedOperator):
             SF_I0 = np.repeat(g.subentities(1, g.dim)[RI], 2).ravel()
             SF_I1 = np.tile(g.subentities(1, g.dim)[RI], [1, 2]).ravel()
             I = coo_matrix((SF_INTS, (SF_I0, SF_I1)), shape=(g.size(g.dim), g.size(g.dim)))
+            I.eliminate_zeros()
             return csc_matrix(I).copy()
 
 

--- a/src/pymor/discretizers/builtin/fv.py
+++ b/src/pymor/discretizers/builtin/fv.py
@@ -418,6 +418,7 @@ class NonlinearAdvectionOperator(Operator):
                        D_NUM_FLUX_0[BOUNDARIES]])
 
         A = coo_matrix((V, (I0, I1)), shape=(g.size(0), g.size(0)))
+        A.eliminate_zeros()
         A = csc_matrix(A).copy()   # See pymor.discretizers.builtin.cg.DiffusionOperatorP1 for why copy() is necessary
         A = dia_matrix(([1. / VOLS0], [0]), shape=(g.size(0),) * 2) * A
 
@@ -509,6 +510,7 @@ class LinearAdvectionLaxFriedrichsOperator(NumpyMatrixBasedOperator):
         V = np.hstack([V_inner, V_out, V_dir])
 
         A = coo_matrix((V, (I0, I1)), shape=(g.size(0), g.size(0)))
+        A.eliminate_zeros()
         A = csc_matrix(A).copy()   # See pymor.discretizers.builtin.cg.DiffusionOperatorP1 for why copy() is necessary
         A = dia_matrix(([1. / g.volumes(0)], [0]), shape=(g.size(0),) * 2) * A
 
@@ -846,6 +848,7 @@ class DiffusionOperator(NumpyMatrixBasedOperator):
             FLUXES_I1 = np.concatenate((FLUXES_I1, SE_I0_D))
 
         A = coo_matrix((FLUXES, (FLUXES_I0, FLUXES_I1)), shape=(self.source.dim, self.source.dim))
+        A.eliminate_zeros()
         A = (dia_matrix(([1. / grid.volumes(0)], [0]), shape=(grid.size(0),) * 2) * A).tocsc()
 
         return A


### PR DESCRIPTION
I just came across this tiny (but potentially very costly) detail in our discretizers: Let's assume that we have a parameter $\mu$ that only acts on a small local domain $\omega$. Then, for instance, the respective analytic function would be something like a characteristic function on it. In turn, the (globally defined) stiffness matrix $A_\mu$ has a lot of zero entries not just because of the natural sparsity pattern from the discretization, but also because the analytic function is zero almost everywhere.
Currently, our discretizers do not track this and still store all zeros in the matrix.

In this PR, I simply do another `eliminate_zeros` call on all these matrices, to use as less memory as possible. For large matrices this then will also affect the time that a matrix-vector multiplication requires.