### PR TITLE
[logger] fix typo

### DIFF
--- a/src/pymor/core/logger.py
+++ b/src/pymor/core/logger.py
@@ -239,7 +239,7 @@ class DummyLogger:
     log = nop
     exception = nop
 
-    def isEnabledFor(sefl, lvl):
+    def isEnabledFor(self, lvl):
         return False
 
     def getEffectiveLevel(self):


### PR DESCRIPTION
when playing around with ruff, the `pep8-naming` module found this typo :)