### PR TITLE
[CI] silence dubious ownership git error

### DIFF
--- a/.ci/gitlab/test_pip_installed.bash
+++ b/.ci/gitlab/test_pip_installed.bash
@@ -32,6 +32,9 @@ pip install -e .[full]
 pip install -r requirements-ci.txt
 python setup.py sdist -d ${SDIST_DIR}/ --format=gztar
 twine check ${SDIST_DIR}/*
+# silence 'detected dubious ownership in repository at '/builds/pymor/pymor''
+# no idea where this comes from
+git config --global --add safe.directory /builds/pymor/pymor
 check-manifest -p python ${PWD}
 pushd ${SDIST_DIR}
 uninstall


### PR DESCRIPTION
See error [here](https://zivgitlab.uni-muenster.de/pymor/pymor/-/jobs/1338743#L1632).

I don't understand what is affecting file ownership, but I think it is ok to just silence the error.