### PR TITLE
Edit README

### DIFF
--- a/.github/markdown_link_check_config.json
+++ b/.github/markdown_link_check_config.json
@@ -17,6 +17,9 @@
     },
     {
       "pattern": "^https://www.researchgate.net"
+    },
+    {
+      "pattern": "^https://epubs.siam.org"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -81,22 +81,25 @@ optional dependencies.
 There are some optional packages not included with `pymor[full]`
 because they need additional setup on your system:
 
-* mpi4py: support of MPI distributed models and parallelization of greedy
+* [mpi4py](https://mpi4py.readthedocs.io/en/stable/mpi4py.html):
+  support of MPI distributed models and parallelization of greedy
   algorithms (requires MPI development headers and a C compiler):
 
       pip install mpi4py
 
-* Slycot: dense matrix equation solvers for system-theoretic methods and
+* [Slycot](https://github.com/python-control/Slycot):
+  dense matrix equation solvers for system-theoretic methods and
   H-infinity norm calculation (requires OpenBLAS headers and a
   Fortran compiler):
 
       pip install slycot
 
-* Py-M.E.S.S.: dense and sparse matrix equation solvers for system-theoretic
-  methods (other backends available):
-  * from [source](https://gitlab.mpi-magdeburg.mpg.de/mess/cmess-releases)
-    (recommended)
-  * using a [wheel](https://www.mpi-magdeburg.mpg.de/projects/mess)
+* [Py-M.E.S.S.](https://www.mpi-magdeburg.mpg.de/projects/mess):
+  dense and sparse matrix equation solvers for system-theoretic methods
+  (it is recommended to install from
+  [source](https://gitlab.mpi-magdeburg.mpg.de/mess/cmess-releases)):
+
+      pip install pymess
 
 #### Latest Development Version
 
@@ -176,22 +179,6 @@ can be found in `src/pymordemos/minimal_cpp_demo`.
 
 An alternative approach is to import system matrices from file and use
 `scipy.sparse`-based solvers.
-
-## External Matrix Equation Solvers
-
-pyMOR also provides bindings to matrix equation solvers (in `pymor.bindings`),
-which are needed for the system-theoretic methods and need to be installed
-separately. Bindings for the following solver libraries are included:
-
-* [Py-M.E.S.S.](https://www.mpi-magdeburg.mpg.de/projects/mess)
-
-  The Matrix Equation Sparse Solver library is intended for solving large sparse
-  matrix equations (`pymor.bindings.pymess`).
-
-* [Slycot](https://github.com/python-control/Slycot)
-
-  Python wrapper for the Subroutine Library in Systems and Control Theory
-  (SLICOT) is also used for Hardy norm computations (`pymor.bindings.slycot`).
 
 ## Environments for pyMOR Development and Tests
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ because they need additional setup on your system:
 
 To install the latest development version of pyMOR, execute
 
-    pip install git+https://github.com/pymor/pymor#egg=pymor[full]
+    pip install 'pymor[full] @ git+https://github.com/pymor/pymor'
 
 which requires that the [git](https://git-scm.com/) version control system is
 installed on your system.
@@ -110,7 +110,7 @@ might break (this is usually announced in our
 [discussion forum](https://github.com/pymor/pymor/discussions)),
 so you might prefer to install pyMOR from the current release branch:
 
-    pip install git+https://github.com/pymor/pymor@2022.2.x#egg=pymor[full]
+    pip install 'pymor[full] @ git+https://github.com/pymor/pymor@2022.2.x'
 
 Release branches will always stay stable and will only receive bugfix commits
 after the corresponding release has been made.

--- a/README.md
+++ b/README.md
@@ -44,9 +44,7 @@ If you use pyMOR for academic work, please consider citing our
     pyMOR - Generic Algorithms and Interfaces for Model Order Reduction
     SIAM J. Sci. Comput., 38(5), pp. S194--S216, 2016
 
-## Installation
-
-### pip
+## Installation via pip
 
 We recommend installation of pyMOR in a [virtual environment](https://virtualenv.pypa.io/en/latest/).
 
@@ -62,7 +60,7 @@ If you are not operating in a virtual environment, you can pass the optional
 pyMOR will then only be installed for your local user, not requiring
 administrator privileges.
 
-#### Latest Release (without Optional Dependencies)
+### Latest Release (without Optional Dependencies)
 
 For an installation with minimal dependencies, run
 
@@ -71,7 +69,7 @@ For an installation with minimal dependencies, run
 Note that most included demo scripts additionally require `matplotlib` and
 Qt bindings such as `pyside2` to function.
 
-#### Latest Release (with all Optional Dependencies)
+### Latest Release (with all Optional Dependencies)
 
 The following installs the latest release of pyMOR on your system with most
 optional dependencies.
@@ -101,7 +99,7 @@ because they need additional setup on your system:
 
       pip install pymess
 
-#### Latest Development Version
+### Latest Development Version
 
 To install the latest development version of pyMOR, execute
 
@@ -110,7 +108,7 @@ To install the latest development version of pyMOR, execute
 which requires that the [git](https://git-scm.com/) version control system is
 installed on your system.
 
-#### Current Release Branch Version
+### Current Release Branch Version
 
 From time to time, the main branch of pyMOR undergoes major changes and things
 might break (this is usually announced in our
@@ -122,7 +120,7 @@ so you might prefer to install pyMOR from the current release branch:
 Release branches will always stay stable and will only receive bugfix commits
 after the corresponding release has been made.
 
-### conda/mamba
+## Installation via conda/mamba
 
 We recommend installation of pyMOR in a
 [conda environment](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html)
@@ -147,7 +145,6 @@ run the following from inside the root directory of the pyMOR source tree.
     make docs
 
 This will generate HTML documentation in `docs/_build/html`.
-
 
 ## External PDE Solvers
 

--- a/README.md
+++ b/README.md
@@ -146,17 +146,7 @@ This will generate HTML documentation in `docs/_build/html`.
 
 pyMOR has been designed with easy integration of external PDE solvers in mind.
 
-A basic approach is to use the solver only to generate high-dimensional
-system matrices which are then read by pyMOR from disk (`pymor.discretizers.disk`).
-Another possibility is to steer the solver via an appropriate network
-protocol.
-
-Whenever possible, we recommend to recompile the solver as a
-Python extension module which gives pyMOR direct access to the solver without
-any communication overhead. A basic example using
-[pybind11](https://github.com/pybind/pybind11) can be found in
-`src/pymordemos/minimal_cpp_demo`. Moreover,
-we provide bindings for the following solver libraries:
+We provide bindings for the following solver libraries:
 
 * [FEniCS](https://fenicsproject.org)
 
@@ -177,9 +167,11 @@ we provide bindings for the following solver libraries:
     For an example see `pymordemos.thermalblock_simple`.
     It is tested using NGSolve version v6.2.2104.
 
-Do not hesitate to contact
-[us](https://github.com/pymor/pymor/discussions) if you
-need help with the integration of your PDE solver.
+A simple example for direct integration of pyMOR with a a custom solver
+can be found in `src/pymordemos/minimal_cpp_demo`.
+
+An alternative approach is to import system matrices from file and use
+`scipy.sparse`-based solvers.
 
 ## External Matrix Equation Solvers
 

--- a/README.md
+++ b/README.md
@@ -27,30 +27,8 @@ reduction applications with the Python programming language.
 
 ## License
 
-Copyright pyMOR developers and contributors. All rights reserved.
-
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
-following conditions are met:
-
-* Redistributions of source code must retain the above copyright notice, this list of conditions and the following
-  disclaimer.
-* Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
-  disclaimer in the documentation and/or other materials provided with the distribution.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
-INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
-WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
-THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-The following files contain source code originating from other open source software projects:
-
-* docs/source/pymordocstring.py  (sphinxcontrib-napoleon)
-* src/pymor/algorithms/genericsolvers.py (SciPy)
-
-See these files for more information.
+pyMOR is licensed under BSD-2-clause.
+See [LICENSE.txt](LICENSE.txt).
 
 ## Citing
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 ![pyMOR Logo](./logo/pymor_logo.svg)
 
+[![PyPI](https://img.shields.io/pypi/pyversions/pymor.svg)](https://pypi.python.org/pypi/pymor)
+[![PyPI](https://img.shields.io/pypi/v/pymor.svg)](https://pypi.python.org/pypi/pymor)
+[![Docs](https://img.shields.io/endpoint?url=https%3A%2F%2Fdocs.pymor.org%2Fbadge.json)](https://docs.pymor.org/)
+[![DOI](https://zenodo.org/badge/9220688.svg)](https://zenodo.org/badge/latestdoi/9220688)
+[![GitLab Pipeline](https://zivgitlab.uni-muenster.de/pymor/pymor/badges/main/pipeline.svg)](https://zivgitlab.uni-muenster.de/pymor/pymor/commits/main)
+[![Conda Tests](https://github.com/pymor/pymor/actions/workflows/conda_tests.yml/badge.svg)](https://github.com/pymor/pymor/actions/workflows/conda_tests.yml)
+[![codecov](https://codecov.io/gh/pymor/pymor/branch/main/graph/badge.svg)](https://codecov.io/gh/pymor/pymor)
+[![pre-commit.ci status](https://results.pre-commit.ci/badge/github/pymor/pymor/main.svg)](https://results.pre-commit.ci/latest/github/pymor/pymor/main)
+
 # pyMOR - Model Order Reduction with Python
 
 pyMOR is a software library for building model order
@@ -12,15 +21,6 @@ external PDE (Partial Differential Equation) solver packages.  Moreover, pure
 Python implementations of FEM (Finite Element Method) and FVM (Finite Volume
 Method) discretizations using the NumPy/SciPy scientific computing stack are
 provided for getting started quickly.
-
-[![PyPI](https://img.shields.io/pypi/pyversions/pymor.svg)](https://pypi.python.org/pypi/pymor)
-[![PyPI](https://img.shields.io/pypi/v/pymor.svg)](https://pypi.python.org/pypi/pymor)
-[![Docs](https://img.shields.io/endpoint?url=https%3A%2F%2Fdocs.pymor.org%2Fbadge.json)](https://docs.pymor.org/)
-[![DOI](https://zenodo.org/badge/9220688.svg)](https://zenodo.org/badge/latestdoi/9220688)
-[![GitLab Pipeline](https://zivgitlab.uni-muenster.de/pymor/pymor/badges/main/pipeline.svg)](https://zivgitlab.uni-muenster.de/pymor/pymor/commits/main)
-[![Conda Tests](https://github.com/pymor/pymor/actions/workflows/conda_tests.yml/badge.svg)](https://github.com/pymor/pymor/actions/workflows/conda_tests.yml)
-[![codecov](https://codecov.io/gh/pymor/pymor/branch/main/graph/badge.svg)](https://codecov.io/gh/pymor/pymor)
-[![pre-commit.ci status](https://results.pre-commit.ci/badge/github/pymor/pymor/main.svg)](https://results.pre-commit.ci/latest/github/pymor/pymor/main)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ We recommend installation of pyMOR in a [virtual environment](https://virtualenv
 pyMOR can easily be installed with the [pip](https://pip.pypa.io/en/stable/)
 command.
 Please note that pip versions prior to 21.1 might have problems resolving all
-dependencies, so running the following first is recommended.
+dependencies, so running the following first is recommended:
 
     pip install --upgrade pip
 
@@ -72,7 +72,7 @@ Qt bindings such as `pyside2` to function.
 ### Latest Release (with all Optional Dependencies)
 
 The following installs the latest release of pyMOR on your system with most
-optional dependencies.
+optional dependencies:
 
     pip install pymor[full]
 
@@ -140,7 +140,7 @@ We recommend starting with
 [technical overview](https://docs.pymor.org/latest/technical_overview.html).
 
 To build the documentation locally,
-run the following from inside the root directory of the pyMOR source tree.
+run the following from inside the root directory of the pyMOR source tree:
 
     make docs
 
@@ -172,7 +172,7 @@ We provide bindings for the following solver libraries:
     It is tested using NGSolve version v6.2.2104.
 
 A simple example for direct integration of pyMOR with a a custom solver
-can be found in `src/pymordemos/minimal_cpp_demo`.
+can be found in `pymordemos.minimal_cpp_demo`.
 
 An alternative approach is to import system matrices from file and use
 `scipy.sparse`-based solvers.

--- a/README.md
+++ b/README.md
@@ -196,6 +196,6 @@ Please see the [Developer Documentation](https://docs.pymor.org/latest/developer
 ## Contact
 
 Should you have any questions regarding pyMOR or wish to contribute,
-do not hesitate to contact us via our GitHub discussions forum:
+do not hesitate to send us an email at
 
-<https://github.com/pymor/pymor/discussions>
+    main.developers@pymor.org

--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@
 
 # pyMOR - Model Order Reduction with Python
 
-pyMOR is a software library for building model order
-reduction applications with the Python programming language.
+pyMOR is a software library for building
+[model order reduction](https://morwiki.mpi-magdeburg.mpg.de)
+applications with the Python programming language.
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ To install the latest development version of pyMOR, execute
 
     pip install git+https://github.com/pymor/pymor#egg=pymor[full]
 
-which will require that the [git](https://git-scm.com/) version control system is
+which requires that the [git](https://git-scm.com/) version control system is
 installed on your system.
 
 #### Current Release Branch Version
@@ -123,9 +123,9 @@ pyMOR can be installed using conda/mamba by running
 
 ## Documentation
 
-Documentation is available [online](https://docs.pymor.org/)
-or you can build it yourself from inside the root directory of the pyMOR source tree
-by executing:
+Documentation is available [online](https://docs.pymor.org/).
+To build it locally, run the following from inside the root directory of the
+pyMOR source tree.
 
     make docs
 
@@ -137,10 +137,9 @@ This will generate HTML documentation in `docs/_build/html`.
 * [Getting Started](https://docs.pymor.org/latest/getting_started.html)
 * [Dependencies](https://github.com/pymor/pymor/blob/2022.2.x/requirements.txt)
 
-## External PDE solvers
+## External PDE Solvers
 
-pyMOR has been designed with easy integration of external PDE solvers
-in mind.
+pyMOR has been designed with easy integration of external PDE solvers in mind.
 
 A basic approach is to use the solver only to generate high-dimensional
 system matrices which are then read by pyMOR from disk (`pymor.discretizers.disk`).
@@ -185,12 +184,13 @@ separately. Bindings for the following solver libraries are included:
 
 * [Py-M.E.S.S.](https://www.mpi-magdeburg.mpg.de/projects/mess)
 
-    The Matrix Equation Sparse Solver library is intended for solving large sparse matrix equations (`pymor.bindings.pymess`).
+  The Matrix Equation Sparse Solver library is intended for solving large sparse
+  matrix equations (`pymor.bindings.pymess`).
 
 * [Slycot](https://github.com/python-control/Slycot)
 
-    Python wrapper for the Subroutine Library in Systems and Control Theory (SLICOT) is also
-    used for Hardy norm computations (`pymor.bindings.slycot`).
+  Python wrapper for the Subroutine Library in Systems and Control Theory
+  (SLICOT) is also used for Hardy norm computations (`pymor.bindings.slycot`).
 
 ## Environments for pyMOR Development and Tests
 

--- a/README.md
+++ b/README.md
@@ -39,49 +39,58 @@ If you use pyMOR for academic work, please consider citing our
     pyMOR - Generic Algorithms and Interfaces for Model Order Reduction
     SIAM J. Sci. Comput., 38(5), pp. S194--S216, 2016
 
-## Installation via pip
+## Installation
+
+### pip
 
 We recommend installation of pyMOR in a [virtual environment](https://virtualenv.pypa.io/en/latest/).
 
 pyMOR can easily be installed with the [pip](https://pip.pypa.io/en/stable/)
-command:
+command.
+Please note that pip versions prior to 21.1 might have problems resolving all
+dependencies, so running the following first is recommended.
 
-    pip install --upgrade pip  # make sure that pip is reasonably new
-    pip install pymor[full]
+    pip install --upgrade pip
 
-(Please note that pip versions prior to 21.1 might have problems resolving all dependencies)
+If you are not operating in a virtual environment, you can pass the optional
+`--user` argument to pip.
+pyMOR will then only be installed for your local user, not requiring
+administrator privileges.
 
-This will install the latest release of pyMOR on your system with most optional
-dependencies.
-For Linux we provide binary wheels, so no further system packages should
-be required. Use
+#### Latest Release (without Optional Dependencies)
+
+For an installation with minimal dependencies, run
 
     pip install pymor
 
-for an installation with minimal dependencies.
+#### Latest Release (with all Optional Dependencies)
+
+The following installs the latest release of pyMOR on your system with most
+optional dependencies.
+
+    pip install pymor[full]
+
 There are some optional packages not included with `pymor[full]`
 because they need additional setup on your system:
 
-* for support of MPI distributed models and parallelization of greedy algorithms
-  (requires MPI development headers and a C compiler):
+* mpi4py: support of MPI distributed models and parallelization of greedy
+  algorithms (requires MPI development headers and a C compiler):
 
       pip install mpi4py
 
-* dense matrix equation solver for system-theoretic MOR methods, required for
-  H-infinity norm calculation (requires OpenBLAS headers and a Fortran
-  compiler):
+* Slycot: dense matrix equation solvers for system-theoretic methods and
+  H-infinity norm calculation (requires OpenBLAS headers and a
+  Fortran compiler):
 
       pip install slycot
 
-* dense and sparse matrix equation solver for system-theoretic MOR methods
-  (other backends available):
+* Py-M.E.S.S.: dense and sparse matrix equation solvers for system-theoretic
+  methods (other backends available):
   * from [source](https://gitlab.mpi-magdeburg.mpg.de/mess/cmess-releases)
     (recommended)
   * using a [wheel](https://www.mpi-magdeburg.mpg.de/projects/mess)
 
-If you are not operating in a virtual environment, you can pass the optional `--user`
-argument to pip. pyMOR will then only be installed for your
-local user, not requiring administrator privileges.
+#### Latest Development Version
 
 To install the latest development version of pyMOR, execute
 
@@ -89,6 +98,8 @@ To install the latest development version of pyMOR, execute
 
 which will require that the [git](https://git-scm.com/) version control system is
 installed on your system.
+
+#### Current Release Branch Version
 
 From time to time, the main branch of pyMOR undergoes major changes and things
 might break (this is usually announced in our
@@ -100,11 +111,15 @@ so you might prefer to install pyMOR from the current release branch:
 Release branches will always stay stable and will only receive bugfix commits
 after the corresponding release has been made.
 
-## Installation via conda
+### conda
 
-pyMOR can be installed using `conda` by running
+We recommend installation of pyMOR in a
+[conda environment](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html).
 
-    conda install -c conda-forge pymor
+pyMOR can be installed using conda/mamba by running
+
+    conda install -c conda-forge mamba
+    mamba install -c conda-forge pymor
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ See [LICENSE.txt](LICENSE.txt).
 ## Citing
 
 If you use pyMOR for academic work, please consider citing our
-[publication](https://doi.org/10.1137/15M1026614):
+[publication](https://epubs.siam.org/doi/10.1137/15M1026614):
 
     R. Milk, S. Rave, F. Schindler
     pyMOR - Generic Algorithms and Interfaces for Model Order Reduction

--- a/README.md
+++ b/README.md
@@ -12,15 +12,18 @@
 # pyMOR - Model Order Reduction with Python
 
 pyMOR is a software library for building model order
-reduction applications with the Python programming language. Implemented
-algorithms include reduced basis methods for parametric linear and non-linear
-problems, as well as system-theoretic methods such as balanced truncation or
-IRKA (Iterative Rational Krylov Algorithm).  All algorithms in pyMOR are
-formulated in terms of abstract interfaces for seamless integration with
-external PDE (Partial Differential Equation) solver packages.  Moreover, pure
-Python implementations of FEM (Finite Element Method) and FVM (Finite Volume
-Method) discretizations using the NumPy/SciPy scientific computing stack are
-provided for getting started quickly.
+reduction applications with the Python programming language.
+
+## Features
+
+* reduced basis methods for parametric linear and non-linear problems
+* system-theoretic methods such as balanced truncation or iterative rational
+  Krylov algorithm
+* all algorithms in pyMOR are formulated in terms of abstract interfaces for
+  seamless integration with external PDE (Partial Differential Equation) solver
+  packages.
+* pure Python implementations of finite element and finite volume
+  discretizations using the NumPy/SciPy scientific computing stack
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 ![pyMOR Logo](./logo/pymor_logo.svg)
 
-pyMOR - Model Order Reduction with Python
-=========================================
+# pyMOR - Model Order Reduction with Python
 
 pyMOR is a software library for building model order
 reduction applications with the Python programming language. Implemented
@@ -23,9 +22,7 @@ provided for getting started quickly.
 [![codecov](https://codecov.io/gh/pymor/pymor/branch/main/graph/badge.svg)](https://codecov.io/gh/pymor/pymor)
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/pymor/pymor/main.svg)](https://results.pre-commit.ci/latest/github/pymor/pymor/main)
 
-
-License
--------
+## License
 
 Copyright pyMOR developers and contributors. All rights reserved.
 
@@ -52,8 +49,7 @@ The following files contain source code originating from other open source softw
 
 See these files for more information.
 
-Citing
-------
+## Citing
 
 If you use pyMOR for academic work, please consider citing our
 [publication](https://doi.org/10.1137/15M1026614):
@@ -62,8 +58,7 @@ If you use pyMOR for academic work, please consider citing our
     pyMOR - Generic Algorithms and Interfaces for Model Order Reduction
     SIAM J. Sci. Comput., 38(5), pp. S194--S216, 2016
 
-Installation via pip
---------------------
+## Installation via pip
 
 We recommend installation of pyMOR in a [virtual environment](https://virtualenv.pypa.io/en/latest/).
 
@@ -124,15 +119,13 @@ so you might prefer to install pyMOR from the current release branch:
 Release branches will always stay stable and will only receive bugfix commits
 after the corresponding release has been made.
 
-Installation via conda
-----------------------
+## Installation via conda
 
 pyMOR can be installed using `conda` by running
 
     conda install -c conda-forge pymor
 
-Documentation
--------------
+## Documentation
 
 Documentation is available [online](https://docs.pymor.org/)
 or you can build it yourself from inside the root directory of the pyMOR source tree
@@ -142,15 +135,13 @@ by executing:
 
 This will generate HTML documentation in `docs/_build/html`.
 
-Useful Links
-------------
+## Useful Links
 
 * [Latest Changelog](https://docs.pymor.org/latest/release_notes/all.html)
 * [Getting Started](https://docs.pymor.org/latest/getting_started.html)
 * [Dependencies](https://github.com/pymor/pymor/blob/2022.2.x/requirements.txt)
 
-External PDE solvers
---------------------
+## External PDE solvers
 
 pyMOR has been designed with easy integration of external PDE solvers
 in mind.
@@ -190,8 +181,7 @@ Do not hesitate to contact
 [us](https://github.com/pymor/pymor/discussions) if you
 need help with the integration of your PDE solver.
 
-External Matrix Equation Solvers
---------------------------------
+## External Matrix Equation Solvers
 
 pyMOR also provides bindings to matrix equation solvers (in `pymor.bindings`),
 which are needed for the system-theoretic methods and need to be installed
@@ -206,13 +196,11 @@ separately. Bindings for the following solver libraries are included:
     Python wrapper for the Subroutine Library in Systems and Control Theory (SLICOT) is also
     used for Hardy norm computations (`pymor.bindings.slycot`).
 
-Environments for pyMOR Development and Tests
------------------------------------------------
+## Environments for pyMOR Development and Tests
 
 Please see the [Developer Documentation](https://docs.pymor.org/latest/developer_docs.html).
 
-Contact
--------
+## Contact
 
 Should you have any questions regarding pyMOR or wish to contribute,
 do not hesitate to contact us via our GitHub discussions forum:

--- a/README.md
+++ b/README.md
@@ -14,17 +14,21 @@
 pyMOR is a software library for building
 [model order reduction](https://morwiki.mpi-magdeburg.mpg.de)
 applications with the Python programming language.
+All algorithms in pyMOR are formulated in terms of abstract interfaces,
+allowing generic implementations to work with different backends,
+from NumPy/SciPy to external partial differential equation solver packages.
 
 ## Features
 
-* reduced basis methods for parametric linear and non-linear problems
-* system-theoretic methods such as balanced truncation or iterative rational
-  Krylov algorithm
-* all algorithms in pyMOR are formulated in terms of abstract interfaces for
-  seamless integration with external PDE (Partial Differential Equation) solver
-  packages.
-* pure Python implementations of finite element and finite volume
-  discretizations using the NumPy/SciPy scientific computing stack
+* Reduced basis methods for parametric linear and non-linear problems.
+* System-theoretic methods for linear time-invariant systems.
+* Neural network-based methods for parametric problems.
+* Proper orthogonal decomposition.
+* Dynamic mode decomposition.
+* Rational interpolation of data (Loewner, AAA).
+* Numerical linear algebra (Gram-Schmidt, time-stepping, ...).
+* Pure Python implementations of finite element and finite volume
+  discretizations using the NumPy/SciPy scientific computing stack.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -133,18 +133,18 @@ pyMOR can be installed using conda/mamba by running
 ## Documentation
 
 Documentation is available [online](https://docs.pymor.org/).
-To build it locally, run the following from inside the root directory of the
-pyMOR source tree.
+We recommend starting with
+[getting started](https://docs.pymor.org/latest/getting_started.html),
+[tutorials](https://docs.pymor.org/latest/tutorials.html), and
+[technical overview](https://docs.pymor.org/latest/technical_overview.html).
+
+To build the documentation locally,
+run the following from inside the root directory of the pyMOR source tree.
 
     make docs
 
 This will generate HTML documentation in `docs/_build/html`.
 
-## Useful Links
-
-* [Latest Changelog](https://docs.pymor.org/latest/release_notes/all.html)
-* [Getting Started](https://docs.pymor.org/latest/getting_started.html)
-* [Dependencies](https://github.com/pymor/pymor/blob/2022.2.x/requirements.txt)
 
 ## External PDE Solvers
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ For an installation with minimal dependencies, run
 
     pip install pymor
 
+Note that most included demo scripts additionally require `matplotlib` and
+Qt bindings such as `pyside2` to function.
+
 #### Latest Release (with all Optional Dependencies)
 
 The following installs the latest release of pyMOR on your system with most

--- a/README.md
+++ b/README.md
@@ -112,10 +112,11 @@ so you might prefer to install pyMOR from the current release branch:
 Release branches will always stay stable and will only receive bugfix commits
 after the corresponding release has been made.
 
-### conda
+### conda/mamba
 
 We recommend installation of pyMOR in a
-[conda environment](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html).
+[conda environment](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html)
+with mamba.
 
 pyMOR can be installed using conda/mamba by running
 


### PR DESCRIPTION
This PR is to close #1936 and #1934 and fix some other issues:

- [x] add "features" section
- [x] link to MOR Wiki
- [x] use `#` for section formatting
- [x] remove license text and link to the license file (to avoid the screaming font)
- [x] restructure the "installation" section (such that the pip section doesn't look long and complicated)
- [x] recommend using mamba instead of conda (mamba resolves much quicker)
- [x] remove the "useful links" section
- [x] remove the "external matrix equations solvers" section (because they are also mentioned in the "installation" section)
- [x] remove reference to `pymor.discretizers.disk`