### PR TITLE
Add rule for preassembling QuadraticFunctional

### DIFF
--- a/src/pymor/algorithms/preassemble.py
+++ b/src/pymor/algorithms/preassemble.py
@@ -11,6 +11,7 @@ from pymor.operators.constructions import (
     LincombOperator,
     ProjectedOperator,
     SelectionOperator,
+    QuadraticFunctional
 )
 from pymor.operators.interface import Operator
 
@@ -30,7 +31,7 @@ class PreAssembleRules(RuleTable):
     def __init__(self):
         super().__init__(use_caching=True)
 
-    @match_class(Model, AffineOperator, ConcatenationOperator, SelectionOperator)
+    @match_class(Model, AffineOperator, ConcatenationOperator, SelectionOperator, QuadraticFunctional)
     def action_recurse(self, op):
         return self.replace_children(op)
 

--- a/src/pymor/algorithms/preassemble.py
+++ b/src/pymor/algorithms/preassemble.py
@@ -10,8 +10,8 @@ from pymor.operators.constructions import (
     ConcatenationOperator,
     LincombOperator,
     ProjectedOperator,
+    QuadraticFunctional,
     SelectionOperator,
-    QuadraticFunctional
 )
 from pymor.operators.interface import Operator
 


### PR DESCRIPTION
Apparently, we forgot about the preassmbly rule for the QuadraticFunctional. So far, the operator is assembled every time it is used.

This should probably enter the release.