### PR TITLE
Edit and document Markdown rules

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,22 +1,13 @@
 ---
-###########################
-###########################
-## Markdown Linter rules ##
-###########################
-###########################
+# Markdown linter rules
+# linter rules doc: https://github.com/DavidAnson/markdownlint
 
-# Linter rules doc:
-# - https://github.com/DavidAnson/markdownlint
-
-###############
-# Rules by id #
-###############
+MD003:
+  style: atx # use "#" for headers
 MD013:
-  line_length: 120 # Line length 80 is far to short
-MD041: false # require heading as first line in file
+  line_length: 120 # line length 80 is far too short
+MD033:
+  allowed_elements: # allowed HTML tags
+    - img
 MD040: false # ``` fenced code must have language set
-
-#################
-# Rules by tags #
-#################
-blank_lines: false  # Error on blank lines
+MD041: false # require heading as first line in file

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -20,6 +20,7 @@ Replace `RELEASE_TAG` below with the actual release tag.
        git checkout "${CI_IMAGE_TAG}"
        git tag -a RELEASE_TAG -m RELEASE_TAG
        ```
+
  1. [ ] Push tag `RELEASE_TAG` to `pymor/docker`.
  1. [ ] Wait for CI build to finish in `pymor/docker`.
  1. [ ] Push tag `RELEASE_TAG` to `pymor/pymor`.

--- a/docs/source/developer_docs.md
+++ b/docs/source/developer_docs.md
@@ -116,7 +116,6 @@ or directly call
 flake8 src
 ```
 
-
 ### GitHub Project
 
 All new code enters pyMOR by means of a pull request. Pull requests (PR) trigger [automatic tests](#continuous-testing--integration-setup)
@@ -189,7 +188,6 @@ Run `make full-test` to also generate a
 
 This file records defaults used when executing CI scripts. These are loaded by make and can be
 overridden like this: `make DOCKER_BASE_PYTHON=3.8 docker_test` (see also the top of the `Makefile`).
-
 
 ## Continuous Testing / Integration Setup
 
@@ -317,7 +315,6 @@ add to an allow list in the config to protect CI secrets. If a PR build does not
 for a user a comment is added in that PR.
 This service currently runs on the `ammservices` machine under the git user.
 
-
 ### GitHub Actions
 
 :::{note}
@@ -342,7 +339,6 @@ Configured by individual files in `.github/workflows/*`
   - Pytest XML reports can also be found there.
 
 (ref_docker_images)=
-
 
 ### pre-commit.ci
 

--- a/docs/source/developer_docs.md
+++ b/docs/source/developer_docs.md
@@ -60,7 +60,7 @@ work on pyMOR with [PyCharm](https://www.jetbrains.com/help/pycharm/docker-compo
 
 ## Coding Guidelines and Project Management
 
-### Code Style
+### Python Code Style
 
 pyMOR follows the coding style of
 [PEP8](https://www.python.org/dev/peps/pep-0008/) apart from a
@@ -95,7 +95,7 @@ style. The main developers will be happy to help you to bring your code
 into proper shape for inclusion in pyMOR.
 :::
 
-#### How to Check Code Style
+#### How to Check Python Code Style
 
 Firstly, make sure that you installed the dependencies in `requirements-ci.txt`
 with
@@ -115,6 +115,15 @@ or directly call
 ```
 flake8 src
 ```
+
+### Markdown Style
+
+The Markdown style is determined by the
+[`markdownlint`](https://github.com/DavidAnson/markdownlint) rules,
+specified in `.markdownlint.yml`.
+The [`markdownlint-cli2`](https://github.com/DavidAnson/markdownlint-cli2) tool
+(or the `pre-commit` hook; see below)
+can be used to check for errors.
 
 ### GitHub Project
 

--- a/docs/source/getting_started.md
+++ b/docs/source/getting_started.md
@@ -312,5 +312,3 @@ Should you have any problems regarding pyMOR, questions or
 [feature requests](<https://github.com/pymor/pymor/issues>), do not hesitate
 to contact us via
 [GitHub discussions](<https://github.com/pymor/pymor/discussions>)!
-
-

--- a/docs/source/tutorial_basis_generation.md
+++ b/docs/source/tutorial_basis_generation.md
@@ -27,11 +27,7 @@ kernelspec:
 
 ```
 
-Tutorial: Building a Reduced Basis
-==================================
-
-
-
+# Tutorial: Building a Reduced Basis
 
 In this tutorial we will learn more about {{ VectorArrays }} and how to
 construct a reduced basis using pyMOR.
@@ -97,9 +93,7 @@ d_N(\mathcal{M}) \leq C \cdot e^{-N^c}.
 In this tutorial we will construct reduced spaces {math}`V_N` for a concrete problem
 with pyMOR and study their error decay.
 
-
-Model setup
------------
+## Model setup
 
 First we need to define a {{ Model }} and a {{ ParameterSpace }} for which we want
 to build a reduced basis. We choose here the standard
@@ -150,9 +144,7 @@ The main use of {{ ParameterSpaces }} in pyMOR is that they allow to easily samp
 {meth}`~pymor.parameters.base.ParameterSpace.sample_uniformly` and
 {meth}`~pymor.parameters.base.ParameterSpace.sample_randomly`.
 
-
-Computing the snapshot data
----------------------------
+## Computing the snapshot data
 
 Reduced basis methods are snapshot-based, which means that they build
 the reduced space as a linear subspace of the linear span of solutions
@@ -224,8 +216,7 @@ time series:
 fom.visualize(training_data)
 ```
 
-A trivial reduced basis
------------------------
+## A trivial reduced basis
 
 Given some snapshot data, the easiest option to get a reduced basis
 is to just use the snapshot vectors as the basis:
@@ -444,9 +435,7 @@ We can do better, however. If we want to use a smaller basis than we
 have snapshots available, just picking the first of these obviously
 won't be optimal.
 
-
-Strong greedy algorithm
------------------------
+## Strong greedy algorithm
 
 The strong greedy algorithm iteratively builds reduced spaces
 {math}`V_N` with a small worst-case best approximation error on a
@@ -501,9 +490,7 @@ algorithm constructs quasi-optimal spaces in the sense that polynomial
 or exponential decay of the N-widths {math}`d_N` yields similar rates
 for the worst-case best-approximation errors of the constructed {math}`V_N`.
 
-
-Orthonormalization required
----------------------------
+## Orthonormalization required
 
 There is one technical problem with both algorithms however: the
 condition numbers of the Gramians used to compute the projection
@@ -581,8 +568,7 @@ plt.legend()
 plt.show()
 ```
 
-Proper Orthogonal Decomposition
--------------------------------
+## Proper Orthogonal Decomposition
 
 Another popular method to create a reduced basis out of snapshot data is the so-called
 Proper Orthogonal Decomposition (POD) which can be seen as a non-centered version of
@@ -697,9 +683,7 @@ As you can see, the first (more important) basis vectors account for the approxi
 the solutions in the bulk of the subdomains, whereas the higher modes are responsible for
 approximating the solutions at the subdomain interfaces.
 
-
-Weak greedy algorithm
----------------------
+## Weak greedy algorithm
 
 Both POD and the strong greedy algorithm require the computation of all
 {meth}`solutions <pymor.models.interface.Model.solve>` {math}`u(\mu)`
@@ -836,7 +820,6 @@ plt.show()
 ```
 
 Indeed we see that the weak-greedy basis generalizes to the validation data much better than all the other bases.
-
 
 Download the code:
 {download}`tutorial_basis_generation.md`

--- a/docs/source/tutorial_bt.md
+++ b/docs/source/tutorial_bt.md
@@ -29,7 +29,6 @@ kernelspec:
 
 # Tutorial: Reducing an LTI system using balanced truncation
 
-
 Here we briefly describe the balanced truncation method,
 for asymptotically stable LTI systems with an invertible {math}`E` matrix,
 and demonstrate it on the heat equation example from

--- a/docs/source/tutorial_mor_with_anns.md
+++ b/docs/source/tutorial_mor_with_anns.md
@@ -395,7 +395,6 @@ np.median(outputs_speedups)
 
 ## Neural networks for instationary problems
 
-
 To solve instationary problems using neural networks, we have extended the
 {class}`~pymor.reductors.neural_network.NeuralNetworkReductor` to the
 {class}`~pymor.reductors.neural_network.NeuralNetworkInstationaryReductor`, which treats time
@@ -426,6 +425,7 @@ avoid problems like vanishing or exploding gradients that often occur during tra
 neural networks.
 
 #### The architecture of an LSTM neural network
+
 In an LSTM neural network, multiple so-called LSTM cells are chained with each other such that the
 cell state {math}`c_k` and the hidden state {math}`h_k` of the {math}`k`-th LSTM cell serve as the
 input hidden states for the {math}`k+1`-th LSTM cell. Therefore, information from former time
@@ -439,6 +439,7 @@ that is also implemented in the same way in pyMOR:
 ```
 
 #### The LSTM cell
+
 The main building block of an LSTM network is the *LSTM cell*, which is denoted by {math}`\Phi`,
 and sketched in the following figure:
 
@@ -468,10 +469,12 @@ We will take a closer look at the individual components of an LSTM cell in the s
 paragraphs.
 
 ##### The forget gate
+
 ```{image} lstm_cell_forget_gate.svg
 :alt: Forget gate of an LSTM cell
 :align: right
 ```
+
 As the name already suggests, the *forget gate* determines which part of the cell state
 {math}`c_{k-1}` the network forgets when moving to the next cell state {math}`c_k`. The main
 component of the forget gate is a neural network layer consisting of an affine-linear function
@@ -484,10 +487,12 @@ state remain intact. As input of the forget gate serves the pair {math}`(h_{k-1}
 in the second step also the cell state {math}`c_{k-1}`.
 
 ##### The input gate
+
 ```{image} lstm_cell_input_gate.svg
 :alt: Input gate of an LSTM cell
 :align: right
 ```
+
 To further change the cell state, an LSTM cell contains a so-called *input gate*. This gate mainly
 consists of two layers, a sigmoid layer and an hyperbolic tangent layer, acting on the pair
 {math}`(h_{k-1},\mu(t_k))`. As in the forget gate, the sigmoid layer determines which parts of the
@@ -499,10 +504,12 @@ is added to the cell state (after the cell state passed the forget gate). The ne
 now prepared to be passed to the subsequent LSTM cell.
 
 ##### The output gate
+
 ```{image} lstm_cell_output_gate.svg
 :alt: Output gate of an LSTM cell
 :align: right
 ```
+
 For computing the output {math}`o(t_k)` (and the new hidden state {math}`h_k`), the updated cell
 state {math}`c_k` is first of all entry-wise transformed using a hyperbolic tangent function such
 that the result again takes values between -1 and 1. Simultaneously, a neural network layer with a
@@ -517,6 +524,7 @@ output {math}`o(t_k)` that is returned and a new hidden state {math}`h_k` that c
 (together with the updated cell state {math}`c_k`) to the next LSTM cell.
 
 #### LSTMs for model order reduction
+
 The idea of the approach implemented in pyMOR is the following: Instead of passing the current
 time instance as an additional input of the neural network, we use an LSTM that takes at each time
 instance {math}`t_k` the (potentially) time-dependent input {math}`\mu(t_k)` as an input and uses

--- a/logo/README.md
+++ b/logo/README.md
@@ -1,5 +1,4 @@
-pyMOR Logo Usage Guidelines
-===========================
+# pyMOR Logo Usage Guidelines
 
 If you wish to reference pyMOR on your webpage, publication or presentation slides,
 you are welcome to use our logo. Here you can find different versions of the logo
@@ -12,7 +11,6 @@ that you may use. Please use the logo as is and make no modifications. In partic
 
 If you want to create a derived version of the logo for your own project, please ask us first.
 
-<!-- markdownlint-disable MD033 -->
 type  | PNG                                                 | SVG
 ------|-----------------------------------------------------|----------------------------------------------------
 color | <img src="pymor_logo.png" width=320>                | <img src="pymor_logo.svg" width=320>


### PR DESCRIPTION
- set ATX style for headers (`#` instead of dashes)
- allow `img` HTML tags everywhere
- disallow multiple blank lines
- fix issues introduced by new rules
- add "Markdown Style" section to developer docs