### PR TITLE
Algebraic ops for Mu instances

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -15,6 +15,7 @@
 
 * Peter Oehme, oehme.pb@gmail.com
   * quadratic functionals and quadratic output keyword for CG discretization
+  * simple algebraic operations for parameter values
 
 * Mohamed Adel Naguib Ahmed, mohamedadel1551998@gmail.com
   * Input-output selection in `bode_plot` function

--- a/src/pymor/parameters/base.py
+++ b/src/pymor/parameters/base.py
@@ -277,6 +277,8 @@ class Mu(FrozenDict):
     """
 
     __slots__ = ('_raw_values')
+    __array_priority__ = 100.0
+    __array_ufunc__ = None
 
     def __new__(cls, *args, **kwargs):
         raw_values = dict(*args, **kwargs)
@@ -377,21 +379,30 @@ class Mu(FrozenDict):
     def __neg__(self):
         return Mu({key: -self[key] for key in self.keys()})
 
-    def __add__(self, mu):
-        if not isinstance(mu, Mu):
+    def __add__(self, other):
+        if not isinstance(other, Mu):
             try:
-                mu = Mu(mu)
+                other = self.parameters.parse(other)
             except Exception:
                 raise NotImplementedError
-        assert self.keys() == mu.keys()
-        return Mu({key: self[key] + mu[key] for key in self.keys()})
+        assert self.keys() == other.keys()
+        return Mu({key: self[key] + other[key] for key in self.keys()})
 
-    def __sub__(self, mu):
-        return self + -mu
+    def __radd__(self, other):
+        return self + other
+
+    def __sub__(self, other):
+        return self + -other
+
+    def __rsub__(self, other):
+        return self - other
+
+    def __mul__(self, other):
+        assert isinstance(other, Number)
+        return Mu({key: self[key] * other for key in self.keys()})
 
     def __rmul__(self, other):
-        assert isinstance(other, Number)
-        return Mu({key: other * self[key] for key in self.keys()})
+        return self * other
 
     def __str__(self):
         def format_value(k, v):

--- a/src/pymor/parameters/base.py
+++ b/src/pymor/parameters/base.py
@@ -377,7 +377,7 @@ class Mu(FrozenDict):
         return self.keys() == mu.keys() and all(np.array_equal(v, mu[k]) for k, v in self.items())
 
     def __neg__(self):
-        return Mu({key: -self[key] for key in self.keys()})
+        return Mu({key: -value for key, value in self.items()})
 
     def __add__(self, other):
         if not isinstance(other, Mu):
@@ -386,7 +386,7 @@ class Mu(FrozenDict):
             except Exception:
                 raise NotImplementedError
         assert self.keys() == other.keys()
-        return Mu({key: self[key] + other[key] for key in self.keys()})
+        return Mu({key: self[key] + other[key] for key in self})
 
     def __radd__(self, other):
         return self + other
@@ -395,11 +395,11 @@ class Mu(FrozenDict):
         return self + -other
 
     def __rsub__(self, other):
-        return self - other
+        return -self + other
 
     def __mul__(self, other):
         assert isinstance(other, Number)
-        return Mu({key: self[key] * other for key in self.keys()})
+        return Mu({key: self[key] * other for key in self})
 
     def __rmul__(self, other):
         return self * other

--- a/src/pymor/parameters/base.py
+++ b/src/pymor/parameters/base.py
@@ -374,6 +374,25 @@ class Mu(FrozenDict):
                 return False
         return self.keys() == mu.keys() and all(np.array_equal(v, mu[k]) for k, v in self.items())
 
+    def __neg__(self):
+        return Mu({key: -self[key] for key in self.keys()})
+
+    def __add__(self, mu):
+        if not isinstance(mu, Mu):
+            try:
+                mu = Mu(mu)
+            except Exception:
+                raise NotImplementedError
+        assert self.keys() == mu.keys()
+        return Mu({key: self[key] + mu[key] for key in self.keys()})
+
+    def __sub__(self, mu):
+        return self + -mu
+
+    def __rmul__(self, other):
+        assert isinstance(other, Number)
+        return Mu({key: other * self[key] for key in self.keys()})
+
     def __str__(self):
         def format_value(k, v):
             if self.is_time_dependent(k):

--- a/src/pymor/parameters/base.py
+++ b/src/pymor/parameters/base.py
@@ -381,10 +381,7 @@ class Mu(FrozenDict):
 
     def __add__(self, other):
         if not isinstance(other, Mu):
-            try:
-                other = self.parameters.parse(other)
-            except Exception:
-                raise NotImplementedError
+            other = self.parameters.parse(other)
         assert self.keys() == other.keys()
         return Mu({key: self[key] + other[key] for key in self})
 

--- a/src/pymortests/parameters/parameters.py
+++ b/src/pymortests/parameters/parameters.py
@@ -143,6 +143,18 @@ def test_mu_to_numpy(mu):
     assert mu == mu2
 
 
+@given(pyst.mus)
+def test_mu_algebra(mu):
+    mu_np = mu.to_numpy()
+    other_np = np.ones(len(mu_np))
+    other = mu.parameters.parse(other_np)
+
+    assert all((mu + other).to_numpy() == (mu_np + other_np))
+    assert all((mu - other).to_numpy() == (mu_np - other_np))
+    assert all((-mu).to_numpy() == -mu_np)
+    assert all((2. * mu).to_numpy() == 2. * mu_np)
+
+
 def test_mu_t_wrong_value():
     with pytest.raises(Exception):
         Mu(t=ConstantFunction(np.array([3])))

--- a/src/pymortests/parameters/parameters.py
+++ b/src/pymortests/parameters/parameters.py
@@ -142,17 +142,19 @@ def test_mu_to_numpy(mu):
     mu2 = mu.parameters.parse(mu_array)
     assert mu == mu2
 
-
 @given(pyst.mus)
 def test_mu_algebra(mu):
     mu_np = mu.to_numpy()
     other_np = np.ones(len(mu_np))
     other = mu.parameters.parse(other_np)
 
+    assert mu + other == other + mu
+    assert other_np + mu == other + mu_np
     assert all((mu + other).to_numpy() == (mu_np + other_np))
     assert all((mu - other).to_numpy() == (mu_np - other_np))
     assert all((-mu).to_numpy() == -mu_np)
     assert all((2. * mu).to_numpy() == 2. * mu_np)
+    assert 2. * mu == mu * 2.
 
 
 def test_mu_t_wrong_value():

--- a/src/pymortests/parameters/parameters.py
+++ b/src/pymortests/parameters/parameters.py
@@ -152,6 +152,8 @@ def test_mu_algebra(mu):
     assert other_np + mu == other + mu_np
     assert all((mu + other).to_numpy() == (mu_np + other_np))
     assert all((mu - other).to_numpy() == (mu_np - other_np))
+    assert all((other + mu).to_numpy() == (other_np + mu_np))
+    assert all((other - mu).to_numpy() == (other_np - mu_np))
     assert all((-mu).to_numpy() == -mu_np)
     assert all((2. * mu).to_numpy() == 2. * mu_np)
     assert 2. * mu == mu * 2.


### PR DESCRIPTION
This is a continuation of  #1824.

In essence, this makes use of `__array_priority__` as suggested by @pmli.

If there is interest in enabling the internal storage as `np.ndarray`s [as suggested again by @pmli](https://github.com/pymor/pymor/pull/1824#issuecomment-1437347393), I'd be happy to have a look at that. I can imagine however, that this change might have a few consequences further down the line.