### PR TITLE
Reduce `eigs` Tests

### DIFF
--- a/src/pymortests/algorithms/eigs.py
+++ b/src/pymortests/algorithms/eigs.py
@@ -11,18 +11,16 @@ from pymor.operators.numpy import NumpyMatrixOperator
 
 n_list = [100, 200]
 k_list = [1, 7]
-which_list = ['LM', 'LR', 'LI']
 sigma_list = [None, 0]
 
 
 @pytest.mark.parametrize('n', n_list)
 @pytest.mark.parametrize('k', k_list)
-@pytest.mark.parametrize('which', which_list)
 @pytest.mark.parametrize('sigma', sigma_list)
-def test_eigs(n, k, which, sigma):
+def test_eigs(n, k, sigma):
     np.random.seed(0)
     A = sps.random(n, n, density=0.1)
     Aop = NumpyMatrixOperator(A)
-    ew, ev = eigs(Aop, k=k, which=which, sigma=sigma)
+    ew, ev = eigs(Aop, k=k, sigma=sigma)
 
     assert np.sum((Aop.apply(ev) - ev * ew).norm()) < 1e-4


### PR DESCRIPTION
This PR reduces the tests for the `eigs` implementation to the case where the `which` attribute is `'LM'`. For random test matrices and other types of eigenvalue selections the Krylov-based methods can be a bit unreliable (even ARPACKs implementation). We could add more extensive tests for `eigs` in the future maybe by considering a "nicer" set of test matrices, but for now I would be for reducing the tests to the default `'LM'` case.