### PR TITLE
docs | fix reference in technical_overview.rst

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -14,13 +14,14 @@ Dennis Eickhorn <d.eickhorn@uni-muenster.de>
 Dennis Eickhorn <d.eickhorn@uni-muenster.de> <d.eickhorn@mail.de>
 Dennis Eickhorn <d.eickhorn@uni-muenster.de> <d.eickhorn@wwu.de>
 Falk Meyer <falk.meyer@uni-muenster.de>
-Felix Schindler <ftschindler@noreply.github.com>
-Felix Schindler <ftschindler@noreply.github.com> <felix.albrecht@uni-muenster.de>
-Felix Schindler <ftschindler@noreply.github.com> <felix.albrecht@wwu.de>
-Felix Schindler <ftschindler@noreply.github.com> <felix.schindler@wwu.de>
-Felix Schindler <ftschindler@noreply.github.com> <felix@schindlerfamily.de>
-Felix Schindler <ftschindler@noreply.github.com> <ftalbrecht@users.noreply.github.com>
-Felix Schindler <ftschindler@noreply.github.com> <mail@felixalbrecht.de>
+Felix Schindler <107669806+ftschindler@users.noreply.github.com>
+Felix Schindler <107669806+ftschindler@users.noreply.github.com> <felix.albrecht@uni-muenster.de>
+Felix Schindler <107669806+ftschindler@users.noreply.github.com> <felix.albrecht@wwu.de>
+Felix Schindler <107669806+ftschindler@users.noreply.github.com> <felix.schindler@wwu.de>
+Felix Schindler <107669806+ftschindler@users.noreply.github.com> <felix@schindlerfamily.de>
+Felix Schindler <107669806+ftschindler@users.noreply.github.com> <ftalbrecht@users.noreply.github.com>
+Felix Schindler <107669806+ftschindler@users.noreply.github.com> <ftschindler@noreply.github.com>
+Felix Schindler <107669806+ftschindler@users.noreply.github.com> <mail@felixalbrecht.de>
 Geordie McBain <gdmcbain@protonmail.com>
 Gonc Berk Gunes <goncberk@gmail.com> <32432787+Congpy@users.noreply.github.com>
 Hendrik Kleikamp <hendrik.kleikamp@uni-muenster.de>

--- a/docs/source/technical_overview.rst
+++ b/docs/source/technical_overview.rst
@@ -352,7 +352,7 @@ data (e.g. the reduced basis) to create reduced |Models|. For instance, the
 :class:`~pymor.reductors.basic.StationaryRBReductor` and
 :class:`~pymor.reductors.basic.InstationaryRBReductor` reductors can reduce any
 :class:`~pymor.models.basic.StationaryModel` and :class:`~pymor.models.basic.InstationaryModel`,
-while the :class:`~pymor.reductors.bt.GenericBTReductor` reduces
+while the :class:`~pymor.reductors.bt.BTReductor` reduces
 :class:`~pymor.models.iosys.LTIModel` (just to name a few).
 
 If proper offline/online decomposition is achieved by the reductor, the reduced
@@ -366,7 +366,7 @@ reduced basis method: the operators and functionals of a given discrete problem
 are projected onto the reduced basis space whereas the structure of the problem
 (i.e. the type of |Model| containing the operators) stays the same.
 pyMOR reflects this fact by offering with :meth:`~pymor.algorithms.projection.project`
-generic algorithms which can be used to RB-project any model available to pyMOR.
+generic algorithms which can be used to RB-project any |Operator| available to pyMOR.
 
 In addition to the projection of the |Model|, reductors may also assemble efficient
 offline-online decomposed a posterior error estimates (available via the

--- a/docs/source/technical_overview.rst
+++ b/docs/source/technical_overview.rst
@@ -359,7 +359,7 @@ This observation is particularly apparent in the case of the classical
 reduced basis method: the operators and functionals of a given discrete problem
 are projected onto the reduced basis space whereas the structure of the problem
 (i.e. the type of |Model| containing the operators) stays the same.
-pyMOR reflects this fact by offering with :class:`!GenericRBReductor`
+pyMOR reflects this fact by offering with :class:`~pymor.reductors.basic.ProjectionBasedReductor`
 a generic algorithm which can be used to RB-project any model available to pyMOR.
 It should be noted however that this reductor is only able to efficiently
 offline/online-decompose affinely |Parameter|-dependent linear problems.
@@ -367,6 +367,6 @@ Non-linear problems or such with no affine |Parameter| dependence require
 additional techniques such as :mod:`empirical interpolation <pymor.algorithms.ei>`.
 
 If you want to further dive into the inner workings of pyMOR, we
-recommend to study the source code of :class:`!GenericRBReductor`
+recommend to study the source code of :class:`~pymor.reductors.basic.ProjectionBasedReductor`
 and to step through calls of it's `reduce` method with a Python debugger, such as
 `ipdb <https://pypi.python.org/pypi/ipdb>`_.

--- a/docs/source/technical_overview.rst
+++ b/docs/source/technical_overview.rst
@@ -361,12 +361,16 @@ distinction between low- and high-dimensional |Models| in pyMOR. The only
 difference lies in the different types of operators, the |Model|
 contains.
 
-This observation is particularly apparent in the case of the classical
-reduced basis method: the operators and functionals of a given discrete problem
-are projected onto the reduced basis space whereas the structure of the problem
+In particular, in most projection-based MOR methods, only the
+operators and functionals of a given discrete problem are projected onto the
+reduced basis space, whereas the structure of the problem
 (i.e. the type of |Model| containing the operators) stays the same.
-pyMOR reflects this fact by offering with :meth:`~pymor.algorithms.projection.project`
-generic algorithms which can be used to RB-project any |Operator| available to pyMOR.
+The actual projection of an individual |Operator| is performed by the generic
+:meth:`~pymor.algorithms.projection.project` algorithm, which is able to perform a
+Petrov-Galerkin projection of any |Operator| available to pyMOR.
+The algorithm automatically exploits the structure of the given |Operator|
+(linearity, parameter separability, etc.) where possible
+to decouple the evaluation of the projected |Operator| from any high-dimensional spaces.
 
 In addition to the projection of the |Model|, reductors may also assemble efficient
 offline-online decomposed a posterior error estimates (available via the
@@ -375,11 +379,5 @@ about the underlying problem yielding the full order |Model| is available
 (a popular example is the `CoerciveRBReductor` for |Models| representing stationary
 coercive problems).
 
-It should be noted that a successfull reduction of more involved |Models| (say those
-arising from non-linear problems or such with no affine |Parameter| dependence) require
-additional techniques such as :mod:`empirical interpolation <pymor.algorithms.ei>`.
-
 If you want to further dive into the inner workings of pyMOR, we
-recommend to study the source code of :class:`~pymor.reductors.basic.ProjectionBasedReductor`
-and to step through calls of it's `reduce` method with a Python debugger, such as
-`ipdb <https://pypi.python.org/pypi/ipdb>`_.
+recommend to study the :doc:`Projecting a Model <tutorial_projection>` tutorial.

--- a/docs/source/technical_overview.rst
+++ b/docs/source/technical_overview.rst
@@ -346,12 +346,18 @@ This approach has several advantages over an inheritance-based model:
 The Reduction Process
 ---------------------
 
-The reduction process in pyMOR is handled by so called :mod:`~pymor.reductors`
-which take arbitrary |Models| and additional data (e.g. the reduced
-basis) to create reduced |Models|. If proper offline/online
-decomposition is achieved by the reductor, the reduced |Model| will
-not store any high-dimensional data. Note that there is no inherent distinction
-between low- and high-dimensional |Models| in pyMOR. The only
+The reduction process in pyMOR is handled by so called :mod:`~pymor.reductors`,
+where each reductor takes arbitrary |Models| of associated type, and additional
+data (e.g. the reduced basis) to create reduced |Models|. For instance, the
+:class:`~pymor.reductors.basic.StationaryRBReductor` and
+:class:`~pymor.reductors.basic.InstationaryRBReductor` reductors can reduce any
+:class:`~pymor.models.basic.StationaryModel` and :class:`~pymor.models.basic.InstationaryModel`,
+while the :class:`~pymor.reductors.bt.GenericBTReductor` reduces
+:class:`~pymor.models.iosys.LTIModel` (just to name a few).
+
+If proper offline/online decomposition is achieved by the reductor, the reduced
+|Model| will not store any high-dimensional data. Note that there is no inherent
+distinction between low- and high-dimensional |Models| in pyMOR. The only
 difference lies in the different types of operators, the |Model|
 contains.
 
@@ -359,11 +365,18 @@ This observation is particularly apparent in the case of the classical
 reduced basis method: the operators and functionals of a given discrete problem
 are projected onto the reduced basis space whereas the structure of the problem
 (i.e. the type of |Model| containing the operators) stays the same.
-pyMOR reflects this fact by offering with :class:`~pymor.reductors.basic.ProjectionBasedReductor`
-a generic algorithm which can be used to RB-project any model available to pyMOR.
-It should be noted however that this reductor is only able to efficiently
-offline/online-decompose affinely |Parameter|-dependent linear problems.
-Non-linear problems or such with no affine |Parameter| dependence require
+pyMOR reflects this fact by offering with :meth:`~pymor.algorithms.projection.project`
+generic algorithms which can be used to RB-project any model available to pyMOR.
+
+In addition to the projection of the |Model|, reductors may also assemble efficient
+offline-online decomposed a posterior error estimates (available via the
+`estimate_error` method of the resulting reduced order |Model|), if more information
+about the underlying problem yielding the full order |Model| is available
+(a popular example is the `CoerciveRBReductor` for |Models| representing stationary
+coercive problems).
+
+It should be noted that a successfull reduction of more involved |Models| (say those
+arising from non-linear problems or such with no affine |Parameter| dependence) require
 additional techniques such as :mod:`empirical interpolation <pymor.algorithms.ei>`.
 
 If you want to further dive into the inner workings of pyMOR, we

--- a/docs/source/technical_overview.rst
+++ b/docs/source/technical_overview.rst
@@ -362,9 +362,9 @@ difference lies in the different types of operators, the |Model|
 contains.
 
 In particular, in most projection-based MOR methods, only the
-operators and functionals of a given discrete problem are projected onto the
-reduced basis space, whereas the structure of the problem
-(i.e. the type of |Model| containing the operators) stays the same.
+|Operators| of a given |Model| are projected onto the
+reduced-basis space, whereas the structure of the problem
+(i.e. the type of the |Model|) stays the same.
 The actual projection of an individual |Operator| is performed by the generic
 :meth:`~pymor.algorithms.projection.project` algorithm, which is able to perform a
 Petrov-Galerkin projection of any |Operator| available to pyMOR.

--- a/docs/source/technical_overview.rst
+++ b/docs/source/technical_overview.rst
@@ -376,7 +376,7 @@ In addition to the projection of the |Model|, reductors may also assemble effici
 offline-online decomposed a posterior error estimates (available via the
 `estimate_error` method of the resulting reduced order |Model|), if more information
 about the underlying problem yielding the full order |Model| is available
-(a popular example is the `CoerciveRBReductor` for |Models| representing stationary
+(a popular example is the :class:`~pymor.reductors.coercive.CoerciveRBReductor` for |Models| representing stationary
 coercive problems).
 
 If you want to further dive into the inner workings of pyMOR, we

--- a/docs/source/tutorial_projection.md
+++ b/docs/source/tutorial_projection.md
@@ -339,7 +339,15 @@ Let's see, how good our reduced approximation is:
 (U-U_N).norm(fom.h1_0_product) / U.norm(fom.h1_0_product)
 ```
 
-With only 10 basis vectors, we have achieved a relative {math}`H^1`-error of 2%.
+```{code-cell}
+:tags: [remove-cell]
+
+
+# ensure the statement in the text below is accurate
+assert (U-U_N).norm(fom.h1_0_product) / U.norm(fom.h1_0_product) < 0.5
+```
+
+With only 10 basis vectors, we have achieved a relative {math}`H^1`-error of about 0.5%.
 We can also visually inspect our solution and the approximation error:
 
 ```{code-cell}


### PR DESCRIPTION
Updates technical overview in docs to match better reflect current state of reductors.