### PR TITLE
[ci] adds an automerge workflow

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,37 @@
+name: Automerge
+
+on:
+  # Try enabling auto-merge for all open pull requests.
+  schedule:
+    - cron: 0 * * * *
+
+  # Try enabling auto-merge for a pull request when a draft is marked as “ready for review”, when
+  # a required label is applied or when a “do not merge” label is removed, or when a pull request
+  # is updated in any way (opened, synchronized, reopened, edited).
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - edited
+      - labeled
+      - unlabeled
+      - ready_for_review
+
+  # Try enabling auto-merge for the specified pull request or all open pull requests if none is specified.
+  workflow_dispatch:
+    inputs:
+      pull-request:
+        description: Pull Request Number
+        required: false
+
+jobs:
+  automerge:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: reitermarkus/automerge@v2
+        with:
+          token: ${{ secrets.AUTOMERGE_TOKEN }}
+          merge-method: merge
+          required-labels: automerge
+          pull-request: ${{ github.event.inputs.pull-request }}


### PR DESCRIPTION
This workflow only enables github's own auto-merge function
and is intended for the requirements update functionality
in #1845. Only PRs labeled "automerge" will be considered.
