### PR TITLE
add era and dd_parametric_heat to demo tests

### DIFF
--- a/src/pymordemos/era.py
+++ b/src/pymordemos/era.py
@@ -5,7 +5,7 @@
 
 import matplotlib.pyplot as plt
 import numpy as np
-from typer import run
+from typer import Option, run
 
 from pymor.core.logger import set_log_levels
 from pymor.models.iosys import LTIModel
@@ -68,13 +68,15 @@ def compute_markov_parameters(sys, n=100):
     return mp
 
 
-def main():
+def main(
+        n: int = Option(10, help='Order of the full model.')
+):
     set_log_levels({'pymor.algorithms.gram_schmidt.gram_schmidt': 'WARNING'})
 
     sampling_time = 0.1
     w = np.geomspace(1e-2, 1, 100) * np.pi
     with new_rng(0):
-        fom = example_system(10, sampling_time=sampling_time)
+        fom = example_system(n, sampling_time=sampling_time)
 
     mp = compute_markov_parameters(fom, n=100)
 

--- a/src/pymordemos/era.py
+++ b/src/pymordemos/era.py
@@ -5,7 +5,7 @@
 
 import matplotlib.pyplot as plt
 import numpy as np
-from typer import Option, run
+from typer import Argument, run
 
 from pymor.core.logger import set_log_levels
 from pymor.models.iosys import LTIModel
@@ -69,7 +69,7 @@ def compute_markov_parameters(sys, n=100):
 
 
 def main(
-        n: int = Option(10, help='Order of the full model.')
+        n: int = Argument(10, help='Order of the full model.')
 ):
     set_log_levels({'pymor.algorithms.gram_schmidt.gram_schmidt': 'WARNING'})
 

--- a/src/pymortests/demos.py
+++ b/src/pymortests/demos.py
@@ -116,7 +116,7 @@ SYS_MOR_ARGS = (
 )
 
 DD_MOR_ARGS = (
-    ('dd_parabolic_heat', [0.01, 50, 10]),
+    ('dd_parametric_heat', [0.01, 50, 10]),
     ('era', [10]),
 )
 

--- a/src/pymortests/demos.py
+++ b/src/pymortests/demos.py
@@ -115,6 +115,11 @@ SYS_MOR_ARGS = (
     ('unstable_heat', [50, 10]),
 )
 
+DD_MOR_ARGS = (
+    ('dd_parabolic_heat', [0.01, 50, 10]),
+    ('era', [10]),
+)
+
 HAPOD_ARGS = (
     ('hapod', ['--snap=3', 1e-2, 10, 100]),
     ('hapod', ['--snap=3', '--threads=2', 1e-2, 10, 100]),
@@ -165,6 +170,7 @@ DEMO_ARGS = (
     + THERMALBLOCK_GUI_ARGS
     + BURGERS_EI_ARGS
     + PARABOLIC_MOR_ARGS
+    + DD_MOR_ARGS
     + SYS_MOR_ARGS
     + HAPOD_ARGS
     + FENICS_NONLINEAR_ARGS


### PR DESCRIPTION
As mentioned in #1516, the `era` and `aaa` reductors are not currently tested. I have added their demos to the tests.