### PR TITLE
Test different PDE backends in different CI jobs

### DIFF
--- a/.ci/gitlab/ci.yml
+++ b/.ci/gitlab/ci.yml
@@ -631,6 +631,14 @@ submit coverage:
         - vanilla 3 8
         - vanilla 3 10
         - oldest 3 8
+        - fenics 3 8
+        - fenics 3 10
+        - ngsolve 3 8
+        - ngsolve 3 10
+        - dunegdt 3 8
+        - dunegdt 3 10
+        - scikit_fem 3 8
+        - scikit_fem 3 10
 
 coverage html:
     extends: .submit

--- a/.ci/gitlab/ci.yml
+++ b/.ci/gitlab/ci.yml
@@ -177,6 +177,7 @@ mpi 3 8:
     - when: on_success
     variables:
         COVERAGE_FILE: coverage_mpi__3.8
+        PYMOR_CONFIG_DISABLE: "ngsolve scikit_fem dealii dunegdt"
     retry:
         max: 2
         when: always
@@ -200,6 +201,7 @@ mpi 3 10:
     - when: on_success
     variables:
         COVERAGE_FILE: coverage_mpi__3.10
+        PYMOR_CONFIG_DISABLE: "ngsolve scikit_fem dealii dunegdt"
     retry:
         max: 2
         when: always

--- a/.ci/gitlab/ci.yml
+++ b/.ci/gitlab/ci.yml
@@ -449,6 +449,144 @@ fenics 3 10:
             export PYMOR_HYPOTHESIS_PROFILE="ci"
           fi
         - ./.ci/gitlab/test_fenics.bash
+ngsolve 3 8:
+    extends: .pytest
+    rules:
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+      when: never
+    - when: on_success
+    variables:
+        COVERAGE_FILE: coverage_ngsolve__3.8
+        PYMOR_PYTEST_EXTRA: "-m 'not builtin'"
+        PYMOR_CONFIG_DISABLE: "fenics scikit_fem dealii dunegdt"
+        PYMOR_FIXTURES_DISABLE_BUILTIN: "1"
+    services:
+    image: zivgitlab.wwu.io/pymor/docker/pymor/testing_py3.8:${CI_IMAGE_TAG}
+    script:
+        - |
+          if [[ "$CI_COMMIT_REF_NAME" == *"github/PR_"* ]]; then
+            echo selecting hypothesis profile "ci_pr" for branch $CI_COMMIT_REF_NAME
+            export PYMOR_HYPOTHESIS_PROFILE="ci_pr"
+          else
+            echo selecting hypothesis profile "ci" for branch $CI_COMMIT_REF_NAME
+            export PYMOR_HYPOTHESIS_PROFILE="ci"
+          fi
+        - ./.ci/gitlab/test_ngsolve.bash
+ngsolve 3 10:
+    extends: .pytest
+    rules:
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+      when: never
+    - when: on_success
+    variables:
+        COVERAGE_FILE: coverage_ngsolve__3.10
+        PYMOR_PYTEST_EXTRA: "-m 'not builtin'"
+        PYMOR_CONFIG_DISABLE: "fenics scikit_fem dealii dunegdt"
+        PYMOR_FIXTURES_DISABLE_BUILTIN: "1"
+    services:
+    image: zivgitlab.wwu.io/pymor/docker/pymor/testing_py3.10:${CI_IMAGE_TAG}
+    script:
+        - |
+          if [[ "$CI_COMMIT_REF_NAME" == *"github/PR_"* ]]; then
+            echo selecting hypothesis profile "ci_pr" for branch $CI_COMMIT_REF_NAME
+            export PYMOR_HYPOTHESIS_PROFILE="ci_pr"
+          else
+            echo selecting hypothesis profile "ci" for branch $CI_COMMIT_REF_NAME
+            export PYMOR_HYPOTHESIS_PROFILE="ci"
+          fi
+        - ./.ci/gitlab/test_ngsolve.bash
+dunegdt 3 8:
+    extends: .pytest
+    rules:
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+      when: never
+    - when: on_success
+    variables:
+        COVERAGE_FILE: coverage_dunegdt__3.8
+        PYMOR_PYTEST_EXTRA: "-m 'not builtin'"
+        PYMOR_CONFIG_DISABLE: "fenics ngsolve scikit_fem dealii"
+        PYMOR_FIXTURES_DISABLE_BUILTIN: "1"
+    services:
+    image: zivgitlab.wwu.io/pymor/docker/pymor/testing_py3.8:${CI_IMAGE_TAG}
+    script:
+        - |
+          if [[ "$CI_COMMIT_REF_NAME" == *"github/PR_"* ]]; then
+            echo selecting hypothesis profile "ci_pr" for branch $CI_COMMIT_REF_NAME
+            export PYMOR_HYPOTHESIS_PROFILE="ci_pr"
+          else
+            echo selecting hypothesis profile "ci" for branch $CI_COMMIT_REF_NAME
+            export PYMOR_HYPOTHESIS_PROFILE="ci"
+          fi
+        - ./.ci/gitlab/test_dunegdt.bash
+dunegdt 3 10:
+    extends: .pytest
+    rules:
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+      when: never
+    - when: on_success
+    variables:
+        COVERAGE_FILE: coverage_dunegdt__3.10
+        PYMOR_PYTEST_EXTRA: "-m 'not builtin'"
+        PYMOR_CONFIG_DISABLE: "fenics ngsolve scikit_fem dealii"
+        PYMOR_FIXTURES_DISABLE_BUILTIN: "1"
+    services:
+    image: zivgitlab.wwu.io/pymor/docker/pymor/testing_py3.10:${CI_IMAGE_TAG}
+    script:
+        - |
+          if [[ "$CI_COMMIT_REF_NAME" == *"github/PR_"* ]]; then
+            echo selecting hypothesis profile "ci_pr" for branch $CI_COMMIT_REF_NAME
+            export PYMOR_HYPOTHESIS_PROFILE="ci_pr"
+          else
+            echo selecting hypothesis profile "ci" for branch $CI_COMMIT_REF_NAME
+            export PYMOR_HYPOTHESIS_PROFILE="ci"
+          fi
+        - ./.ci/gitlab/test_dunegdt.bash
+scikit_fem 3 8:
+    extends: .pytest
+    rules:
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+      when: never
+    - when: on_success
+    variables:
+        COVERAGE_FILE: coverage_scikit_fem__3.8
+        PYMOR_PYTEST_EXTRA: "-m 'not builtin'"
+        PYMOR_CONFIG_DISABLE: "fenics ngsolve dealii dunegdt"
+        PYMOR_FIXTURES_DISABLE_BUILTIN: "1"
+    services:
+    image: zivgitlab.wwu.io/pymor/docker/pymor/testing_py3.8:${CI_IMAGE_TAG}
+    script:
+        - |
+          if [[ "$CI_COMMIT_REF_NAME" == *"github/PR_"* ]]; then
+            echo selecting hypothesis profile "ci_pr" for branch $CI_COMMIT_REF_NAME
+            export PYMOR_HYPOTHESIS_PROFILE="ci_pr"
+          else
+            echo selecting hypothesis profile "ci" for branch $CI_COMMIT_REF_NAME
+            export PYMOR_HYPOTHESIS_PROFILE="ci"
+          fi
+        - ./.ci/gitlab/test_scikit_fem.bash
+scikit_fem 3 10:
+    extends: .pytest
+    rules:
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+      when: never
+    - when: on_success
+    variables:
+        COVERAGE_FILE: coverage_scikit_fem__3.10
+        PYMOR_PYTEST_EXTRA: "-m 'not builtin'"
+        PYMOR_CONFIG_DISABLE: "fenics ngsolve dealii dunegdt"
+        PYMOR_FIXTURES_DISABLE_BUILTIN: "1"
+    services:
+    image: zivgitlab.wwu.io/pymor/docker/pymor/testing_py3.10:${CI_IMAGE_TAG}
+    script:
+        - |
+          if [[ "$CI_COMMIT_REF_NAME" == *"github/PR_"* ]]; then
+            echo selecting hypothesis profile "ci_pr" for branch $CI_COMMIT_REF_NAME
+            export PYMOR_HYPOTHESIS_PROFILE="ci_pr"
+          else
+            echo selecting hypothesis profile "ci" for branch $CI_COMMIT_REF_NAME
+            export PYMOR_HYPOTHESIS_PROFILE="ci"
+          fi
+        - ./.ci/gitlab/test_scikit_fem.bash
 ci_weekly 3 8:
     extends: .pytest
     timeout: 5h

--- a/.ci/gitlab/ci.yml
+++ b/.ci/gitlab/ci.yml
@@ -403,14 +403,14 @@ cpp_demo 3 10:
             export PYMOR_HYPOTHESIS_PROFILE="ci"
           fi
         - ./.ci/gitlab/test_cpp_demo.bash
-fenics:
+fenics 3 8:
     extends: .pytest
     rules:
     - if: $CI_PIPELINE_SOURCE == "schedule"
       when: never
     - when: on_success
     variables:
-        COVERAGE_FILE: coverage_fenics
+        COVERAGE_FILE: coverage_fenics__3.8
         PYMOR_PYTEST_EXTRA: "-m 'not builtin'"
         PYMOR_CONFIG_DISABLE: "ngsolve scikit_fem dealii dunegdt"
         PYMOR_FIXTURES_DISABLE_BUILTIN: "1"
@@ -425,7 +425,30 @@ fenics:
             echo selecting hypothesis profile "ci" for branch $CI_COMMIT_REF_NAME
             export PYMOR_HYPOTHESIS_PROFILE="ci"
           fi
-        - ./.ci/gitlab/test_vanilla.bash
+        - ./.ci/gitlab/test_fenics.bash
+fenics 3 10:
+    extends: .pytest
+    rules:
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+      when: never
+    - when: on_success
+    variables:
+        COVERAGE_FILE: coverage_fenics__3.10
+        PYMOR_PYTEST_EXTRA: "-m 'not builtin'"
+        PYMOR_CONFIG_DISABLE: "ngsolve scikit_fem dealii dunegdt"
+        PYMOR_FIXTURES_DISABLE_BUILTIN: "1"
+    services:
+    image: zivgitlab.wwu.io/pymor/docker/pymor/testing_py3.10:${CI_IMAGE_TAG}
+    script:
+        - |
+          if [[ "$CI_COMMIT_REF_NAME" == *"github/PR_"* ]]; then
+            echo selecting hypothesis profile "ci_pr" for branch $CI_COMMIT_REF_NAME
+            export PYMOR_HYPOTHESIS_PROFILE="ci_pr"
+          else
+            echo selecting hypothesis profile "ci" for branch $CI_COMMIT_REF_NAME
+            export PYMOR_HYPOTHESIS_PROFILE="ci"
+          fi
+        - ./.ci/gitlab/test_fenics.bash
 ci_weekly 3 8:
     extends: .pytest
     timeout: 5h

--- a/.ci/gitlab/ci.yml
+++ b/.ci/gitlab/ci.yml
@@ -27,6 +27,7 @@ stages:
         CI_IMAGE_TAG: 623b44380673e2e60a51dea8bafe1de775614cf7
         PYMOR_HYPOTHESIS_PROFILE: ci
         PYMOR_PYTEST_EXTRA: ""
+        PYMOR_CONFIG_DISABLE: "fenics ngsolve scikit_fem dealii dunegdt"
         BINDERIMAGE: ${CI_REGISTRY_IMAGE}/binder:${CI_COMMIT_REF_SLUG}
 
 .pytest:
@@ -400,6 +401,29 @@ cpp_demo 3 10:
             export PYMOR_HYPOTHESIS_PROFILE="ci"
           fi
         - ./.ci/gitlab/test_cpp_demo.bash
+fenics:
+    extends: .pytest
+    rules:
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+      when: never
+    - when: on_success
+    variables:
+        COVERAGE_FILE: coverage_fenics
+        PYMOR_PYTEST_EXTRA: "-m 'not builtin'"
+        PYMOR_CONFIG_DISABLE: "ngsolve scikit_fem dealii dunegdt"
+        PYMOR_FIXTURES_DISABLE_BUILTIN: "1"
+    services:
+    image: zivgitlab.wwu.io/pymor/docker/pymor/testing_py3.8:${CI_IMAGE_TAG}
+    script:
+        - |
+          if [[ "$CI_COMMIT_REF_NAME" == *"github/PR_"* ]]; then
+            echo selecting hypothesis profile "ci_pr" for branch $CI_COMMIT_REF_NAME
+            export PYMOR_HYPOTHESIS_PROFILE="ci_pr"
+          else
+            echo selecting hypothesis profile "ci" for branch $CI_COMMIT_REF_NAME
+            export PYMOR_HYPOTHESIS_PROFILE="ci"
+          fi
+        - ./.ci/gitlab/test_vanilla.bash
 ci_weekly 3 8:
     extends: .pytest
     timeout: 5h

--- a/.ci/gitlab/template.ci.py
+++ b/.ci/gitlab/template.ci.py
@@ -193,6 +193,18 @@ ci setup:
         PYMOR_PYTEST_EXTRA: "-m 'not builtin'"
         PYMOR_CONFIG_DISABLE: "ngsolve scikit_fem dealii dunegdt"
         PYMOR_FIXTURES_DISABLE_BUILTIN: "1"
+    {%- elif script == "ngsolve" %}
+        PYMOR_PYTEST_EXTRA: "-m 'not builtin'"
+        PYMOR_CONFIG_DISABLE: "fenics scikit_fem dealii dunegdt"
+        PYMOR_FIXTURES_DISABLE_BUILTIN: "1"
+    {%- elif script == "dunegdt" %}
+        PYMOR_PYTEST_EXTRA: "-m 'not builtin'"
+        PYMOR_CONFIG_DISABLE: "fenics ngsolve scikit_fem dealii"
+        PYMOR_FIXTURES_DISABLE_BUILTIN: "1"
+    {%- elif script == "scikit_fem" %}
+        PYMOR_PYTEST_EXTRA: "-m 'not builtin'"
+        PYMOR_CONFIG_DISABLE: "fenics ngsolve dealii dunegdt"
+        PYMOR_FIXTURES_DISABLE_BUILTIN: "1"
     {%- endif %}
     {%- if script == "mpi" %}
     retry:
@@ -429,6 +441,9 @@ test_scripts = [
     ('oldest', oldest, 1),
     ('cpp_demo', pythons, 1),
     ('fenics', pythons, 1),
+    ('ngsolve', pythons, 1),
+    ('dunegdt', pythons, 1),
+    ('scikit_fem', pythons, 1),
 ]
 # these should be all instances in the federation
 binder_urls = [f'https://{sub}.mybinder.org/build/gh/pymor/pymor' for sub in ('gke', 'ovh', 'gesis')]

--- a/.ci/gitlab/template.ci.py
+++ b/.ci/gitlab/template.ci.py
@@ -188,6 +188,7 @@ ci setup:
     variables:
         COVERAGE_FILE: coverage_{{script}}__{{py}}
     {%- if script == "mpi" %}
+        PYMOR_CONFIG_DISABLE: "ngsolve scikit_fem dealii dunegdt"
     retry:
         max: 2
         when: always

--- a/.ci/gitlab/template.ci.py
+++ b/.ci/gitlab/template.ci.py
@@ -189,6 +189,12 @@ ci setup:
         COVERAGE_FILE: coverage_{{script}}__{{py}}
     {%- if script == "mpi" %}
         PYMOR_CONFIG_DISABLE: "ngsolve scikit_fem dealii dunegdt"
+    {%- elif script == "fenics" %}
+        PYMOR_PYTEST_EXTRA: "-m 'not builtin'"
+        PYMOR_CONFIG_DISABLE: "ngsolve scikit_fem dealii dunegdt"
+        PYMOR_FIXTURES_DISABLE_BUILTIN: "1"
+    {%- endif %}
+    {%- if script == "mpi" %}
     retry:
         max: 2
         when: always
@@ -213,29 +219,6 @@ ci setup:
           fi
         - ./.ci/gitlab/test_{{script}}.bash
 {%- endfor %}
-fenics:
-    extends: .pytest
-    rules:
-    - if: $CI_PIPELINE_SOURCE == "schedule"
-      when: never
-    - when: on_success
-    variables:
-        COVERAGE_FILE: coverage_fenics
-        PYMOR_PYTEST_EXTRA: "-m 'not builtin'"
-        PYMOR_CONFIG_DISABLE: "ngsolve scikit_fem dealii dunegdt"
-        PYMOR_FIXTURES_DISABLE_BUILTIN: "1"
-    services:
-    image: zivgitlab.wwu.io/pymor/docker/pymor/testing_py3.8:${CI_IMAGE_TAG}
-    script:
-        - |
-          if [[ "$CI_COMMIT_REF_NAME" == *"github/PR_"* ]]; then
-            echo selecting hypothesis profile "ci_pr" for branch $CI_COMMIT_REF_NAME
-            export PYMOR_HYPOTHESIS_PROFILE="ci_pr"
-          else
-            echo selecting hypothesis profile "ci" for branch $CI_COMMIT_REF_NAME
-            export PYMOR_HYPOTHESIS_PROFILE="ci"
-          fi
-        - ./.ci/gitlab/test_vanilla.bash
 
 {%- for py in pythons %}
 ci_weekly {{py[0]}} {{py[2:]}}:
@@ -445,6 +428,7 @@ test_scripts = [
     ('vanilla', pythons, 1),
     ('oldest', oldest, 1),
     ('cpp_demo', pythons, 1),
+    ('fenics', pythons, 1),
 ]
 # these should be all instances in the federation
 binder_urls = [f'https://{sub}.mybinder.org/build/gh/pymor/pymor' for sub in ('gke', 'ovh', 'gesis')]

--- a/.ci/gitlab/template.ci.py
+++ b/.ci/gitlab/template.ci.py
@@ -257,7 +257,7 @@ submit coverage:
         paths:
             - reports/
     dependencies:
-    {%- for script, py, para in matrix if script in ['tutorials', 'vanilla', 'oldest', 'numpy_git', 'mpi'] %}
+    {%- for script, py, para in matrix if script in ['tutorials', 'vanilla', 'oldest', 'numpy_git', 'mpi', 'fenics', 'ngsolve', 'dunegdt', 'scikit_fem'] %}
         - {{script}} {{py[0]}} {{py[2:]}}
     {%- endfor %}
 

--- a/.ci/gitlab/test_dunegdt.bash
+++ b/.ci/gitlab/test_dunegdt.bash
@@ -1,0 +1,1 @@
+test_vanilla.bash

--- a/.ci/gitlab/test_fenics.bash
+++ b/.ci/gitlab/test_fenics.bash
@@ -1,0 +1,1 @@
+test_vanilla.bash

--- a/.ci/gitlab/test_ngsolve.bash
+++ b/.ci/gitlab/test_ngsolve.bash
@@ -1,0 +1,1 @@
+test_vanilla.bash

--- a/.ci/gitlab/test_scikit_fem.bash
+++ b/.ci/gitlab/test_scikit_fem.bash
@@ -1,0 +1,1 @@
+test_vanilla.bash

--- a/.ci/gitlab/test_vanilla.bash
+++ b/.ci/gitlab/test_vanilla.bash
@@ -4,5 +4,7 @@ THIS_DIR="$(cd "$(dirname ${BASH_SOURCE[0]})" ; pwd -P )"
 source ${THIS_DIR}/common_test_setup.bash
 # this runs in pytest in a fake, auto numbered, X Server
 #xvfb-run -a pytest ${COMMON_PYTEST_OPTS} --hypothesis-show-statistics
-xvfb-run -a pytest ${COMMON_PYTEST_OPTS}
+echo ${PYMOR_PYTEST_EXTRA}
+echo ${COMMON_PYTEST_OPTS}
+eval xvfb-run -a pytest ${COMMON_PYTEST_OPTS}
 _coverage_xml

--- a/.github/actions/miniconda_tests/action.yml
+++ b/.github/actions/miniconda_tests/action.yml
@@ -91,7 +91,6 @@ runs:
         PYTHONPATH: ./src
         PYMOR_HYPOTHESIS_PROFILE: ${{ inputs.hypothesis_profile }}
         # we may be able to limit this to macos
-        PYMOR_ALLOW_DEADLINE_EXCESS: 1
         COMMON_PYTEST_OPTS: "--cov-report= --cov --cov-config=setup.cfg --cov-context=test --junitxml=${{ inputs.results_file }}"
         COVERAGE_FILE: ${{ inputs.coverage_file }}
       run: |

--- a/conftest.py
+++ b/conftest.py
@@ -15,7 +15,7 @@ _common_settings = {
     'print_blob': True,
     'suppress_health_check': (HealthCheck.data_too_large, HealthCheck.too_slow,
                               HealthCheck.filter_too_much),
-    'deadline': 1000,
+    'deadline': 5000,
     'verbosity': Verbosity.normal,
 }
 settings.register_profile('ci_large', max_examples=400, **_common_settings)

--- a/docs/source/environment.rst
+++ b/docs/source/environment.rst
@@ -21,6 +21,10 @@ PYMOR_CONFIG_DISABLE
 PYMOR_COLORS_DISABLE
     If ``1``, disable coloring of logging output.
 
+PYMOR_FIXTURES_DISABLE_BUILTIN
+    If set, |VectorArray|, |Operator| and related fixtures only only use
+    external solver backends.
+
 PYMOR_WITH_SPHINX
     This variable is set to `1` during API documentation generation
     using sphinx.

--- a/docs/source/environment.rst
+++ b/docs/source/environment.rst
@@ -43,7 +43,3 @@ PYMOR_MPI_FINALIZE
     If set controls the value for `mpi4py.rc.finalize`. If `PYMOR_MPI_FINALIZE` is unset the value
     of `mpi4py.rc.finalize` remains unchanged, unless `mpi4py.rc.finalize is None` in which
     case it is defaulted to `True`.
-
-PYMOR_ALLOW_DEADLINE_EXCESS
-    If set, test functions decorated with :func:`~pymortests.base.might_exceed_deadline` are allowed
-    to exceed the default test deadline set in :mod:`~pymortests.conftest`.

--- a/docs/source/environment.rst
+++ b/docs/source/environment.rst
@@ -12,6 +12,12 @@ PYMOR_CACHE_DISABLE
     useful for debugging. See :mod:`pymor.core.cache` for more
     details.
 
+PYMOR_CONFIG_DISABLE
+    Whitespace separated list of :mod:`~pymor.core.config` items
+    which should be reported as missing even though they may be present.
+    E.g., `PYMOR_CONFIG_DISABLE="SLYCOT"` can be used to prevent pyMOR
+    from importing the SLYCOT library.
+
 PYMOR_COLORS_DISABLE
     If ``1``, disable coloring of logging output.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,6 +60,8 @@ python_files = *.py
 # exclude misbehaving plugin from auto load
 addopts=-p no:nb_regression -p no:memprof -p no:pytest-qt --durations 10
 junit_family=xunit2
+markers =
+  builtin: test does not require external PDE solver
 
 [metadata]
 # this is mandatory to lave license end up in .whl

--- a/src/pymor/algorithms/basic.py
+++ b/src/pymor/algorithms/basic.py
@@ -59,7 +59,12 @@ def almost_equal(U, V, product=None, sup_norm=False, rtol=1e-14, atol=1e-14):
 
 def relative_error(U, V, product=None):
     """Compute error between U and V relative to norm of U."""
-    return (U - V).norm(product) / U.norm(product)
+    err = (U - V).norm(product)
+    if np.all(err == 0.):
+        # ensure to return 0 here even when the norm of U is zero
+        return err
+    else:
+        return err / U.norm(product)
 
 
 def project_array(U, basis, product=None, orthonormal=True):

--- a/src/pymor/vectorarrays/list.py
+++ b/src/pymor/vectorarrays/list.py
@@ -434,6 +434,8 @@ class ListVectorArrayImpl(VectorArrayImpl):
     def gramian(self, ind):
         self_list = self._indexed(ind)
         l = len(self_list)
+        if l == 0:
+            return np.zeros((0,0))
         R = [[0.] * l for _ in range(l)]
         for i in range(l):
             for j in range(i, l):

--- a/src/pymortests/algorithms/basic.py
+++ b/src/pymortests/algorithms/basic.py
@@ -172,14 +172,14 @@ def test_almost_equal_incompatible(vector_arrays):
 
 @settings(deadline=None)
 @pyst.given_vector_arrays(count=2)
-def test_project_array(arrays):
-    U, basis = arrays
+def test_project_array(vector_arrays):
+    U, basis = vector_arrays
     U_p = project_array(U, basis, orthonormal=False)
     onb = gram_schmidt(basis)
     U_p2 = project_array(U, onb, orthonormal=True)
     err = relative_error(U_p, U_p2)
-    tol = np.finfo(np.float64).eps * np.linalg.cond(basis.gramian()) * 100.
-    assert np.all(err < tol)
+    tol = 0 if len(basis) == 0 else np.finfo(np.float64).eps * np.linalg.cond(basis.gramian()) * 100.
+    assert np.all(err <= tol)
 
 
 @pytest.mark.builtin

--- a/src/pymortests/algorithms/basic.py
+++ b/src/pymortests/algorithms/basic.py
@@ -182,6 +182,7 @@ def test_project_array(arrays):
     assert np.all(err < tol)
 
 
+@pytest.mark.builtin
 def test_project_array_with_product():
     U = NumpyVectorSpace.from_numpy(np.random.random((1, 10)))
     basis = NumpyVectorSpace.from_numpy(np.random.random((3, 10)))

--- a/src/pymortests/algorithms/basic.py
+++ b/src/pymortests/algorithms/basic.py
@@ -174,8 +174,10 @@ def test_almost_equal_incompatible(vector_arrays):
 @pyst.given_vector_arrays(count=2)
 def test_project_array(vector_arrays):
     U, basis = vector_arrays
-    U_p = project_array(U, basis, orthonormal=False)
     onb = gram_schmidt(basis)
+    if len(onb) < len(basis):
+        return
+    U_p = project_array(U, basis, orthonormal=False)
     U_p2 = project_array(U, onb, orthonormal=True)
     err = relative_error(U_p, U_p2)
     tol = 0 if len(basis) == 0 else np.finfo(np.float64).eps * np.linalg.cond(basis.gramian()) * 100.

--- a/src/pymortests/algorithms/basic.py
+++ b/src/pymortests/algorithms/basic.py
@@ -170,8 +170,8 @@ def test_almost_equal_incompatible(vector_arrays):
                 almost_equal(c1[ind1], c2[ind2], sup_norm=sup_norm)
 
 
-@given(pyst.base_vector_arrays(count=2))
 @settings(deadline=None)
+@pyst.given_vector_arrays(count=2)
 def test_project_array(arrays):
     U, basis = arrays
     U_p = project_array(U, basis, orthonormal=False)

--- a/src/pymortests/algorithms/basic.py
+++ b/src/pymortests/algorithms/basic.py
@@ -4,7 +4,7 @@
 
 import numpy as np
 import pytest
-from hypothesis import assume, given, settings
+from hypothesis import assume, settings
 from hypothesis import strategies as hyst
 
 import pymor

--- a/src/pymortests/algorithms/bernoulli.py
+++ b/src/pymortests/algorithms/bernoulli.py
@@ -13,6 +13,8 @@ from pymor.algorithms.to_matrix import to_matrix
 from pymor.operators.constructions import LowRankOperator
 from pymor.operators.numpy import NumpyMatrixOperator
 
+pytestmark = pytest.mark.builtin
+
 n_list = [10, 20, 30]
 
 

--- a/src/pymortests/algorithms/eigs.py
+++ b/src/pymortests/algorithms/eigs.py
@@ -9,6 +9,8 @@ import scipy.sparse as sps
 from pymor.algorithms.eigs import eigs
 from pymor.operators.numpy import NumpyMatrixOperator
 
+pytestmark = pytest.mark.builtin
+
 n_list = [100, 200]
 k_list = [1, 7]
 sigma_list = [None, 0]

--- a/src/pymortests/algorithms/gram_schmidt.py
+++ b/src/pymortests/algorithms/gram_schmidt.py
@@ -96,6 +96,13 @@ def test_gram_schmidt_biorth(vector_arrays):
             A1, A2 = gram_schmidt_biorth(U1, U2, copy=True)
         return
 
+    onb1 = gram_schmidt(U1)
+    if len(onb1) < len(U1):
+        return
+    onb2 = gram_schmidt(U2)
+    if len(onb2) < len(U2):
+        return
+
     V1 = U1.copy()
     V2 = U2.copy()
 

--- a/src/pymortests/algorithms/gram_schmidt.py
+++ b/src/pymortests/algorithms/gram_schmidt.py
@@ -3,7 +3,8 @@
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
 import numpy as np
-from hypothesis import assume, given, settings
+import pytest
+from hypothesis import assume, settings
 
 import pymortests.strategies as pyst
 from pymor.algorithms.basic import almost_equal, contains_zero_vector
@@ -90,6 +91,11 @@ def test_gram_schmidt_with_product_and_R(operator_with_arrays_and_products):
 def test_gram_schmidt_biorth(vector_arrays):
     U1, U2 = vector_arrays
 
+    if len(U1) != len(U2):
+        with pytest.raises(Exception):
+            A1, A2 = gram_schmidt_biorth(U1, U2, copy=True)
+        return
+
     V1 = U1.copy()
     V2 = U2.copy()
 
@@ -100,7 +106,8 @@ def test_gram_schmidt_biorth(vector_arrays):
     assert np.all(almost_equal(U1, V1))
     assert np.all(almost_equal(U2, V2))
     assert np.allclose(A2.inner(A1), np.eye(len(A1)), atol=check_tol)
-    c = np.linalg.cond(A1.to_numpy()) * np.linalg.cond(A2.to_numpy())
+    c = (1 if len(A1) == 0 else np.linalg.cond(A1.to_numpy())) \
+        * (1 if len(A2) == 0 else np.linalg.cond(A2.to_numpy()))
     assert np.all(almost_equal(U1, A1.lincomb(A2.inner(U1).T), rtol=c * 1e-14))
     assert np.all(almost_equal(U2, A2.lincomb(A1.inner(U2).T), rtol=c * 1e-14))
 

--- a/src/pymortests/algorithms/gram_schmidt.py
+++ b/src/pymortests/algorithms/gram_schmidt.py
@@ -85,8 +85,8 @@ def test_gram_schmidt_with_product_and_R(operator_with_arrays_and_products):
     assert np.all(almost_equal(onb, U))
 
 
-@given(pyst.base_vector_arrays(count=2))
 @settings(deadline=None)
+@pyst.given_vector_arrays(count=2)
 def test_gram_schmidt_biorth(vector_arrays):
     U1, U2 = vector_arrays
 

--- a/src/pymortests/algorithms/gram_schmidt.py
+++ b/src/pymortests/algorithms/gram_schmidt.py
@@ -14,7 +14,6 @@ from pymortests.base import runmodule
 
 
 @pyst.given_vector_arrays()
-@settings(deadline=20000)
 def test_gram_schmidt(vector_array):
     U = vector_array
     # TODO assumption here masks a potential issue with the algorithm

--- a/src/pymortests/algorithms/lyapunov.py
+++ b/src/pymortests/algorithms/lyapunov.py
@@ -18,6 +18,8 @@ from pymor.algorithms.lyapunov import (
 from pymor.operators.numpy import NumpyMatrixOperator
 from pymortests.base import skip_if_missing
 
+pytestmark = pytest.mark.builtin
+
 n_list_small = [10, 20]
 n_list_big = [300]
 m_list = [1, 2]

--- a/src/pymortests/algorithms/newton.py
+++ b/src/pymortests/algorithms/newton.py
@@ -11,6 +11,8 @@ from pymor.vectorarrays.numpy import NumpyVectorSpace
 from pymortests.base import runmodule
 from pymortests.fixtures.operator import MonomOperator
 
+pytestmark = pytest.mark.builtin
+
 
 def _newton(mop, initial_value=1.0, **kwargs):
     rhs = NumpyVectorSpace.from_numpy([0.0])

--- a/src/pymortests/algorithms/rand_la.py
+++ b/src/pymortests/algorithms/rand_la.py
@@ -3,12 +3,15 @@
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
 import numpy as np
+import pytest
 import scipy as sp
 from numpy.random import uniform
 
 from pymor.algorithms.rand_la import adaptive_rrf, random_generalized_svd, random_ghep, rrf
 from pymor.operators.constructions import VectorArrayOperator
 from pymor.operators.numpy import NumpyMatrixOperator
+
+pytestmark = pytest.mark.builtin
 
 
 def test_adaptive_rrf():

--- a/src/pymortests/algorithms/riccati.py
+++ b/src/pymortests/algorithms/riccati.py
@@ -14,6 +14,9 @@ from pymor.operators.numpy import NumpyMatrixOperator
 from pymortests.algorithms.lyapunov import conv_diff_1d_fd, conv_diff_1d_fem, fro_norm
 from pymortests.base import skip_if_missing
 
+pytestmark = pytest.mark.builtin
+
+
 n_list_small = [10, 20]
 n_list_big = [250]
 m_list = [1, 2]

--- a/src/pymortests/algorithms/samdp.py
+++ b/src/pymortests/algorithms/samdp.py
@@ -9,6 +9,9 @@ import scipy.sparse as sps
 from pymor.algorithms.samdp import samdp
 from pymor.operators.numpy import NumpyMatrixOperator
 
+pytestmark = pytest.mark.builtin
+
+
 n_list = [50, 100]
 m_list = [1, 2]
 k_list = [2, 3]

--- a/src/pymortests/algorithms/simplify.py
+++ b/src/pymortests/algorithms/simplify.py
@@ -5,6 +5,7 @@
 from itertools import product
 
 import numpy as np
+import pytest
 
 from pymor.algorithms.basic import almost_equal
 from pymor.algorithms.simplify import contract, expand
@@ -12,6 +13,8 @@ from pymor.algorithms.to_matrix import to_matrix
 from pymor.operators.constructions import ConcatenationOperator, LincombOperator
 from pymor.operators.numpy import NumpyMatrixOperator
 from pymor.parameters.functionals import ProjectionParameterFunctional
+
+pytestmark = pytest.mark.builtin
 
 
 def test_expand():

--- a/src/pymortests/algorithms/solver.py
+++ b/src/pymortests/algorithms/solver.py
@@ -12,6 +12,8 @@ from pymor.operators.interface import Operator
 from pymor.operators.numpy import NumpyMatrixOperator
 from pymor.vectorarrays.numpy import NumpyVectorSpace
 
+pytestmark = pytest.mark.builtin
+
 
 class GenericOperator(Operator):
 

--- a/src/pymortests/algorithms/svd_va.py
+++ b/src/pymortests/algorithms/svd_va.py
@@ -56,6 +56,7 @@ def test_method_of_snapshots_with_product(operator_with_arrays_and_products, met
     assert np.all(almost_equal(A, UsVh, rtol=4e-8))
 
 
+@pytest.mark.builtin
 @pytest.mark.parametrize('method', methods)
 def test_not_too_many_modes(method):
     vec_array = NumpyVectorSpace.from_numpy(np.logspace(-5, 0, 10).reshape((-1, 1)))

--- a/src/pymortests/algorithms/sylvester.py
+++ b/src/pymortests/algorithms/sylvester.py
@@ -10,6 +10,9 @@ import scipy.sparse as sps
 from pymor.algorithms.sylvester import solve_sylv_schur
 from pymor.operators.numpy import NumpyMatrixOperator
 
+pytestmark = pytest.mark.builtin
+
+
 n_list = [100, 1000]
 r_list = [1, 10, 20]
 m_list = [1, 2]

--- a/src/pymortests/algorithms/symplectic.py
+++ b/src/pymortests/algorithms/symplectic.py
@@ -1,3 +1,6 @@
+# This file is part of the pyMOR project (https://www.pymor.org).
+# Copyright pyMOR developers and contributors. All rights reserved.
+# License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
 import numpy as np
 import pytest
@@ -11,6 +14,9 @@ from pymor.algorithms.symplectic import (
 from pymor.operators.symplectic import CanonicalSymplecticFormOperator
 from pymor.vectorarrays.block import BlockVectorSpace
 from pymor.vectorarrays.numpy import NumpyVectorSpace
+
+pytestmark = pytest.mark.builtin
+
 
 METHODS_DICT = {
     'psd_cotengent_lift': psd_cotengent_lift,

--- a/src/pymortests/algorithms/to_matrix.py
+++ b/src/pymortests/algorithms/to_matrix.py
@@ -3,6 +3,7 @@
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
 import numpy as np
+import pytest
 import scipy.linalg as spla
 import scipy.sparse as sps
 
@@ -40,6 +41,7 @@ def assert_type_and_allclose(A, Aop, default_format):
     assert np.allclose(A, to_matrix(Aop, format='csr').toarray())
 
 
+@pytest.mark.builtin
 def test_to_matrix_NumpyMatrixOperator():
     A = np.random.randn(2, 2)
 
@@ -50,6 +52,7 @@ def test_to_matrix_NumpyMatrixOperator():
     assert_type_and_allclose(A, Aop, 'csc')
 
 
+@pytest.mark.builtin
 def test_to_matrix_BlockOperator():
     A11 = np.random.randn(2, 2)
     A12 = np.random.randn(2, 3)
@@ -72,6 +75,7 @@ def test_to_matrix_BlockOperator():
     assert_type_and_allclose(B, Bop, 'sparse')
 
 
+@pytest.mark.builtin
 def test_to_matrix_BlockDiagonalOperator():
     A1 = np.random.randn(2, 2)
     A2 = np.random.randn(3, 3)
@@ -89,6 +93,7 @@ def test_to_matrix_BlockDiagonalOperator():
     assert_type_and_allclose(B, Bop, 'sparse')
 
 
+@pytest.mark.builtin
 def test_to_matrix_AdjointOperator():
     A = np.random.randn(2, 2)
     S = np.random.randn(2, 2)
@@ -129,6 +134,7 @@ def test_to_matrix_AdjointOperator():
     assert_type_and_allclose(spla.solve(S, A.T.dot(R)), Aadj, 'sparse')
 
 
+@pytest.mark.builtin
 def test_to_matrix_ComponentProjectionOperator():
     dofs = np.array([0, 1, 2, 4, 8])
     n = 10
@@ -140,6 +146,7 @@ def test_to_matrix_ComponentProjectionOperator():
     assert_type_and_allclose(A, Aop, 'sparse')
 
 
+@pytest.mark.builtin
 def test_to_matrix_ConcatenationOperator():
     A = np.random.randn(2, 3)
     B = np.random.randn(3, 4)
@@ -166,6 +173,7 @@ def test_to_matrix_ConcatenationOperator():
     assert_type_and_allclose(A, Aop, 'sparse')
 
 
+@pytest.mark.builtin
 def test_to_matrix_IdentityOperator():
     n = 3
     I = np.eye(n)
@@ -174,6 +182,7 @@ def test_to_matrix_IdentityOperator():
     assert_type_and_allclose(I, Iop, 'sparse')
 
 
+@pytest.mark.builtin
 def test_to_matrix_LincombOperator():
     A = np.random.randn(3, 3)
     B = np.random.randn(3, 2)
@@ -202,6 +211,7 @@ def test_to_matrix_LincombOperator():
     assert_type_and_allclose(C, Cop, 'sparse')
 
 
+@pytest.mark.builtin
 def test_to_matrix_LowRankOperator():
     m = 6
     n = 5
@@ -219,6 +229,7 @@ def test_to_matrix_LowRankOperator():
     assert_type_and_allclose(L @ spla.solve(C, R.T), LR, 'dense')
 
 
+@pytest.mark.builtin
 def test_to_matrix_LowRankUpdatedOperator():
     m = 6
     n = 5
@@ -236,6 +247,7 @@ def test_to_matrix_LowRankUpdatedOperator():
     assert_type_and_allclose(A + L @ C @ R.T, op, 'dense')
 
 
+@pytest.mark.builtin
 def test_to_matrix_VectorArrayOperator():
     V = np.random.randn(10, 2)
 
@@ -247,6 +259,7 @@ def test_to_matrix_VectorArrayOperator():
     assert_type_and_allclose(V.T, Vop, 'dense')
 
 
+@pytest.mark.builtin
 def test_to_matrix_ZeroOperator():
     n = 3
     m = 4

--- a/src/pymortests/analyticalproblems/analyticalproblem.py
+++ b/src/pymortests/analyticalproblems/analyticalproblem.py
@@ -3,9 +3,13 @@
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 import warnings
 
+import pytest
+
 from pymor.analyticalproblems.text import text_problem
 from pymortests.base import runmodule
 from pymortests.core.pickling import assert_picklable, assert_picklable_without_dumps_function
+
+pytestmark = pytest.mark.builtin
 
 
 def test_pickle(analytical_problem):

--- a/src/pymortests/analyticalproblems/function.py
+++ b/src/pymortests/analyticalproblems/function.py
@@ -11,6 +11,8 @@ from pymortests.core.pickling import assert_picklable, assert_picklable_without_
 from pymortests.fixtures.function import function_argument
 from pymortests.fixtures.parameter import mu_of_type
 
+pytestmark = pytest.mark.builtin
+
 
 def test_evaluate(function):
     f = function

--- a/src/pymortests/analyticalproblems/polygonal_chain.py
+++ b/src/pymortests/analyticalproblems/polygonal_chain.py
@@ -1,5 +1,13 @@
+# This file is part of the pyMOR project (https://www.pymor.org).
+# Copyright pyMOR developers and contributors. All rights reserved.
+# License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
+
+import pytest
+
 from pymor.analyticalproblems.domaindescriptions import PolygonalDomain
 from pymortests.base import runmodule
+
+pytestmark = pytest.mark.builtin
 
 
 def _determine_boundary_type(point):

--- a/src/pymortests/base.py
+++ b/src/pymortests/base.py
@@ -9,7 +9,6 @@ from functools import wraps
 from pickle import dump, load
 from pprint import pformat
 
-import hypothesis
 import numpy as np
 from pkg_resources import resource_filename, resource_stream
 from pytest import skip
@@ -81,23 +80,6 @@ def assert_all_almost_equal(U, V, product=None, sup_norm=False, rtol=1e-14, atol
     too_large_relative_errors = dict((i, relative_error(u, v, product=product))
                                      for i, (u, v, f) in enumerate(zip(U, V, cmp_array)) if not f)
     assert np.all(cmp_array), f'Relative errors for not-equal elements:{pformat(too_large_relative_errors)}'
-
-
-def might_exceed_deadline(deadline=-1):
-    """For hypothesis magic to work properly this must be the topmost decorator on test function."""
-    def _outer_wrapper(func):
-        @wraps(func)
-        def _inner_wrapper(*args, **kwargs):
-            dl = deadline
-            if os.environ.get('PYMOR_ALLOW_DEADLINE_EXCESS', False):
-                dl = None
-            elif dl == -1:
-                dl = hypothesis.settings.default.deadline.total_seconds() * 1e3
-            assert dl is None or dl > 1
-            return hypothesis.settings(deadline=dl)(func)(*args, **kwargs)
-        return _inner_wrapper
-    return _outer_wrapper
-
 
 def skip_if_missing(config_name):
     """Wrapper for requiring certain module dependencies on tests.

--- a/src/pymortests/base.py
+++ b/src/pymortests/base.py
@@ -18,6 +18,8 @@ from pymor.algorithms.basic import almost_equal, relative_error
 from pymor.core import config
 from pymor.core.exceptions import DependencyMissingError, NoResultDataError
 
+BUILTIN_DISABLED = bool(os.environ.get('PYMOR_FIXTURES_DISABLE_BUILTIN', False))
+
 
 def runmodule(filename):
     import pytest

--- a/src/pymortests/base.py
+++ b/src/pymortests/base.py
@@ -119,7 +119,7 @@ def skip_if_missing(config_name):
                 config.config.require(config_name)
             except DependencyMissingError as dm:
                 # skip does not return
-                if config_name in str(dm.dependency) and not os.environ.get('DOCKER_PYMOR', False):
+                if config_name in str(dm.dependency):
                     skip_string = 'skipped test due to missing dependency ' + config_name
                     skip(skip_string)
                 raise dm

--- a/src/pymortests/basic.py
+++ b/src/pymortests/basic.py
@@ -2,6 +2,10 @@
 # Copyright pyMOR developers and contributors. All rights reserved.
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
+import pytest
+
+pytestmark = pytest.mark.builtin
+
 
 def test_importable():
     __import__('pymor.basic')

--- a/src/pymortests/bindings/skfem.py
+++ b/src/pymortests/bindings/skfem.py
@@ -3,17 +3,14 @@
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
 import numpy as np
-import pytest
 
 from pymor.basic import ConstantFunction, ExpressionFunction, LineDomain, RectDomain, StationaryProblem
-from pymor.core.config import config
 from pymor.discretizers.builtin.cg import discretize_stationary_cg as discretize_stationary_cg_builtin
+from pymortests.base import skip_if_missing
 
 
+@skip_if_missing('SCIKIT_FEM')
 def test_skfem1d():
-    if not config.HAVE_SCIKIT_FEM:
-        pytest.xfail('scikit-fem missing')
-
     from pymor.discretizers.skfem.cg import discretize_stationary_cg
 
     p = StationaryProblem(
@@ -35,10 +32,8 @@ def test_skfem1d():
     assert np.linalg.norm((o_builtin - o_skfem) / o_builtin) < 0.01
 
 
+@skip_if_missing('SCIKIT_FEM')
 def test_skfem2d():
-    if not config.HAVE_SCIKIT_FEM:
-        pytest.xfail('scikit-fem missing')
-
     from pymor.discretizers.skfem.cg import discretize_stationary_cg
 
     p = StationaryProblem(

--- a/src/pymortests/complex_values.py
+++ b/src/pymortests/complex_values.py
@@ -3,9 +3,12 @@
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
 import numpy as np
+import pytest
 
 from pymor.operators.numpy import NumpyMatrixOperator
 from pymor.vectorarrays.numpy import NumpyVectorSpace
+
+pytestmark = pytest.mark.builtin
 
 
 def test_complex():

--- a/src/pymortests/core/base.py
+++ b/src/pymortests/core/base.py
@@ -3,9 +3,12 @@
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
 import numpy as np
+import pytest
 
 from pymor.discretizers.builtin import RectGrid, TriaGrid
 from pymortests.base import runmodule
+
+pytestmark = pytest.mark.builtin
 
 
 def test_with_newtype():

--- a/src/pymortests/core/cache.py
+++ b/src/pymortests/core/cache.py
@@ -16,6 +16,9 @@ from pymor.models.basic import StationaryModel
 from pymor.operators.numpy import NumpyMatrixOperator
 from pymortests.base import runmodule
 
+pytestmark = pytest.mark.builtin
+
+
 SLEEP_DELTA = timedelta(milliseconds=200)
 
 

--- a/src/pymortests/core/config.py
+++ b/src/pymortests/core/config.py
@@ -7,6 +7,9 @@ import pytest
 from pymor.core.config import _PACKAGES, config
 from pymor.core.exceptions import DependencyMissingError
 
+pytestmark = pytest.mark.builtin
+
+
 
 def test_repr():
     repr(config)

--- a/src/pymortests/core/defaults.py
+++ b/src/pymortests/core/defaults.py
@@ -6,6 +6,8 @@ import pytest
 from pymor.core.defaults import defaults, load_defaults_from_file, print_defaults, set_defaults, write_defaults_to_file
 from pymor.tools.io import safe_temporary_filename
 
+pytestmark = pytest.mark.builtin
+
 
 @defaults('c', 'd')
 def func(a, b, c=2, d=3, e=4):

--- a/src/pymortests/core/logger.py
+++ b/src/pymortests/core/logger.py
@@ -11,6 +11,8 @@ from pymor.core.logger import log_levels
 from pymor.operators.numpy import NumpyMatrixOperator
 from pymortests.base import runmodule
 
+pytestmark = pytest.mark.builtin
+
 
 def test_logger():
     logger = NumpyMatrixOperator._logger

--- a/src/pymortests/demos.py
+++ b/src/pymortests/demos.py
@@ -21,7 +21,7 @@ from pymor.core.exceptions import (
     TorchMissingError,
 )
 from pymor.tools.mpi import parallel
-from pymortests.base import check_results, runmodule, BUILTIN_DISABLED
+from pymortests.base import BUILTIN_DISABLED, check_results, runmodule
 
 runner = CliRunner()
 

--- a/src/pymortests/demos.py
+++ b/src/pymortests/demos.py
@@ -351,6 +351,7 @@ def test_thermalblock_results(thermalblock_args):
                   'min_effectivities', 'max_effectivities', 'errors')
 
 
+@pytest.mark.builtin
 def test_burgers_ei_results():
     from pymordemos import burgers_ei
     app = Typer()
@@ -363,6 +364,7 @@ def test_burgers_ei_results():
                   (1e-13, 1e-7), 'errors', 'triangularity_errors', 'greedy_max_errs')
 
 
+@pytest.mark.builtin
 def test_parabolic_mor_results():
     from pymordemos import parabolic_mor
     args = ['pymor', 'greedy', 5, 20, 3]
@@ -374,6 +376,7 @@ def test_parabolic_mor_results():
                   'min_effectivities', 'max_effectivities', 'errors')
 
 
+@pytest.mark.builtin
 def test_check_check_results_missing(tmp_path):
     test_name = tmp_path.name
     args = ['NONE', tmp_path]

--- a/src/pymortests/demos.py
+++ b/src/pymortests/demos.py
@@ -190,8 +190,7 @@ def _skip_if_no_solver(param):
         has_solver = getattr(config, f'HAVE_{package}')
         builtin = builtin and (not needs_solver or package == 'TORCH')
         if needs_solver and not has_solver:
-            if not os.environ.get('DOCKER_PYMOR', False):
-                pytest.skip('skipped test due to missing ' + solver)
+            pytest.skip('skipped test due to missing ' + solver)
     if builtin and BUILTIN_DISABLED:
         pytest.skip('builtin discretizations disabled')
 

--- a/src/pymortests/discretizers/affine_grid.py
+++ b/src/pymortests/discretizers/affine_grid.py
@@ -15,6 +15,8 @@ from pymortests.fixtures.grid import (
     hy_grid_with_orthogonal_centers,
 )
 
+pytestmark = pytest.mark.builtin
+
 
 def _scale_tols_if_domain_bad(g, atol=1e-05, rtol=1e-08):
     # "badly" shaped domains produce excessive errors

--- a/src/pymortests/discretizers/grid.py
+++ b/src/pymortests/discretizers/grid.py
@@ -9,7 +9,6 @@ import pytest
 from hypothesis import given, settings
 
 from pymor.core.exceptions import QtMissingError
-from pymortests.base import might_exceed_deadline
 from pymortests.core.pickling import assert_picklable_without_dumps_function
 from pymortests.fixtures.grid import (
     hy_grid,
@@ -248,7 +247,6 @@ def test_neighbours_wrong_arguments(grid_and_dims):
         g.neighbours(-1, 0, g.dim)
 
 
-@might_exceed_deadline(2000)
 @given(hy_grid_and_dim_range_product_and_s_max_en())
 def test_neighbours_shape(grid_and_dims):
     g, e, n, s = grid_and_dims
@@ -256,14 +254,12 @@ def test_neighbours_shape(grid_and_dims):
     assert g.neighbours(e, n, s).shape[0] == g.size(e)
 
 
-@might_exceed_deadline(2000)
 @given(hy_grid_and_dim_range_product_and_s_max_en())
 def test_neighbours_dtype(grid_and_dims):
     g, e, n, s = grid_and_dims
     assert g.neighbours(e, n, s).dtype == np.dtype('int32')
 
 
-@might_exceed_deadline(2000)
 @given(hy_grid_and_dim_range_product_and_s_max_en())
 def test_neighbours_entry_value_range(grid_and_dims):
     g, e, n, s = grid_and_dims
@@ -271,7 +267,6 @@ def test_neighbours_entry_value_range(grid_and_dims):
     np.testing.assert_array_less(-2, g.neighbours(e, n, s))
 
 
-@might_exceed_deadline(2000)
 @given(hy_grid_and_dim_range_product_and_s_max_en())
 def test_neighbours_entry_values_unique(grid_and_dims):
     g, e, n, s = grid_and_dims
@@ -280,7 +275,6 @@ def test_neighbours_entry_values_unique(grid_and_dims):
         assert S.size == np.unique(S).size
 
 
-@might_exceed_deadline(5000)
 @given(hy_grid_and_dim_range_product_and_s_max_en())
 def test_neighbours_each_entry_neighbour(grid_and_dims):
     g, e, n, s = grid_and_dims
@@ -296,7 +290,6 @@ def test_neighbours_each_entry_neighbour(grid_and_dims):
                 assert len(inter) > 0
 
 
-@might_exceed_deadline(4000)
 @given(hy_grid_and_dim_range_product_and_s_max_en())
 def test_neighbours_each_neighbour_has_entry(grid_and_dims):
     g, e, n, s = grid_and_dims
@@ -317,7 +310,6 @@ def test_neighbours_each_neighbour_has_entry(grid_and_dims):
                         f'Failed for\n{g}\ne={e}, n={n}, s={s}, ei={ei}, ni={ni}'
 
 
-@might_exceed_deadline(2000)
 @given(hy_grid_and_dim_range_product_and_s_max_en())
 def test_neighbours_not_neighbour_of_itself(grid_and_dims):
     g, e, _, s = grid_and_dims
@@ -406,7 +398,6 @@ def test_boundaries_dtype(grid):
         assert g.boundaries(d).dtype == np.dtype('int32')
 
 
-@might_exceed_deadline(2000)
 @given(hy_grid)
 def test_boundaries_entry_value_range(grid):
     g = grid

--- a/src/pymortests/discretizers/grid.py
+++ b/src/pymortests/discretizers/grid.py
@@ -20,6 +20,8 @@ from pymortests.fixtures.grid import (
     hy_grids_with_visualize,
 )
 
+pytestmark = pytest.mark.builtin
+
 
 @given(hy_grid)
 def test_dim(grid):

--- a/src/pymortests/discretizers/gui.py
+++ b/src/pymortests/discretizers/gui.py
@@ -14,6 +14,8 @@ from pymor.discretizers.builtin.domaindiscretizers.default import discretize_dom
 from pymor.discretizers.builtin.grids.oned import OnedGrid
 from pymortests.base import runmodule
 
+pytestmark = pytest.mark.builtin
+
 
 @pytest.fixture(params=(('matplotlib', RectGrid), ('gl', RectGrid), ('matplotlib', OnedGrid)))
 def backend_gridtype(request):

--- a/src/pymortests/docker_ci_smoketest.py
+++ b/src/pymortests/docker_ci_smoketest.py
@@ -13,18 +13,22 @@ from pymor.core.config import _PACKAGES, config
 @pytest.mark.skipif(condition=not os.environ.get('DOCKER_PYMOR', False),
                     reason='Guarantee only valid in the docker container')
 def test_config(pkg):
-    assert getattr(config, f'HAVE_{pkg}')
+    assert getattr(config, f'HAVE_{pkg}') or pkg in config.disabled
 
 
 @pytest.mark.skipif(condition=not os.environ.get('DOCKER_PYMOR', False),
                     reason='Guarantee only valid in the docker container')
 def test_no_dune_warnings():
+    if not config.HAVE_DUNEGDT:
+        pytest.skip('dune-gdt not enalbed')
     _test_dune_import_warn()
 
 
 @pytest.mark.skipif(condition=not os.environ.get('DOCKER_PYMOR', False),
                     reason='Guarantee only valid in the docker container')
 def test_dune_warnings(monkeypatch):
+    if not config.HAVE_DUNEGDT:
+        pytest.skip('dune-gdt not enalbed')
     from dune import gdt, xt
     monkeypatch.setattr(gdt, '__version__', '2020.0.0')
     monkeypatch.setattr(xt, '__version__', '2020.0.0')

--- a/src/pymortests/fixtures/model.py
+++ b/src/pymortests/fixtures/model.py
@@ -7,6 +7,7 @@ from itertools import product
 import pytest
 
 from pymor.discretizers.builtin import discretize_instationary_fv, discretize_stationary_cg
+from pymortests.base import BUILTIN_DISABLED
 from pymortests.fixtures.analyticalproblem import (
     burgers_problems,
     non_picklable_thermalblock_problems,
@@ -30,17 +31,18 @@ non_picklable_model_generators = \
 model_generators = picklable_model_generators + non_picklable_model_generators
 
 
-@pytest.fixture(params=model_generators)
+@pytest.fixture(params=[] if BUILTIN_DISABLED else model_generators)
 def model(request):
     return request.param()
 
 
-@pytest.fixture(params=[lambda p=p, d=d: discretize_stationary_cg(p, diameter=d)[0]
-                        for p, d in product(non_picklable_thermalblock_problems, [1./20., 1./30.])])
+@pytest.fixture(params=[] if BUILTIN_DISABLED else
+                       ([lambda p=p, d=d: discretize_stationary_cg(p, diameter=d)[0]
+                        for p, d in product(non_picklable_thermalblock_problems, [1./20., 1./30.])]))
 def stationary_models(request):
     return request.param()
 
 
-@pytest.fixture(params=picklable_model_generators)
+@pytest.fixture(params=[] if BUILTIN_DISABLED else picklable_model_generators)
 def picklable_model(request):
     return request.param()

--- a/src/pymortests/fixtures/operator.py
+++ b/src/pymortests/fixtures/operator.py
@@ -12,6 +12,7 @@ from pymor.operators.interface import Operator
 from pymor.operators.list import NumpyListVectorArrayMatrixOperator
 from pymor.operators.numpy import NumpyMatrixOperator
 from pymor.vectorarrays.numpy import NumpyVectorSpace
+from pymortests.base import BUILTIN_DISABLED
 
 
 class MonomOperator(Operator):
@@ -559,7 +560,8 @@ else:
     fenics_with_arrays_generators = []
 
 
-@pytest.fixture(params=(
+builtin_operator_with_arrays_and_products_generators = (
+    [] if BUILTIN_DISABLED else
     thermalblock_operator_with_arrays_and_products_generators
     + thermalblock_assemble_operator_with_arrays_and_products_generators
     + thermalblock_concatenation_operator_with_arrays_and_products_generators
@@ -572,13 +574,19 @@ else:
     + thermalblock_fixedparam_operator_with_arrays_and_products_generators
     + misc_operator_with_arrays_and_products_generators
     + unpicklable_misc_operator_with_arrays_and_products_generators
+)
+
+
+@pytest.fixture(params=(
+    builtin_operator_with_arrays_and_products_generators
     + fenics_with_arrays_and_products_generators
 ))
 def operator_with_arrays_and_products(reset_rng, request):
     return request.param()
 
 
-@pytest.fixture(params=(
+builtin_operator_with_arrays_generators = (
+    [] if BUILTIN_DISABLED else
     numpy_matrix_operator_with_arrays_generators
     + numpy_list_vector_array_matrix_operator_with_arrays_generators
     + thermalblock_operator_with_arrays_generators
@@ -593,13 +601,18 @@ def operator_with_arrays_and_products(reset_rng, request):
     + thermalblock_fixedparam_operator_with_arrays_generators
     + misc_operator_with_arrays_generators
     + unpicklable_misc_operator_with_arrays_generators
+)
+
+@pytest.fixture(params=(
+    builtin_operator_with_arrays_generators
     + fenics_with_arrays_generators
 ))
 def operator_with_arrays(reset_rng, request):
     return request.param()
 
 
-@pytest.fixture(params=(
+builtin_operator_generators = (
+    [] if BUILTIN_DISABLED else
     numpy_matrix_operator_generators
     + numpy_list_vector_array_matrix_operator_generators
     + thermalblock_operator_generators
@@ -614,12 +627,17 @@ def operator_with_arrays(reset_rng, request):
     + thermalblock_fixedparam_operator_generators
     + misc_operator_generators
     + unpicklable_misc_operator_generators
+)
+
+@pytest.fixture(params=(
+    builtin_operator_generators
 ))
 def operator(reset_rng, request):
     return request.param()
 
 
-@pytest.fixture(params=(
+builtin_picklable_operator_generators = (
+    [] if BUILTIN_DISABLED else
     numpy_matrix_operator_generators
     + numpy_list_vector_array_matrix_operator_generators
     + thermalblock_operator_generators
@@ -633,6 +651,10 @@ def operator(reset_rng, request):
     + thermalblock_vectorfunc_operator_generators
     + thermalblock_fixedparam_operator_generators
     + misc_operator_generators
+)
+
+@pytest.fixture(params=(
+    builtin_picklable_operator_generators
 ))
 def picklable_operator(reset_rng, request):
     return request.param()

--- a/src/pymortests/models/iosys_add_sub_mul.py
+++ b/src/pymortests/models/iosys_add_sub_mul.py
@@ -9,6 +9,9 @@ from pymor.models.iosys import LinearDelayModel, LTIModel, PHLTIModel, SecondOrd
 from pymor.models.transfer_function import FactorizedTransferFunction, TransferFunction
 from pymor.operators.numpy import NumpyMatrixOperator
 
+pytestmark = pytest.mark.builtin
+
+
 type_list = [
     'LTIModel',
     'SecondOrderModel',

--- a/src/pymortests/models/iosys_save_load.py
+++ b/src/pymortests/models/iosys_save_load.py
@@ -12,6 +12,8 @@ import scipy.sparse as sps
 
 from pymor.models.iosys import LTIModel, SecondOrderModel
 
+pytestmark = pytest.mark.builtin
+
 
 def _build_matrices_lti(with_D, with_E):
     A = sps.csc_matrix([[1, 2], [3, 4]])

--- a/src/pymortests/models/model.py
+++ b/src/pymortests/models/model.py
@@ -19,6 +19,8 @@ from pymor.vectorarrays.numpy import NumpyVectorSpace
 from pymortests.base import runmodule
 from pymortests.core.pickling import assert_picklable, assert_picklable_without_dumps_function
 
+pytestmark = pytest.mark.builtin
+
 
 def test_pickle(model):
     assert_picklable(model)

--- a/src/pymortests/models/transforms.py
+++ b/src/pymortests/models/transforms.py
@@ -14,6 +14,8 @@ type_list = ['BilinearTransformation', 'CayleyTransformation', 'MoebiusTransform
 points_list = list(combinations([0, 1, -1, 1j, -1j, np.inf], 3))
 sampling_time_list = [0, 1/100, 2]
 
+pytestmark = pytest.mark.builtin
+
 
 def get_transformation(name):
     if name == 'BilinearTransformation':

--- a/src/pymortests/neural_network.py
+++ b/src/pymortests/neural_network.py
@@ -3,8 +3,11 @@
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
 import numpy as np
+import pytest
 
 from pymortests.base import skip_if_missing
+
+pytestmark = pytest.mark.builtin
 
 
 @skip_if_missing('TORCH')

--- a/src/pymortests/operators/block.py
+++ b/src/pymortests/operators/block.py
@@ -3,12 +3,15 @@
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
 import numpy as np
+import pytest
 import scipy.linalg as spla
 
 from pymor.operators.block import BlockDiagonalOperator, BlockOperator
 from pymor.operators.numpy import NumpyMatrixOperator
 from pymor.vectorarrays.block import BlockVectorSpace
 from pymor.vectorarrays.numpy import NumpyVectorSpace
+
+pytestmark = pytest.mark.builtin
 
 
 def test_apply():

--- a/src/pymortests/operators/la.py
+++ b/src/pymortests/operators/la.py
@@ -3,12 +3,15 @@
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
 import numpy as np
+import pytest
 
 from pymor.discretizers.builtin.cg import L2ProductP1
 from pymor.discretizers.builtin.grids.boundaryinfos import AllDirichletBoundaryInfo
 from pymor.discretizers.builtin.grids.tria import TriaGrid
 from pymor.operators.constructions import induced_norm
 from pymortests.base import runmodule
+
+pytestmark = pytest.mark.builtin
 
 
 def test_induced():

--- a/src/pymortests/operators/low_rank_op.py
+++ b/src/pymortests/operators/low_rank_op.py
@@ -3,6 +3,7 @@
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
 import numpy as np
+import pytest
 import scipy.linalg as spla
 
 from pymor.algorithms.lincomb import assemble_lincomb
@@ -10,6 +11,8 @@ from pymor.operators.constructions import LowRankOperator, LowRankUpdatedOperato
 from pymor.operators.numpy import NumpyMatrixOperator
 from pymor.tools.random import get_rng
 from pymor.vectorarrays.numpy import NumpyVectorSpace
+
+pytestmark = pytest.mark.builtin
 
 
 def construct_operators_and_vectorarrays(m, n, r, k):

--- a/src/pymortests/operators/operators.py
+++ b/src/pymortests/operators/operators.py
@@ -32,6 +32,7 @@ from pymortests.fixtures.operator import MonomOperator
 from pymortests.strategies import valid_inds, valid_inds_of_same_length
 
 
+@pytest.mark.builtin
 def test_selection_op():
     p1 = MonomOperator(1)
     select_rhs_functional = GenericParameterFunctional(
@@ -65,6 +66,7 @@ def test_selection_op():
     assert s2._get_operator_number(s2.parameters.parse({'nrrhs': 9})) == 3
 
 
+@pytest.mark.builtin
 def test_lincomb_op():
     p1 = MonomOperator(1)
     p2 = MonomOperator(2)
@@ -93,6 +95,7 @@ def test_lincomb_op():
         assert almost_equal(pa, p.apply(vx)).all()
 
 
+@pytest.mark.builtin
 def test_lincomb_op_with_zero_coefficients():
     p1 = MonomOperator(1)
     p2 = MonomOperator(2)
@@ -123,6 +126,7 @@ def test_lincomb_op_with_zero_coefficients():
     assert almost_equal(pc10.apply_adjoint(vx), pc1.apply_adjoint(vx)).all()
 
 
+@pytest.mark.builtin
 def test_lincomb_adjoint():
     op = LincombOperator([NumpyMatrixOperator(np.eye(10)), NumpyMatrixOperator(np.eye(10))],
                          [1+3j, ExpressionParameterFunctional('c[0] + 3', {'c': 1})])
@@ -135,6 +139,7 @@ def test_lincomb_adjoint():
     assert np.all(almost_equal(V, VVV))
 
 
+@pytest.mark.builtin
 def test_identity_lincomb():
     space = NumpyVectorSpace(10)
     identity = IdentityOperator(space)
@@ -149,6 +154,7 @@ def test_identity_lincomb():
     assert almost_equal(ones * 0.5, idid_.apply_inverse_adjoint(ones))
 
 
+@pytest.mark.builtin
 def test_identity_numpy_lincomb():
     n = 2
     space = NumpyVectorSpace(n)
@@ -162,6 +168,7 @@ def test_identity_numpy_lincomb():
             assert np.array_equal(mat1, mat2)
 
 
+@pytest.mark.builtin
 def test_block_identity_lincomb():
     space = NumpyVectorSpace(10)
     space2 = BlockVectorSpace([space, space])
@@ -176,6 +183,7 @@ def test_block_identity_lincomb():
     assert almost_equal(ones2 * 0.5, idid.apply_inverse_adjoint(ones2))
 
 
+@pytest.mark.builtin
 def test_bilin_functional():
     space = NumpyVectorSpace(10)
     scalar = NumpyVectorSpace(1)
@@ -198,6 +206,7 @@ def test_bilin_functional():
     assert almost_equal(four_s, bilin_op.apply(two_v))
 
 
+@pytest.mark.builtin
 def test_bilin_prod_functional():
     from pymor.operators.constructions import VectorFunctional
     space = NumpyVectorSpace(10)
@@ -484,6 +493,7 @@ def test_InverseAdjointOperator(operator_with_arrays):
         pass
 
 
+@pytest.mark.builtin
 def test_vectorarray_op_apply_inverse():
     O = np.random.random((5, 5))
     op = VectorArrayOperator(NumpyVectorSpace.make_array(O))
@@ -494,6 +504,7 @@ def test_vectorarray_op_apply_inverse():
     assert np.all(almost_equal(U, U.space.from_numpy(u), rtol=1e-10))
 
 
+@pytest.mark.builtin
 def test_vectorarray_op_apply_inverse_lstsq():
     O = np.random.random((3, 5))
     op = VectorArrayOperator(NumpyVectorSpace.make_array(O))
@@ -504,6 +515,7 @@ def test_vectorarray_op_apply_inverse_lstsq():
     assert np.all(almost_equal(U, U.space.from_numpy(u)))
 
 
+@pytest.mark.builtin
 def test_adjoint_vectorarray_op_apply_inverse_lstsq():
     O = np.random.random((3, 5))
     op = VectorArrayOperator(NumpyVectorSpace.make_array(O), adjoint=True)
@@ -524,6 +536,7 @@ def test_as_range_array(operator_with_arrays):
     assert np.all(almost_equal(array.lincomb(U.to_numpy()), op.apply(U, mu=mu)))
 
 
+@pytest.mark.builtin
 def test_issue_1276():
     from pymor.operators.block import BlockOperator
     from pymor.operators.constructions import IdentityOperator
@@ -536,6 +549,7 @@ def test_issue_1276():
     B.apply_inverse(v)
 
 
+@pytest.mark.builtin
 @pytest.mark.parametrize('iscomplex', [False, True])
 def test_hankel_operator(iscomplex):
     s, p, m = 4, 2, 3

--- a/src/pymortests/parameters/min_max_theta_functionals.py
+++ b/src/pymortests/parameters/min_max_theta_functionals.py
@@ -15,6 +15,8 @@ from pymor.parameters.functionals import (
 )
 from pymortests.base import runmodule
 
+pytestmark = pytest.mark.builtin
+
 
 def test_min_theta_parameter_functional():
     thetas = (ExpressionParameterFunctional('2*mu[0]', {'mu': 1}),

--- a/src/pymortests/parameters/mu_derivatives.py
+++ b/src/pymortests/parameters/mu_derivatives.py
@@ -3,10 +3,13 @@
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
 import numpy as np
+import pytest
 
 from pymor.basic import Mu, NumpyVectorSpace
 from pymor.operators.constructions import LincombOperator, ZeroOperator
 from pymor.parameters.functionals import ExpressionParameterFunctional, ProjectionParameterFunctional
+
+pytestmark = pytest.mark.builtin
 
 
 def test_ProjectionParameterFunctional():

--- a/src/pymortests/parameters/parameter_functionals.py
+++ b/src/pymortests/parameters/parameter_functionals.py
@@ -2,8 +2,12 @@
 # Copyright pyMOR developers and contributors. All rights reserved.
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
+import pytest
+
 from pymor.basic import Mu
 from pymor.parameters.functionals import ExpressionParameterFunctional, ProjectionParameterFunctional
+
+pytestmark = pytest.mark.builtin
 
 
 def test_LincombParameterFunctional():

--- a/src/pymortests/parameters/parameters.py
+++ b/src/pymortests/parameters/parameters.py
@@ -11,6 +11,9 @@ from pymor.analyticalproblems.functions import ConstantFunction
 from pymor.parameters.base import Mu, Parameters
 from pymortests.base import runmodule
 
+pytestmark = pytest.mark.builtin
+
+
 num_samples = 100
 
 

--- a/src/pymortests/reductors/h2.py
+++ b/src/pymortests/reductors/h2.py
@@ -3,9 +3,12 @@
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
 import numpy as np
+import pytest
 
 from pymor.models.iosys import LTIModel
 from pymor.reductors.h2 import IRKAReductor
+
+pytestmark = pytest.mark.builtin
 
 
 def test_irka():

--- a/src/pymortests/strategies.py
+++ b/src/pymortests/strategies.py
@@ -125,8 +125,6 @@ if config.HAVE_FENICS:
             ret.append((_FENICS_spaces[d], ar))
         return ret
     _other_vector_space_types.append('fenics')
-else:
-    assert not os.environ.get('DOCKER_PYMOR', False)
 
 if config.HAVE_NGSOLVE:
     _NGSOLVE_spaces = {}
@@ -146,22 +144,16 @@ if config.HAVE_NGSOLVE:
     def _ngsolve_vector_spaces(draw, np_data_list, compatible, count, dims):
         return [(_create_ngsolve_space(d), ar) for d, ar in zip(dims, np_data_list)]
     _other_vector_space_types.append('ngsolve')
-else:
-    assert not os.environ.get('DOCKER_PYMOR', False)
 
 if config.HAVE_DEALII:
     def _dealii_vector_spaces(draw, np_data_list, compatible, count, dims):
         return [(DealIIVectorSpace(d), ar) for d, ar in zip(dims, np_data_list)]
     _other_vector_space_types.append('dealii')
-else:
-    assert not os.environ.get('DOCKER_PYMOR', False)
 
 if config.HAVE_DUNEGDT:
     def _dunegdt_vector_spaces(draw, np_data_list, compatible, count, dims):
         return [(DuneXTVectorSpace(d), ar) for d, ar in zip(dims, np_data_list)]
     _other_vector_space_types.append('dunegdt')
-else:
-    assert not os.environ.get('DOCKER_PYMOR', False)
 
 
 _picklable_vector_space_types = [] if BUILTIN_DISABLED else ['numpy', 'numpy_list', 'block']

--- a/src/pymortests/strategies.py
+++ b/src/pymortests/strategies.py
@@ -16,6 +16,7 @@ from pymor.parameters.base import Mu
 from pymor.vectorarrays.block import BlockVectorSpace
 from pymor.vectorarrays.list import NumpyListVectorSpace
 from pymor.vectorarrays.numpy import NumpyVectorSpace
+from pymortests.base import BUILTIN_DISABLED
 
 if config.HAVE_FENICS:
     import dolfin as df
@@ -163,7 +164,7 @@ else:
     assert not os.environ.get('DOCKER_PYMOR', False)
 
 
-_picklable_vector_space_types = ['numpy', 'numpy_list', 'block']
+_picklable_vector_space_types = [] if BUILTIN_DISABLED else ['numpy', 'numpy_list', 'block']
 
 
 @hyst.composite
@@ -219,6 +220,9 @@ def given_vector_arrays(which='all', count=1, dtype=None, length=None, compatibl
                         'picklable': _picklable_vector_space_types}[which]
         except KeyError:
             use_imps = which
+        if not use_imps:
+            import pytest
+            return pytest.mark.skip('no backend')(func)
         first_args = {}
         if index_strategy:
             arr_ind_strategy = index_strategy(vector_arrays(

--- a/src/pymortests/strategies.py
+++ b/src/pymortests/strategies.py
@@ -2,7 +2,6 @@
 # Copyright pyMOR developers and contributors. All rights reserved.
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 import functools
-import os
 
 import numpy as np
 from hypothesis import assume, given

--- a/src/pymortests/tools.py
+++ b/src/pymortests/tools.py
@@ -26,6 +26,9 @@ from pymor.vectorarrays.numpy import NumpyVectorSpace
 from pymortests.base import runmodule
 from pymortests.fixtures.grid import hy_rect_or_tria_grid
 
+pytestmark = pytest.mark.builtin
+
+
 logger = getLogger('pymortests.tools')
 
 

--- a/src/pymortests/vectorarray.py
+++ b/src/pymortests/vectorarray.py
@@ -138,7 +138,8 @@ def test_random_uniform_all(vector_array, realizations, low, high):
     if config.HAVE_DUNEGDT:
         # atm needs special casing due to norm implementation handling of large vector elements
         from pymor.bindings.dunegdt import DuneXTVectorSpace
-        assume(not isinstance(vector_array.space, DuneXTVectorSpace))
+        if isinstance(vector_array.space, DuneXTVectorSpace):
+            return
     _test_random_uniform(vector_array, realizations, low, high)
 
 

--- a/src/pymortests/vectorarray.py
+++ b/src/pymortests/vectorarray.py
@@ -15,7 +15,6 @@ from pymor.core.config import config
 from pymor.tools.floatcmp import bounded, float_cmp
 from pymor.vectorarrays.interface import VectorSpace
 from pymor.vectorarrays.numpy import NumpyVectorSpace
-from pymortests.base import might_exceed_deadline
 from pymortests.core.pickling import assert_picklable_without_dumps_function
 
 MAX_RNG_REALIZATIONS = 30
@@ -942,7 +941,6 @@ def test_append_incompatible(vector_arrays):
         c1.append(c2, remove_from_other=True)
 
 
-@might_exceed_deadline(2000)
 @pyst.given_vector_arrays(count=2, compatible=False)
 def test_axpy_incompatible(vector_arrays):
     v1, v2 = vector_arrays


### PR DESCRIPTION
This PR splits tests using different PDE solver backends into separate CI job. In particular:

- The `PYMOR_CONFIG_DISABLE` environment variable allows to prevent pyMOR from loading optional dependencies even though they are available. Listing all external solvers here enables a test run where only the builtin discretization toolkit is used.
- Test which only use the builtin toolkit are marked with the `builtin` pytest marker. (Note that this does not include parameterized tests, where some instantiation might use an external solver.)
- Setting `PYMOR_FIXTURES_DISABLE_BUILTIN` will disable the builtin PDE toolkit, `NumpyVectorArrays` and such in parameterized fixtures. Thus, setting this variable and ignoring all tests marked as builtin will only execute tests which depend on the enabled PDE solver backends.
- CI jobs for the fenics, ngsolve, dunegdt and scikit-fem backends have been added.
- The hypothesis execution deadline was globally increased to 5000ms.
- `relative_error` now returns 0, if the absolute error is 0, even when the norm is 0 as well.
- I have removed the `might_exceed_deadline` decorator.

The main reason for this PR is to be able to use different docker images for different PDE solver backends in CI in the future.