### PR TITLE
Loewner Reductor

### DIFF
--- a/docs/source/bibliography.bib
+++ b/docs/source/bibliography.bib
@@ -239,6 +239,17 @@
   doi =          {10.1137/1.9781611974829.ch2}
 }
 
+@InCollection{ALI17,,
+  author = {Athanasios C. Antoulas and Sanda Lefteriu and A. Cosmin Ionita},
+  title = {A Tutorial Introduction to the Loewner Framework for Model Reduction},
+  booktitle =    {Model Reduction and Approximation: Theory and Algorithms},
+  publisher =    {SIAM},
+  year =         2017,
+  editor =       {Benner, P. and Cohen, A. and Ohlberger, M. and Willcox, K.},
+  pages = {335--376},
+  doi = {10.1137/1.9781611974829.ch8},
+}
+
 @Article{HDO11,
   author =       {Haasdonk, B. and Dihlmann, M. and Ohlberger, M.},
   title =        {A Training Set and Multiple Basis Generation Approach for

--- a/src/pymor/reductors/loewner.py
+++ b/src/pymor/reductors/loewner.py
@@ -21,20 +21,21 @@ class LoewnerReductor(BasicObject):
     s
         |Numpy Array| of shape (n,) containing the frequencies.
     Hs
-        |Numpy Array| of shape (n, p, m) or |TransferFunction| resembling the transfer function samples.
+        |Numpy Array| of shape (n, p, m) or |TransferFunction| resembling the transfer function
+        samples.
     partitioning
         `str` or `tuple` of length 2. Strings can either be 'even-odd' or 'half-half' defining
-        the splitting rule. A user-defined partitioning can be defined by passing a tuple of the left and
-        right indices. Defaults to `even-odd`.
+        the splitting rule. A user-defined partitioning can be defined by passing a tuple of the
+        left and right indices. Defaults to `even-odd`.
     ordering
-        The ordering with respect to which the splitting rule is executed. Can be either 'magnitude',
-        'random' or 'regular'. Defaults to 'regular'.
+        The ordering with respect to which the splitting rule is executed. Can be either
+        'magnitude', 'random' or 'regular'. Defaults to 'regular'.
     ltd
-        |Numpy Array| representing left tangential directions. If `None` tangential directions will be
-        chosen randomly (normal distribution).
+        |Numpy Array| representing left tangential directions. If `None` tangential directions will
+        be chosen randomly (normal distribution).
     rtd
-        |Numpy Array| representing right tangential directions. If `None` tangential directions will be
-        chosen randomly (normal distribution).
+        |Numpy Array| representing right tangential directions. If `None` tangential directions will
+        be chosen randomly (normal distribution).
     """
 
     def __init__(self, s, Hs, partitioning='even-odd', ordering='regular', ltd=None, rtd=None):
@@ -53,7 +54,8 @@ class LoewnerReductor(BasicObject):
         rom
             Reduced |LTIModel|.
         """
-        L, Ls, V, W = loewner_quadruple(self.s, self.Hs, partitioning='even-odd', ordering='regular', ltd=None, rtd=None)
+        L, Ls, V, W = loewner_quadruple(self.s, self.Hs, partitioning='even-odd', ordering='regular',
+                                        ltd=None, rtd=None)
         LLS = np.vstack([L, Ls])
         Y, S, _ = spla.svd(LLS, full_matrices=False)
         _, _, Xh = spla.svd(LLS.T, full_matrices=False)
@@ -123,28 +125,29 @@ def loewner_quadruple(s, Hs, partitioning='even-odd', ordering='regular', ltd=No
     .. math::
         (\mathbb{L},\mathbb{L}_s,V,W)
 
-    consists of the Loewner matrix :math:`\mathbb{L}`, the shifted Loewner matrix :math:`\mathbb{L}_s`,
-    left interpolation data :math:`V` and right interpolation data :math:`W`.
+    consists of the Loewner matrix :math:`\mathbb{L}`, the shifted Loewner matrix
+    :math:`\mathbb{L}_s`, left interpolation data :math:`V` and right interpolation data :math:`W`.
 
     Parameters
     ----------
     s
         |Numpy Array| of shape (n,) containing the frequencies.
     Hs
-        |Numpy Array| of shape (n, p, m) or |TransferFunction| resembling the transfer function samples.
+        |Numpy Array| of shape (n, p, m) or |TransferFunction| resembling the transfer function
+        samples.
     partitioning
         `str` or `tuple` of length 2. Strings can either be 'even-odd' or 'half-half' defining
-        the splitting rule. A user-defined partitioning can be defined by passing a tuple of the left and
-        right indices. Defaults to `even-odd`.
+        the splitting rule. A user-defined partitioning can be defined by passing a tuple of the
+        left and right indices. Defaults to `even-odd`.
     ordering
-        The ordering with respect to which the splitting rule is executed. Can be either 'magnitude',
-        'random' or 'regular'. Defaults to 'regular'.
+        The ordering with respect to which the splitting rule is executed. Can be either
+        'magnitude', 'random' or 'regular'. Defaults to 'regular'.
     ltd
-        |Numpy Array| representing left tangential directions. If `None` tangential directions will be
-        chosen randomly (normal distribution).
+        |Numpy Array| representing left tangential directions. If `None` tangential directions will
+        be chosen randomly (normal distribution).
     rtd
-        |Numpy Array| representing right tangential directions. If `None` tangential directions will be
-        chosen randomly (normal distribution).
+        |Numpy Array| representing right tangential directions. If `None` tangential directions will
+        be chosen randomly (normal distribution).
 
     Returns
     -------

--- a/src/pymor/reductors/loewner.py
+++ b/src/pymor/reductors/loewner.py
@@ -216,11 +216,11 @@ def loewner_quadruple(s, Hs, partitioning='even-odd', ordering='regular', ltd=No
         W = np.empty((dim_output, len(jp)), dtype=np.complex_)
         for i, si in enumerate(ip):
             for j, sj in enumerate(jp):
-                L[i, j] = ltd[i] @ (Hs[si] - Hs[sj]) @ rtd[:,j] / (s[si] - s[sj])
-                Ls[i, j] = ltd[i] @ (s[si] * Hs[si] - s[sj] * Hs[sj]) @ rtd[:,j] / (s[si] - s[sj])
+                L[i, j] = ltd[i] @ (Hs[si] - Hs[sj]) @ rtd[:, j] / (s[si] - s[sj])
+                Ls[i, j] = ltd[i] @ (s[si] * Hs[si] - s[sj] * Hs[sj]) @ rtd[:, j] / (s[si] - s[sj])
             V[i, :] = Hs[si].T @ ltd[i]
         for j, sj in enumerate(jp):
-            W[:, j] = Hs[sj] @ rtd[:,j]
+            W[:, j] = Hs[sj] @ rtd[:, j]
 
     # transform the system to have real matrices
     TL = np.zeros((len(ip), len(ip)), dtype=np.complex_)

--- a/src/pymor/reductors/loewner.py
+++ b/src/pymor/reductors/loewner.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+import numpy as np
+
+from pymor.models.transfer_function import TransferFunction
+
+
+def _partition_frequencies(s, Hs, partitioning='even-odd', ordering='regular'):
+    """Create a frequency partitioning."""
+    if ordering == 'magnitude':
+        idx = np.argsort(np.linalg.norm(Hs), axis=(1, 2))
+    elif ordering == 'random':
+        idx = np.random.permutation(s.shape[0])
+    elif ordering == 'regular':
+        idx = np.arange(s.shape[0])
+
+    if partitioning == 'even-odd':
+        return idx[::2], idx[1::2]
+    elif partitioning == 'half-half':
+        return np.array_split(idx, 2)
+    elif partitioning == 'same':
+        return idx, idx
+
+
+def _construct_loewner_matrix(s, Hs, dHs=None, shifted=False, partitioning='even-odd', ordering='regular'):
+    """Constructs a (shifted) Loewner matrix as a |NumPy array|."""
+    assert isinstance(s, np.ndarray)
+    if hasattr(Hs, 'transfer_function'):
+        Hs = Hs.transfer_function
+    assert isinstance(Hs, TransferFunction) or isinstance(Hs, np.ndarray) and Hs.shape[0] == s.shape[0]
+    assert dHs is None or isinstance(dHs, np.ndarray)
+
+    assert isinstance(shifted, bool)
+    assert partitioning in ('even-odd', 'half-half', 'same') or len(partitioning) == 2
+    if partitioning == 'same':
+        raise NotImplementedError
+    assert ordering in ('magnitude', 'random', 'regular')
+
+    # compute derivatives if needed
+    if not isinstance(partitioning, str) and np.any(np.isin(*partitioning)) or partitioning == 'same':
+        if isinstance(Hs, TransferFunction):
+            assert Hs.dtf is not None
+            dHs = np.stack([Hs.eval_dtf(si) for si in s])
+        else:
+            assert isinstance(dHs, np.ndarray) and Hs.shape == dHs.shape
+
+    if isinstance(Hs, TransferFunction):
+        Hs = np.stack([Hs.eval_tf(si) for si in s])
+
+    i, j = _partition_frequencies(s, Hs, partitioning, ordering) if isinstance(partitioning, str) else partitioning
+
+    if shifted:
+        L = (np.expand_dims(s[i], axis=(1, 2)) * Hs[i])[:, np.newaxis] - (np.expand_dims(s[j], axis=(1, 2)) * Hs[j])[np.newaxis]
+    else:
+        L = Hs[i][:, np.newaxis] - Hs[j][np.newaxis]
+
+    L /= np.expand_dims(np.subtract.outer(s[i], s[j]), axis=(2, 3))
+
+    return np.concatenate(np.concatenate(L, axis=1), axis=1)

--- a/src/pymor/reductors/loewner.py
+++ b/src/pymor/reductors/loewner.py
@@ -1,58 +1,253 @@
-#!/usr/bin/env python3
-import numpy as np
+# This file is part of the pyMOR project (https://www.pymor.org).
+# Copyright pyMOR developers and contributors. All rights reserved.
+# License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
+import numpy as np
+import scipy.linalg as spla
+
+from pymor.core.base import BasicObject
+from pymor.models.iosys import LTIModel
 from pymor.models.transfer_function import TransferFunction
+from pymor.tools.random import new_rng
+
+
+class LoewnerReductor(BasicObject):
+    """Reductor based on Loewner interpolation framework.
+
+    The reductor implements interpolation based on the Loewner framework as in :cite:`ALI17`.
+
+    Parameters
+    ----------
+    s
+        |Numpy Array| of shape (n,) containing the frequencies.
+    Hs
+        |Numpy Array| of shape (n, p, m) or |TransferFunction| resembling the transfer function samples.
+    partitioning
+        `str` or `tuple` of length 2. Strings can either be 'even-odd' or 'half-half' defining
+        the splitting rule. A user-defined partitioning can be defined by passing a tuple of the left and
+        right indices. Defaults to `even-odd`.
+    ordering
+        The ordering with respect to which the splitting rule is executed. Can be either 'magnitude',
+        'random' or 'regular'. Defaults to 'regular'.
+    ltd
+        |Numpy Array| representing left tangential directions. If `None` tangential directions will be
+        chosen randomly (normal distribution).
+    rtd
+        |Numpy Array| representing right tangential directions. If `None` tangential directions will be
+        chosen randomly (normal distribution).
+    """
+
+    def __init__(self, s, Hs, partitioning='even-odd', ordering='regular', ltd=None, rtd=None):
+        self.__auto_init(locals())
+
+    def reduce(self, tol=1e-7):
+        """Reduce using Loewner framework.
+
+        Parameters
+        ----------
+        tol
+            Truncation tolerance for rank of Loewner matrices.
+
+        Returns
+        -------
+        rom
+            Reduced |LTIModel|.
+        """
+        L, Ls, V, W = loewner_quadruple(self.s, self.Hs, partitioning='even-odd', ordering='regular', ltd=None, rtd=None)
+        LLS = np.vstack([L, Ls])
+        Y, S, _ = spla.svd(LLS, full_matrices=False)
+        _, _, Xh = spla.svd(LLS.T, full_matrices=False)
+
+        r = len(S[S > tol])
+        Yr = Y[:r, :]
+        Xhr = Xh[:, :r]
+        B = Yr @ V
+        C = W @ Xhr.conj()
+        E = - Yr @ L @ Xhr.conj()
+        A = - Yr @ Ls @ Xhr.conj()
+
+        return LTIModel.from_matrices(A, B, C, D=None, E=E)
 
 
 def _partition_frequencies(s, Hs, partitioning='even-odd', ordering='regular'):
     """Create a frequency partitioning."""
+
+    # partition frequencies corresponding to positive imaginary part
+    pimidx = np.where(np.imag(s) > 0)[0]
+
+    # treat real-valued samples separately in order to ensure balanced splitting
+    ridx = np.where(np.imag(s) == 0)[0]
+
     if ordering == 'magnitude':
-        idx = np.argsort(np.linalg.norm(Hs), axis=(1, 2))
+        pimidx_sort = np.argsort([np.linalg.norm(Hs[i]) for i in pimidx])
+        pimidx_ordered = pimidx[pimidx_sort]
+        ridx_sort = np.argsort([np.linalg.norm(Hs[i]) for i in ridx])
+        ridx_ordered = ridx[ridx_sort]
     elif ordering == 'random':
-        idx = np.random.permutation(s.shape[0])
+        np.random.shuffle(pimidx)
+        pimidx_ordered = pimidx
+        np.random.permutation(ridx)
+        ridx_ordered = ridx
     elif ordering == 'regular':
-        idx = np.arange(s.shape[0])
+        pimidx_ordered = pimidx
+        ridx_ordered = ridx
 
     if partitioning == 'even-odd':
-        return idx[::2], idx[1::2]
+        left = np.concatenate((ridx_ordered[::2], pimidx_ordered[::2]))
+        right = np.concatenate((ridx_ordered[1::2], pimidx_ordered[1::2]))
     elif partitioning == 'half-half':
-        return np.array_split(idx, 2)
-    elif partitioning == 'same':
-        return idx, idx
+        pim_split = np.array_split(pimidx_ordered, 2)
+        r_split = np.array_split(ridx_ordered, 2)
+        left = np.concatenate((r_split[0], pim_split[0]))
+        right = np.concatenate((r_split[1], pim_split[1]))
+
+    l_cc = np.array([], dtype=int)
+    for le in left:
+        if np.imag(s[le]) != 0:
+            l_cc = np.concatenate((l_cc, np.where(s == s[le].conj())[0]))
+    left = np.concatenate((left, l_cc))
+
+    r_cc = np.array([], dtype=int)
+    for ri in right:
+        if np.imag(s[ri]) != 0:
+            r_cc = np.concatenate((r_cc, np.where(s == s[ri].conj())[0]))
+    right = np.concatenate((right, r_cc))
+
+    return (left, right)
 
 
-def _construct_loewner_matrix(s, Hs, dHs=None, shifted=False, partitioning='even-odd', ordering='regular'):
-    """Constructs a (shifted) Loewner matrix as a |NumPy array|."""
+def loewner_quadruple(s, Hs, partitioning='even-odd', ordering='regular', ltd=None, rtd=None):
+    r"""Constructs a Loewner quadruple as |NumPy arrays|.
+
+    The Loewner quadruple :cite:`ALI17`
+
+    .. math::
+        (\mathbb{L},\mathbb{L}_s,V,W)
+
+    consists of the Loewner matrix :math:`\mathbb{L}`, the shifted Loewner matrix :math:`\mathbb{L}_s`,
+    left interpolation data :math:`V` and right interpolation data :math:`W`.
+
+    Parameters
+    ----------
+    s
+        |Numpy Array| of shape (n,) containing the frequencies.
+    Hs
+        |Numpy Array| of shape (n, p, m) or |TransferFunction| resembling the transfer function samples.
+    partitioning
+        `str` or `tuple` of length 2. Strings can either be 'even-odd' or 'half-half' defining
+        the splitting rule. A user-defined partitioning can be defined by passing a tuple of the left and
+        right indices. Defaults to `even-odd`.
+    ordering
+        The ordering with respect to which the splitting rule is executed. Can be either 'magnitude',
+        'random' or 'regular'. Defaults to 'regular'.
+    ltd
+        |Numpy Array| representing left tangential directions. If `None` tangential directions will be
+        chosen randomly (normal distribution).
+    rtd
+        |Numpy Array| representing right tangential directions. If `None` tangential directions will be
+        chosen randomly (normal distribution).
+
+    Returns
+    -------
+    L
+        Loewner matrix.
+    Ls
+        Shifted Loewner matrix.
+    V
+        Left interpolation data.
+    W
+        Right interpolation data.
+    """
     assert isinstance(s, np.ndarray)
     if hasattr(Hs, 'transfer_function'):
         Hs = Hs.transfer_function
     assert isinstance(Hs, TransferFunction) or isinstance(Hs, np.ndarray) and Hs.shape[0] == s.shape[0]
-    assert dHs is None or isinstance(dHs, np.ndarray)
 
-    assert isinstance(shifted, bool)
-    assert partitioning in ('even-odd', 'half-half', 'same') or len(partitioning) == 2
-    if partitioning == 'same':
-        raise NotImplementedError
+    assert partitioning in ('even-odd', 'half-half') or len(partitioning) == 2
     assert ordering in ('magnitude', 'random', 'regular')
 
-    # compute derivatives if needed
-    if not isinstance(partitioning, str) and np.any(np.isin(*partitioning)) or partitioning == 'same':
-        if isinstance(Hs, TransferFunction):
-            assert Hs.dtf is not None
-            dHs = np.stack([Hs.eval_dtf(si) for si in s])
-        else:
-            assert isinstance(dHs, np.ndarray) and Hs.shape == dHs.shape
-
     if isinstance(Hs, TransferFunction):
-        Hs = np.stack([Hs.eval_tf(si) for si in s])
-
-    i, j = _partition_frequencies(s, Hs, partitioning, ordering) if isinstance(partitioning, str) else partitioning
-
-    if shifted:
-        L = (np.expand_dims(s[i], axis=(1, 2)) * Hs[i])[:, np.newaxis] - (np.expand_dims(s[j], axis=(1, 2)) * Hs[j])[np.newaxis]
+        Hss = np.empty((len(s), Hs.dim_output, Hs.dim_input), dtype=s[0].dtype)
+        for i, ss in enumerate(s):
+            Hss[i] = Hs.eval_tf(ss)
+        Hs = Hss
     else:
-        L = Hs[i][:, np.newaxis] - Hs[j][np.newaxis]
+        assert len(Hs[0]) == len(s)
 
-    L /= np.expand_dims(np.subtract.outer(s[i], s[j]), axis=(2, 3))
+    # ensure that complex sampling values appear in complex conjugate pairs
+    for i, ss in enumerate(s):
+        if np.conj(ss) not in s:
+            s = np.append(s, np.conj(ss))
+            Hs = np.append(Hs, np.conj(Hs[i])[None, ...], axis=0)
 
-    return np.concatenate(np.concatenate(L, axis=1), axis=1)
+    ip, jp = _partition_frequencies(s, Hs, partitioning, ordering) if isinstance(partitioning, str) else partitioning
+
+    if len(Hs.shape) > 1:
+        dim_output = Hs.shape[1]
+        dim_input = Hs.shape[2]
+        if ltd is None:
+            rng = new_rng(0)
+            ltd = rng.normal(size=(len(ip), dim_output))
+        else:
+            assert ltd.shape == (len(ip), dim_output)
+
+        if rtd is None:
+            rng = new_rng(0)
+            rtd = rng.normal(size=(dim_input, len(jp)))
+        else:
+            assert rtd.shape == (dim_input, len(jp))
+    else:
+        dim_input = 1
+        dim_output = 1
+
+    if rtd is None and ltd is None:
+        L = Hs[ip][:, np.newaxis] - Hs[jp][np.newaxis]
+        L /= s[ip][:, np.newaxis] - s[jp][np.newaxis]
+        Ls = (s[ip] * Hs[ip])[:, np.newaxis] - (s[jp] * Hs[jp])[np.newaxis]
+        Ls /= s[ip][:, np.newaxis] - s[jp][np.newaxis]
+        V = Hs[ip][:, np.newaxis]
+        W = Hs[jp][np.newaxis]
+    else:
+        L = np.empty((len(ip), len(jp)), dtype=np.complex_)
+        Ls = np.empty((len(ip), len(jp)), dtype=np.complex_)
+        V = np.empty((len(ip), dim_input), dtype=np.complex_)
+        W = np.empty((dim_output, len(jp)), dtype=np.complex_)
+        for i, si in enumerate(ip):
+            for j, sj in enumerate(jp):
+                L[i, j] = ltd[i] @ (Hs[si] - Hs[sj]) @ rtd[:,j] / (s[si] - s[sj])
+                Ls[i, j] = ltd[i] @ (s[si] * Hs[si] - s[sj] * Hs[sj]) @ rtd[:,j] / (s[si] - s[sj])
+            V[i, :] = Hs[si].T @ ltd[i]
+        for j, sj in enumerate(jp):
+            W[:, j] = Hs[sj] @ rtd[:,j]
+
+    # transform the system to have real matrices
+    TL = np.zeros((len(ip), len(ip)), dtype=np.complex_)
+    for i, si in enumerate(ip):
+        if s[si].imag == 0:
+            TL[i, i] = 1
+        else:
+            j = np.argmin(np.abs(s[ip] - s[si].conjugate()))
+            if i < j:
+                TL[i, i] = 1
+                TL[i, j] = 1
+                TL[j, i] = -1j
+                TL[j, j] = 1j
+
+    TR = np.zeros((len(jp), len(jp)), dtype=np.complex_)
+    for i, si in enumerate(jp):
+        if s[si].imag == 0:
+            TR[i, i] = 1
+        else:
+            j = np.argmin(np.abs(s[jp] - s[si].conjugate()))
+            if i < j:
+                TR[i, i] = 1
+                TR[i, j] = 1
+                TR[j, i] = -1j
+                TR[j, j] = 1j
+
+    L = (TL @ L @ TR.conj().T).real
+    Ls = (TL @ Ls @ TR.conj().T).real
+    V = (TL @ V).real
+    W = (W @ TR.conj().T).real
+
+    return L, Ls, V, W

--- a/src/pymor/reductors/loewner.py
+++ b/src/pymor/reductors/loewner.py
@@ -71,7 +71,6 @@ class LoewnerReductor(BasicObject):
 
 def _partition_frequencies(s, Hs, partitioning='even-odd', ordering='regular'):
     """Create a frequency partitioning."""
-
     # partition frequencies corresponding to positive imaginary part
     pimidx = np.where(np.imag(s) > 0)[0]
 

--- a/src/pymor/reductors/loewner.py
+++ b/src/pymor/reductors/loewner.py
@@ -98,7 +98,7 @@ class LoewnerReductor(CacheableObject):
 
         self.__auto_init(locals())
 
-    def reduce(self, r=None, tol=1e-7):
+    def reduce(self, r=None, tol=1e-12):
         """Reduce using Loewner framework.
 
         Parameters
@@ -129,7 +129,7 @@ class LoewnerReductor(CacheableObject):
             if r1 != r2:
                 self.logger.warning(f'Mismatch in numerical rank of stacked Loewner matrices ({r1} and {r2}).'
                                     ' Consider increasing tol, specifying r or changing the partitioning.')
-                r = (r1 + r2) // 2
+                r = min(r1, r2)
             else:
                 r = r1
 

--- a/src/pymor/reductors/loewner.py
+++ b/src/pymor/reductors/loewner.py
@@ -67,7 +67,6 @@ class LoewnerReductor(BasicObject):
         rom
             Reduced |LTIModel|.
         """
-
         if self.loewner_svds is None:
             L, Ls, V, W = loewner_quadruple(self.s, self.Hs, partitioning=self.partitioning, ordering=self.ordering,
                                             conjugate=self.conjugate, mimo_handling=self.mimo_handling)
@@ -223,7 +222,8 @@ def loewner_quadruple(s, Hs, partitioning='even-odd', ordering='regular', conjug
         Hs = Hs.transfer_function
     assert isinstance(Hs, (TransferFunction, np.ndarray, list))
 
-    assert partitioning in ('even-odd', 'half-half') or len(partitioning) == 2
+    assert partitioning in ('even-odd', 'half-half') \
+        or len(partitioning) == 2 and len(partitioning[0]) + len(partitioning[1]) == len(s)
     assert ordering in ('magnitude', 'random', 'regular')
 
     if isinstance(Hs, TransferFunction):
@@ -332,7 +332,7 @@ def loewner_quadruple(s, Hs, partitioning='even-odd', ordering='regular', conjug
         TR = TR / np.sqrt(2)
         TL = TL / np.sqrt(2)
 
-        if mimo_handling == 'full':
+        if mimo_handling == 'full' and not dim_input == dim_output == 1:
             L = np.tensordot(TL, L, axes=(1, 0))
             L = np.tensordot(L, TR.conj().T, axes=(1, 0))
             L = L.real
@@ -352,7 +352,7 @@ def loewner_quadruple(s, Hs, partitioning='even-odd', ordering='regular', conjug
             V = (TL @ V).real
             W = (W @ TR.conj().T).real
 
-    if mimo_handling == 'full':
+    if mimo_handling == 'full' and not dim_input == dim_output == 1:
         L = np.concatenate(np.concatenate(L, axis=1), axis=1)
         Ls = np.concatenate(np.concatenate(Ls, axis=1), axis=1)
         V = np.concatenate(np.concatenate(V, axis=1), axis=1)

--- a/src/pymor/reductors/loewner.py
+++ b/src/pymor/reductors/loewner.py
@@ -27,10 +27,10 @@ class LoewnerReductor(BasicObject):
         attribute.
     partitioning
         `str` or `tuple` of length 2. Strings can either be 'even-odd' or 'half-half' defining
-        the splitting rule. A user-defined partitioning can be defined by passing a tuple of the
+        the partitioning rule. A user-defined partitioning can be defined by passing a tuple of the
         left and right indices. Defaults to `even-odd`.
     ordering
-        The ordering with respect to which the splitting rule is executed. Can be either
+        The ordering with respect to which the partitioning rule is executed. Can be either
         'magnitude', 'random' or 'regular'. Defaults to 'regular'.
     conjugate
         Whether to guarantee realness of reduced |LTIModel| by keeping complex conjugates in the
@@ -112,7 +112,7 @@ def _partition_frequencies(s, Hs, partitioning='even-odd', ordering='regular', c
         # partition frequencies corresponding to positive imaginary part
         pimidx = np.where(s.imag > 0)[0]
 
-        # treat real-valued samples separately in order to ensure balanced splitting
+        # treat real-valued samples separately in order to ensure balanced partitioning
         ridx = np.where(s.imag == 0)[0]
 
         if ordering == 'magnitude':
@@ -190,10 +190,10 @@ def loewner_quadruple(s, Hs, partitioning='even-odd', ordering='regular', conjug
         attribute.
     partitioning
         `str` or `tuple` of length 2. Strings can either be 'even-odd' or 'half-half' defining
-        the splitting rule. A user-defined partitioning can be defined by passing a tuple of the
+        the partitioning rule. A user-defined partitioning can be defined by passing a tuple of the
         left and right indices. Defaults to `even-odd`.
     ordering
-        The ordering with respect to which the splitting rule is executed. Can be either
+        The ordering with respect to which the partitioning rule is executed. Can be either
         'magnitude', 'random' or 'regular'. Defaults to 'regular'.
     conjugate
         Whether to guarantee realness of reduced |LTIModel| by keeping complex conjugates in the

--- a/src/pymor/reductors/loewner.py
+++ b/src/pymor/reductors/loewner.py
@@ -6,6 +6,7 @@ import numpy as np
 import scipy.linalg as spla
 
 from pymor.core.base import BasicObject
+from pymor.core.cache import cached
 from pymor.models.iosys import LTIModel
 from pymor.models.transfer_function import TransferFunction
 from pymor.tools.random import new_rng
@@ -45,6 +46,55 @@ class LoewnerReductor(BasicObject):
     """
 
     def __init__(self, s, Hs, partitioning='even-odd', ordering='regular', conjugate=True, mimo_handling='random'):
+        assert isinstance(s, np.ndarray)
+        if hasattr(Hs, 'transfer_function'):
+            Hs = Hs.transfer_function
+        assert isinstance(Hs, (TransferFunction, np.ndarray, list))
+
+        assert partitioning in ('even-odd', 'half-half') \
+            or len(partitioning) == 2 \
+            and len(partitioning[0]) + len(partitioning[1]) == len(s)
+        assert ordering in ('magnitude', 'random', 'regular')
+
+        if isinstance(Hs, TransferFunction):
+            Hss = np.empty((len(s), Hs.dim_output, Hs.dim_input), dtype=s[0].dtype)
+            for i, ss in enumerate(s):
+                Hss[i] = Hs.eval_tf(ss)
+            Hs = Hss
+        else:
+            Hs = Hs
+            assert Hs.shape[0] == len(s)
+
+        # ensure that complex sampling values appear in complex conjugate pairs
+        if conjugate:
+            # if user provides partitioning sizes, make sure they are adjusted
+            if isinstance(partitioning, tuple):
+                p0 = partitioning[0]
+                p1 = partitioning[1]
+                for i, ss in enumerate(s):
+                    if np.conj(ss) not in s:
+                        s = np.append(s, np.conj(ss))
+                        Hs = np.append(Hs, np.conj(Hs[i])[np.newaxis, ...], axis=0)
+                        if i in p0:
+                            p0 = np.append(p0, len(s)-1)
+                        else:
+                            p1 = np.append(p1, len(s)-1)
+                partitioning = (p0, p1)
+            else:
+                for i, ss in enumerate(s):
+                    if np.conj(ss) not in s:
+                        s = np.append(s, np.conj(ss))
+                        Hs = np.append(Hs, np.conj(Hs[i])[np.newaxis, ...], axis=0)
+
+        if len(Hs.shape) > 1:
+            self.dim_output = Hs.shape[1]
+            self.dim_input = Hs.shape[2]
+            if self.dim_output == self.dim_output == 1:
+                Hs = np.squeeze(Hs)
+        else:
+            self.dim_output = 1
+            self.dim_input = 1
+
         self.__auto_init(locals())
         self.loewner_svds = None
         self.loewner_quadruple = None
@@ -68,8 +118,7 @@ class LoewnerReductor(BasicObject):
             Reduced |LTIModel|.
         """
         if self.loewner_svds is None:
-            L, Ls, V, W = loewner_quadruple(self.s, self.Hs, partitioning=self.partitioning, ordering=self.ordering,
-                                            conjugate=self.conjugate, mimo_handling=self.mimo_handling)
+            L, Ls, V, W = self.construct_loewner_quadruple()
 
             LhLs = np.hstack([L, Ls])
             Y, S1, _ = spla.svd(LhLs, full_matrices=False)
@@ -105,257 +154,187 @@ class LoewnerReductor(BasicObject):
         return LTIModel.from_matrices(A, B, C, D=None, E=E)
 
 
-def _partition_frequencies(s, Hs, partitioning='even-odd', ordering='regular', conjugate=True):
-    """Create a frequency partitioning."""
-    # must keep complex conjugate frequencies in the same partioning
-    if conjugate:
-        # partition frequencies corresponding to positive imaginary part
-        pimidx = np.where(s.imag > 0)[0]
+    def _partition_frequencies(self):
+        """Create a frequency partitioning."""
+        # must keep complex conjugate frequencies in the same partioning
+        if self.conjugate:
+            # partition frequencies corresponding to positive imaginary part
+            pimidx = np.where(self.s.imag > 0)[0]
 
-        # treat real-valued samples separately in order to ensure balanced partitioning
-        ridx = np.where(s.imag == 0)[0]
+            # treat real-valued samples separately in order to ensure balanced partitioning
+            ridx = np.where(self.s.imag == 0)[0]
 
-        if ordering == 'magnitude':
-            pimidx_sort = np.argsort([np.linalg.norm(Hs[i]) for i in pimidx])
-            pimidx_ordered = pimidx[pimidx_sort]
-            ridx_sort = np.argsort([np.linalg.norm(Hs[i]) for i in ridx])
-            ridx_ordered = ridx[ridx_sort]
-        elif ordering == 'random':
-            rng = new_rng(0)
-            rng.shuffle(pimidx)
-            pimidx_ordered = pimidx
-            rng.shuffle(ridx)
-            ridx_ordered = ridx
-        elif ordering == 'regular':
-            pimidx_ordered = pimidx
-            ridx_ordered = ridx
-
-        if partitioning == 'even-odd':
-            left = np.concatenate((ridx_ordered[::2], pimidx_ordered[::2]))
-            right = np.concatenate((ridx_ordered[1::2], pimidx_ordered[1::2]))
-        elif partitioning == 'half-half':
-            pim_split = np.array_split(pimidx_ordered, 2)
-            r_split = np.array_split(ridx_ordered, 2)
-            left = np.concatenate((r_split[0], pim_split[0]))
-            right = np.concatenate((r_split[1], pim_split[1]))
-
-        l_cc = np.array([], dtype=int)
-        for le in left:
-            if s[le].imag != 0:
-                l_cc = np.concatenate((l_cc, np.where(s == s[le].conj())[0]))
-        left = np.concatenate((left, l_cc))
-
-        r_cc = np.array([], dtype=int)
-        for ri in right:
-            if s[ri].imag != 0:
-                r_cc = np.concatenate((r_cc, np.where(s == s[ri].conj())[0]))
-        right = np.concatenate((right, r_cc))
-
-        return (left, right)
-    else:
-        if ordering == 'magnitude':
-            idx = np.argsort([np.linalg.norm(Hs[i]) for i in len(Hs[0])])
-        elif ordering == 'random':
-            rng = new_rng(0)
-            idx = rng.permutation(s.shape[0])
-        elif ordering == 'regular':
-            idx = np.arange(s.shape[0])
-
-        if partitioning == 'even-odd':
-            return (idx[::2], idx[1::2])
-        elif partitioning == 'half-half':
-            idx_split = np.array_split(idx, 2)
-            return (idx_split[0], idx_split[1])
-
-
-def loewner_quadruple(s, Hs, partitioning='even-odd', ordering='regular', conjugate=True, mimo_handling='random'):
-    r"""Constructs a Loewner quadruple as |NumPy arrays|.
-
-    The Loewner quadruple :cite:`ALI17`
-
-    .. math::
-        (\mathbb{L},\mathbb{L}_s,V,W)
-
-    consists of the Loewner matrix :math:`\mathbb{L}`, the shifted Loewner matrix
-    :math:`\mathbb{L}_s`, left interpolation data :math:`V` and right interpolation data :math:`W`.
-
-    Parameters
-    ----------
-    s
-        |Numpy Array| of shape (n,) containing the frequencies.
-    Hs
-        |Numpy Array| of shape (n, p, m) for MIMO systems with p outputs and m inputs or
-        |Numpy Array| of shape (n,) for SISO systems where the |Numpy Arrays| resemble the transfer
-        function samples. Alternatively, |TransferFunction| or `Model` with `transfer_function`
-        attribute.
-    partitioning
-        `str` or `tuple` of length 2. Strings can either be 'even-odd' or 'half-half' defining
-        the partitioning rule. A user-defined partitioning can be defined by passing a tuple of the
-        left and right indices. Defaults to `even-odd`.
-    ordering
-        The ordering with respect to which the partitioning rule is executed. Can be either
-        'magnitude', 'random' or 'regular'. Defaults to 'regular'.
-    conjugate
-        Whether to guarantee realness of reduced |LTIModel| by keeping complex conjugates in the
-        same partitioning or not. If `True` will automatically generate conjugate data if necessary.
-    mimo_handling
-        Option indicating how to treat MIMO systems. Can be:
-
-        - `'random'` for using random tangential directions.
-        - `'full'` for fully interpolating all input-output pairs.
-        - Tuple `(ltd, rtd)` where `ltd` corresponds to left and `rtd` to right tangential
-          directions.
-
-    Returns
-    -------
-    L
-        Loewner matrix as a |NumPy array|.
-    Ls
-        Shifted Loewner matrix as a |NumPy array|.
-    V
-        Left interpolation data as a |NumPy array|.
-    W
-        Right interpolation data as a |NumPy array|.
-    """
-    assert isinstance(s, np.ndarray)
-    if hasattr(Hs, 'transfer_function'):
-        Hs = Hs.transfer_function
-    assert isinstance(Hs, (TransferFunction, np.ndarray, list))
-
-    assert partitioning in ('even-odd', 'half-half') \
-        or len(partitioning) == 2 and len(partitioning[0]) + len(partitioning[1]) == len(s)
-    assert ordering in ('magnitude', 'random', 'regular')
-
-    if isinstance(Hs, TransferFunction):
-        Hss = np.empty((len(s), Hs.dim_output, Hs.dim_input), dtype=s[0].dtype)
-        for i, ss in enumerate(s):
-            Hss[i] = Hs.eval_tf(ss)
-        Hs = Hss
-    else:
-        assert Hs.shape[0] == len(s)
-
-    # ensure that complex sampling values appear in complex conjugate pairs
-    if conjugate:
-        # if user provides partitioning sizes, make sure they are adjusted
-        if isinstance(partitioning, tuple):
-            p0 = partitioning[0]
-            p1 = partitioning[1]
-            for i, ss in enumerate(s):
-                if np.conj(ss) not in s:
-                    s = np.append(s, np.conj(ss))
-                    Hs = np.append(Hs, np.conj(Hs[i])[np.newaxis, ...], axis=0)
-                    if i in p0:
-                        p0 = np.append(p0, len(s)-1)
-                    else:
-                        p1 = np.append(p1, len(s)-1)
-            partitioning = (p0, p1)
-        else:
-            for i, ss in enumerate(s):
-                if np.conj(ss) not in s:
-                    s = np.append(s, np.conj(ss))
-                    Hs = np.append(Hs, np.conj(Hs[i])[np.newaxis, ...], axis=0)
-
-    ip, jp = _partition_frequencies(s, Hs, partitioning, ordering, conjugate) \
-        if isinstance(partitioning, str) else partitioning
-
-    if len(Hs.shape) > 1:
-        dim_output = Hs.shape[1]
-        dim_input = Hs.shape[2]
-    else:
-        dim_input = 1
-        dim_output = 1
-
-    if dim_input == dim_output == 1:
-        Hs = np.squeeze(Hs)
-        L = Hs[ip][:, np.newaxis] - Hs[jp]
-        L /= s[ip][:, np.newaxis] - s[jp]
-        Ls = (s[ip] * Hs[ip])[:, np.newaxis] - s[jp] * Hs[jp]
-        Ls /= s[ip][:, np.newaxis] - s[jp]
-        V = Hs[ip][:, np.newaxis]
-        W = Hs[jp][np.newaxis]
-    else:
-        if mimo_handling == 'full':
-            L = Hs[ip][:, np.newaxis] - Hs[jp][np.newaxis]
-            L /= (s[ip][:, np.newaxis] - s[jp][np.newaxis])[:, :, np.newaxis, np.newaxis]
-            Ls = (s[ip, np.newaxis, np.newaxis] * Hs[ip])[:, np.newaxis] \
-                - (s[jp, np.newaxis, np.newaxis] * Hs[jp])[np.newaxis]
-            Ls /= (s[ip][:, np.newaxis] - s[jp][np.newaxis])[:, :, np.newaxis, np.newaxis]
-            V = Hs[ip][:, np.newaxis]
-            W = Hs[jp][np.newaxis]
-        else:
-            if mimo_handling == 'random':
+            if self.ordering == 'magnitude':
+                pimidx_sort = np.argsort([np.linalg.norm(self.Hs[i]) for i in pimidx])
+                pimidx_ordered = pimidx[pimidx_sort]
+                ridx_sort = np.argsort([np.linalg.norm(self.Hs[i]) for i in ridx])
+                ridx_ordered = ridx[ridx_sort]
+            elif self.ordering == 'random':
                 rng = new_rng(0)
-                ltd = rng.normal(size=(len(ip), dim_output))
-                rtd = rng.normal(size=(dim_input, len(jp)))
-            elif len(mimo_handling) == 2:
-                ltd = mimo_handling[0]
-                rtd = mimo_handling[1]
-                assert ltd.shape == (len(ip), dim_output)
-                assert rtd.shape == (dim_input, len(jp))
-            L = np.empty((len(ip), len(jp)), dtype=np.complex_)
-            Ls = np.empty((len(ip), len(jp)), dtype=np.complex_)
-            V = np.empty((len(ip), dim_input), dtype=np.complex_)
-            W = np.empty((dim_output, len(jp)), dtype=np.complex_)
-            for i, si in enumerate(ip):
-                for j, sj in enumerate(jp):
-                    L[i, j] = ltd[i] @ (Hs[si] - Hs[sj]) @ rtd[:, j] / (s[si] - s[sj])
-                    Ls[i, j] = ltd[i] @ (s[si] * Hs[si] - s[sj] * Hs[sj]) @ rtd[:, j] / (s[si] - s[sj])
-                V[i, :] = Hs[si].T @ ltd[i]
-            for j, sj in enumerate(jp):
-                W[:, j] = Hs[sj] @ rtd[:, j]
+                rng.shuffle(pimidx)
+                pimidx_ordered = pimidx
+                rng.shuffle(ridx)
+                ridx_ordered = ridx
+            elif self.ordering == 'regular':
+                pimidx_ordered = pimidx
+                ridx_ordered = ridx
 
-    # transform the system to have real matrices
-    if conjugate:
-        TL = np.zeros((len(ip), len(ip)), dtype=np.complex_)
-        for i, si in enumerate(ip):
-            if s[si].imag == 0:
-                TL[i, i] = 1
-            else:
-                j = np.argmin(np.abs(s[ip] - s[si].conjugate()))
-                if i < j:
-                    TL[i, i] = 1
-                    TL[i, j] = 1
-                    TL[j, i] = -1j
-                    TL[j, j] = 1j
+            if self.partitioning == 'even-odd':
+                left = np.concatenate((ridx_ordered[::2], pimidx_ordered[::2]))
+                right = np.concatenate((ridx_ordered[1::2], pimidx_ordered[1::2]))
+            elif self.partitioning == 'half-half':
+                pim_split = np.array_split(pimidx_ordered, 2)
+                r_split = np.array_split(ridx_ordered, 2)
+                left = np.concatenate((r_split[0], pim_split[0]))
+                right = np.concatenate((r_split[1], pim_split[1]))
 
-        TR = np.zeros((len(jp), len(jp)), dtype=np.complex_)
-        for i, si in enumerate(jp):
-            if s[si].imag == 0:
-                TR[i, i] = 1
-            else:
-                j = np.argmin(np.abs(s[jp] - s[si].conjugate()))
-                if i < j:
-                    TR[i, i] = 1
-                    TR[i, j] = 1
-                    TR[j, i] = -1j
-                    TR[j, j] = 1j
-        TR = TR / np.sqrt(2)
-        TL = TL / np.sqrt(2)
+            l_cc = np.array([], dtype=int)
+            for le in left:
+                if self.s[le].imag != 0:
+                    l_cc = np.concatenate((l_cc, np.where(self.s == self.s[le].conj())[0]))
+            left = np.concatenate((left, l_cc))
 
-        if mimo_handling == 'full' and not dim_input == dim_output == 1:
-            L = np.tensordot(TL, L, axes=(1, 0))
-            L = np.tensordot(L, TR.conj().T, axes=(1, 0))
-            L = L.real
-            L = np.transpose(L, (0, 3, 1, 2))
+            r_cc = np.array([], dtype=int)
+            for ri in right:
+                if self.s[ri].imag != 0:
+                    r_cc = np.concatenate((r_cc, np.where(self.s == self.s[ri].conj())[0]))
+            right = np.concatenate((right, r_cc))
 
-            Ls = np.tensordot(TL, Ls, axes=(1, 0))
-            Ls = np.tensordot(Ls, TR.conj().T, axes=(1, 0))
-            Ls = Ls.real
-            Ls = np.transpose(Ls, (0, 3, 1, 2))
-
-            V = np.tensordot(TL, V, axes=(1, 0)).real
-            W = np.tensordot(W, TR.conj().T, axes=(1, 0)).real
-            W = np.transpose(W, (0, 3, 1, 2))
+            return (left, right)
         else:
-            L = (TL @ L @ TR.conj().T).real
-            Ls = (TL @ Ls @ TR.conj().T).real
-            V = (TL @ V).real
-            W = (W @ TR.conj().T).real
+            if self.ordering == 'magnitude':
+                idx = np.argsort([np.linalg.norm(self.Hs[i]) for i in len(self.Hs[0])])
+            elif self.ordering == 'random':
+                rng = new_rng(0)
+                idx = rng.permutation(self.s.shape[0])
+            elif self.ordering == 'regular':
+                idx = np.arange(self.s.shape[0])
 
-    if mimo_handling == 'full' and not dim_input == dim_output == 1:
-        L = np.concatenate(np.concatenate(L, axis=1), axis=1)
-        Ls = np.concatenate(np.concatenate(Ls, axis=1), axis=1)
-        V = np.concatenate(np.concatenate(V, axis=1), axis=1)
-        W = np.concatenate(np.concatenate(W, axis=0), axis=1)
+            if self.partitioning == 'even-odd':
+                return (idx[::2], idx[1::2])
+            elif self.partitioning == 'half-half':
+                idx_split = np.array_split(idx, 2)
+                return (idx_split[0], idx_split[1])
 
-    return L, Ls, V, W
+    @cached
+    def construct_loewner_quadruple(self):
+        r"""Constructs a Loewner quadruple as |NumPy arrays|.
+
+        The Loewner quadruple :cite:`ALI17`
+
+        .. math::
+            (\mathbb{L},\mathbb{L}_s,V,W)
+
+        consists of the Loewner matrix :math:`\mathbb{L}`, the shifted Loewner matrix
+        :math:`\mathbb{L}_s`, left interpolation data :math:`V` and right interpolation
+        data :math:`W`.
+
+        Returns
+        -------
+        L
+            Loewner matrix as a |NumPy array|.
+        Ls
+            Shifted Loewner matrix as a |NumPy array|.
+        V
+            Left interpolation data as a |NumPy array|.
+        W
+            Right interpolation data as a |NumPy array|.
+        """
+        ip, jp = self._partition_frequencies() if isinstance(self.partitioning, str) else self.partitioning
+
+        if self.dim_input == self.dim_output == 1:
+            print(self.Hs.shape)
+            print(self.s.shape)
+            L = self.Hs[ip][:, np.newaxis] - self.Hs[jp]
+            L /= self.s[ip][:, np.newaxis] - self.s[jp]
+            Ls = (self.s[ip] * self.Hs[ip])[:, np.newaxis] - self.s[jp] * self.Hs[jp]
+            Ls /= self.s[ip][:, np.newaxis] - self.s[jp]
+            V = self.Hs[ip][:, np.newaxis]
+            W = self.Hs[jp][np.newaxis]
+        else:
+            if self.mimo_handling == 'full':
+                L = self.Hs[ip][:, np.newaxis] - self.Hs[jp][np.newaxis]
+                L /= (self.s[ip][:, np.newaxis] - self.s[jp][np.newaxis])[:, :, np.newaxis, np.newaxis]
+                Ls = (self.s[ip, np.newaxis, np.newaxis] * self.Hs[ip])[:, np.newaxis] \
+                    - (self.s[jp, np.newaxis, np.newaxis] * self.Hs[jp])[np.newaxis]
+                Ls /= (self.s[ip][:, np.newaxis] - self.s[jp][np.newaxis])[:, :, np.newaxis, np.newaxis]
+                V = self.Hs[ip][:, np.newaxis]
+                W = self.Hs[jp][np.newaxis]
+            else:
+                if self.mimo_handling == 'random':
+                    rng = new_rng(0)
+                    ltd = rng.normal(size=(len(ip), self.dim_output))
+                    rtd = rng.normal(size=(self.dim_input, len(jp)))
+                elif len(self.mimo_handling) == 2:
+                    ltd = self.mimo_handling[0]
+                    rtd = self.mimo_handling[1]
+                    assert ltd.shape == (len(ip), self.dim_output)
+                    assert rtd.shape == (self.dim_input, len(jp))
+                L = np.empty((len(ip), len(jp)), dtype=np.complex_)
+                Ls = np.empty((len(ip), len(jp)), dtype=np.complex_)
+                V = np.empty((len(ip), self.dim_input), dtype=np.complex_)
+                W = np.empty((self.dim_output, len(jp)), dtype=np.complex_)
+                for i, si in enumerate(ip):
+                    for j, sj in enumerate(jp):
+                        L[i, j] = ltd[i] @ (self.Hs[si] - self.Hs[sj]) @ rtd[:, j] / (self.s[si] - self.s[sj])
+                        Ls[i, j] = ltd[i] @ (self.s[si] * self.Hs[si] - self.s[sj] * self.Hs[sj]) @ rtd[:, j] \
+                            / (self.s[si] - self.s[sj])
+                    V[i, :] = self.Hs[si].T @ ltd[i]
+                for j, sj in enumerate(jp):
+                    W[:, j] = self.Hs[sj] @ rtd[:, j]
+
+        # transform the system to have real matrices
+        if self.conjugate:
+            TL = np.zeros((len(ip), len(ip)), dtype=np.complex_)
+            for i, si in enumerate(ip):
+                if self.s[si].imag == 0:
+                    TL[i, i] = 1
+                else:
+                    j = np.argmin(np.abs(self.s[ip] - self.s[si].conjugate()))
+                    if i < j:
+                        TL[i, i] = 1
+                        TL[i, j] = 1
+                        TL[j, i] = -1j
+                        TL[j, j] = 1j
+
+            TR = np.zeros((len(jp), len(jp)), dtype=np.complex_)
+            for i, si in enumerate(jp):
+                if self.s[si].imag == 0:
+                    TR[i, i] = 1
+                else:
+                    j = np.argmin(np.abs(self.s[jp] - self.s[si].conjugate()))
+                    if i < j:
+                        TR[i, i] = 1
+                        TR[i, j] = 1
+                        TR[j, i] = -1j
+                        TR[j, j] = 1j
+            TR = TR / np.sqrt(2)
+            TL = TL / np.sqrt(2)
+
+            if self.mimo_handling == 'full' and not self.dim_input == self.dim_output == 1:
+                L = np.tensordot(TL, L, axes=(1, 0))
+                L = np.tensordot(L, TR.conj().T, axes=(1, 0))
+                L = L.real
+                L = np.transpose(L, (0, 3, 1, 2))
+
+                Ls = np.tensordot(TL, Ls, axes=(1, 0))
+                Ls = np.tensordot(Ls, TR.conj().T, axes=(1, 0))
+                Ls = Ls.real
+                Ls = np.transpose(Ls, (0, 3, 1, 2))
+
+                V = np.tensordot(TL, V, axes=(1, 0)).real
+                W = np.tensordot(W, TR.conj().T, axes=(1, 0)).real
+                W = np.transpose(W, (0, 3, 1, 2))
+            else:
+                L = (TL @ L @ TR.conj().T).real
+                Ls = (TL @ Ls @ TR.conj().T).real
+                V = (TL @ V).real
+                W = (W @ TR.conj().T).real
+
+        if self.mimo_handling == 'full' and not self.dim_input == self.dim_output == 1:
+            L = np.concatenate(np.concatenate(L, axis=1), axis=1)
+            Ls = np.concatenate(np.concatenate(Ls, axis=1), axis=1)
+            V = np.concatenate(np.concatenate(V, axis=1), axis=1)
+            W = np.concatenate(np.concatenate(W, axis=0), axis=1)
+
+        return L, Ls, V, W

--- a/src/pymordemos/dd_heat.py
+++ b/src/pymordemos/dd_heat.py
@@ -74,7 +74,11 @@ def main(
 
     ss = np.logspace(-1, 4, n)
 
+<<<<<<< HEAD
     run_mor_method_dd(lti, ss, PAAAReductor, 'AAA')
+=======
+    run_mor_method_dd(lti, ss, LoewnerReductor, 'Loewner')
+>>>>>>> [reductors.loewner] fix MIMO loewner matrices, fix minor things
 
 
 if __name__ == '__main__':

--- a/src/pymordemos/dd_heat.py
+++ b/src/pymordemos/dd_heat.py
@@ -13,7 +13,9 @@ from pymor.analyticalproblems.functions import ConstantFunction, ExpressionFunct
 from pymor.analyticalproblems.instationary import InstationaryProblem
 from pymor.core.logger import set_log_levels
 from pymor.discretizers.builtin import discretize_instationary_cg
+from pymor.models.transfer_function import TransferFunction
 from pymor.reductors.aaa import PAAAReductor
+from pymor.reductors.loewner import LoewnerReductor
 
 
 def run_mor_method_dd(fom, ss, reductor_cls, reductor_short_name, **reductor_kwargs):
@@ -41,8 +43,12 @@ def run_mor_method_dd(fom, ss, reductor_cls, reductor_short_name, **reductor_kwa
 
     fig, ax = plt.subplots(constrained_layout=True)
     fom.transfer_function.mag_plot(w, ax=ax, label='FOM')
-    rom.mag_plot(w, ax=ax, label='ROM', linestyle='dashed')
-    err.mag_plot(w, ax=ax, label='Error', linestyle='dotted')
+    if isinstance(rom, TransferFunction):
+        rom.mag_plot(w, ax=ax, label='ROM', linestyle='dashed')
+        err.mag_plot(w, ax=ax, label='Error', linestyle='dotted')
+    else:
+        rom.transfer_function.mag_plot(w, ax=ax, label='ROM', linestyle='dashed')
+        err.transfer_function.mag_plot(w, ax=ax, label='Error', linestyle='dotted')
     ax.set_title(fr'Magnitude plot for {reductor_short_name}')
     ax.legend()
 
@@ -74,11 +80,8 @@ def main(
 
     ss = np.logspace(-1, 4, n)
 
-<<<<<<< HEAD
     run_mor_method_dd(lti, ss, PAAAReductor, 'AAA')
-=======
     run_mor_method_dd(lti, ss, LoewnerReductor, 'Loewner')
->>>>>>> [reductors.loewner] fix MIMO loewner matrices, fix minor things
 
 
 if __name__ == '__main__':

--- a/src/pymortests/demos.py
+++ b/src/pymortests/demos.py
@@ -114,6 +114,7 @@ DD_MOR_ARGS = (
     ('dd_parametric_heat', [0.01, 50, 10]),
     ('dd_heat', [0.1, 10]),
     ('era', [10]),
+    ('dd_heat', [0.1, 50]),
 )
 
 HAPOD_ARGS = (

--- a/src/pymortests/demos.py
+++ b/src/pymortests/demos.py
@@ -114,7 +114,6 @@ DD_MOR_ARGS = (
     ('dd_parametric_heat', [0.01, 50, 10]),
     ('dd_heat', [0.1, 10]),
     ('era', [10]),
-    ('dd_heat', [0.1, 50]),
 )
 
 HAPOD_ARGS = (

--- a/src/pymortests/reductors/loewner.py
+++ b/src/pymortests/reductors/loewner.py
@@ -12,50 +12,53 @@ from pymor.reductors.loewner import LoewnerReductor
 pytestmark = pytest.mark.builtin
 
 np.random.seed(0)
-custom_partitioning = np.random.permutation(10)
+custom_partitioning = np.random.permutation(40)
 
 test_data = [
-    ({'r': 3}, {}),
-    ({'tol': 1e-3}, {}),
-    ({'tol': 1e-3}, {'partitioning': 'even-odd'}),
-    ({'tol': 1e-3}, {'partitioning': 'half-half'}),
-    ({'tol': 1e-3}, {'partitioning': (custom_partitioning[:5], custom_partitioning[5:])}),
-    ({'tol': 1e-3}, {'ordering': 'magnitude'}),
-    ({'tol': 1e-3}, {'ordering': 'random'}),
-    ({'tol': 1e-3}, {'ordering': 'regular'}),
-    ({'tol': 1e-3}, {'conjugate': False}),
-    ({'tol': 1e-3}, {'mimo_handling': 'full'}),
-    ({'tol': 1e-3}, {'mimo_handling': 'random'}),
-    ({'tol': 1e-3}, {'mimo_handling': (np.random.rand(10, 3), np.random.rand(2, 10))})
+    ({'r': 20}, {}),
+    ({'tol': 1e-12}, {}),
+    ({'tol': 1e-12}, {'partitioning': 'even-odd'}),
+    ({'tol': 1e-12}, {'partitioning': 'half-half'}),
+    ({'tol': 1e-12}, {'partitioning': (custom_partitioning[:20], custom_partitioning[20:])}),
+    ({'tol': 1e-12}, {'ordering': 'magnitude'}),
+    ({'tol': 1e-12}, {'ordering': 'random'}),
+    ({'tol': 1e-12}, {'ordering': 'regular'}),
+    ({'tol': 1e-12}, {'conjugate': False}),
+    ({'tol': 1e-12}, {'mimo_handling': 'full'}),
+    ({'tol': 1e-12}, {'mimo_handling': 'random'}),
+    ({'tol': 1e-12}, {'mimo_handling': (np.random.rand(40, 3), np.random.rand(2, 40))})
 ]
 
 
 @pytest.mark.parametrize('reduce_kwargs,loewner_kwargs', test_data)
 def test_loewner_lti(reduce_kwargs, loewner_kwargs):
     fom = make_fom(10)
-    s = np.logspace(-2, 2, 10)*1j
+    s = np.logspace(1, 3, 40)*1j
     loewner = LoewnerReductor(s, fom, **loewner_kwargs)
     rom = loewner.reduce(**reduce_kwargs)
-    assert isinstance(rom, LTIModel)
+    assert np.all([np.abs(fom.transfer_function.eval_tf(ss) - rom.transfer_function.eval_tf(ss))
+        / np.abs(fom.transfer_function.eval_tf(ss)) < 1e-10 for ss in s])
 
 
 @pytest.mark.parametrize('reduce_kwargs,loewner_kwargs', test_data)
 def test_loewner_tf(reduce_kwargs, loewner_kwargs):
     fom = make_fom(10)
-    s = np.logspace(-2, 2, 10)*1j
+    s = np.logspace(1, 3, 40)*1j
     loewner = LoewnerReductor(s, fom.transfer_function, **loewner_kwargs)
     rom = loewner.reduce(**reduce_kwargs)
-    assert isinstance(rom, LTIModel)
+    assert np.all([np.abs(fom.transfer_function.eval_tf(ss) - rom.transfer_function.eval_tf(ss))
+        / np.abs(fom.transfer_function.eval_tf(ss)) < 1e-10 for ss in s])
 
 
 @pytest.mark.parametrize('reduce_kwargs,loewner_kwargs', test_data)
 def test_loewner_data(reduce_kwargs, loewner_kwargs):
     fom = make_fom(10)
-    s = np.logspace(-2, 2, 10)
+    s = np.logspace(1, 3, 40)
     Hs = fom.transfer_function.freq_resp(s)
     loewner = LoewnerReductor(s*1j, Hs, **loewner_kwargs)
     rom = loewner.reduce(**reduce_kwargs)
-    assert isinstance(rom, LTIModel)
+    assert np.all([np.abs(fom.transfer_function.eval_tf(ss) - rom.transfer_function.eval_tf(ss))
+        / np.abs(fom.transfer_function.eval_tf(ss)) < 1e-10 for ss in s])
 
 
 def make_fom(n):

--- a/src/pymortests/reductors/loewner.py
+++ b/src/pymortests/reductors/loewner.py
@@ -1,0 +1,80 @@
+# This file is part of the pyMOR project (https://www.pymor.org).
+# Copyright pyMOR developers and contributors. All rights reserved.
+# License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
+
+import numpy as np
+import pytest
+import scipy.sparse as sps
+
+from pymor.models.iosys import LTIModel
+from pymor.reductors.loewner import LoewnerReductor
+
+pytestmark = pytest.mark.builtin
+
+custom_partitioning = np.random.permutation(10)
+test_data = [
+    ({'r': 3}, {}),
+    ({'tol': 1e-3}, {}),
+    ({'tol': 1e-3}, {'partitioning': 'even-odd'}),
+    ({'tol': 1e-3}, {'partitioning': 'half-half'}),
+    ({'tol': 1e-3}, {'partitioning': (custom_partitioning[:5], custom_partitioning[5:])}),
+    ({'tol': 1e-3}, {'ordering': 'magnitude'}),
+    ({'tol': 1e-3}, {'ordering': 'random'}),
+    ({'tol': 1e-3}, {'ordering': 'regular'}),
+    ({'tol': 1e-3}, {'conjugate': False}),
+    ({'tol': 1e-3}, {'mimo_handling': 'full'}),
+    ({'tol': 1e-3}, {'mimo_handling': 'random'}),
+    ({'tol': 1e-3}, {'mimo_handling': (np.random.rand(10, 3), np.random.rand(2, 10))})
+]
+
+
+@pytest.mark.parametrize('reduce_kwargs,loewner_kwargs', test_data)
+def test_loewner_lti(reduce_kwargs, loewner_kwargs):
+    n = 10
+    A1 = np.array([[-1, 100], [-100, -1]])
+    A2 = np.array([[-1, 200], [-200, -1]])
+    A3 = np.array([[-1, 400], [-400, -1]])
+    A4 = sps.diags(np.arange(-1, -n + 5, -1))
+    A = sps.block_diag((A1, A2, A3, A4))
+    B = np.arange(2*n).reshape(n, 2)
+    C = np.arange(3*n).reshape(3, n)
+    s = np.logspace(-2, 2, 10)*1j
+    fom = LTIModel.from_matrices(A, B, C)
+    loewner = LoewnerReductor(s, fom, **loewner_kwargs)
+    rom = loewner.reduce(**reduce_kwargs)
+    assert isinstance(rom, LTIModel)
+
+
+@pytest.mark.parametrize('reduce_kwargs,loewner_kwargs', test_data)
+def test_loewner_tf(reduce_kwargs, loewner_kwargs):
+    n = 10
+    A1 = np.array([[-1, 100], [-100, -1]])
+    A2 = np.array([[-1, 200], [-200, -1]])
+    A3 = np.array([[-1, 400], [-400, -1]])
+    A4 = sps.diags(np.arange(-1, -n + 5, -1))
+    A = sps.block_diag((A1, A2, A3, A4))
+    B = np.arange(2*n).reshape(n, 2)
+    C = np.arange(3*n).reshape(3, n)
+    s = np.logspace(-2, 2, 10)*1j
+    fom = LTIModel.from_matrices(A, B, C)
+    loewner = LoewnerReductor(s, fom.transfer_function, **loewner_kwargs)
+    rom = loewner.reduce(**reduce_kwargs)
+    assert isinstance(rom, LTIModel)
+
+
+@pytest.mark.parametrize('reduce_kwargs,loewner_kwargs', test_data)
+def test_loewner_data(reduce_kwargs, loewner_kwargs):
+    n = 10
+    A1 = np.array([[-1, 100], [-100, -1]])
+    A2 = np.array([[-1, 200], [-200, -1]])
+    A3 = np.array([[-1, 400], [-400, -1]])
+    A4 = sps.diags(np.arange(-1, -n + 5, -1))
+    A = sps.block_diag((A1, A2, A3, A4))
+    B = np.arange(2*n).reshape(n, 2)
+    C = np.arange(3*n).reshape(3, n)
+    s = np.logspace(-2, 2, 10)
+    fom = LTIModel.from_matrices(A, B, C)
+    Hs = fom.transfer_function.freq_resp(s)
+    loewner = LoewnerReductor(s*1j, Hs, **loewner_kwargs)
+    rom = loewner.reduce(**reduce_kwargs)
+    assert isinstance(rom, LTIModel)

--- a/src/pymortests/reductors/mt.py
+++ b/src/pymortests/reductors/mt.py
@@ -2,12 +2,11 @@
 # Copyright pyMOR developers and contributors. All rights reserved.
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
-import numpy as np
 import pytest
-import scipy.sparse as sps
 
 from pymor.models.iosys import LTIModel
 from pymor.reductors.mt import MTReductor
+from pymortests.reductors.loewner import make_fom
 
 pytestmark = pytest.mark.builtin
 
@@ -31,16 +30,7 @@ test_data = [
 
 @pytest.mark.parametrize('r,mt_kwargs', test_data)
 def test_mt(r, mt_kwargs):
-    n = 10
-    A1 = np.array([[-1, 100], [-100, -1]])
-    A2 = np.array([[-1, 200], [-200, -1]])
-    A3 = np.array([[-1, 400], [-400, -1]])
-    A4 = sps.diags(np.arange(-1, -n + 5, -1))
-    A = sps.block_diag((A1, A2, A3, A4))
-    B = np.ones((n, 1))
-    B[:6] = 10
-    C = B.T
-    fom = LTIModel.from_matrices(A, B, C)
+    fom = make_fom(10)
     mt = MTReductor(fom)
 
     rom = mt.reduce(r, **mt_kwargs)


### PR DESCRIPTION
This PR implements a reductor based on the Loewner interpolation framework. This is a draft for now because there might be some room for discussion regarding:

1. `_partition_frequencies` is more or less an attempt to generalize the different partitioning choices considered [here](https://pure.mpg.de/rest/items/item_3215398/component/file_3348562/content). In the chapter it seems like frequencies are considered to be complex only (makes sense, although it would be good to at least take 0 into consideration) and also they don't seem to care about keeping complex conjugate pairs together which is something I tried to do in the implementation.
2. There is the `loewner_quadruple` function for all related matrices. However, it maybe makes sense to have separate functions to generate the individual matrices. As I couldn't think of a use case I left them together for now.
3. There is also room for optimization in the setup of the matrices.