### PR TITLE
Add iterable time stepping

### DIFF
--- a/src/pymor/algorithms/timestepping.py
+++ b/src/pymor/algorithms/timestepping.py
@@ -26,10 +26,11 @@ from pymor.vectorarrays.interface import VectorArray
 class TimeStepper(ImmutableObject):
     """Interface for time-stepping algorithms.
 
-    Algorithms implementing this interface solve time-dependent problems
+    Algorithms implementing this interface solve time-dependent initial value problems
     of the form ::
 
-        M * d_t u + A(u, mu, t) = F(mu, t).
+        M(mu) * d_t u + A(u, mu, t) = F(mu, t),
+                         u(mu, t_0) = u_0(mu).
 
     Time-steppers used by |InstationaryModel| have to fulfill
     this interface.
@@ -41,7 +42,8 @@ class TimeStepper(ImmutableObject):
 
         The equation is of the form ::
 
-            M * d_t u + A(u, mu, t) = F(mu, t).
+            M(mu) * d_t u + A(u, mu, t) = F(mu, t),
+                             u(mu, t_0) = u_0(mu).
 
         Parameters
         ----------
@@ -77,7 +79,10 @@ class ImplicitEulerTimeStepper(TimeStepper):
 
     Solves equations of the form ::
 
-        M * d_t u + A(u, mu, t) = F(mu, t).
+        M(mu) * d_t u + A(u, mu, t) = F(mu, t),
+                         u(mu, t_0) = u_0(mu).
+
+    by implicit Euler time integration.
 
     Parameters
     ----------
@@ -103,7 +108,10 @@ class ExplicitEulerTimeStepper(TimeStepper):
 
     Solves equations of the form ::
 
-        M * d_t u + A(u, mu, t) = F(mu, t).
+        M(mu) * d_t u + A(u, mu, t) = F(mu, t),
+                         u(mu, t_0) = u_0(mu).
+
+    by explicit Euler time integration.
 
     Parameters
     ----------
@@ -125,7 +133,10 @@ class ImplicitMidpointTimeStepper(TimeStepper):
 
     Solves equations of the form ::
 
-        M * d_t u + A(u, mu, t) = F(mu, t).
+        M(mu) * d_t u + A(u, mu, t) = F(mu, t),
+                         u(mu, t_0) = u_0(mu).
+
+    by implicit midpoint time integration.
 
     Parameters
     ----------
@@ -154,6 +165,9 @@ class DiscreteTimeStepper(TimeStepper):
     Solves equations of the form ::
 
         M(mu) * u_k+1 + A(u_k, mu, k) = F(mu, k).
+                           u(mu, k_0) = u_0(mu).
+
+    by direct time stepping.
     """
 
     def __init__(self):

--- a/src/pymor/algorithms/timestepping.py
+++ b/src/pymor/algorithms/timestepping.py
@@ -191,7 +191,7 @@ class ImplicitEulerTimeStepper(TimeStepper):
         assert U0 in A.source
         assert len(U0) == 1
 
-        time_steps = 1
+        num_ret_values = 1
         yield U0, t0
 
         options = (A.solver_options if self.solver_options == 'operator' else
@@ -215,8 +215,8 @@ class ImplicitEulerTimeStepper(TimeStepper):
             if F:
                 rhs += dt_F
             U = M_dt_A.apply_inverse(rhs, mu=mu, initial_guess=U)
-            while t - t0 + (min(dt, DT) * 0.5) >= time_steps * DT:
-                time_steps += 1
+            while t - t0 + (min(dt, DT) * 0.5) >= num_ret_values * DT:
+                num_ret_values += 1
                 yield U, t
 
 
@@ -272,7 +272,7 @@ class ExplicitEulerTimeStepper(TimeStepper):
 
         dt = (t1 - t0) / nt
         DT = (t1 - t0) / (num_values - 1)
-        time_steps = 1
+        num_ret_values = 1
         yield U0, t0
 
         t = t0
@@ -285,8 +285,8 @@ class ExplicitEulerTimeStepper(TimeStepper):
                 t += dt
                 mu = mu.with_(t=t)
                 U.axpy(-dt, A.apply(U, mu=mu))
-                while t - t0 + (min(dt, DT) * 0.5) >= time_steps * DT:
-                    time_steps += 1
+                while t - t0 + (min(dt, DT) * 0.5) >= num_ret_values * DT:
+                    num_ret_values += 1
                     yield U, t
         else:
             for n in range(nt):
@@ -295,8 +295,8 @@ class ExplicitEulerTimeStepper(TimeStepper):
                 if F_time_dep:
                     F_ass = F.as_vector(mu)
                 U.axpy(dt, F_ass - A.apply(U, mu=mu))
-                while t - t0 + (min(dt, DT) * 0.5) >= time_steps * DT:
-                    time_steps += 1
+                while t - t0 + (min(dt, DT) * 0.5) >= num_ret_values * DT:
+                    num_ret_values += 1
                     yield U, t
 
 
@@ -362,7 +362,7 @@ class ImplicitMidpointTimeStepper(TimeStepper):
         assert U0 in A.source
         assert len(U0) == 1
 
-        time_steps = 1
+        num_ret_values = 1
         yield U0, t0
 
         if self.solver_options == 'operator':
@@ -393,8 +393,8 @@ class ImplicitMidpointTimeStepper(TimeStepper):
             if F:
                 rhs += dt_F
             U = M_dt_A_impl.apply_inverse(rhs, mu=mu)
-            while t - t0 + (min(dt, DT) * 0.5) >= time_steps * DT:
-                time_steps += 1
+            while t - t0 + (min(dt, DT) * 0.5) >= num_ret_values * DT:
+                num_ret_values += 1
                 yield U, t
 
 
@@ -448,7 +448,7 @@ class DiscreteTimeStepper(TimeStepper):
         assert U0 in A.source
         assert len(U0) == 1
 
-        time_steps = 1
+        num_ret_values = 1
         yield U0, k0
 
         if not _depends_on_time(M, mu):
@@ -466,8 +466,8 @@ class DiscreteTimeStepper(TimeStepper):
             if F:
                 rhs += Fk
             U = M.apply_inverse(rhs, mu=mu, initial_guess=U)
-            while k - k0 + 1 + (min(dt, DT) * 0.5) >= time_steps * DT:
-                time_steps += 1
+            while k - k0 + 1 + (min(dt, DT) * 0.5) >= num_ret_values * DT:
+                num_ret_values += 1
                 yield U, k
 
 

--- a/src/pymor/algorithms/timestepping.py
+++ b/src/pymor/algorithms/timestepping.py
@@ -82,10 +82,13 @@ class TimeStepper(ImmutableObject):
         -------
         |VectorArray| containing the solution trajectory.
         """
-        num_time_steps = self.estimate_time_step_number(initial_time, end_time)
+        try:
+            num_time_steps = self.estimate_time_step_count(initial_time, end_time)
+        except NotImplementedError:
+            num_time_steps = 0
         iterator = self.iterate(initial_time, end_time, initial_data, operator, rhs=rhs, mass=mass, mu=mu,
                                 num_values=num_values)
-        U = operator.source.empty(reserve=min(num_time_steps, num_values) if num_values else num_time_steps)
+        U = operator.source.empty(reserve=num_values if num_values else num_time_steps)
         for U_n, _ in iterator:
             U.append(U_n)
         return U
@@ -152,7 +155,7 @@ class ImplicitEulerTimeStepper(TimeStepper):
     def __init__(self, nt, solver_options='operator'):
         self.__auto_init(locals())
 
-    def estimate_time_step_number(self, initial_time, end_time):
+    def estimate_time_step_count(self, initial_time, end_time):
         return self.nt + 1
 
     def iterate(self, initial_time, end_time, initial_data, operator, rhs=None, mass=None, mu=None, num_values=None):
@@ -236,7 +239,7 @@ class ExplicitEulerTimeStepper(TimeStepper):
     def __init__(self, nt):
         self.__auto_init(locals())
 
-    def estimate_time_step_number(self, initial_time, end_time):
+    def estimate_time_step_count(self, initial_time, end_time):
         return self.nt + 1
 
     def iterate(self, initial_time, end_time, initial_data, operator, rhs=None, mass=None, mu=None, num_values=None):
@@ -321,7 +324,7 @@ class ImplicitMidpointTimeStepper(TimeStepper):
     def __init__(self, nt, solver_options='operator'):
         self.__auto_init(locals())
 
-    def estimate_time_step_number(self, initial_time, end_time):
+    def estimate_time_step_count(self, initial_time, end_time):
         return self.nt + 1
 
     def iterate(self, initial_time, end_time, initial_data, operator, rhs=None, mass=None, mu=None, num_values=None):
@@ -409,7 +412,7 @@ class DiscreteTimeStepper(TimeStepper):
     def __init__(self):
         pass
 
-    def estimate_time_step_number(self, initial_time, end_time):
+    def estimate_time_step_count(self, initial_time, end_time):
         return end_time - initial_time + 1
 
     def iterate(self, initial_time, end_time, initial_data, operator, rhs=None, mass=None, mu=None, num_values=None):

--- a/src/pymor/algorithms/timestepping.py
+++ b/src/pymor/algorithms/timestepping.py
@@ -88,7 +88,7 @@ class TimeStepper(ImmutableObject):
             num_time_steps = 0
         iterator = self.iterate(initial_time, end_time, initial_data, operator, rhs=rhs, mass=mass, mu=mu,
                                 num_values=num_values)
-        U = operator.source.empty(reserve=num_values if num_values else num_time_steps)
+        U = operator.source.empty(reserve=num_values if num_values else num_time_steps + 1)
         for U_n, _ in iterator:
             U.append(U_n)
         return U
@@ -156,7 +156,7 @@ class ImplicitEulerTimeStepper(TimeStepper):
         self.__auto_init(locals())
 
     def estimate_time_step_count(self, initial_time, end_time):
-        return self.nt + 1
+        return self.nt
 
     def iterate(self, initial_time, end_time, initial_data, operator, rhs=None, mass=None, mu=None, num_values=None):
         A, F, M, U0, t0, t1, nt = operator, rhs, mass, initial_data, initial_time, end_time, self.nt
@@ -240,7 +240,7 @@ class ExplicitEulerTimeStepper(TimeStepper):
         self.__auto_init(locals())
 
     def estimate_time_step_count(self, initial_time, end_time):
-        return self.nt + 1
+        return self.nt
 
     def iterate(self, initial_time, end_time, initial_data, operator, rhs=None, mass=None, mu=None, num_values=None):
         if mass is not None:
@@ -325,7 +325,7 @@ class ImplicitMidpointTimeStepper(TimeStepper):
         self.__auto_init(locals())
 
     def estimate_time_step_count(self, initial_time, end_time):
-        return self.nt + 1
+        return self.nt
 
     def iterate(self, initial_time, end_time, initial_data, operator, rhs=None, mass=None, mu=None, num_values=None):
         if not operator.linear:
@@ -413,7 +413,7 @@ class DiscreteTimeStepper(TimeStepper):
         pass
 
     def estimate_time_step_count(self, initial_time, end_time):
-        return end_time - initial_time + 1
+        return end_time - initial_time
 
     def iterate(self, initial_time, end_time, initial_data, operator, rhs=None, mass=None, mu=None, num_values=None):
         A, F, M, U0, k0, k1 = operator, rhs, mass, initial_data, initial_time, end_time

--- a/src/pymor/algorithms/timestepping.py
+++ b/src/pymor/algorithms/timestepping.py
@@ -76,7 +76,7 @@ class TimeStepper(ImmutableObject):
         for U_n, _ in iterator:
             U.append(U_n)
         return U
- #
+
     @abstractmethod
     def iterate(self, initial_time, end_time, initial_data, operator, rhs=None, mass=None, mu=None, num_values=None):
         """Iterate time-stepper to the equation.

--- a/src/pymor/algorithms/timestepping.py
+++ b/src/pymor/algorithms/timestepping.py
@@ -36,8 +36,7 @@ class TimeStepper(ImmutableObject):
     this interface.
     """
 
-    @abstractmethod
-    def estimate_time_step_number(self, initial_time, end_time):
+    def estimate_time_step_count(self, initial_time, end_time):
         """Estimate the number of time steps.
 
         Parameters
@@ -47,7 +46,7 @@ class TimeStepper(ImmutableObject):
         end_time
             The time until which to perform time-stepping.
         """
-        pass
+        raise NotImplementedError
 
     def solve(self, initial_time, end_time, initial_data, operator, rhs=None, mass=None, mu=None, num_values=None):
         """Apply time-stepper to the equation.


### PR DESCRIPTION
Inspired by #1529, this PR:

- improves IVP documentation
- removes time-stepping functions
- allows iterating over time steps (using a generator function)