### PR TITLE
Refactorization of PHLTIModel to inherit from LTIModel and support Q matrix

### DIFF
--- a/src/pymor/algorithms/simplify.py
+++ b/src/pymor/algorithms/simplify.py
@@ -4,7 +4,7 @@
 
 from pymor.algorithms.rules import RuleTable, match_class
 from pymor.models.interface import Model
-from pymor.operators.constructions import ConcatenationOperator, LincombOperator, VectorArrayOperator
+from pymor.operators.constructions import LincombOperator, ConcatenationOperator, VectorArrayOperator, IdentityOperator
 from pymor.operators.interface import Operator, as_array_max_length
 from pymor.operators.numpy import NumpyMatrixOperator
 from pymor.parameters.functionals import ParameterFunctional
@@ -175,7 +175,9 @@ class ContractRules(RuleTable):
         ops_rev = list(op.operators[::-1])
         i = 0
         while i + 1 < len(ops_rev):
-            if (ops_rev[i+1].linear and not ops_rev[i+1].parametric):
+            if isinstance(ops_rev[i], IdentityOperator) and len(ops_rev) > 1:
+                del ops_rev[i]
+            elif (ops_rev[i+1].linear and not ops_rev[i+1].parametric):
                 if isinstance(ops_rev[i], NumpyMatrixOperator):
                     if not ops_rev[i].sparse:  # do not touch sparse matrices
                         U = ops_rev[i+1].source.from_numpy(ops_rev[i].matrix.T)

--- a/src/pymor/algorithms/simplify.py
+++ b/src/pymor/algorithms/simplify.py
@@ -170,6 +170,9 @@ class ContractRules(RuleTable):
 
     @match_class(ConcatenationOperator)
     def action_ConcatenationOperator(self, op):
+        source_id = op.source.id
+        range_id = op.range.id
+
         op = self.replace_children(op)
 
         ops_rev = list(op.operators[::-1])
@@ -177,11 +180,11 @@ class ContractRules(RuleTable):
         while i + 1 < len(ops_rev):
             if isinstance(ops_rev[i], IdentityOperator) and len(ops_rev) > 1:
                 del ops_rev[i]
-            elif (ops_rev[i+1].linear and not ops_rev[i+1].parametric):
+            elif (ops_rev[i + 1].linear and not ops_rev[i + 1].parametric):
                 if isinstance(ops_rev[i], NumpyMatrixOperator):
                     if not ops_rev[i].sparse:  # do not touch sparse matrices
-                        U = ops_rev[i+1].source.from_numpy(ops_rev[i].matrix.T)
-                        ops_rev[i+1] = VectorArrayOperator(ops_rev[i+1].apply(U), space_id=ops_rev[i].source_id)
+                        U = ops_rev[i + 1].source.from_numpy(ops_rev[i].matrix.T)
+                        ops_rev[i + 1] = VectorArrayOperator(ops_rev[i + 1].apply(U), space_id=ops_rev[i].source.id)
                         del ops_rev[i]
                     else:
                         i += 1
@@ -191,7 +194,7 @@ class ContractRules(RuleTable):
                     # the following might in fact convert small sparse matrices in external solvers
                     # to dense ...
                     U = ops_rev[i].as_range_array()
-                    ops_rev[i+1] = VectorArrayOperator(ops_rev[i+1].apply(U), space_id=ops_rev[i].source_id)
+                    ops_rev[i + 1] = VectorArrayOperator(ops_rev[i + 1].apply(U), space_id=ops_rev[i].source.id)
                     del ops_rev[i]
                 else:
                     i += 1
@@ -202,7 +205,7 @@ class ContractRules(RuleTable):
             op = ops_rev[0]
             if isinstance(op, VectorArrayOperator) and isinstance(op.array.space, NumpyVectorSpace):
                 array = op.array.to_numpy()
-                op = NumpyMatrixOperator(array if op.adjoint else array.T)
+                op = NumpyMatrixOperator(array if op.adjoint else array.T, source_id=source_id, range_id=range_id)
             return op
 
         op = op.with_(operators=ops_rev[::-1])

--- a/src/pymor/algorithms/simplify.py
+++ b/src/pymor/algorithms/simplify.py
@@ -181,7 +181,7 @@ class ContractRules(RuleTable):
                 if isinstance(ops_rev[i], NumpyMatrixOperator):
                     if not ops_rev[i].sparse:  # do not touch sparse matrices
                         U = ops_rev[i+1].source.from_numpy(ops_rev[i].matrix.T)
-                        ops_rev[i+1] = VectorArrayOperator(ops_rev[i+1].apply(U))
+                        ops_rev[i+1] = VectorArrayOperator(ops_rev[i+1].apply(U), space_id=ops_rev[i].source_id)
                         del ops_rev[i]
                     else:
                         i += 1
@@ -191,7 +191,7 @@ class ContractRules(RuleTable):
                     # the following might in fact convert small sparse matrices in external solvers
                     # to dense ...
                     U = ops_rev[i].as_range_array()
-                    ops_rev[i+1] = VectorArrayOperator(ops_rev[i+1].apply(U))
+                    ops_rev[i+1] = VectorArrayOperator(ops_rev[i+1].apply(U), space_id=ops_rev[i].source_id)
                     del ops_rev[i]
                 else:
                     i += 1

--- a/src/pymor/algorithms/simplify.py
+++ b/src/pymor/algorithms/simplify.py
@@ -4,7 +4,7 @@
 
 from pymor.algorithms.rules import RuleTable, match_class
 from pymor.models.interface import Model
-from pymor.operators.constructions import LincombOperator, ConcatenationOperator, VectorArrayOperator, IdentityOperator
+from pymor.operators.constructions import ConcatenationOperator, IdentityOperator, LincombOperator, VectorArrayOperator
 from pymor.operators.interface import Operator, as_array_max_length
 from pymor.operators.numpy import NumpyMatrixOperator
 from pymor.parameters.functionals import ParameterFunctional

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -1496,8 +1496,8 @@ class PHLTIModel(LTIModel):
     This class describes input-state-output systems given by
 
     .. math::
-        E(\mu) \dot{x}(t, \mu) & = (J(\mu) - R(\mu))Q(\mu)   x(t, \mu) + (G(\mu) - P(\mu)) u(t), \\
-                     y(t, \mu) & = (G(\mu) + P(\mu))^TQ(\mu) x(t, \mu) + (S(\mu) - N(\mu)) u(t),
+        E(\mu) \dot{x}(t, \mu) & = (J(\mu) - R(\mu)) Q(\mu)   x(t, \mu) + (G(\mu) - P(\mu)) u(t), \\
+                     y(t, \mu) & = (G(\mu) + P(\mu))^T Q(\mu) x(t, \mu) + (S(\mu) - N(\mu)) u(t),
 
     with :math:`H(\mu)=Q(\mu)^T E(\mu) \succ 0`,
 

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -1499,7 +1499,7 @@ class PHLTIModel(LTIModel):
         E(\mu) \dot{x}(t, \mu) & = (J(\mu) - R(\mu)) Q(\mu)   x(t, \mu) + (G(\mu) - P(\mu)) u(t), \\
                      y(t, \mu) & = (G(\mu) + P(\mu))^T Q(\mu) x(t, \mu) + (S(\mu) - N(\mu)) u(t),
 
-    with :math:`H(\mu)=Q(\mu)^T E(\mu) \succ 0`,
+    with :math:`H(\mu) = Q(\mu)^T E(\mu) \succ 0`,
 
     .. math::
         \Gamma(\mu) =

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -1499,7 +1499,7 @@ class PHLTIModel(LTIModel):
         E(\mu) \dot{x}(t, \mu) & = (J(\mu) - R(\mu))Q(\mu)   x(t, \mu) + (G(\mu) - P(\mu)) u(t), \\
                      y(t, \mu) & = (G(\mu) + P(\mu))^TQ(\mu) x(t, \mu) + (S(\mu) - N(\mu)) u(t),
 
-    with :math:`H(\mu)=E(\mu)Q(\mu)^T \succeq 0` and
+    with :math:`H(\mu)=Q(\mu)^T E(\mu) \succ 0`,
 
     .. math::
         \Gamma(\mu) =
@@ -1518,8 +1518,8 @@ class PHLTIModel(LTIModel):
         \succeq 0.
 
     A dynamical system of this form, together with a given quadratic (energy) function
-    :math:`\mathcal{H}=\tfrac{1}{2} x(t, \mu)^T H(\mu) x(t, \mu)`, called Hamiltonian
-    with :math:`H(\mu) \succeq 0`, is called port-Hamiltonian system.
+    :math:`\mathcal{H}=\tfrac{1}{2} x(t, \mu)^T H(\mu) x(t, \mu)`, typically called Hamiltonian,
+    is called port-Hamiltonian system.
 
     All methods related to the transfer function
     (e.g., frequency response calculation and Bode plots)

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -1751,15 +1751,15 @@ class PHLTIModel(LTIModel):
         G
             The |NumPy array| or |SciPy spmatrix| G.
         P
-            The |NumPy array| or |SciPy spmatrix| P.
+            The |NumPy array| or |SciPy spmatrix| P or `None` (if P is a `ZeroOperator`).
         S
-            The |NumPy array| or |SciPy spmatrix| S or `None` (if Cv is a `ZeroOperator`).
+            The |NumPy array| or |SciPy spmatrix| S or `None` (if S is a `ZeroOperator`).
         N
-            The |NumPy array| or |SciPy spmatrix| N or `None` (if Cv is a `ZeroOperator`).
+            The |NumPy array| or |SciPy spmatrix| N or `None` (if N is a `ZeroOperator`).
         E
-            The |NumPy array| or |SciPy spmatrix| E.
+            The |NumPy array| or |SciPy spmatrix| E or `None` (if E is an `IdentityOperator`).
         Q
-            The |NumPy array| or |SciPy spmatrix| Q.
+            The |NumPy array| or |SciPy spmatrix| Q  or `None` (if Q is an `IdentityOperator`).
         """
         J = to_matrix(self.J)
         R = to_matrix(self.R)

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -1785,7 +1785,7 @@ class PHLTIModel(LTIModel):
         G = BlockColumnOperator([self.G, other.G])
         P = BlockColumnOperator([self.P, other.P])
         S = self.S + other.S
-        N = self.S + other.S
+        N = self.N + other.N
         if isinstance(self.E, IdentityOperator) and isinstance(other.E, IdentityOperator):
             E = IdentityOperator(BlockVectorSpace([self.solution_space, other.solution_space]))
         else:

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -1777,10 +1777,6 @@ class PHLTIModel(LTIModel):
             return super().__add__(other)
 
         assert self.S.source == other.S.source
-        assert self.S.range == other.S.range
-
-        assert self.N.source == other.N.source
-        assert self.N.range == other.N.range
 
         J = BlockDiagonalOperator([self.J, other.J])
         R = BlockDiagonalOperator([self.R, other.R])

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -1504,27 +1504,29 @@ class PHLTIModel(LTIModel):
         E(\mu) \dot{x}(t, \mu) & = (J(\mu) - R(\mu)) Q(\mu)   x(t, \mu) + (G(\mu) - P(\mu)) u(t), \\
                      y(t, \mu) & = (G(\mu) + P(\mu))^T Q(\mu) x(t, \mu) + (S(\mu) - N(\mu)) u(t),
 
-    with :math:`H(\mu) = Q(\mu)^T E(\mu) \succ 0`,
+    where :math:`H(\mu) = Q(\mu)^T E(\mu)`,
 
     .. math::
         \Gamma(\mu) =
         \begin{bmatrix}
             J(\mu) & G(\mu) \\
             -G(\mu)^T & N(\mu)
-        \end{bmatrix}
-
-        \qquad \text{and} \qquad
-
+        \end{bmatrix},
+        \text{ and }
         W(\mu) =
         \begin{bmatrix}
             R(\mu) & P(\mu) \\
             P(\mu)^T & S(\mu)
         \end{bmatrix}
-        \succeq 0.
+
+    satisfy
+    :math:`H(\mu) = H(\mu)^T \succ 0`,
+    :math:`\Gamma(\mu)^T = -\Gamma(\mu)`, and
+    :math:`W(\mu) = W(\mu)^T \succcurlyeq 0`.
 
     A dynamical system of this form, together with a given quadratic (energy) function
-    :math:`\mathcal{H} = \tfrac{1}{2} x(t, \mu)^T H(\mu) x(t, \mu)`, typically called Hamiltonian,
-    is called port-Hamiltonian system.
+    :math:`\mathcal{H}(x, \mu) = \tfrac{1}{2} x^T H(\mu) x`, typically called Hamiltonian,
+    is called a port-Hamiltonian system.
 
     All methods related to the transfer function
     (e.g., frequency response calculation and Bode plots)

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -1518,7 +1518,7 @@ class PHLTIModel(LTIModel):
         \succeq 0.
 
     A dynamical system of this form, together with a given quadratic (energy) function
-    :math:`\mathcal{H}=\tfrac{1}{2} x(t, \mu)^T H(\mu) x(t, \mu)`, typically called Hamiltonian,
+    :math:`\mathcal{H} = \tfrac{1}{2} x(t, \mu)^T H(\mu) x(t, \mu)`, typically called Hamiltonian,
     is called port-Hamiltonian system.
 
     All methods related to the transfer function

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -9,11 +9,16 @@ import scipy.sparse as sps
 
 from pymor.algorithms.bernoulli import bernoulli_stabilize
 from pymor.algorithms.eigs import eigs
-from pymor.algorithms.lyapunov import (_chol, solve_cont_lyap_lrcf, solve_disc_lyap_lrcf, solve_cont_lyap_dense,
-                                       solve_disc_lyap_dense)
-from pymor.algorithms.riccati import solve_ricc_lrcf, solve_pos_ricc_lrcf
+from pymor.algorithms.lyapunov import (
+    _chol,
+    solve_cont_lyap_dense,
+    solve_cont_lyap_lrcf,
+    solve_disc_lyap_dense,
+    solve_disc_lyap_lrcf,
+)
+from pymor.algorithms.riccati import solve_pos_ricc_lrcf, solve_ricc_lrcf
 from pymor.algorithms.simplify import contract, expand
-from pymor.algorithms.timestepping import TimeStepper, DiscreteTimeStepper
+from pymor.algorithms.timestepping import DiscreteTimeStepper, TimeStepper
 from pymor.algorithms.to_matrix import to_matrix
 from pymor.analyticalproblems.functions import GenericFunction
 from pymor.core.cache import cached
@@ -1626,9 +1631,9 @@ class PHLTIModel(LTIModel):
         self.__auto_init(locals())
 
     def to_berlin_form(self):
-        """
-        Convert the |PHLTIModel| into its Berlin form, i.e. a |PHLTIModel| with :math:`Q=I`,
-        by left multiplication with :math:`Q^T`.
+        """Convert the |PHLTIModel| into its Berlin form.
+
+        Returns a |PHLTIModel| with :math:`Q=I`, by left multiplication with :math:`Q^T`.
 
         Returns
         -------

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -1625,15 +1625,15 @@ class PHLTIModel(LTIModel):
                          name=name)
         self.__auto_init(locals())
 
-    def to_generalized_model(self):
+    def to_berlin_form(self):
         """
-        Convert the |PHLTIModel| to a |PHLTIModel| with :math:`Q=I`,
+        Convert the |PHLTIModel| into its Berlin form, i.e. a |PHLTIModel| with :math:`Q=I`,
         by left multiplication with :math:`Q^T`.
 
         Returns
         -------
         model
-            Generalized |PHLTIModel|.
+            |PHLTIModel| with :math:`Q=I`.
 
         """
         if isinstance(self.Q, IdentityOperator):

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -1639,7 +1639,6 @@ class PHLTIModel(LTIModel):
         -------
         model
             |PHLTIModel| with :math:`Q=I`.
-
         """
         if isinstance(self.Q, IdentityOperator):
             return self

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -698,7 +698,7 @@ class LTIModel(Model):
 
     def __neg__(self):
         """Negate the |LTIModel|."""
-        return self.with_(C=-self.C, D=-self.D)
+        return self.with_(C=-self.C, D=-self.D, new_type=LTIModel)  # ensure that __neg__ works in subclasses
 
     def __mul__(self, other):
         """Postmultiply by an |LTIModel|."""
@@ -1494,7 +1494,7 @@ class LTIModel(Model):
         return self.moebius_substitution(d2c, sampling_time=0)
 
 
-class PHLTIModel(Model):
+class PHLTIModel(LTIModel):
     r"""Class for (continuous) port-Hamiltonian linear time-invariant systems.
 
     This class describes input-state-output systems given by
@@ -1600,36 +1600,10 @@ class PHLTIModel(Model):
 
         assert solver_options is None or solver_options.keys() <= {'lyap_lrcf', 'lyap_dense'}
 
-        super().__init__(dim_input=G.source.dim, error_estimator=error_estimator, visualizer=visualizer, name=name)
+        super().__init__(A=J - R, B=G - P, C=(G + P).H, D=S - N, E=E,
+                         solver_options=solver_options, error_estimator=error_estimator, visualizer=visualizer,
+                         name=name)
         self.__auto_init(locals())
-        self.solution_space = J.source
-        self.dim_output = G.source.dim
-        self.sampling_time = 0
-
-        K = lambda s: s * self.E - (self.J - self.R)
-        B = lambda s: self.G - self.P
-        C = lambda s: (self.G + self.P).H
-        D = lambda s: self.S - self.N
-        dK = lambda s: self.E
-        dB = lambda s: ZeroOperator(self.G.range, self.G.source)
-        dC = lambda s: ZeroOperator(self.G.source, self.G.range)
-        dD = lambda s: ZeroOperator(self.S.range, self.S.source)
-        parameters = Parameters.of(self.J, self.R, self.G, self.P, self.S, self.N, self.E)
-
-        self.transfer_function = FactorizedTransferFunction(
-            self.dim_input, self.dim_output,
-            K, B, C, D, dK, dB, dC, dD,
-            parameters=parameters, name=self.name + '_transfer_function')
-
-        self._lti_model = LTIModel(A=self.J - self.R,
-                                   B=self.G - self.P,
-                                   C=(self.G + self.P).H,
-                                   D=self.S - self.N,
-                                   E=self.E,
-                                   solver_options=self.solver_options,
-                                   error_estimator=self.error_estimator,
-                                   visualizer=self.visualizer,
-                                   name=self.name + '_as_lti')
 
     def __str__(self):
         string = (
@@ -1744,190 +1718,9 @@ class PHLTIModel(Model):
 
         return J, R, G, P, S, N, E
 
-    def to_lti(self):
-        r"""Return a standard linear time-invariant system representation.
-
-        The representation
-
-        .. math::
-            A = J - R,\qquad B = G - P,\qquad C = (G + P)^T,\qquad D = S - N,\qquad E = E
-
-        is returned.
-
-        Returns
-        -------
-        lti
-            |LTIModel| equivalent to the port-Hamiltonian model.
-        """
-        return self._lti_model
-
-    def poles(self, mu=None):
-        """Compute system poles.
-
-        .. note::
-            Assumes the systems is small enough to use a dense eigenvalue solver.
-
-        Parameters
-        ----------
-        mu
-            |Parameter values|.
-
-        Returns
-        -------
-        One-dimensional |NumPy array| of system poles.
-        """
-        return self.to_lti().poles(mu=mu)
-
-    def gramian(self, typ, mu=None):
-        """Compute a Gramian.
-
-        Parameters
-        ----------
-        typ
-            The type of the Gramian:
-
-            - `'c_lrcf'`: low-rank Cholesky factor of the controllability Gramian,
-            - `'o_lrcf'`: low-rank Cholesky factor of the observability Gramian,
-            - `'c_dense'`: dense controllability Gramian,
-            - `'o_dense'`: dense observability Gramian.
-
-            .. note::
-                For `'*_lrcf'` types, the method assumes the system is asymptotically stable.
-                For `'*_dense'` types, the method assumes that the underlying Lyapunov equation
-                has a unique solution, i.e. no pair of system poles adds to zero in the
-                continuous-time case and no pair of system poles multiplies to one in the
-                discrete-time case.
-        mu
-            |Parameter values|.
-
-        Returns
-        -------
-        If typ is `'c_lrcf'` or `'o_lrcf'`, then the Gramian factor as a |VectorArray| from
-        `self.A.source`.
-        If typ is `'c_dense'` or `'o_dense'`, then the Gramian as a |NumPy array|.
-        """
-        assert typ in ('c_lrcf', 'o_lrcf', 'c_dense', 'o_dense')
-
-        return self.to_lti().gramian(typ, mu=mu)
-
-    def _sv_U_V(self, typ='lyap', mu=None):
-        """Compute (Hankel) singular values and vectors.
-
-        .. note::
-            Assumes the system is asymptotically stable.
-
-        Parameters
-        ----------
-        typ
-            The type of the Gramians used (see :meth:`LTIModel._sv_U_V`).
-        mu
-            |Parameter values|.
-
-        Returns
-        -------
-        sv
-            One-dimensional |NumPy array| of singular values.
-        Uh
-            |NumPy array| of left singular vectors as rows.
-        Vh
-            |NumPy array| of right singular vectors as rows.
-        """
-        return self.to_lti()._sv_U_V(typ=typ, mu=mu)
-
-    def hsv(self, mu=None):
-        """Hankel singular values.
-
-        .. note::
-            Assumes the system is asymptotically stable.
-
-        Parameters
-        ----------
-        mu
-            |Parameter values|.
-
-        Returns
-        -------
-        sv
-            One-dimensional |NumPy array| of singular values.
-        """
-        return self._sv_U_V(mu=mu)[0]
-
-    def h2_norm(self, mu=None):
-        """Compute the H2-norm.
-
-        .. note::
-            Assumes the system is asymptotically stable.
-
-        Parameters
-        ----------
-        mu
-            |Parameter values|.
-
-        Returns
-        -------
-        norm
-            H_2-norm.
-        """
-        return self.to_lti().h2_norm(mu=mu)
-
-    @defaults('tol')
-    def hinf_norm(self, mu=None, return_fpeak=False, ab13dd_equilibrate=False, tol=1e-10):
-        """Compute the H_infinity-norm.
-
-        .. note::
-            Assumes the system is asymptotically stable.
-
-        Parameters
-        ----------
-        mu
-            |Parameter values|.
-        return_fpeak
-            Should the frequency at which the maximum is achieved should be returned.
-        ab13dd_equilibrate
-            Should `slycot.ab13dd` use equilibration.
-        tol
-            Tolerance in norm computation.
-
-        Returns
-        -------
-        norm
-            H_infinity-norm.
-        fpeak
-            Frequency at which the maximum is achieved (if `return_fpeak` is `True`).
-        """
-        return self.to_lti().hinf_norm(mu=mu,
-                                       return_fpeak=return_fpeak,
-                                       ab13dd_equilibrate=ab13dd_equilibrate,
-                                       tol=tol)
-
-    def hankel_norm(self, mu=None):
-        """Compute the Hankel-norm.
-
-        .. note::
-            Assumes the system is asymptotically stable.
-
-        Parameters
-        ----------
-        mu
-            |Parameter values|.
-
-        Returns
-        -------
-        norm
-            Hankel-norm.
-        """
-        return self.hsv(mu=mu)[0]
-
     def __add__(self, other):
-        """Add a |PHLTIModel|, an |LTIModel|, or a |SecondOrderModel|."""
-        if isinstance(other, LTIModel):
-            return self.to_lti() + other
-
-        if isinstance(other, SecondOrderModel):
-            return self.to_lti() + other.to_lti()
-
         if not isinstance(other, PHLTIModel):
-            return NotImplemented
+            return super().__add__(other)
 
         assert self.S.source == other.S.source
         assert self.S.range == other.S.range
@@ -1947,38 +1740,6 @@ class PHLTIModel(Model):
             E = BlockDiagonalOperator([self.E, other.E])
 
         return self.with_(J=J, R=R, G=G, P=P, S=S, N=N, E=E)
-
-    def __radd__(self, other):
-        """Add to an |LTIModel| or |SecondOrderModel|."""
-        if isinstance(other, LTIModel):
-            return other + self.to_lti()
-        elif isinstance(other, SecondOrderModel):
-            return other.to_lti() + self.to_lti()
-        else:
-            return NotImplemented
-
-    def __sub__(self, other):
-        """Subtract a |PHLTIModel| or an |LTIModel|."""
-        return self + (-other)
-
-    def __rsub__(self, other):
-        """Subtract from an |LTIModel|."""
-        if isinstance(other, LTIModel):
-            return other - self.to_lti()
-        else:
-            return NotImplemented
-
-    def __neg__(self):
-        """Negate the |PHLTIModel|."""
-        return -self.to_lti()
-
-    def __mul__(self, other):
-        """Postmultiply by an |LTIModel|."""
-        return self.to_lti() * other
-
-    def __rmul__(self, other):
-        """Premultiply by an |LTIModel|."""
-        return other * self.to_lti()
 
 
 class SecondOrderModel(Model):
@@ -2837,7 +2598,7 @@ class LinearDelayModel(Model):
 
     def __add__(self, other):
         """Add an |LTIModel|, |SecondOrderModel|, |PHLTIModel|, or |LinearDelayModel|."""
-        if isinstance(other, (SecondOrderModel, PHLTIModel)):
+        if isinstance(other, SecondOrderModel):
             other = other.to_lti()
 
         if isinstance(other, LTIModel):

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -1622,7 +1622,7 @@ class PHLTIModel(LTIModel):
 
         assert solver_options is None or solver_options.keys() <= {'lyap_lrcf', 'lyap_dense'}
 
-        super().__init__(A=(J - R) if isinstance(Q, IdentityOperator) else (J - R) @ Q,
+        super().__init__(A=J - R if isinstance(Q, IdentityOperator) else contract((J - R) @ Q),
                          B=G - P,
                          C=(G + P).H if isinstance(Q, IdentityOperator) else (G + P).H @ Q,
                          D=S - N, E=E,

--- a/src/pymor/reductors/ph/basic.py
+++ b/src/pymor/reductors/ph/basic.py
@@ -5,6 +5,7 @@ import numpy as np
 
 from pymor.algorithms.projection import project, project_to_subbasis
 from pymor.models.iosys import PHLTIModel
+from pymor.operators.constructions import IdentityOperator
 from pymor.reductors.basic import ProjectionBasedReductor
 
 
@@ -17,28 +18,28 @@ class PHLTIPGReductor(ProjectionBasedReductor):
         The full order |PHLTIModel| to reduce.
     V
         The basis of the trail space.
-    E_biorthonormal
+    QTE_orthonormal
         If `True`, no `E` matrix will be assembled for the reduced |Model|.
-        Set to `True` if `W` and `V` are biorthonormal w.r.t. `fom.E`.
+        Set to `True` if `V` is orthonormal w.r.t. `fom.Q.apply_adjoint(fom.E)`.
     """
 
-    def __init__(self, fom, V, E_biorthonormal=False):
+    def __init__(self, fom, V, QTE_orthonormal=False):
         assert isinstance(fom, PHLTIModel)
 
         W = fom.Q.apply(V)
-        # .lincomb(np.linalg.inv(fom.Q.apply2(V, V)))
 
         super().__init__(fom, {'W': W, 'V': V})
-        self.E_biorthonormal = E_biorthonormal
+        self.QTE_orthonormal = QTE_orthonormal
 
     def project_operators(self):
         fom = self.fom
         W = self.bases['W']
         V = self.bases['V']
-        projected_operators = {'E': None if self.E_biorthonormal else project(fom.E, W, V),
-                               'J': project(fom.J, W, W),
+        J = project(fom.J, W, W)
+        projected_operators = {'E': None if self.QTE_orthonormal else project(fom.E, W, V),
+                               'J': J,
                                'R': project(fom.R, W, W),
-                               # 'Q': project(fom.Q, V, V),
+                               'Q': IdentityOperator(J.source),
                                'G': project(fom.G, W, None),
                                'P': project(fom.P, W, None),
                                'S': fom.S,
@@ -50,10 +51,11 @@ class PHLTIPGReductor(ProjectionBasedReductor):
             raise ValueError
         rom = self._last_rom
         dim = dims['V']
-        projected_operators = {'E': None if self.E_biorthonormal else project_to_subbasis(rom.E, dim, dim),
-                               'J': project_to_subbasis(rom.J, dim, dim),
+        J = project_to_subbasis(rom.J, dim, dim)
+        projected_operators = {'E': None if self.QTE_orthonormal else project_to_subbasis(rom.E, dim, dim),
+                               'J': J,
                                'R': project_to_subbasis(rom.R, dim, dim),
-                               'Q': project_to_subbasis(rom.Q, dim, dim),
+                               'Q': IdentityOperator(J.source),
                                'G': project_to_subbasis(rom.B, dim, None),
                                'P': project_to_subbasis(rom.P, dim, None),
                                'S': rom.S,

--- a/src/pymor/reductors/ph/basic.py
+++ b/src/pymor/reductors/ph/basic.py
@@ -1,6 +1,7 @@
 # This file is part of the pyMOR project (https://www.pymor.org).
 # Copyright pyMOR developers and contributors. All rights reserved.
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
+import numpy as np
 
 from pymor.algorithms.projection import project, project_to_subbasis
 from pymor.models.iosys import PHLTIModel
@@ -25,6 +26,7 @@ class PHLTIPGReductor(ProjectionBasedReductor):
         assert isinstance(fom, PHLTIModel)
 
         W = fom.Q.apply(V)
+        # .lincomb(np.linalg.inv(fom.Q.apply2(V, V)))
 
         super().__init__(fom, {'W': W, 'V': V})
         self.E_biorthonormal = E_biorthonormal
@@ -34,8 +36,9 @@ class PHLTIPGReductor(ProjectionBasedReductor):
         W = self.bases['W']
         V = self.bases['V']
         projected_operators = {'E': None if self.E_biorthonormal else project(fom.E, W, V),
-                               'J': project(fom.J, W, V),
-                               'R': project(fom.R, W, V),
+                               'J': project(fom.J, W, W),
+                               'R': project(fom.R, W, W),
+                               # 'Q': project(fom.Q, V, V),
                                'G': project(fom.G, W, None),
                                'P': project(fom.P, W, None),
                                'S': fom.S,
@@ -50,6 +53,7 @@ class PHLTIPGReductor(ProjectionBasedReductor):
         projected_operators = {'E': None if self.E_biorthonormal else project_to_subbasis(rom.E, dim, dim),
                                'J': project_to_subbasis(rom.J, dim, dim),
                                'R': project_to_subbasis(rom.R, dim, dim),
+                               'Q': project_to_subbasis(rom.Q, dim, dim),
                                'G': project_to_subbasis(rom.B, dim, None),
                                'P': project_to_subbasis(rom.P, dim, None),
                                'S': rom.S,

--- a/src/pymor/reductors/ph/basic.py
+++ b/src/pymor/reductors/ph/basic.py
@@ -20,7 +20,7 @@ class PHLTIPGReductor(ProjectionBasedReductor):
         The basis of the trail space.
     QTE_orthonormal
         If `True`, no `E` matrix will be assembled for the reduced |Model|.
-        Set to `True` if `V` is orthonormal w.r.t. `fom.Q.apply_adjoint(fom.E)`.
+        Set to `True` if `V` is orthonormal w.r.t. `fom.Q.H @ fom.E`.
     """
 
     def __init__(self, fom, V, QTE_orthonormal=False):

--- a/src/pymor/reductors/ph/basic.py
+++ b/src/pymor/reductors/ph/basic.py
@@ -23,7 +23,10 @@ class PHLTIPGReductor(ProjectionBasedReductor):
 
     def __init__(self, fom, V, E_biorthonormal=False):
         assert isinstance(fom, PHLTIModel)
-        super().__init__(fom, {'W': V, 'V': V})
+       
+        W = fom.Q.apply(V)
+
+        super().__init__(fom, {'W': W, 'V': V})
         self.E_biorthonormal = E_biorthonormal
 
     def project_operators(self):

--- a/src/pymor/reductors/ph/basic.py
+++ b/src/pymor/reductors/ph/basic.py
@@ -23,7 +23,7 @@ class PHLTIPGReductor(ProjectionBasedReductor):
 
     def __init__(self, fom, V, E_biorthonormal=False):
         assert isinstance(fom, PHLTIModel)
-       
+
         W = fom.Q.apply(V)
 
         super().__init__(fom, {'W': W, 'V': V})

--- a/src/pymor/reductors/ph/basic.py
+++ b/src/pymor/reductors/ph/basic.py
@@ -1,7 +1,6 @@
 # This file is part of the pyMOR project (https://www.pymor.org).
 # Copyright pyMOR developers and contributors. All rights reserved.
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
-import numpy as np
 
 from pymor.algorithms.projection import project, project_to_subbasis
 from pymor.models.iosys import PHLTIModel

--- a/src/pymor/reductors/ph/basic.py
+++ b/src/pymor/reductors/ph/basic.py
@@ -56,7 +56,7 @@ class PHLTIPGReductor(ProjectionBasedReductor):
                                'J': J,
                                'R': project_to_subbasis(rom.R, dim, dim),
                                'Q': IdentityOperator(J.source),
-                               'G': project_to_subbasis(rom.B, dim, None),
+                               'G': project_to_subbasis(rom.G, dim, None),
                                'P': project_to_subbasis(rom.P, dim, None),
                                'S': rom.S,
                                'N': rom.N}

--- a/src/pymor/reductors/ph/ph_irka.py
+++ b/src/pymor/reductors/ph/ph_irka.py
@@ -121,6 +121,6 @@ class PHIRKAReductor(GenericIRKAReductor):
                                             sigma, orth=False)
         product = None if projection == 'orth' else fom.Q.H @ fom.E
         gram_schmidt(self.V, atol=0, rtol=0, product=product, copy=False)
-        
+
         self._pg_reductor = PHLTIPGReductor(fom, self.V, projection == 'QTEorth')
         self.W = self._pg_reductor.bases['W']

--- a/src/pymor/reductors/ph/ph_irka.py
+++ b/src/pymor/reductors/ph/ph_irka.py
@@ -80,11 +80,11 @@ class PHIRKAReductor(GenericIRKAReductor):
         rom
             Reduced-order |PHLTIModel|.
         """
-        one_sided_irka_reductor = OneSidedIRKAReductor(self.fom, 'V')
+        one_sided_irka_reductor = OneSidedIRKAReductor(self.fom.to_qless_model(), 'V')
         _ = one_sided_irka_reductor.reduce(rom0_params, tol=tol, maxit=maxit, num_prev=num_prev,
                                            projection=projection, conv_crit=conv_crit, compute_errors=compute_errors)
-
-        self._pg_reductor = PHLTIPGReductor(self.fom, one_sided_irka_reductor.V)
+        
+        self._pg_reductor = PHLTIPGReductor(self.fom.to_generalized_model(), one_sided_irka_reductor.V)
         rom = self._pg_reductor.reduce()
 
         return rom

--- a/src/pymor/reductors/ph/ph_irka.py
+++ b/src/pymor/reductors/ph/ph_irka.py
@@ -61,7 +61,7 @@ class PHIRKAReductor(GenericIRKAReductor):
             - `'orth'`: projection matrix `V` is orthogonalized with
               respect to the Euclidean inner product.
             - `'QTEorth'`: projection matrix `V` is orthogonalized with
-              respect to the `fom.Q.apply_adjoint(fom.E)` product.
+              respect to the `fom.Q.H @ fom.E` product.
         conv_crit
             Convergence criterion:
 
@@ -119,9 +119,8 @@ class PHIRKAReductor(GenericIRKAReductor):
 
         self.V = tangential_rational_krylov(fom.A, fom.E, fom.B, fom.B.source.from_numpy(b),
                                             sigma, orth=False)
-        gram_schmidt(self.V, atol=0, rtol=0,
-                     product=None if projection == 'orth' else fom.Q.apply_adjoint(fom.E),
-                     copy=False)
+        product = None if projection == 'orth' else fom.Q.H @ fom.E
+        gram_schmidt(self.V, atol=0, rtol=0, product=product, copy=False)
         
         self._pg_reductor = PHLTIPGReductor(fom, self.V, projection == 'QTEorth')
         self.W = self._pg_reductor.bases['W']

--- a/src/pymor/reductors/ph/ph_irka.py
+++ b/src/pymor/reductors/ph/ph_irka.py
@@ -123,3 +123,4 @@ class PHIRKAReductor(GenericIRKAReductor):
         product = None if projection == 'orth' else fom.Q.H @ fom.E
         gram_schmidt(self.V, atol=0, rtol=0, product=product, copy=False)
         self._pg_reductor = PHLTIPGReductor(fom, self.V, projection == 'QTEorth')
+        self.W = self._pg_reductor.bases['W']

--- a/src/pymor/reductors/ph/ph_irka.py
+++ b/src/pymor/reductors/ph/ph_irka.py
@@ -80,7 +80,7 @@ class PHIRKAReductor(GenericIRKAReductor):
         rom
             Reduced-order |PHLTIModel|.
         """
-        one_sided_irka_reductor = OneSidedIRKAReductor(self.fom.to_qless_model(), 'V')
+        one_sided_irka_reductor = OneSidedIRKAReductor(self.fom, 'V')
         _ = one_sided_irka_reductor.reduce(rom0_params, tol=tol, maxit=maxit, num_prev=num_prev,
                                            projection=projection, conv_crit=conv_crit, compute_errors=compute_errors)
         

--- a/src/pymor/reductors/ph/ph_irka.py
+++ b/src/pymor/reductors/ph/ph_irka.py
@@ -2,8 +2,10 @@
 # Copyright pyMOR developers and contributors. All rights reserved.
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
+from pymor.algorithms.gram_schmidt import gram_schmidt
+from pymor.algorithms.krylov import tangential_rational_krylov
 from pymor.models.iosys import PHLTIModel
-from pymor.reductors.h2 import GenericIRKAReductor, OneSidedIRKAReductor
+from pymor.reductors.h2 import GenericIRKAReductor
 from pymor.reductors.ph.basic import PHLTIPGReductor
 
 
@@ -22,11 +24,10 @@ class PHIRKAReductor(GenericIRKAReductor):
         assert isinstance(fom, PHLTIModel)
         super().__init__(fom, mu=mu)
 
-    def reduce(self, rom0_params, tol=1e-4, maxit=100, num_prev=1, projection='orth', conv_crit='sigma',
+    def reduce(self, rom0_params, tol=1e-4, maxit=100, num_prev=1,
+               force_sigma_in_rhp=False, projection='orth', conv_crit='sigma',
                compute_errors=False):
         r"""Reduce using pH-IRKA.
-
-        It uses IRKA as the intermediate reductor.
 
         See :cite:`GPBV12`.
 
@@ -57,10 +58,10 @@ class PHIRKAReductor(GenericIRKAReductor):
         projection
             Projection method:
 
-            - `'orth'`: projection matrices are orthogonalized with
+            - `'orth'`: projection matrix `V` is orthogonalized with
               respect to the Euclidean inner product.
-            - `'Eorth'`: projection matrix is orthogonalized with
-              respect to the E product.
+            - `'QTEorth'`: projection matrix `V` is orthogonalized with
+              respect to the `fom.Q.apply_adjoint(fom.E)` product.
         conv_crit
             Convergence criterion:
 
@@ -80,11 +81,47 @@ class PHIRKAReductor(GenericIRKAReductor):
         rom
             Reduced-order |PHLTIModel|.
         """
-        one_sided_irka_reductor = OneSidedIRKAReductor(self.fom, 'V')
-        _ = one_sided_irka_reductor.reduce(rom0_params, tol=tol, maxit=maxit, num_prev=num_prev,
-                                           projection=projection, conv_crit=conv_crit, compute_errors=compute_errors)
+        if self.fom.sampling_time > 0:
+            raise NotImplementedError
 
-        self._pg_reductor = PHLTIPGReductor(self.fom, one_sided_irka_reductor.V)
-        rom = self._pg_reductor.reduce()
+        self._clear_lists()
+        sigma, b, c = self._rom0_params_to_sigma_b_c(rom0_params, force_sigma_in_rhp)
+        self._store_sigma_b_c(sigma, b, c)
+        self._check_common_args(tol, maxit, num_prev, conv_crit)
+        assert projection in ('orth', 'QTEorth')
+
+        self.logger.info('Starting pH-IRKA')
+        self._conv_data = (num_prev + 1) * [None]
+        if conv_crit == 'sigma':
+            self._conv_data[0] = sigma
+        for it in range(maxit):
+            self._set_V_reductor(sigma, b, projection)
+            rom = self._pg_reductor.reduce()
+            sigma, b, c = self._rom_to_sigma_b_c(rom, force_sigma_in_rhp)
+            self._store_sigma_b_c(sigma, b, c)
+            self._update_conv_data(sigma, rom, conv_crit)
+            self._compute_conv_crit(rom, conv_crit, it)
+            self._compute_error(rom, it, compute_errors)
+            if self.conv_crit[-1] < tol:
+                break
 
         return rom
+
+    def _set_V_reductor(self, sigma, b, projection):
+        fom = (
+            self.fom.with_(
+                **{op: getattr(self.fom, op).assemble(mu=self.mu)
+                   for op in ['A', 'B', 'C', 'D', 'E']}
+            )
+            if self.fom.parametric
+            else self.fom
+        )
+
+        self.V = tangential_rational_krylov(fom.A, fom.E, fom.B, fom.B.source.from_numpy(b),
+                                            sigma, orth=False)
+        gram_schmidt(self.V, atol=0, rtol=0,
+                     product=None if projection == 'orth' else fom.Q.apply_adjoint(fom.E),
+                     copy=False)
+        
+        self._pg_reductor = PHLTIPGReductor(fom, self.V, projection == 'QTEorth')
+        self.W = self._pg_reductor.bases['W']

--- a/src/pymor/reductors/ph/ph_irka.py
+++ b/src/pymor/reductors/ph/ph_irka.py
@@ -84,7 +84,7 @@ class PHIRKAReductor(GenericIRKAReductor):
         _ = one_sided_irka_reductor.reduce(rom0_params, tol=tol, maxit=maxit, num_prev=num_prev,
                                            projection=projection, conv_crit=conv_crit, compute_errors=compute_errors)
         
-        self._pg_reductor = PHLTIPGReductor(self.fom.to_generalized_model(), one_sided_irka_reductor.V)
+        self._pg_reductor = PHLTIPGReductor(self.fom, one_sided_irka_reductor.V)
         rom = self._pg_reductor.reduce()
 
         return rom

--- a/src/pymor/reductors/ph/ph_irka.py
+++ b/src/pymor/reductors/ph/ph_irka.py
@@ -80,7 +80,7 @@ class PHIRKAReductor(GenericIRKAReductor):
         rom
             Reduced-order |PHLTIModel|.
         """
-        one_sided_irka_reductor = OneSidedIRKAReductor(self.fom.to_lti(), 'V')
+        one_sided_irka_reductor = OneSidedIRKAReductor(self.fom, 'V')
         _ = one_sided_irka_reductor.reduce(rom0_params, tol=tol, maxit=maxit, num_prev=num_prev,
                                            projection=projection, conv_crit=conv_crit, compute_errors=compute_errors)
 

--- a/src/pymor/reductors/ph/ph_irka.py
+++ b/src/pymor/reductors/ph/ph_irka.py
@@ -5,8 +5,8 @@
 from pymor.algorithms.gram_schmidt import gram_schmidt
 from pymor.algorithms.krylov import tangential_rational_krylov
 from pymor.models.iosys import PHLTIModel
-from pymor.reductors.h2 import GenericIRKAReductor
 from pymor.reductors.basic import LTIPGReductor
+from pymor.reductors.h2 import GenericIRKAReductor
 from pymor.reductors.ph.basic import PHLTIPGReductor
 
 
@@ -129,7 +129,7 @@ class PHIRKAReductor(GenericIRKAReductor):
                                             sigma, orth=False)
         product = None if projection == 'orth' else fom.Q.H @ fom.E
         gram_schmidt(self.V, atol=0, rtol=0, product=product, copy=False)
-        
+
         self.W = self.fom.Q.apply(self.V)
         self._pg_reductor = LTIPGReductor(fom, self.W, self.V,
                                           projection == 'QTEorth')

--- a/src/pymor/reductors/ph/ph_irka.py
+++ b/src/pymor/reductors/ph/ph_irka.py
@@ -83,7 +83,7 @@ class PHIRKAReductor(GenericIRKAReductor):
         one_sided_irka_reductor = OneSidedIRKAReductor(self.fom, 'V')
         _ = one_sided_irka_reductor.reduce(rom0_params, tol=tol, maxit=maxit, num_prev=num_prev,
                                            projection=projection, conv_crit=conv_crit, compute_errors=compute_errors)
-        
+
         self._pg_reductor = PHLTIPGReductor(self.fom, one_sided_irka_reductor.V)
         rom = self._pg_reductor.reduce()
 

--- a/src/pymordemos/phlti.py
+++ b/src/pymordemos/phlti.py
@@ -5,7 +5,7 @@
 
 import numpy as np
 from matplotlib import pyplot as plt
-from typer import run, Option
+from typer import Option, run
 
 from pymor.models.iosys import PHLTIModel
 from pymor.reductors.ph.ph_irka import PHIRKAReductor
@@ -146,7 +146,7 @@ def main(
     for i, reductor in enumerate(reductors):
         plt.semilogy(reduced_order, h2_errors[i], label=reductor, marker=markers[reductor])
 
-    plt.ylabel('Relative $\mathcal{H}_2$-error')
+    plt.ylabel('Relative $\\mathcal{H}_2$-error')
     plt.xlabel('Reduced order r')
     plt.legend()
     plt.show()

--- a/src/pymordemos/phlti.py
+++ b/src/pymordemos/phlti.py
@@ -126,15 +126,9 @@ def main(
 
     fom = PHLTIModel.from_matrices(J, R, G, Q=Q)
 
-    # J = Q.T @ J @ Q
-    # R = Q.T @ R @ Q
-    # G = Q.T @ G
-    #
-    # fom = PHLTIModel.from_matrices(J, R, G)
-
     h2 = fom.h2_norm()
 
-    phirka = PHIRKAReductor(fom.to_berlin_form())
+    phirka = PHIRKAReductor(fom)
 
     reductors = {'pH-IRKA': phirka}
     markers = {'pH-IRKA': 's'}

--- a/src/pymordemos/phlti.py
+++ b/src/pymordemos/phlti.py
@@ -8,6 +8,7 @@ from matplotlib import pyplot as plt
 from typer import Argument, run
 
 from pymor.models.iosys import PHLTIModel
+from pymor.reductors.h2 import IRKAReductor
 from pymor.reductors.ph.ph_irka import PHIRKAReductor
 
 
@@ -128,10 +129,11 @@ def main(
 
     fom = PHLTIModel.from_matrices(J, R, G, Q=Q)
 
+    irka = IRKAReductor(fom)
     phirka = PHIRKAReductor(fom)
 
-    reductors = {'pH-IRKA': phirka}
-    markers = {'pH-IRKA': 's'}
+    reductors = {'IRKA': irka, 'pH-IRKA': phirka}
+    markers = {'IRKA': 'o', 'pH-IRKA': 's'}
 
     if reduced_order > 0:
         reduced_order = [reduced_order]

--- a/src/pymortests/algorithms/simplify.py
+++ b/src/pymortests/algorithms/simplify.py
@@ -18,7 +18,7 @@ pytestmark = pytest.mark.builtin
 
 
 def test_expand():
-    ops = [NumpyMatrixOperator(np.eye(1) * i) for i in range(8)]
+    ops = [NumpyMatrixOperator(np.eye(1) * i, source_id='id', range_id='id') for i in range(8)]
     pfs = [ProjectionParameterFunctional('p', 9, i) for i in range(8)]
     prods = [o * p for o, p in zip(ops, pfs)]
 
@@ -44,7 +44,7 @@ def test_expand_matrix_operator():
 
 
 def test_contract():
-    ops = [NumpyMatrixOperator(np.eye(1) * i) for i in range(1, 6)]
+    ops = [NumpyMatrixOperator(np.eye(1) * i, source_id='id', range_id='id') for i in range(1, 6)]
     pf = ProjectionParameterFunctional('p', 1, 0)
 
     op = (ops[0] * pf) @ (ops[1] + ops[2]) @ ops[3] @ (ops[4] * pf)

--- a/src/pymortests/demos.py
+++ b/src/pymortests/demos.py
@@ -150,7 +150,7 @@ DMD_ARGS = (
 )
 
 PHLTI_ARGS = (
-    ('phlti', []),
+    ('phlti', [10, 2, 4]),
 )
 
 SYMPLECTIC_WAVE_ARGS = (

--- a/src/pymortests/models/iosys_add_sub_mul.py
+++ b/src/pymortests/models/iosys_add_sub_mul.py
@@ -39,14 +39,19 @@ def get_model(name, sampling_time, parametric):
         D = NumpyMatrixOperator(np.array([[1]]))
         return LTIModel(A, B, C, D, sampling_time=sampling_time)
     elif name == 'PHLTIModel':
-        J = NumpyMatrixOperator(np.array([[0]]))
+        J = NumpyMatrixOperator(np.zeros((1, 1)))
         if not parametric:
-            R = NumpyMatrixOperator(np.array([[1]]))
+            R = NumpyMatrixOperator(np.eye(1))
         else:
             R = (NumpyMatrixOperator(np.array([[1]]))
                  + ProjectionParameterFunctional('mu') * NumpyMatrixOperator(np.eye(1)))
-        G = NumpyMatrixOperator(np.array([[1]]))
-        return PHLTIModel(J, R, G)
+        G = NumpyMatrixOperator(np.eye(1))
+        P = NumpyMatrixOperator(-np.eye(1))
+        S = NumpyMatrixOperator(np.eye(1))
+        N = NumpyMatrixOperator(np.zeros([1, 1]))
+        E = NumpyMatrixOperator(np.eye(1))
+        Q = NumpyMatrixOperator(np.eye(1))
+        return PHLTIModel(J, R, G, P=P, S=S, N=N, E=E, Q=Q)
     elif name == 'SecondOrderModel':
         M = NumpyMatrixOperator(np.array([[1]]))
         E = NumpyMatrixOperator(np.array([[1]]))

--- a/src/pymortests/models/iosys_save_load.py
+++ b/src/pymortests/models/iosys_save_load.py
@@ -10,7 +10,7 @@ import pytest
 import scipy.io as spio
 import scipy.sparse as sps
 
-from pymor.models.iosys import LTIModel, SecondOrderModel, PHLTIModel
+from pymor.models.iosys import LTIModel, PHLTIModel, SecondOrderModel
 
 pytestmark = pytest.mark.builtin
 

--- a/src/pymortests/models/iosys_save_load.py
+++ b/src/pymortests/models/iosys_save_load.py
@@ -10,7 +10,7 @@ import pytest
 import scipy.io as spio
 import scipy.sparse as sps
 
-from pymor.models.iosys import LTIModel, SecondOrderModel
+from pymor.models.iosys import LTIModel, SecondOrderModel, PHLTIModel
 
 pytestmark = pytest.mark.builtin
 
@@ -38,6 +38,47 @@ def _test_matrices_lti(A, B, C, D, E,
         assert np.allclose(E, E2)
     else:
         assert E2 is None
+
+
+def _build_matrices_phlti(with_P, with_S, with_N, with_E, with_Q):
+    J = sps.csc_matrix([[0, -1], [1, 0]])
+    R = sps.csc_matrix([[1, 0], [0, 1]])
+    G = np.array([[1], [0]])
+    P = np.array([[1], [0]]) if with_P else None
+    S = np.array([[1]]) if with_S else None
+    N = np.array([[0]]) if with_N else None
+    E = np.array([[1, 0], [0, 1]]) if with_E else None
+    Q = np.array([[1, 0], [0, 1]]) if with_Q else None
+    return J, R, G, P, S, N, E, Q
+
+
+def _test_matrices_phlti(J, R, G, P, S, N, E, Q,
+                         J2, R2, G2, P2, S2, N2, E2, Q2,
+                         with_P, with_S, with_N, with_E, with_Q):
+    assert np.allclose(J.toarray(), J2.toarray())
+    assert np.allclose(R.toarray(), R2.toarray())
+    assert np.allclose(G, G2)
+
+    if with_P:
+        assert np.allclose(P, P2)
+    else:
+        assert P2 is None
+    if with_S:
+        assert np.allclose(S, S2)
+    else:
+        assert S2 is None
+    if with_N:
+        assert np.allclose(N, N2)
+    else:
+        assert N2 is None
+    if with_E:
+        assert np.allclose(E, E2)
+    else:
+        assert E2 is None
+    if with_Q:
+        assert np.allclose(Q, Q2)
+    else:
+        assert Q2 is None
 
 
 def _build_matrices_so(with_Cv, with_D):
@@ -143,6 +184,20 @@ def test_abcde_files(with_D, with_E):
     matrices2 = lti2.to_matrices()
 
     _test_matrices_lti(*matrices, *matrices2, with_D, with_E)
+
+
+@pytest.mark.parametrize('with_P', [False, True])
+@pytest.mark.parametrize('with_S', [False, True])
+@pytest.mark.parametrize('with_N', [False, True])
+@pytest.mark.parametrize('with_E', [False, True])
+@pytest.mark.parametrize('with_Q', [False, True])
+def test_matrices_phlti(with_P, with_S, with_N, with_E, with_Q):
+    matrices = _build_matrices_phlti(with_P, with_S, with_N, with_E, with_Q)
+
+    phlti = PHLTIModel.from_matrices(*matrices)
+    matrices2 = phlti.to_matrices()
+
+    _test_matrices_phlti(*matrices, *matrices2, with_P, with_S, with_N, with_E, with_Q)
 
 
 @pytest.mark.parametrize('with_Cv', [False, True])

--- a/src/pymortests/models/iosys_save_load.py
+++ b/src/pymortests/models/iosys_save_load.py
@@ -44,11 +44,11 @@ def _build_matrices_phlti(with_P, with_S, with_N, with_E, with_Q):
     J = sps.csc_matrix([[0, -1], [1, 0]])
     R = sps.csc_matrix([[1, 0], [0, 1]])
     G = np.array([[1], [0]])
-    P = np.array([[1], [0]]) if with_P else None
+    P = np.array([[2], [0]]) if with_P else None
     S = np.array([[1]]) if with_S else None
     N = np.array([[0]]) if with_N else None
-    E = np.array([[1, 0], [0, 1]]) if with_E else None
-    Q = np.array([[1, 0], [0, 1]]) if with_Q else None
+    E = np.array([[1, 0], [0, 2]]) if with_E else None
+    Q = np.array([[2, 0], [0, 1]]) if with_Q else None
     return J, R, G, P, S, N, E, Q
 
 

--- a/src/pymortests/reductors/ph/ph_irka.py
+++ b/src/pymortests/reductors/ph/ph_irka.py
@@ -36,7 +36,7 @@ def test_irka():
 
     Jr = np.array([0])
     Rr = np.array([1])
-    Br = np.array([1])
-    initial_rom = PHLTIModel.from_matrices(Jr, Rr, Br)
+    Gr = np.array([1])
+    initial_rom = PHLTIModel.from_matrices(Jr, Rr, Gr)
     rom = phirka.reduce(initial_rom)
     assert isinstance(rom, PHLTIModel) and rom.order == 1

--- a/src/pymortests/reductors/ph/ph_irka.py
+++ b/src/pymortests/reductors/ph/ph_irka.py
@@ -62,4 +62,6 @@ def test_ph_irka_E_and_Q():
     assert isinstance(rom2.E, IdentityOperator)
     assert np.isclose(np.array([[1]]), fom.E.apply2(phirka.W, phirka.V))
 
-    assert (rom1 - rom2).h2_norm() < 1e-8
+    err1 = (rom1 - fom).h2_norm()
+    err2 = (rom2 - fom).h2_norm()
+    assert abs(err1-err2) < 1e-12

--- a/src/pymortests/reductors/ph/ph_irka.py
+++ b/src/pymortests/reductors/ph/ph_irka.py
@@ -54,7 +54,7 @@ def test_ph_irka_E_and_Q():
     rom1 = phirka.reduce(1)
     assert isinstance(rom1, PHLTIModel) and rom1.order == 1
     Er = to_matrix(rom1.E, format='dense')
-    assert not np.isclose(Er,np.array([[1]]))
+    assert not np.isclose(Er, np.array([[1]]))
     assert np.isclose(Er, fom.E.apply2(phirka.W, phirka.V))
 
     rom2 = phirka.reduce(1, projection='QTEorth')
@@ -64,4 +64,4 @@ def test_ph_irka_E_and_Q():
 
     err1 = (rom1 - fom).h2_norm()
     err2 = (rom2 - fom).h2_norm()
-    assert abs(err1-err2) < 1e-12
+    assert abs(err1 - err2) < 1e-12

--- a/src/pymortests/reductors/ph/ph_irka.py
+++ b/src/pymortests/reductors/ph/ph_irka.py
@@ -5,10 +5,12 @@
 import numpy as np
 
 from pymor.models.iosys import LTIModel, PHLTIModel
+from pymor.operators.constructions import IdentityOperator
 from pymor.reductors.ph.ph_irka import PHIRKAReductor
+from pymor.algorithms.to_matrix import to_matrix
 
 
-def test_irka():
+def test_ph_irka():
     J = np.array([[0, 1], [-1, 0]])
     R = np.array([[1, 0], [0, 1]])
     G = np.array([[1], [0]])
@@ -30,7 +32,6 @@ def test_irka():
     Br = np.array([1])
     Cr = np.array([1])
     initial_rom = LTIModel.from_matrices(Ar, Br, Cr)
-
     rom = phirka.reduce(initial_rom)
     assert isinstance(rom, PHLTIModel) and rom.order == 1
 
@@ -40,3 +41,25 @@ def test_irka():
     initial_rom = PHLTIModel.from_matrices(Jr, Rr, Gr)
     rom = phirka.reduce(initial_rom)
     assert isinstance(rom, PHLTIModel) and rom.order == 1
+
+def test_ph_irka_E_and_Q():
+    J = np.array([[0, 1], [-1, 0]])
+    R = np.array([[1, 0], [0, 1]])
+    G = np.array([[1], [0]])
+    E = np.array([[2, 0], [0, 1]])
+    Q = np.array([[5, 0], [0, 3]])
+    fom = PHLTIModel.from_matrices(J, R, G, E=E, Q=Q)
+    phirka = PHIRKAReductor(fom)
+
+    rom1 = phirka.reduce(1)
+    assert isinstance(rom1, PHLTIModel) and rom1.order == 1
+    Er = to_matrix(rom1.E, format='dense')
+    assert not np.isclose(Er,np.array([[1]]))
+    assert np.isclose(Er, fom.E.apply2(phirka.W, phirka.V))
+
+    rom2 = phirka.reduce(1, projection='QTEorth')
+    assert isinstance(rom2, PHLTIModel) and rom2.order == 1
+    assert isinstance(rom2.E, IdentityOperator)
+    assert np.isclose(np.array([[1]]), fom.E.apply2(phirka.W, phirka.V))
+
+    assert (rom1 - rom2).h2_norm() < 1e-8

--- a/src/pymortests/reductors/ph/ph_irka.py
+++ b/src/pymortests/reductors/ph/ph_irka.py
@@ -4,10 +4,10 @@
 
 import numpy as np
 
+from pymor.algorithms.to_matrix import to_matrix
 from pymor.models.iosys import LTIModel, PHLTIModel
 from pymor.operators.constructions import IdentityOperator
 from pymor.reductors.ph.ph_irka import PHIRKAReductor
-from pymor.algorithms.to_matrix import to_matrix
 
 
 def test_ph_irka():

--- a/src/pymortests/reductors/ph/ph_irka.py
+++ b/src/pymortests/reductors/ph/ph_irka.py
@@ -33,3 +33,10 @@ def test_irka():
 
     rom = phirka.reduce(initial_rom)
     assert isinstance(rom, PHLTIModel) and rom.order == 1
+
+    Jr = np.array([0])
+    Rr = np.array([1])
+    Br = np.array([1])
+    initial_rom = PHLTIModel.from_matrices(Jr, Rr, Br)
+    rom = phirka.reduce(initial_rom)
+    assert isinstance(rom, PHLTIModel) and rom.order == 1


### PR DESCRIPTION
This PR refactors the PHLTIModel to inherit from the LTIModel and extends the PHLTIModel to support Q. Additional a conversion from PHLTIModel with Q to PHLTIModel without Q (Q=I) is implemented.
