### PR TITLE
Edit release checklist

### DIFF
--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -39,15 +39,16 @@ Replace `RELEASE_TAG` below with the actual release tag.
       (Omit in case of a bugfix release.)
 - [ ] Update homepage
       (`gh-pages` branch in `pymor/pymor`, similar to changes in `README.md`).
-- [ ] Make a GitHub release.
-      [Zenodo](https://zenodo.org/record/7494334) is hooked into that.
+- [ ] Make a GitHub release
+      ([Zenodo](https://zenodo.org/record/7494334) is hooked into that) and
+      announce the release in
+      [GitHub Discussions](https://github.com/pymor/pymor/discussions)
+      (can be done as part of making the release).
 - [ ] Update MOR Wiki:
       [pyMOR page](https://morwiki.mpi-magdeburg.mpg.de/morwiki/index.php/PyMOR),
       [software comparison table](https://morwiki.mpi-magdeburg.mpg.de/morwiki/index.php/Comparison_of_Software).
 - [ ] Submit release to [NA-digest](http://icl.utk.edu/na-digest/websubmit.html).
       (Omit in case of a bugfix release.)
-- [ ] Announce release in
-      [GitHub discussions](https://github.com/pymor/pymor/discussions).
 - [ ] All developers check if (stale) branches can be pruned.
 - [ ] All developers check for `.mailmap` correctness.
 - [ ] Remove deprecated features in main in `pymor/pymor`.

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -44,8 +44,6 @@ Replace `RELEASE_TAG` below with the actual release tag.
 - [ ] Update MOR Wiki:
       [pyMOR page](https://morwiki.mpi-magdeburg.mpg.de/morwiki/index.php/PyMOR),
       [software comparison table](https://morwiki.mpi-magdeburg.mpg.de/morwiki/index.php/Comparison_of_Software).
-- [ ] Update [ResearchGate](https://www.researchgate.net/project/pyMOR-Model-Order-Reduction-with-Python)
-      (check formatting after submit!).
 - [ ] Submit release to [NA-digest](http://icl.utk.edu/na-digest/websubmit.html).
       (Omit in case of a bugfix release.)
 - [ ] Announce release in

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -2,44 +2,53 @@
 
 Replace `RELEASE_TAG` below with the actual release tag.
 
- 1. [ ] Check that release notes are finished and merged.
- 1. [ ] Update `README.md`.
- 1. [ ] Create a release branch in `pymor/pymor`. Should have a `.x` as the last part of the branch name in contrast
-        to the `RELEASE_TAG`.
- 1. [ ] Tag commit in `pymor/pymor` as `RELEASE_TAG`.
-        Use an annotated tag (`git tag -a RELEASE_TAG -m RELEASE_TAG`) with the annotation being `RELEASE_TAG`.
- 1. [ ] Run `python setup.py sdist` (on checked out tag `RELEASE_TAG`) and check that it
-        produces `dist/pymor-RELEASE_TAG.tar.gz`.
- 1. [ ] Tag commit in `pymor/docker` as `RELEASE_TAG`, make sure to use the commit mentioned in the `.env` in the
-        tagged commit in `pymor/pymor`. Use an annotated tag with the annotation being the version number.
-        For instance:
+- [ ] Check that release notes are finished and merged.
+- [ ] Update `README.md`.
+- [ ] Create a release branch in `pymor/pymor`.
+      Should have a `.x` as the last part of the branch name in contrast
+      to the `RELEASE_TAG`.
+- [ ] Tag commit in `pymor/pymor` as `RELEASE_TAG`.
+      Use an annotated tag (`git tag -a RELEASE_TAG -m RELEASE_TAG`) with the
+      annotation being `RELEASE_TAG`.
+- [ ] Run `python setup.py sdist` (on checked out tag `RELEASE_TAG`) and check
+      that it produces `dist/pymor-RELEASE_TAG.tar.gz`.
+- [ ] Tag commit in `pymor/docker` as `RELEASE_TAG`, make sure to use the commit
+      mentioned in the `.env` in the tagged commit in `pymor/pymor`.
+      Use an annotated tag with the annotation being the version number.
+      For instance:
 
-       ```bash
-       source pymor/pymor/.env
-       cd pymor/docker
-       git checkout "${CI_IMAGE_TAG}"
-       git tag -a RELEASE_TAG -m RELEASE_TAG
-       ```
+      ```bash
+      source pymor/pymor/.env
+      cd pymor/docker
+      git checkout "${CI_IMAGE_TAG}"
+      git tag -a RELEASE_TAG -m RELEASE_TAG
+      ```
 
- 1. [ ] Push tag `RELEASE_TAG` to `pymor/docker`.
- 1. [ ] Wait for CI build to finish in `pymor/docker`.
- 1. [ ] Push tag `RELEASE_TAG` to `pymor/pymor`.
- 1. [ ] Wait for CI build to finish in `pymor/pymor`. The tagged commit will be deployed to PyPI automatically,
-        see [the developer docs](https://docs.pymor.org/main/developer_docs.html#stage-deploy).
- 1. [ ] Bump/create demo docker, i.e., in `pymor/docker` go to the `demo` folder and copy the subfolder of the last
-        version, change the version in the `Dockerfile` (lines 1 and 6) and extend the `DEMO_TAGS` in `common.mk`
-        (last line).
- 1. [ ] Update homepage (`gh-pages` branch in `pymor/pymor`, similar to changes in `README.md`).
- 1. [ ] Make a GitHub release. [Zenodo](https://zenodo.org/record/7494334) is hooked into that.
- 1. [ ] Update MOR Wiki:
-        [pyMOR page](https://morwiki.mpi-magdeburg.mpg.de/morwiki/index.php/PyMOR),
-        [software comparison table](https://morwiki.mpi-magdeburg.mpg.de/morwiki/index.php/Comparison_of_Software).
- 1. [ ] Update [ResearchGate](https://www.researchgate.net/project/pyMOR-Model-Order-Reduction-with-Python)
-        (check formatting after submit!).
- 1. [ ] Submit release to [NA-digest](http://icl.utk.edu/na-digest/websubmit.html).
- 1. [ ] Announce release in
-        [GitHub discussions](https://github.com/pymor/pymor/discussions).
- 1. [ ] All developers check if (stale) branches can be pruned.
- 1. [ ] All developers check for `.mailmap` correctness.
- 1. [ ] Remove deprecated features in main in `pymor/pymor` (omit this step in case of a bugfix release).
- 1. [ ] Close the [GitHub milestone](https://github.com/pymor/pymor/milestones) for the release.
+- [ ] Push tag `RELEASE_TAG` to `pymor/docker`.
+- [ ] Wait for CI build to finish in `pymor/docker`.
+- [ ] Push tag `RELEASE_TAG` to `pymor/pymor`.
+- [ ] Wait for CI build to finish in `pymor/pymor`.
+      The tagged commit will be deployed to PyPI automatically, see
+      [the developer docs](https://docs.pymor.org/main/developer_docs.html#stage-deploy).
+- [ ] Bump/create demo docker, i.e., in `pymor/docker` go to the `demo` folder
+      and copy the subfolder of the last version, change the version in the
+      `Dockerfile` (lines 1 and 6) and extend the `DEMO_TAGS` in `common.mk`
+      (last line).
+- [ ] Update homepage
+      (`gh-pages` branch in `pymor/pymor`, similar to changes in `README.md`).
+- [ ] Make a GitHub release.
+      [Zenodo](https://zenodo.org/record/7494334) is hooked into that.
+- [ ] Update MOR Wiki:
+      [pyMOR page](https://morwiki.mpi-magdeburg.mpg.de/morwiki/index.php/PyMOR),
+      [software comparison table](https://morwiki.mpi-magdeburg.mpg.de/morwiki/index.php/Comparison_of_Software).
+- [ ] Update [ResearchGate](https://www.researchgate.net/project/pyMOR-Model-Order-Reduction-with-Python)
+      (check formatting after submit!).
+- [ ] Submit release to [NA-digest](http://icl.utk.edu/na-digest/websubmit.html).
+- [ ] Announce release in
+      [GitHub discussions](https://github.com/pymor/pymor/discussions).
+- [ ] All developers check if (stale) branches can be pruned.
+- [ ] All developers check for `.mailmap` correctness.
+- [ ] Remove deprecated features in main in `pymor/pymor`
+      (omit this step in case of a bugfix release).
+- [ ] Close the [GitHub milestone](https://github.com/pymor/pymor/milestones)
+      for the release.

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -3,10 +3,12 @@
 Replace `RELEASE_TAG` below with the actual release tag.
 
 - [ ] Check that release notes are finished and merged.
+      (Omit in case of a bugfix release.)
 - [ ] Update `README.md`.
 - [ ] Create a release branch in `pymor/pymor`.
       Should have a `.x` as the last part of the branch name in contrast
       to the `RELEASE_TAG`.
+      (Omit in case of a bugfix release.)
 - [ ] Tag commit in `pymor/pymor` as `RELEASE_TAG`.
       Use an annotated tag (`git tag -a RELEASE_TAG -m RELEASE_TAG`) with the
       annotation being `RELEASE_TAG`.
@@ -34,6 +36,7 @@ Replace `RELEASE_TAG` below with the actual release tag.
       and copy the subfolder of the last version, change the version in the
       `Dockerfile` (lines 1 and 6) and extend the `DEMO_TAGS` in `common.mk`
       (last line).
+      (Omit in case of a bugfix release.)
 - [ ] Update homepage
       (`gh-pages` branch in `pymor/pymor`, similar to changes in `README.md`).
 - [ ] Make a GitHub release.
@@ -44,11 +47,13 @@ Replace `RELEASE_TAG` below with the actual release tag.
 - [ ] Update [ResearchGate](https://www.researchgate.net/project/pyMOR-Model-Order-Reduction-with-Python)
       (check formatting after submit!).
 - [ ] Submit release to [NA-digest](http://icl.utk.edu/na-digest/websubmit.html).
+      (Omit in case of a bugfix release.)
 - [ ] Announce release in
       [GitHub discussions](https://github.com/pymor/pymor/discussions).
 - [ ] All developers check if (stale) branches can be pruned.
 - [ ] All developers check for `.mailmap` correctness.
-- [ ] Remove deprecated features in main in `pymor/pymor`
-      (omit this step in case of a bugfix release).
+- [ ] Remove deprecated features in main in `pymor/pymor`.
+      (Omit in case of a bugfix release.)
 - [ ] Close the [GitHub milestone](https://github.com/pymor/pymor/milestones)
       for the release.
+      (Omit in case of a bugfix release.)

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -39,6 +39,9 @@ Replace `RELEASE_TAG` below with the actual release tag.
       (Omit in case of a bugfix release.)
 - [ ] Update homepage
       (`gh-pages` branch in `pymor/pymor`, similar to changes in `README.md`).
+- [ ] Check if the [docs](https://docs.pymor.org) got updated.
+- [ ] Check if [`conda-forge/pymor-feedstock`](https://github.com/conda-forge/pymor-feedstock)
+      got updated.
 - [ ] Make a GitHub release
       ([Zenodo](https://zenodo.org/record/7494334) is hooked into that) and
       announce the release in

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -2,32 +2,51 @@
 
 The release manager is responsible for ensuring that the following steps are performed:
 
-1. [ ] Fix the following dates (at least 10 weeks before the release, i.e. 5 weeks before the soft freeze):
-       soft freeze &rarr; (4 weeks) &rarr; hard freeze &rarr; (1 week) &rarr; release day
-1. [ ] As soon as they are fixed, communicate dates for soft freeze, hard freeze and release (via Github discussions).
-1. [ ] In the next community meeting after fixing the release day:
-    - [ ] Go through pull requests and issues without a milestone and assign them to the upcoming release if necessary.
-1. [ ] At the day of the soft freeze:
-    - [ ] Communicate soft freeze (via Github discussions). At this point, no new feature pull requests can be added
-       to the release milestone. Exceptions need to be approved by the release manager.
-    - [ ] Make all developers aware that they should finish their pull requests (ping in the PRs).
-    - [ ] Assign main developers to pull requests that still require review. Make sure that reviews
-       are finished early, such that enough time remains to incorporate requested changes.
-    - [ ] Start working on the release notes. Make sure that all features merged later are mentioned
-       in the release notes as well. All new deprecations need to be mentioned in the release notes.
-1. [ ] One week before the hard freeze:
-    - [ ] Remind everyone of the upcoming hard freeze and missing reviews or unfinished pull requests (ping in the PRs).
-    - [ ] Evaluate if there are pull requests that will not be merged before the hard freeze and decide
-       if the hard freeze has to be postponed (which implies moving the release day as well).
-    - [ ] If the hard freeze has to be moved, it is moved by exactly one week. This has to be communicated.
-1. [ ] At the day of the hard freeze:
-    - [ ] Communicate hard freeze (via Github discussions). At this point, no new pull requests
-       (except for potential bug fixes) can enter the release. Merging into `main` branch is not allowed until the
-       release has happened (new feature PRs have to wait until after the release to get merged).
-    - [ ] Determine number of commits and so on for the release notes and add these information. Merge the
-       release notes branch into `main` when they are finished.
-1. [ ] At the day of the release:
-    - [ ] Follow the steps outlined in [`RELEASE_CHECKLIST`](RELEASE_CHECKLIST.md).
-1. [ ] In the first community meeting after the release:
-    - [ ] Select a new release manager for the next release. However, the current release manager is still responsible
-       for all point releases until the next release.
+- [ ] Fix the following dates
+      (at least 10 weeks before the release, i.e.,
+      5 weeks before the soft freeze):
+      soft freeze &rarr;
+      (4 weeks) &rarr;
+      hard freeze &rarr;
+      (1 week) &rarr;
+      release day
+- [ ] As soon as they are fixed,
+      communicate dates for soft freeze, hard freeze, and release day
+      (via Github discussions).
+- [ ] In the next community meeting after fixing the release day:
+  - [ ] Go through pull requests and issues without a milestone and
+        assign them to the upcoming release if necessary.
+- [ ] At the day of the soft freeze:
+  - [ ] Communicate soft freeze (via Github discussions).
+        At this point,
+        no new feature pull requests can be added to the release milestone.
+        Exceptions need to be approved by the release manager.
+  - [ ] Make all developers aware that they should finish their pull requests
+        (ping in the PRs).
+  - [ ] Assign main developers to pull requests that still require review.
+        Make sure that reviews are finished early,
+        such that enough time remains to incorporate requested changes.
+  - [ ] Start working on the release notes.
+        Make sure that all features merged later are mentioned in the release notes as well.
+        All new deprecations need to be mentioned in the release notes.
+- [ ] One week before the hard freeze:
+  - [ ] Remind everyone of the upcoming hard freeze and missing reviews or unfinished pull requests
+        (ping in the PRs).
+  - [ ] Evaluate if there are pull requests that will not be merged before the hard freeze and
+        decide if the hard freeze has to be postponed
+        (which implies moving the release day as well).
+  - [ ] If the hard freeze has to be moved,
+        it is moved by exactly one week.
+        This has to be communicated.
+- [ ] At the day of the hard freeze:
+  - [ ] Communicate hard freeze (via Github discussions).
+        At this point, no new pull requests (except for potential bug fixes) can enter the release.
+        Merging into `main` branch is not allowed until the release has happened
+        (new feature PRs have to wait until after the release to get merged).
+  - [ ] Determine number of commits and so on for the release notes and add these information.
+        Merge the release notes branch into `main` when they are finished.
+- [ ] At the day of the release:
+  - [ ] Follow the steps outlined in [`RELEASE_CHECKLIST`](RELEASE_CHECKLIST.md).
+- [ ] In the first community meeting after the release:
+  - [ ] Select a new release manager for the next release.
+        However, the current release manager is still responsible for all point releases until the next release.

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -12,12 +12,12 @@ The release manager is responsible for ensuring that the following steps are per
       release day
 - [ ] As soon as they are fixed,
       communicate dates for soft freeze, hard freeze, and release day
-      (via Github discussions).
+      (via GitHub discussions).
 - [ ] In the next community meeting after fixing the release day:
   - [ ] Go through pull requests and issues without a milestone and
         assign them to the upcoming release if necessary.
 - [ ] At the day of the soft freeze:
-  - [ ] Communicate soft freeze (via Github discussions).
+  - [ ] Communicate soft freeze (via GitHub discussions).
         At this point,
         no new feature pull requests can be added to the release milestone.
         Exceptions need to be approved by the release manager.
@@ -39,7 +39,7 @@ The release manager is responsible for ensuring that the following steps are per
         it is moved by exactly one week.
         This has to be communicated.
 - [ ] At the day of the hard freeze:
-  - [ ] Communicate hard freeze (via Github discussions).
+  - [ ] Communicate hard freeze (via GitHub discussions).
         At this point, no new pull requests (except for potential bug fixes) can enter the release.
         Merging into `main` branch is not allowed until the release has happened
         (new feature PRs have to wait until after the release to get merged).


### PR DESCRIPTION
These are the changes based on the recent bugfix release:

- ~~replace `markdownlint-cli2` pre-commit hook with `pymarkdown` hook (I had issues with old nodejs version on ubuntu)~~
- note steps that can be skipped for bugfix releases
- remove ResearchGate announcement (ResearchGate projects are getting removed, see [here](https://www.researchgate.net/researchgate-updates/retiring-projects))
- combine GitHub release and GitHub Discussions announcement (there is a checkmark that can be selected before publishing the GitHub release)
- add docs and conda-forge checks

In addition to NA Digest, we could also make announcements in the MoRePaS mailing list. Any comments on this?