### PR TITLE
Contributing file and developer docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,49 +74,6 @@ documentation or correcting a very simple bug. However, your changes
 including your authorship will always be included in the git
 history of the project.
 
-## Coding style
-
-pyMOR follows the coding style of
-[PEP8](https://www.python.org/dev/peps/pep-0008/) apart from a
-few exceptions. Configurations for the
-[PEP8](https://pypi.python.org/pypi/pep8) and
-[flake8](https://pypi.python.org/pypi/flake8) code
-checkers are contained in
-[setup.cfg](https://github.com/pymor/pymor/blob/main/setup.cfg).
-
-Further guidelines:
-
-- Functions and classes called or instantiated by users should be
-  sufficiently well documented.
-
-- Use keyword arguments for parameters with defaults. This will make your
-  code less likely to break, when the called function is extended.
-
-- Generally use verbose identifiers instead of single letter names, also
-  for mathematical objects (use `residual` instead of `r`). Exceptions
-  are well-established variable names (like A,B,C,D,E for LTI systems)
-  or temporary variables.
-
-- Prefer assertions over exceptions in potentially performance-relevant
-  code. Assertions can be ignored by invoking Python with the `-O`
-  argument. Try to check a single condition in an assertion and add helpful
-  error messages.
-
-- Use `warnings.warn` for code-related issues. Use `self.logger.warning`
-  for issues related to an algorithm or user input.
-
-- It is generally ok to use builtin names as function parameters
-  (e.g. `type`) when there is no other adequate name. There is no need
-  to add underscores before or after the name.
-
-- Use the `self.__auto_init(locals())` idiom to initialize instance
-  attributes from `__init__` args of the same name.
-
-If you are a first-time contributor, do not worry to much about code
-style. The main developers will be happy to help you to bring your code
-into proper shape for inclusion in pyMOR.
-
-
 ## Becoming a main developer
 
 pyMOR's main developers form a small

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ which improve or extend pyMOR. The purpose of this document
 is to make the contribution process easier for you and to answer
 some questions which might arise.
 
-## Contribution process
+## Contribution Process
 
 When you have written some code you want to contribute to
 pyMOR, the first thing you should do is to ensure that
@@ -74,7 +74,7 @@ documentation or correcting a very simple bug. However, your changes
 including your authorship will always be included in the git
 history of the project.
 
-## Becoming a main developer
+## Becoming a Main Developer
 
 pyMOR's main developers form a small
 [group](https://github.com/orgs/pymor/people?query=role:owner+)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,7 +123,7 @@ pyMOR's main developers form a small
 [group](https://github.com/orgs/pymor/people?query=role:owner+)
 of developers which, apart from making contributions to pyMOR,
 have the job of guiding and maintaining the future development of
-pyMOR. They are the only persons with direct push acces to pyMOR's
+pyMOR. They are the only persons with direct push access to pyMOR's
 main repository and have administrative privileges over the
 [pyMOR organization](https://github.com/pymor) on GitHub.
 

--- a/docs/source/developer_docs.md
+++ b/docs/source/developer_docs.md
@@ -2,13 +2,13 @@
 
 ## Setting up an Environment for pyMOR Development
 
-### Getting the source
+### Getting the Source
 
 Clone the pyMOR git repository using:
 
 ```
-git clone https://github.com/pymor/pymor pymor_source
-cd pymor_source
+git clone git@github.com:pymor/pymor.git
+cd pymor
 ```
 
 and, optionally, switch to the branch you are interested in, e.g.:
@@ -17,22 +17,36 @@ and, optionally, switch to the branch you are interested in, e.g.:
 git checkout 2020.2.x
 ```
 
-### Environment with Virtualenv
+### Environment with venv
 
-Create and activate a new virtualenv:
+Create and activate a new venv (alternatively, you can use
+[`virtualenv`](https://virtualenv.pypa.io/en/latest/) and
+[`virtualenvwrapper`](https://virtualenvwrapper.readthedocs.io/en/latest/)):
 
 ```
-python3 -m virtualenv venv
+python3 -m venv venv
 source venv/bin/activate
 ```
 
-Then, make an editable installation of pyMOR with:
+Then, it may be necessary to upgrade `pip`, `setuptools`, and `wheel`:
+
+```
+pip install -U pip setuptools wheel
+```
+
+Finally, make an editable installation of pyMOR with minimal dependencies:
+
+```
+pip install -e .
+```
+
+or almost all dependencies
 
 ```
 pip install -e '.[full]'
 ```
 
-### Environment with docker-compose
+### Environment with `docker-compose`
 
 To get a shell in a preconfigured container run
 (if required set `PYMOR_SUDO=1` in your environment to execute docker with elevated rights):
@@ -42,11 +56,11 @@ make docker_run
 ```
 
 You can also use the setup in `.binder/docker-compose.yml` to easily
-work on pyMOR with [pyCharm](https://www.jetbrains.com/help/pycharm/docker-compose.html).
+work on pyMOR with [PyCharm](https://www.jetbrains.com/help/pycharm/docker-compose.html).
 
-## Coding guidelines and project management
+## Coding Guidelines and Project Management
 
-### Code style
+### Code Style
 
 pyMOR follows the coding style of
 [PEP8](https://www.python.org/dev/peps/pep-0008/) apart from a
@@ -62,20 +76,35 @@ function is extended.
 All functions and classes called or instantiated by users should
 be sufficiently well documented.
 
-#### How to check code style
+#### How to Check Code Style
 
-Firstly, make sure that you installed the `requirements-ci.txt` with `pip install -r requirements-ci.txt`.
-Afterwards use the Makefile to check for flake8 warnings with `make flake8`
-or directly use `flake8` on the `src` folder.
+Firstly, make sure that you installed the dependencies in `requirements-ci.txt`
+with
 
-### GitHub project
+```
+pip install -r requirements-ci.txt
+```
+
+Afterwards use the Makefile to check for flake8 warnings with
+
+```
+make flake8
+```
+
+or directly call
+
+```
+flake8 src
+```
+
+### GitHub Project
 
 All new code enters pyMOR by means of a pull request. Pull requests (PR) trigger [automatic tests](#continuous-testing--integration-setup)
 which are mandatory to pass before the PR can be merged. A PR must also be tagged with either one of the
 `pr:new-feature`, `pr:fix`, `pr:removal`, `pr:deprecation` or `pr:change` labels to clearly identify the type of
 changes it introduces. See the [labels' descriptions](https://github.com/pymor/pymor/labels?q=pr%3A) for more details.
 
-### pre-commit hooks
+### `pre-commit` Hooks
 
 pyMOR ships a config for the [pre-commit](https://pre-commit.com/) hook management system.
 Using this setup can be a good way to find flake8 errors before pushing to GitHub, but using
@@ -89,7 +118,7 @@ Afterwards, the hooks configured in `.pre-commit-config.yaml` will run on all ch
 files prior to committing changes. Errors will block the commit, some
 checks will automatically fix the file.
 
-## pyMOR's dependencies
+## pyMOR's Dependencies
 
 The single source of truth for our dependency setup is `dependencies.py`.
 From it the `requirements*txt` files  and `pyproject.toml` are generated (by calling `make`).
@@ -127,16 +156,16 @@ change the install version in the docker images.
 ## The Makefile
 
 Via the `Makefile` it is possible to execute tests close to how they are run on CI with `make docker_test`.
-All jobs described in {ref}`Gitlab CI Test Stage <ref_gitlab_ci_stage_test>` can be run this way by setting `PYMOR_TEST_SCRIPT`
+All jobs described in {ref}`GitLab CI Test Stage <ref_gitlab_ci_stage_test>` can be run this way by setting `PYMOR_TEST_SCRIPT`
 accordingly. You can pass additional arguments to pytest by setting `PYMOR_PYTEST_EXTRA`.
 To run the test suite without docker,
 simply execute `make test` in the base directory of the pyMOR repository. This will
 run the pytest suite with the default hypothesis profile "dev". For available profiles
 see `src/pymortests/conftest.py`. A profile is selected by running `make PYMOR_HYPOTHESIS_PROFILE=PROFILE_NAME test`.
-Run `make full-test` to also enable
-[pyflakes](https://pypi.python.org/pypi/pyflakes) and [pep8](https://www.python.org/dev/peps/pep-0008/) checks.
+Run `make full-test` to also generate a
+[Coverage](https://coverage.readthedocs.io/en/stable/) report.
 
-### the `.env` file
+### The `.env` file
 
 This file records defaults used when executing CI scripts. These are loaded by make and can be
 overridden like this: `make DOCKER_BASE_PYTHON=3.8 docker_test` (see also the top of the `Makefile`).
@@ -144,8 +173,8 @@ overridden like this: `make DOCKER_BASE_PYTHON=3.8 docker_test` (see also the to
 
 ## Continuous Testing / Integration Setup
 
-Our CI infrastructure is spread across two major platforms. These are Gitlab CI (Linux testsuite)
-and GitHub Actions (Conda-based MacOS and Windows testsuite, misc. checks).
+Our CI infrastructure is spread across two major platforms. These are GitLab CI (Linux test suite)
+and GitHub Actions (Conda-based MacOS and Windows test suite, misc. checks).
 
 pyMOR uses [pytest](https://pytest.org/) for unit testing.
 All tests are contained within the `src/pymortests` directory and can be run
@@ -155,7 +184,7 @@ for detailed examples.
 
 (ref_gitlab_ci)=
 
-### Gitlab CI
+### GitLab CI
 
 :::{note}
 Configured by `.ci/gitlab/ci.yml` which is generated from `.ci/gitlab/template.ci.py`
@@ -163,7 +192,7 @@ by the calling `make template` (needs appropriate Python environment) or `make d
 :::
 
 All stages are run in docker containers ({ref}`more info  <ref_docker_images>`).
-Jobs that potentially install packages get a frozen pypi mirror
+Jobs that potentially install packages get a frozen PyPI mirror
 as a "service" container. The mirror has a "oldest" variant in which all requirements are available
 in the oldest versions that still satisfy all version restrictions (recursively checked).
 
@@ -183,35 +212,28 @@ Also ensures CI config and requirements generated from their templates match the
 This stage executes `./.ci/gitlab/test_{{script}}.bash` for a list of different scripts:
 
 vanilla
-
 : This runs plain `pytest` with the common options defined in `./.ci/gitlab/common_test_setup.bash`.
 
 cpp_demo
-
 : Builds and executes the minimal cpp demo in `src/pymordemos/minimal_cpp_demo/`,
   see also {doc}`tutorial_external_solver`.
 
 mpi
-
 : Runs all demos with `mpirun -np 2` via `src/pymortests/mpi_run_demo_tests.py`, checks against recorded results.
 
 numpy_git
-
 : Same as vanilla, but against the unreleased numpy development branch. This makes sure we catch
   deprecation warnings or breaking changes early.
 
 oldest
-
-: Same as vanilla, but installs only packages from the "oldest" pypi mirror.
+: Same as vanilla, but installs only packages from the "oldest" PyPI mirror.
 
 pip_installed
-
 : First install pyMOR from git over https, uninstall and then install with `pip install .[full]`.
   Uninstall again and install from a generated (and checked) sdist tarball. Lastly run the pytest suite
   on the installed (!) pyMOR, not the git working tree.
 
 tutorials
-
 : Using docutils magic this extracts the Python code from all the tutorials in
   `docs/source/tutorials_*` (except tutorial_external_solver since that needs kernel switching)
   and runs it in parameterized pytest fixtures as imported modules.
@@ -232,17 +254,14 @@ deployment of the documentation in the last stage.
 #### Stage: Install_checks
 
 from wheel
-
-: Try to install wheels produced in previous stage on a few different Linuxs.
+: Try to install wheels produced in previous stage on a few different Linuxes.
 
 from source
-
 : Try to install `pymor[full]` from git checkout. This checks that the extension module compile works,
   which is not covered by the "from wheel" step. Also install full optional requirements, which include
   packages omitted from `[full]`, after necessary additional system package install.
 
 local docker
-
 : Ensures minimal functionality for the local docker development setup .
 
 (ref_gitlab_ci_stage_deploy)=
@@ -250,7 +269,6 @@ local docker
 #### Stage: Deploy
 
 docs
-
 : Commits documentation built in {ref}`ref_gitlab_ci_stage_build` (from a single Python version, not all) to the
   [documentation repository](https://github.com/pymor/docs). This repository is the source for
   [https://docs.pymor.org/](https://docs.pymor.org/) served via GitHub Pages.
@@ -258,19 +276,17 @@ docs
   matching the currently checked out git branch of pyMOR.
 
 pypi
-
-: Upload wheels to either the test or the real instance of the pypi repository, depending on whether
+: Upload wheels to either the test or the real instance of the PyPI repository, depending on whether
   the pipeline runs for a tagged commit.
 
 coverage
-
 : This job accumulates all the coverage databases generated by previous stages and submits that
   to [codecov.io](https://codecov.io/github/pymor/pymor/).
 
-#### Github - Gitlab bridge
+#### GitHub-GitLab Bridge
 
 This a sanic based Python [application](https://github.com/pymor/ci_hooks_app) that receives webhook
-events from GitHub for pull requests and pushes PR branches merged into main to Gitlab to run a
+events from GitHub for pull requests and pushes PR branches merged into main to GitLab to run a
 parallel CI pipeline to check whether the main branch will still pass tests after the PR is merged.
 The service also gets GitLab Pipeline events via hooks and translates those into status check
 updates.
@@ -296,7 +312,7 @@ Configured by individual files in `.github/workflows/*`
 
 - Auto-assign the labels if certain files are changed by the PR.
 
-- Update requirement files / conda env if `depependencies.py` changes.
+- Update requirement files / conda env if `dependencies.py` changes.
 
 - Runs pytest in conda-based environments on Windows/MacOS/Linux for oldest and newest supported Pythons
   - Entire conda envs are cached and only update if either manually invalidated by incrementing `CACHE_NUMBER`
@@ -316,7 +332,7 @@ If the hooks change files, the changes are pushed back to the PR branch.
 [Configuration](https://pre-commit.ci/#configuration) is done
 via the `.pre-commit-config.yaml` file.
 
-### Docker images
+### Docker Images
 
 The source for most of our docker images is this [repository](https://github.com/pymor/docker).
 The images are build by a Makefile system that expresses dependencies, handles parameterization,
@@ -326,5 +342,5 @@ Great effort went into making incremental updates as fast as possible, but full 
 There are two basic categories for images: those that get generated for each supported Python version and those that
 are version independent.
 For CI the main image, in which the pytest suite runs, is defined in `testing/`. The main workflow for this repository
-is adding new packages to the appropriate requirements file in the `constraints/` subdir. From there
+is adding new packages to the appropriate requirements file in the `constraints/` subdirectory. From there
 those packages will become available in the `pypi_mirror-*` images, but also pre-installed in the `testing` image.

--- a/docs/source/developer_docs.md
+++ b/docs/source/developer_docs.md
@@ -67,14 +67,33 @@ pyMOR follows the coding style of
 few exceptions. Configurations for the [PEP8](https://pypi.python.org/pypi/pep8) and
 [flake8](https://pypi.python.org/pypi/flake8) code checkers are contained in `setup.cfg`.
 
-As an additional rule when calling functions, positional
-arguments should generally be passed as positional arguments
-whereas keyword arguments should be passed as keyword arguments.
-This will make your code less likely to break, when the called
-function is extended.
+Further guidelines:
 
-All functions and classes called or instantiated by users should
-be sufficiently well documented.
+- Functions and classes called or instantiated by users should be
+  sufficiently well documented.
+- Use keyword arguments for parameters with defaults. This will make your
+  code less likely to break, when the called function is extended.
+- Generally use verbose identifiers instead of single letter names, also
+  for mathematical objects (use `residual` instead of `r`). Exceptions
+  are well-established variable names (like A,B,C,D,E for LTI systems)
+  or temporary variables.
+- Prefer assertions over exceptions in potentially performance-relevant
+  code. Assertions can be ignored by invoking Python with the `-O`
+  argument. Try to check a single condition in an assertion and add helpful
+  error messages.
+- Use `warnings.warn` for code-related issues. Use `self.logger.warning`
+  for issues related to an algorithm or user input.
+- It is generally ok to use builtin names as function parameters
+  (e.g. `type`) when there is no other adequate name. There is no need
+  to add underscores before or after the name.
+- Use the `self.__auto_init(locals())` idiom to initialize instance
+  attributes from `__init__` args of the same name.
+
+:::{note}
+If you are a first-time contributor, do not worry too much about code
+style. The main developers will be happy to help you to bring your code
+into proper shape for inclusion in pyMOR.
+:::
 
 #### How to Check Code Style
 
@@ -96,6 +115,7 @@ or directly call
 ```
 flake8 src
 ```
+
 
 ### GitHub Project
 


### PR DESCRIPTION
This moves the code style section from `CONTRIBUTING.md` to developer docs (along with some minor improvements in both).

There should probably be a link to `CONTRIBUTING.md` somewhere (e.g., `README.md`), but that could be a different issue/PR.