### PR TITLE
Introduce RandomFieldFunction

### DIFF
--- a/src/pymor/analyticalproblems/functions.py
+++ b/src/pymor/analyticalproblems/functions.py
@@ -392,9 +392,7 @@ class DataFieldFunction(Function):
     dim_domain = 2
     shape_range = ()
 
-    def __init__(self, data_field=None, bounding_box=None, range=None, scaling_factor=1.):
-        range = range or [0., 1.]
-        bounding_box = bounding_box or [[0., 0.], [1., 1.]]
+    def __init__(self, data_field, bounding_box=((0., 0.), (1., 1.)), range=(0., 1.), scaling_factor=1.):
         self.__auto_init(locals())
         self.lower_left = np.array(bounding_box[0])
         self.data_field = data_field
@@ -427,7 +425,7 @@ class RandomFieldFunction(DataFieldFunction):
     dim_domain = 2
     shape_range = ()
 
-    def __init__(self, bounding_box=None, random_range=[0, 1], shape=(1, 1)):
+    def __init__(self, bounding_box=((0., 0.), (1., 1.)), random_range=(0., 1.), shape=(1, 1)):
         a, b = random_range[0], random_range[1]
         random_field = get_rng().uniform(a, b, np.prod(shape)).reshape(shape)
         self.__auto_init(locals())
@@ -450,7 +448,7 @@ class BitmapFunction(DataFieldFunction):
     dim_domain = 2
     shape_range = ()
 
-    def __init__(self, filename, bounding_box=None, range=None):
+    def __init__(self, filename, bounding_box=((0., 0.), (1., 1.)), range=(0., 1.)):
         try:
             from PIL import Image
         except ImportError as e:

--- a/src/pymor/analyticalproblems/functions.py
+++ b/src/pymor/analyticalproblems/functions.py
@@ -383,10 +383,11 @@ class DataFieldFunction(Function):
     bounding_box
         Lower left and upper right coordinates of the domain of the data field.
     range
-        A pixel of value p is mapped to `(p / scaling_factor) * range[1] + range[0]`,
+        A `data_field` value of p is mapped to `(p / scaling_factor) * range[1] + range[0]`,
         where scaling_factor is set below.
     scaling_factor
-        See above.
+        See above. The scaling factor should be chosen, such that `data_field` has values
+        in `[0, scaling_factor]`.
     """
 
     dim_domain = 2

--- a/src/pymortests/analyticalproblems/function.py
+++ b/src/pymortests/analyticalproblems/function.py
@@ -70,3 +70,14 @@ def test_pickle_by_evaluation(function):
 def test_invalid_expressions():
     with pytest.raises(TypeError):
         ExpressionFunction('(-1 < x[0]) and (x[0] < 1)', 1)
+
+
+def test_data_field_function():
+    from pymor.analyticalproblems.functions import RandomFieldFunction
+    f = RandomFieldFunction(shape=(10, 10))
+    for i in range(9):
+        for j in range(9):
+            # all values are between 0 and 1
+            assert 0 <= f([i / 10., j / 10.]) <= 1
+            # all values are different
+            assert (f([i/10., j/10.]) != f([(i+1)/10., (j+1)/10.]))


### PR DESCRIPTION
This introduces the `RandomFieldFunction` as a subclass of  `DataFieldFunction`. With these it is now possible to

1) Construct a random field of arbitrary shape given as a `numpy` matrix (`RandomFieldFunction`).
2) Use a predefined `numpy` matrix and make it a `pymor.analyticalproblems.function` by using `DataFieldFunction`. In this way, it would e.g. be possible to have a 2D-layers of SPE10 as a `pymor.analyticalproblems.function`.

The functionality is more or less stolen from the `BitmapFunction`, which is now also a `DataFieldFunction`.
This could also be generalized to 1D and 3D case.

As a small example:

Calling

```
f = RandomFieldFunction(shape=(10, 10))
```
interpolated on a 100 x 100 grid, looks like this
![myplot](https://github.com/pymor/pymor/assets/11891068/83c2b2b3-2914-4f85-b567-23e3ec55e33b)
