### PR TITLE
Use setup-micromamba instead of provision-with-micromamba

### DIFF
--- a/.github/actions/miniconda_tests/action.yml
+++ b/.github/actions/miniconda_tests/action.yml
@@ -57,7 +57,7 @@ runs:
             channel_priority: strict
         cache-environment: true
         cache-downloads: true
-        cache-envrionment-key: ${{ inputs.python }}-${{ inputs.os }}
+        cache-environment-key: ${{ inputs.python }}-${{ inputs.os }}
         environment-name: pyMOR-ci
         environment-file: ${{ inputs.environment_file }}
         micromamba-version: "latest"

--- a/.github/actions/miniconda_tests/action.yml
+++ b/.github/actions/miniconda_tests/action.yml
@@ -47,17 +47,17 @@ runs:
         ./mesa/systemwidedeploy.cmd
 
     - uses: actions/checkout@v3
-    - name: provision-with-micromamba
-      uses: mamba-org/provision-with-micromamba@v14
+    - name: setup-micromamba
+      uses: mamba-org/setup-micromamba@v1
 
       with:
-        extra-specs: |
+        create-args: >-
             python=${{ inputs.python }}
-        channels: conda-forge
-        channel-priority: strict
-        cache-env: true
+        condarc: |
+            channel_priority: strict
+        cache-environment: true
         cache-downloads: true
-        cache-env-key: ${{ inputs.python }}-${{ inputs.os }}
+        cache-envrionment-key: ${{ inputs.python }}-${{ inputs.os }}
         environment-name: pyMOR-ci
         environment-file: ${{ inputs.environment_file }}
         micromamba-version: "latest"


### PR DESCRIPTION
provision-with-micromamba is abandoned. Thus, we use setup-micromamba instead.