### PR TITLE
Improve parsing of time-dependent parameter values

### DIFF
--- a/src/pymor/parameters/base.py
+++ b/src/pymor/parameters/base.py
@@ -117,7 +117,8 @@ class Parameters(SortedFrozenDict):
             Is raised if `mu` cannot be interpreted as |parameter values| for the
             given |Parameters|.
         """
-        from pymor.analyticalproblems.functions import ExpressionFunction, Function
+        from pymor.analyticalproblems.expressions import Array, Constant
+        from pymor.analyticalproblems.functions import ExpressionFunction, Function, SymbolicExpressionFunction
 
         def fail(msg):
             if isinstance(mu, dict):
@@ -137,20 +138,37 @@ class Parameters(SortedFrozenDict):
 
         # convert mu to dict
         if isinstance(mu, (Number, str, Function)):
-            assert self or fail('too many values')
-            assert len(self) == 1 or fail('not enough values')
-            mu = {next(iter(self.keys())): mu}
+            mu = [mu]
 
-        elif isinstance(mu, (tuple, list, np.ndarray)):
+        def convert_to_function(v):
+            if isinstance(v, Number):
+                return v
+            f = ExpressionFunction(v, dim_domain=1, variable='t') if isinstance(v, str) else v
+            f.dim_domain == 1 or \
+                fail(f'dim_domain of parameter function must be 1 (not {f.dim_domain}):\n'
+                     f'    {v}')
+            len(f.shape_range) <= 1 or \
+                fail(f'parameter function must be scalar- or vector-valued (not {f.shape_range}):\n'
+                     f'    {v}')
+            return f
+
+        if isinstance(mu, (tuple, list, np.ndarray)):
             if isinstance(mu, np.ndarray):
                 mu = mu.ravel()
             all(isinstance(v, (Number, str, Function)) for v in mu) or \
                 fail('not every element a number or function')
+
+            # first convert all strings to functions to get their shape
+            mu = [convert_to_function(v) for v in mu]
+
             parsed_mu = {}
             for k, v in self.items():
-                len(mu) >= v or fail('not enough values')
-                if len(mu) > 0 and isinstance(mu[0], (str, Function)):
+                if len(mu) > 0 and isinstance(mu[0], Function) and \
+                        len(mu[0].shape_range) == 1 and mu[0].shape_range[0] > 1:
                     p, mu = mu[0], mu[1:]
+                    p.shape_range[0] == v or \
+                        fail(f'shape of parameter function for parameter {k} must be {v} (not {p.shape_range[0]}):\n'
+                             f'    {p}')
                 else:
                     len(mu) >= v or fail('not enough values')
                     p, mu = mu[:v], mu[v:]
@@ -161,21 +179,55 @@ class Parameters(SortedFrozenDict):
         set(mu.keys()) == set(self.keys()) or fail('parameters not matching')
 
         def parse_value(k, v):
-            if isinstance(v, (Number, tuple, list, np.ndarray)):
-                if isinstance(v, Number):
-                    v = np.array([v])
-                elif isinstance(v, (tuple, list)):
-                    v = np.array(v)
+            if isinstance(v, Number):
+                v = np.array([v])
+                v = v.ravel()
+                len(v) == self[k] or fail(f'wrong dimension of parameter value {k}')
+                return v
+            elif isinstance(v, np.ndarray):
                 v = v.ravel()
                 len(v) == self[k] or fail(f'wrong dimension of parameter value {k}')
                 return v
             elif isinstance(v, (str, Function)):
-                if isinstance(v, str):
-                    v = ExpressionFunction(v, dim_domain=1, variable='t')
-                v.dim_domain == 1 or fail(f'wrong domain dimension of parameter function {k}')
+                v = convert_to_function(v)
+
+                # convert scalar-valued functions to functions 1D shape_range
+                if v.shape_range == () and self[k] == 1 and isinstance(v, SymbolicExpressionFunction):
+                    v = SymbolicExpressionFunction(Array([v.expression_obj]), dim_domain=1, variable='t')
+
                 len(v.shape_range) == 1 or fail(f'wrong shape_range of parameter function {k}')
                 v.shape_range[0] == self[k] or fail(f'wrong range dimension of prameter function {k}')
                 return v
+            elif isinstance(v, (tuple, list)):
+                all(isinstance(vv, (Number, str, Function)) for vv in v) or \
+                    fail(f"invalid value type '{type(v)}' for parameter {k}")
+                v = [convert_to_function(vv) for vv in v]
+                if any(isinstance(vv, Function) for vv in v):
+                    len(v) == self[k] or fail(f'wrong dimension of parameter value {k}')
+                    funcs = []
+                    for i, vv in enumerate(v):
+                        if isinstance(vv, Number):
+                            f = SymbolicExpressionFunction(Constant(vv), dim_domain=1, variable='t')
+                        else:
+                            f = vv
+
+                        f.dim_domain == 1 or fail(f'wrong domain dimension of parameter function {k}')
+
+                        # convert functions to scalar-valued functions if possible
+                        if f.shape_range == (1,) and isinstance(f, SymbolicExpressionFunction):
+                            f = SymbolicExpressionFunction(f.expression_obj[0], dim_domain=1, variable='t')
+
+                        f.shape_range == () or \
+                            fail(f'parameter function {k}[{i}] not scalar-valued: {vv}')
+                        funcs.append(f)
+                    v = SymbolicExpressionFunction(Array([f.expression_obj for f in funcs]),
+                                                   dim_domain=1, variable='t')
+                    return v
+                else:
+                    v = np.array(v)
+                    v = v.ravel()
+                    len(v) == self[k] or fail(f'wrong dimension of parameter value {k}')
+                    return v
             else:
                 fail(f"invalid value type '{type(v)}' for parameter {k}")
 

--- a/src/pymortests/parameters/parameters.py
+++ b/src/pymortests/parameters/parameters.py
@@ -90,6 +90,13 @@ def test_parse_parameter():
     assert mu_as_list == mu_as_parameter_and_back
 
 
+def test_parse_parameter_time_dep():
+    parameters = Parameters(b=2, a=1)
+    mu = parameters.parse([7, 't**2', 't[0]'])
+    assert list(mu.with_(t=3)['a']) == [7]
+    assert list(mu.with_(t=3)['b']) == [9, 3]
+
+
 @given(pyst.mus)
 def test_parse_mu(mu):
     parameters = mu.parameters


### PR DESCRIPTION
This PR allows to specify time-dependent parameter values with more than one component as a list of scalar valued expression. Also, scalar valued functions are automatically cast to vector-valued functions with shape `(1,)`. For instance, the following is now allowed:

```
Parameters(a=1, b=2).parse(['t[0]', 't[0]*2', 't*3'])
```

For the internal implementation, I have refactored `ExpressionFunction` to inherit from `SymbolicExpressionFunction`, which is instantiated with a symbolic expression object.

Fixes #1396.