### PR TITLE
Passivity preserving model reduction via spectral factorization

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -15,6 +15,7 @@
 
 * Steffen Müller, steffenmu@outlook.de
   * positive-real balanced truncation
+  * passivity preserving model reduction via spectral factorization
 
 * Mohamed Adel Naguib Ahmed, mohamedadel1551998@gmail.com
   * input-output selection in `bode_plot` function

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -1523,19 +1523,13 @@ class PHLTIModel(LTIModel):
     This class describes input-state-output systems given by
 
     .. math::
-        E(\mu) \dot{x}(t, \mu) & = (J(\mu) - R(\mu)) Q(\mu)   x(t, \mu) + (G(\mu) - P(\mu)) u(t), \\
-                     y(t, \mu) & = (G(\mu) + P(\mu))^T Q(\mu) x(t, \mu) + (S(\mu) - N(\mu)) u(t),
+        E(\mu) \dot{x}(t, \mu) & = (J(\mu) - R(\mu)) x(t, \mu) + (G(\mu) - P(\mu)) u(t), \\
+                     y(t, \mu) & = (G(\mu) + P(\mu))^T x(t, \mu) + (S(\mu) - N(\mu)) u(t),
 
     where :math:`H(\mu) = Q(\mu)^T E(\mu)`,
 
     .. math::
-        \Gamma(\mu) =
-        \begin{bmatrix}
-            J(\mu) & G(\mu) \\
-            -G(\mu)^T & N(\mu)
-        \end{bmatrix},
-        \text{ and }
-        W(\mu) =
+        \mathcal{R}(\mu) =
         \begin{bmatrix}
             R(\mu) & P(\mu) \\
             P(\mu)^T & S(\mu)

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -1523,13 +1523,19 @@ class PHLTIModel(LTIModel):
     This class describes input-state-output systems given by
 
     .. math::
-        E(\mu) \dot{x}(t, \mu) & = (J(\mu) - R(\mu)) x(t, \mu) + (G(\mu) - P(\mu)) u(t), \\
-                     y(t, \mu) & = (G(\mu) + P(\mu))^T x(t, \mu) + (S(\mu) - N(\mu)) u(t),
+        E(\mu) \dot{x}(t, \mu) & = (J(\mu) - R(\mu)) Q(\mu)   x(t, \mu) + (G(\mu) - P(\mu)) u(t), \\
+                     y(t, \mu) & = (G(\mu) + P(\mu))^T Q(\mu) x(t, \mu) + (S(\mu) - N(\mu)) u(t),
 
     where :math:`H(\mu) = Q(\mu)^T E(\mu)`,
 
     .. math::
-        \mathcal{R}(\mu) =
+        \Gamma(\mu) =
+        \begin{bmatrix}
+            J(\mu) & G(\mu) \\
+            -G(\mu)^T & N(\mu)
+        \end{bmatrix},
+        \text{ and }
+        W(\mu) =
         \begin{bmatrix}
             R(\mu) & P(\mu) \\
             P(\mu)^T & S(\mu)

--- a/src/pymor/reductors/spectral_factor.py
+++ b/src/pymor/reductors/spectral_factor.py
@@ -1,0 +1,82 @@
+# This file is part of the pyMOR project (https://www.pymor.org).
+# Copyright pyMOR developers and contributors. All rights reserved.
+# License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
+
+from scipy.linalg import solve
+import numpy as np
+
+from pymor.core.base import BasicObject
+from pymor.models.iosys import LTIModel
+from pymor.parameters.base import Mu
+from pymor.algorithms.lyapunov import solve_cont_lyap_dense
+from pymor.algorithms.to_matrix import to_matrix
+from pymor.algorithms.lyapunov import _chol
+from pymor.operators.numpy import NumpyMatrixOperator
+from pymor.reductors.h2 import IRKAReductor
+
+class SpectralFactorReductor(BasicObject):
+    r"""
+    Passivity preserving model reduction via spectral factorization.
+
+    See :cite:`BU22`.
+    """
+
+    def __init__(self, fom, mu=None):
+        assert isinstance(fom, LTIModel)
+        if not isinstance(mu, Mu):
+            mu = fom.parameters.parse(mu)
+        assert fom.parameters.assert_compatible(mu)
+        self.fom = fom
+        self.mu = mu
+
+    def reduce(self, r=None):
+        A = to_matrix(self.fom.A, format='dense')
+        B = to_matrix(self.fom.B, format='dense')
+        C = to_matrix(self.fom.C, format='dense')
+        R = to_matrix(self.fom.D + self.fom.D.H, 'dense')
+        print('[spectralFactor] A')
+        print(A)
+
+        # Compute minimal X
+        Z = self.fom.gramian('pr_o_lrcf', mu=self.mu).to_numpy()
+        # TODO Add option to supply X from outside?
+        # TODO Do we really need to compute the full X out of the low-rank factor Z?
+        # TODO However, currently, `solve_pos_ricc_lrcf` uses a dense solver in the background anyway?
+        X = Z.T@Z
+        print('[spectralFactor] X')
+        print(X)
+        
+        # Compute Cholesky-like factorization of W(X)
+        M = _chol(R).T
+        # TODO Alternatives to taking matrix inverse?
+        L = np.linalg.solve(M.T, C-B.T@X)
+        print('[spectralFactor] L')
+        print(L)
+        # TODO Currently, relative LTL error way too high?
+        print('[spectralFactor] Relative LTL error')
+        LTL = -A.T@X - X@A
+        print(np.linalg.norm(L.T@L-LTL)/np.linalg.norm(LTL))
+        print('[spectralFactor] M')
+        print(M)
+
+        spectral_factor = LTIModel(self.fom.A, self.fom.B,
+            NumpyMatrixOperator(L, source_id=self.fom.A.range.id),
+            NumpyMatrixOperator(M, source_id=self.fom.B.source.id))
+        
+        # TODO Allow to set other reductor or reductor options from outside
+        irka = IRKAReductor(spectral_factor, self.mu)
+        spectral_factor_reduced = irka.reduce(r)
+        Ar = to_matrix(spectral_factor_reduced.A, format='dense')
+        Br = to_matrix(spectral_factor_reduced.B, format='dense')
+        Lr = to_matrix(spectral_factor_reduced.C, format='dense')
+        Mr = to_matrix(spectral_factor_reduced.D, format='dense')
+
+        # TODO Add skew-symmetric part of `Mr`
+        Dr = 0.5*(Mr.T @ Mr)
+
+        Xr = solve_cont_lyap_dense(A=Ar, E=None, B=Lr, trans=True)
+        Cr = Br.T @ Xr + Mr.T @ Lr
+
+        return LTIModel(spectral_factor_reduced.A, spectral_factor_reduced.B,
+            NumpyMatrixOperator(Cr, source_id=spectral_factor_reduced.A.range.id),
+            NumpyMatrixOperator(Dr, source_id=spectral_factor_reduced.B.source.id))

--- a/src/pymor/reductors/spectral_factor.py
+++ b/src/pymor/reductors/spectral_factor.py
@@ -47,7 +47,7 @@ class SpectralFactorReductor(BasicObject):
             - mu |Parameter values|
             and returns an |LTIModel| reduced-order model for the supplied spectral
             factor.
-            
+
             For example, a possible choice to obtain a reduced-order model of order 10 is
             `lambda spectral_factor,mu : IRKAReductor(spectral_factor,mu).reduce(10)`
             or
@@ -67,7 +67,7 @@ class SpectralFactorReductor(BasicObject):
             factor.
 
             If `None`, it is assumed that :math:`D+D^T` is nonsingular, where
-            :math:`D` is the feed-through matrix of the full-order model. 
+            :math:`D` is the feed-through matrix of the full-order model.
             A minimal solution to the KYP inequality is then obtained internally
             by computing the minimal solution of the Riccati equation
               .. math::
@@ -93,7 +93,7 @@ class SpectralFactorReductor(BasicObject):
             assert not isinstance(self.fom.D,ZeroOperator), "D+D^T must be invertible."
             Z = self.fom.gramian('pr_o_lrcf', mu=self.mu).to_numpy()
             X = Z.T@Z
-        
+
         # Compute Cholesky-like factorization of W(X)
         E = to_matrix(self.fom.E, format='dense')
         B = to_matrix(self.fom.B, format='dense')
@@ -115,7 +115,7 @@ class SpectralFactorReductor(BasicObject):
             NumpyMatrixOperator(L, source_id=self.fom.A.range.id),
             NumpyMatrixOperator(M, source_id=self.fom.B.source.id),
             self.fom.E)
-        
+
         spectral_factor_reduced = r_fn(spectral_factor, self.mu)
 
         if compute_errors:

--- a/src/pymor/reductors/spectral_factor.py
+++ b/src/pymor/reductors/spectral_factor.py
@@ -4,14 +4,14 @@
 
 import numpy as np
 
+from pymor.algorithms.lyapunov import _chol, solve_cont_lyap_dense
+from pymor.algorithms.to_matrix import to_matrix
 from pymor.core.base import BasicObject
 from pymor.models.iosys import LTIModel
-from pymor.parameters.base import Mu
-from pymor.algorithms.lyapunov import solve_cont_lyap_dense
-from pymor.algorithms.to_matrix import to_matrix
-from pymor.algorithms.lyapunov import _chol
-from pymor.operators.numpy import NumpyMatrixOperator
 from pymor.operators.constructions import ZeroOperator
+from pymor.operators.numpy import NumpyMatrixOperator
+from pymor.parameters.base import Mu
+
 
 class SpectralFactorReductor(BasicObject):
     r"""
@@ -90,7 +90,7 @@ class SpectralFactorReductor(BasicObject):
         """
         if X is None:
             # Compute minimal solution X to Riccati equation
-            assert not isinstance(self.fom.D,ZeroOperator), "D+D^T must be invertible."
+            assert not isinstance(self.fom.D,ZeroOperator), 'D+D^T must be invertible.'
             Z = self.fom.gramian('pr_o_lrcf', mu=self.mu).to_numpy()
             X = Z.T@Z
 

--- a/src/pymor/reductors/spectral_factor.py
+++ b/src/pymor/reductors/spectral_factor.py
@@ -2,7 +2,6 @@
 # Copyright pyMOR developers and contributors. All rights reserved.
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
-from scipy.linalg import solve
 import numpy as np
 
 from pymor.core.base import BasicObject
@@ -13,6 +12,7 @@ from pymor.algorithms.to_matrix import to_matrix
 from pymor.algorithms.lyapunov import _chol
 from pymor.operators.numpy import NumpyMatrixOperator
 from pymor.reductors.h2 import IRKAReductor
+from pymor.reductors.bt import BTReductor
 
 class SpectralFactorReductor(BasicObject):
     r"""
@@ -33,7 +33,7 @@ class SpectralFactorReductor(BasicObject):
         A = to_matrix(self.fom.A, format='dense')
         B = to_matrix(self.fom.B, format='dense')
         C = to_matrix(self.fom.C, format='dense')
-        R = to_matrix(self.fom.D + self.fom.D.H, 'dense')
+        D = to_matrix(self.fom.D, format='dense')
         print('[spectralFactor] A')
         print(A)
 
@@ -47,7 +47,7 @@ class SpectralFactorReductor(BasicObject):
         print(X)
         
         # Compute Cholesky-like factorization of W(X)
-        M = _chol(R).T
+        M = _chol(D+D.T).T
         # TODO Alternatives to taking matrix inverse?
         L = np.linalg.solve(M.T, C-B.T@X)
         print('[spectralFactor] L')
@@ -58,6 +58,9 @@ class SpectralFactorReductor(BasicObject):
         print(np.linalg.norm(L.T@L-LTL)/np.linalg.norm(LTL))
         print('[spectralFactor] M')
         print(M)
+        print('[spectralFactor] Relative LTM error')
+        LTM = C.T - X@B
+        print(np.linalg.norm(L.T@M-LTM)/np.linalg.norm(LTM))
 
         spectral_factor = LTIModel(self.fom.A, self.fom.B,
             NumpyMatrixOperator(L, source_id=self.fom.A.range.id),
@@ -66,13 +69,26 @@ class SpectralFactorReductor(BasicObject):
         # TODO Allow to set other reductor or reductor options from outside
         irka = IRKAReductor(spectral_factor, self.mu)
         spectral_factor_reduced = irka.reduce(r)
+        # bt = BTReductor(spectral_factor, self.mu)
+        # spectral_factor_reduced = bt.reduce(r, projection='sr')
+
+        spectralH2err = spectral_factor_reduced - spectral_factor
+        print('[spectralFactor] Relative H2 error of spectral factor: '
+            f'{spectralH2err.h2_norm() / spectral_factor.h2_norm():.3e}')
+
         Ar = to_matrix(spectral_factor_reduced.A, format='dense')
         Br = to_matrix(spectral_factor_reduced.B, format='dense')
         Lr = to_matrix(spectral_factor_reduced.C, format='dense')
         Mr = to_matrix(spectral_factor_reduced.D, format='dense')
 
-        # TODO Add skew-symmetric part of `Mr`
-        Dr = 0.5*(Mr.T @ Mr)
+        ev = np.max(np.real(np.linalg.eig(Ar)[0]))
+        if ev > 0:
+            print(f'[spectralFactor] Warning: reduced spectral factor not stable. {ev}')
+
+        print('[spectralFactor] Mr')
+        print(Mr)
+
+        Dr = 0.5*(Mr.T @ Mr) + 0.5*(D-D.T)
 
         Xr = solve_cont_lyap_dense(A=Ar, E=None, B=Lr, trans=True)
         Cr = Br.T @ Xr + Mr.T @ Lr

--- a/src/pymordemos/phlti.py
+++ b/src/pymordemos/phlti.py
@@ -4,7 +4,6 @@
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
 import numpy as np
-from slycot import sb02od
 from matplotlib import pyplot as plt
 from typer import Argument, run
 
@@ -121,23 +120,6 @@ def msd(n=6, m=2, m_i=4, k_i=4, c_i=1, as_lti=False):
 
     return J, R, G, P, S, N, E, Q
 
-def care(A, B=None, Q=None, R=None, S=None):
-    """Solve the continuous-time algebraic Riccati equation.
-            Q + A'X + XA - (S+XB)R^{-1}(S+XB)' = 0
-    """
-    dico = 'C'
-
-    if Q is None:
-        Q = np.zeros(A.shape)
-
-    n = A.shape[0]
-    m = B.shape[1]
-
-    # Q + A'X + XA + (-L-XB)R^{-1} (-L'-B'X) = 0
-    return sb02od(n, m, A, B, Q, R, dico, L=S)
-
-def kyp(A, B, C, D, X):
-    return np.block([[-A.T @ X - X @ A, C.T - X @ B], [C - B.T @ X, D + D.T]])
 
 def main(
         n: int = Argument(100, help='Order of the mass-spring-damper system.'),

--- a/src/pymordemos/phlti.py
+++ b/src/pymordemos/phlti.py
@@ -4,6 +4,7 @@
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
 import numpy as np
+from slycot import sb02od
 from matplotlib import pyplot as plt
 from typer import Argument, run
 
@@ -120,6 +121,23 @@ def msd(n=6, m=2, m_i=4, k_i=4, c_i=1, as_lti=False):
 
     return J, R, G, P, S, N, E, Q
 
+def care(A, B=None, Q=None, R=None, S=None):
+    """Solve the continuous-time algebraic Riccati equation.
+            Q + A'X + XA - (S+XB)R^{-1}(S+XB)' = 0
+    """
+    dico = 'C'
+
+    if Q is None:
+        Q = np.zeros(A.shape)
+
+    n = A.shape[0]
+    m = B.shape[1]
+
+    # Q + A'X + XA + (-L-XB)R^{-1} (-L'-B'X) = 0
+    return sb02od(n, m, A, B, Q, R, dico, L=S)
+
+def kyp(A, B, C, D, X):
+    return np.block([[-A.T @ X - X @ A, C.T - X @ B], [C - B.T @ X, D + D.T]])
 
 def main(
         n: int = Argument(100, help='Order of the mass-spring-damper system.'),

--- a/src/pymordemos/phlti.py
+++ b/src/pymordemos/phlti.py
@@ -12,7 +12,6 @@ from pymor.reductors.bt import BTReductor, PRBTReductor
 from pymor.reductors.h2 import IRKAReductor
 from pymor.reductors.ph.ph_irka import PHIRKAReductor
 from pymor.reductors.spectral_factor import SpectralFactorReductor
-from pymor.reductors.h2 import IRKAReductor
 
 
 def msd(n=6, m=2, m_i=4, k_i=4, c_i=1, as_lti=False):
@@ -138,24 +137,24 @@ def main(
 
     fom = PHLTIModel.from_matrices(J, R, G, S=S, Q=Q, solver_options={'ricc_pos_lrcf': 'slycot'})
 
-    bt = BTReductor(fom)
-    prbt = PRBTReductor(fom)
-    irka = IRKAReductor(fom)
-    phirka = PHIRKAReductor(fom)
+    bt = BTReductor(fom).reduce
+    prbt = PRBTReductor(fom).reduce
+    irka = IRKAReductor(fom).reduce
+    phirka = PHIRKAReductor(fom).reduce
     spectralFactor = SpectralFactorReductor(fom)
     def spectralFactor_reduce(r):
         return spectralFactor.reduce(
             lambda spectral_factor, mu : IRKAReductor(spectral_factor,mu).reduce(r))
 
-    reductors = {'BT': bt, 'PRBT': prbt, 'IRKA': irka, 'pH-IRKA': phirka, 'spectralFactor': spectralFactor}
+    reductors = {'BT': bt, 'PRBT': prbt, 'IRKA': irka, 'pH-IRKA': phirka, 'spectralFactor': spectralFactor_reduce}
     markers = {'BT': '.', 'PRBT': 'x', 'IRKA': 'o', 'pH-IRKA': 's', 'spectralFactor': 'v'}
 
     reduced_order = range(2, max_reduced_order + 1, 2)
     h2_errors = np.zeros((len(reductors), len(reduced_order)))
 
-    for i, reductor in enumerate(reductors.values()):
+    for i, reduce in enumerate(reductors.values()):
         for j, r in enumerate(reduced_order):
-            rom = reductor.reduce(r)
+            rom = reduce(r)
             h2_errors[i, j] = (rom - fom).h2_norm() / fom.h2_norm()
 
     fig, ax = plt.subplots()

--- a/src/pymordemos/phlti.py
+++ b/src/pymordemos/phlti.py
@@ -12,6 +12,7 @@ from pymor.reductors.bt import BTReductor, PRBTReductor
 from pymor.reductors.h2 import IRKAReductor
 from pymor.reductors.ph.ph_irka import PHIRKAReductor
 from pymor.reductors.spectral_factor import SpectralFactorReductor
+from pymor.reductors.h2 import IRKAReductor
 
 
 def msd(n=6, m=2, m_i=4, k_i=4, c_i=1, as_lti=False):
@@ -142,6 +143,9 @@ def main(
     irka = IRKAReductor(fom)
     phirka = PHIRKAReductor(fom)
     spectralFactor = SpectralFactorReductor(fom)
+    def spectralFactor_reduce(r):
+        return spectralFactor.reduce(
+            lambda spectral_factor, mu : IRKAReductor(spectral_factor,mu).reduce(r))
 
     reductors = {'BT': bt, 'PRBT': prbt, 'IRKA': irka, 'pH-IRKA': phirka, 'spectralFactor': spectralFactor}
     markers = {'BT': '.', 'PRBT': 'x', 'IRKA': 'o', 'pH-IRKA': 's', 'spectralFactor': 'v'}

--- a/src/pymordemos/phlti.py
+++ b/src/pymordemos/phlti.py
@@ -11,6 +11,7 @@ from pymor.models.iosys import PHLTIModel
 from pymor.reductors.bt import BTReductor, PRBTReductor
 from pymor.reductors.h2 import IRKAReductor
 from pymor.reductors.ph.ph_irka import PHIRKAReductor
+from pymor.reductors.spectral_factor import SpectralFactorReductor
 
 
 def msd(n=6, m=2, m_i=4, k_i=4, c_i=1, as_lti=False):
@@ -140,9 +141,10 @@ def main(
     prbt = PRBTReductor(fom)
     irka = IRKAReductor(fom)
     phirka = PHIRKAReductor(fom)
+    spectralFactor = SpectralFactorReductor(fom)
 
-    reductors = {'BT': bt, 'PRBT': prbt, 'IRKA': irka, 'pH-IRKA': phirka}
-    markers = {'BT': '.', 'PRBT': 'x', 'IRKA': 'o', 'pH-IRKA': 's'}
+    reductors = {'BT': bt, 'PRBT': prbt, 'IRKA': irka, 'pH-IRKA': phirka, 'spectralFactor': spectralFactor}
+    markers = {'BT': '.', 'PRBT': 'x', 'IRKA': 'o', 'pH-IRKA': 's', 'spectralFactor': 'v'}
 
     reduced_order = range(2, max_reduced_order + 1, 2)
     h2_errors = np.zeros((len(reductors), len(reduced_order)))

--- a/src/pymortests/reductors/ph/ph_irka.py
+++ b/src/pymortests/reductors/ph/ph_irka.py
@@ -3,11 +3,14 @@
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
 import numpy as np
+import pytest
 
 from pymor.algorithms.to_matrix import to_matrix
 from pymor.models.iosys import LTIModel, PHLTIModel
 from pymor.operators.constructions import IdentityOperator
 from pymor.reductors.ph.ph_irka import PHIRKAReductor
+
+pytestmark = pytest.mark.builtin
 
 
 def test_ph_irka():

--- a/src/pymortests/reductors/spectral_factor.py
+++ b/src/pymortests/reductors/spectral_factor.py
@@ -6,8 +6,8 @@ import numpy as np
 import pytest
 
 from pymor.models.iosys import LTIModel
-from pymor.reductors.spectral_factor import SpectralFactorReductor
 from pymor.reductors.h2 import IRKAReductor
+from pymor.reductors.spectral_factor import SpectralFactorReductor
 
 
 def test_spectral_factor():
@@ -18,7 +18,7 @@ def test_spectral_factor():
 
     Z = fom.gramian('pr_o_lrcf').to_numpy()
     X = Z.T@Z
-    assert np.all(np.linalg.eigvals(X) > 0), "Passive FOM expected."
+    assert np.all(np.linalg.eigvals(X) > 0), 'Passive FOM expected.'
 
     spectralFactor = SpectralFactorReductor(fom)
 
@@ -26,11 +26,11 @@ def test_spectral_factor():
         lambda spectral_factor, mu : IRKAReductor(spectral_factor,mu).reduce(1))
     assert isinstance(rom, LTIModel) and rom.order == 1
 
-    assert np.all(np.real(rom.poles()) < 0), "Asymptotically stable ROM expected."
+    assert np.all(np.real(rom.poles()) < 0), 'Asymptotically stable ROM expected.'
 
     Z2 = rom.gramian('pr_o_lrcf').to_numpy()
     X2 = Z2.T@Z2
-    assert np.all(np.linalg.eigvals(X2) > 0), "Passive ROM expected."
+    assert np.all(np.linalg.eigvals(X2) > 0), 'Passive ROM expected.'
 
 def test_spectral_factor_invertible_D_assertion():
     R = np.array([[1, 0], [0, 2]])
@@ -43,4 +43,4 @@ def test_spectral_factor_invertible_D_assertion():
         spectralFactor.reduce(
             lambda spectral_factor, mu : IRKAReductor(spectral_factor,mu).reduce(1))
 
-    assert "D+D^T must be invertible." in str(e.value)
+    assert 'D+D^T must be invertible.' in str(e.value)

--- a/src/pymortests/reductors/spectral_factor.py
+++ b/src/pymortests/reductors/spectral_factor.py
@@ -1,0 +1,32 @@
+# This file is part of the pyMOR project (https://www.pymor.org).
+# Copyright pyMOR developers and contributors. All rights reserved.
+# License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
+
+import numpy as np
+
+from pymor.models.iosys import LTIModel
+from pymor.reductors.spectral_factor import SpectralFactorReductor
+from pymor.reductors.h2 import IRKAReductor
+
+
+def test_spectral_factor():
+    R = np.array([[1, 0], [0, 2]])
+    G = np.array([[1], [2]])
+    S = np.array([[1e-12]])
+    fom = LTIModel.from_matrices(-R, G, G.T, S)
+
+    Z = fom.gramian('pr_o_lrcf').to_numpy()
+    X = Z.T@Z
+    assert np.all(np.linalg.eigvals(X) > 0), "Passive FOM expected."
+
+    spectralFactor = SpectralFactorReductor(fom)
+
+    rom = spectralFactor.reduce(
+        lambda spectral_factor, mu : IRKAReductor(spectral_factor,mu).reduce(1))
+    assert isinstance(rom, LTIModel) and rom.order == 1
+
+    assert np.all(np.real(rom.poles()) < 0), "Asymptotically stable ROM expected."
+    
+    Z2 = rom.gramian('pr_o_lrcf').to_numpy()
+    X2 = Z2.T@Z2
+    assert np.all(np.linalg.eigvals(X2) > 0), "Passive ROM expected."

--- a/src/pymortests/reductors/spectral_factor.py
+++ b/src/pymortests/reductors/spectral_factor.py
@@ -14,7 +14,7 @@ def test_spectral_factor():
     R = np.array([[1, 0], [0, 2]])
     G = np.array([[1], [2]])
     S = np.array([[1e-12]])
-    fom = LTIModel.from_matrices(-R, G, G.T, S)
+    fom = LTIModel.from_matrices(-R, G, G.T, S, solver_options={'ricc_pos_lrcf': 'slycot'})
 
     Z = fom.gramian('pr_o_lrcf').to_numpy()
     X = Z.T@Z
@@ -28,6 +28,7 @@ def test_spectral_factor():
 
     assert np.all(np.real(rom.poles()) < 0), 'Asymptotically stable ROM expected.'
 
+    rom = rom.with_(solver_options={'ricc_pos_lrcf': 'slycot'})
     Z2 = rom.gramian('pr_o_lrcf').to_numpy()
     X2 = Z2.T@Z2
     assert np.all(np.linalg.eigvals(X2) > 0), 'Passive ROM expected.'
@@ -35,7 +36,7 @@ def test_spectral_factor():
 def test_spectral_factor_invertible_D_assertion():
     R = np.array([[1, 0], [0, 2]])
     G = np.array([[1], [2]])
-    fom = LTIModel.from_matrices(-R, G, G.T)
+    fom = LTIModel.from_matrices(-R, G, G.T, solver_options={'ricc_pos_lrcf': 'slycot'})
 
     spectralFactor = SpectralFactorReductor(fom)
 

--- a/src/pymortests/reductors/spectral_factor.py
+++ b/src/pymortests/reductors/spectral_factor.py
@@ -27,7 +27,7 @@ def test_spectral_factor():
     assert isinstance(rom, LTIModel) and rom.order == 1
 
     assert np.all(np.real(rom.poles()) < 0), "Asymptotically stable ROM expected."
-    
+
     Z2 = rom.gramian('pr_o_lrcf').to_numpy()
     X2 = Z2.T@Z2
     assert np.all(np.linalg.eigvals(X2) > 0), "Passive ROM expected."
@@ -42,5 +42,5 @@ def test_spectral_factor_invertible_D_assertion():
     with pytest.raises(AssertionError) as e:
         spectralFactor.reduce(
             lambda spectral_factor, mu : IRKAReductor(spectral_factor,mu).reduce(1))
-        
+
     assert "D+D^T must be invertible." in str(e.value)

--- a/src/pymortests/reductors/spectral_factor.py
+++ b/src/pymortests/reductors/spectral_factor.py
@@ -9,6 +9,8 @@ from pymor.models.iosys import LTIModel
 from pymor.reductors.h2 import IRKAReductor
 from pymor.reductors.spectral_factor import SpectralFactorReductor
 
+pytestmark = pytest.mark.builtin
+
 
 def test_spectral_factor():
     R = np.array([[1, 0], [0, 2]])


### PR DESCRIPTION
This PR implements the method proposed in [[BU22]](#BU22). 

- This PR depends on #1837 and #1847. The method is not depending on PRBT itself, but on other bits included in #1847.

<a id="BU22">[BU22]</a> Tobias Breiten, Benjamin Unger, Passivity preserving model reduction via spectral factorization, Automatica, Volume 142, 2022, 110368, ISSN 0005-1098, https://doi.org/10.1016/j.automatica.2022.110368 (https://www.sciencedirect.com/science/article/pii/S0005109822002187)