### PR TITLE
Integer-valued VectorSpace dimensions 2

### DIFF
--- a/src/pymor/bindings/dunegdt.py
+++ b/src/pymor/bindings/dunegdt.py
@@ -7,6 +7,7 @@ from pymor.core.config import config
 
 config.require('DUNEGDT')
 
+from numbers import Integral
 
 import numpy as np
 from dune.xt.la import IstlVector
@@ -107,6 +108,8 @@ class DuneXTVectorSpace(ComplexifiedListVectorSpace):
     real_vector_type = DuneXTVector
 
     def __init__(self, dim, dune_vector_type=IstlVector, id='STATE'):
+        assert isinstance(dim, Integral)
+        dim = int(dim)
         self.__auto_init(locals())
 
     def __eq__(self, other):

--- a/src/pymor/vectorarrays/numpy.py
+++ b/src/pymor/vectorarrays/numpy.py
@@ -2,7 +2,7 @@
 # Copyright pyMOR developers and contributors. All rights reserved.
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
-from numbers import Number
+from numbers import Integral, Number
 
 import numpy as np
 from scipy.sparse import issparse
@@ -217,7 +217,8 @@ class NumpyVectorSpace(VectorSpace):
     """
 
     def __init__(self, dim, id=None):
-        self.dim = dim
+        assert isinstance(dim, Integral)
+        self.dim = int(dim)
         self.id = id
 
     def __eq__(self, other):

--- a/src/pymortests/vectorarray.py
+++ b/src/pymortests/vectorarray.py
@@ -1039,3 +1039,8 @@ def test_axpy_wrong_coefficients(vectors_and_indices):
 @pyst.given_vector_arrays(which='picklable')
 def test_pickle(vector_array):
     assert_picklable_without_dumps_function(vector_array)
+
+
+def test_numpyvectorspace_dim_must_be_int():
+    with pytest.raises(AssertionError):
+        _ = NumpyVectorSpace(5.)


### PR DESCRIPTION
This PR ensures that `VectorSpaces` cannot be instantiated with non-integer dimensions.

Fixes #2062.

Alternative implementation to #2063.