### PR TITLE
Update BBG Citation to Springer Publication

### DIFF
--- a/docs/source/bibliography.bib
+++ b/docs/source/bibliography.bib
@@ -24,15 +24,17 @@
   doi =          {10.1007/978-1-4419-5757-3_1}
 }
 
-@TechReport{BBG19,
+@InCollection{BBG19,
     title={{$\mathcal{H}_2$}-gap model reduction for stabilizable and detectable systems},
     author={Tobias Breiten and Chris A. Beattie and Serkan Gugercin},
-    institution={arXiv},
-    year={2019},
-    type={e-prints},
-    number={1909.13764},
-    note={math.NA},
-    url={http://arxiv.org/abs/1909.13764}
+    bookTitle={Realization and Model Reduction of Dynamical Systems: A Festschrift in Honor of the 70th Birthday of Thanos Antoulas},
+    editor={Beattie, Christopher and Benner, Peter and Embree, Mark and Gugercin, Serkan and Lefteriu, Sanda},
+    publisher={Springer International Publishing},
+    year={2022},
+    address={Cham},
+    pages={317--334},
+    isbn={978-3-030-95157-3},
+    doi={10.1007/978-3-030-95157-3_17}
 }
 
 @article{BBKS18,


### PR DESCRIPTION
I noticed that the BBG19 source still referenced an arXiv preprint while a Springer publication of the same source has been published just last year. This PR updates the `bibliography.bib` entry to the Springer publication.