### PR TITLE
Disable pre-commit.ci autofixes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,3 +23,5 @@ repos:
   rev: v0.4.0
   hooks:
   - id: markdownlint-cli2
+ci:
+  autofix_prs: false


### PR DESCRIPTION
Use the comment `pre-commit.ci autofix` to trigger an autofix.