### PR TITLE
jupyterlite fix / config improvements / remove progress bar

### DIFF
--- a/src/pymor/core/config.py
+++ b/src/pymor/core/config.py
@@ -92,15 +92,6 @@ def _get_matplotib_version():
     return mpl.__version__
 
 
-def _get_ipython_version():
-    try:
-        import ipyparallel
-        return ipyparallel.__version__
-    except ImportError:
-        import IPython.parallel
-        return getattr(IPython.parallel, '__version__', True)
-
-
 def _get_slycot_version():
     from slycot.version import version
     if list(map(int, version.split('.'))) < [0, 3, 1]:
@@ -144,7 +135,8 @@ _PACKAGES = {
     'DUNEGDT': _get_dunegdt_version,
     'FENICS': _get_fenics_version,
     'GL': lambda: import_module('OpenGL.GL') and import_module('OpenGL').__version__,
-    'IPYTHON': _get_ipython_version,
+    'IPYTHON': lambda: import_module('IPython').__version__,
+    'IPYPARALLEL': lambda: import_module('ipyparallel').__version__,
     'MATPLOTLIB': _get_matplotib_version,
     'VTKIO': lambda: _can_import(('meshio', 'pyevtk', 'lxml', 'xmljson')),
     'MESHIO': lambda: import_module('meshio').__version__,

--- a/src/pymor/core/config.py
+++ b/src/pymor/core/config.py
@@ -127,7 +127,7 @@ def is_jupyter():
     if force is not None:
         return bool(force)
     ipy = type(get_ipython()).__module__
-    return ipy.startswith('ipykernel.') or ipy.startswith('google.colab')
+    return ipy.startswith('ipykernel.') or ipy.startswith('google.colab') or ipy.startswith('pyolite.')
 
 
 _PACKAGES = {

--- a/src/pymor/core/config.py
+++ b/src/pymor/core/config.py
@@ -135,13 +135,12 @@ _PACKAGES = {
     'DUNEGDT': _get_dunegdt_version,
     'FENICS': _get_fenics_version,
     'GL': lambda: import_module('OpenGL.GL') and import_module('OpenGL').__version__,
-    'IPYTHON': lambda: import_module('IPython').__version__,
     'IPYPARALLEL': lambda: import_module('ipyparallel').__version__,
-    'MATPLOTLIB': _get_matplotib_version,
-    'VTKIO': lambda: _can_import(('meshio', 'pyevtk', 'lxml', 'xmljson')),
-    'MESHIO': lambda: import_module('meshio').__version__,
+    'IPYTHON': lambda: import_module('IPython').__version__,
     'IPYWIDGETS': lambda: import_module('ipywidgets').__version__,
     'K3D': lambda: import_module('k3d').__version__,
+    'MATPLOTLIB': _get_matplotib_version,
+    'MESHIO': lambda: import_module('meshio').__version__,
     'MPI': lambda: import_module('mpi4py.MPI') and import_module('mpi4py').__version__,
     'NGSOLVE': lambda: import_module('ngsolve').__version__,
     'NUMPY': lambda: import_module('numpy').__version__,
@@ -156,6 +155,7 @@ _PACKAGES = {
     'SPHINX': lambda: import_module('sphinx').__version__,
     'TORCH': lambda: import_module('torch').__version__,
     'TYPER': lambda: import_module('typer').__version__,
+    'VTKIO': lambda: _can_import(('meshio', 'pyevtk', 'lxml', 'xmljson')),
 }
 
 

--- a/src/pymor/discretizers/builtin/gui/jupyter/__init__.py
+++ b/src/pymor/discretizers/builtin/gui/jupyter/__init__.py
@@ -3,7 +3,7 @@
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
 """This module provides plotting support inside the Jupyter notebook."""
-import IPython
+
 from packaging.version import parse as parse_version
 
 from pymor.core.config import config
@@ -33,60 +33,6 @@ def get_visualizer(backend='prefer_k3d'):
     else:
         from pymor.discretizers.builtin.gui.jupyter.matplotlib import visualize_patch
         return visualize_patch
-
-
-def progress_bar(sequence, every=None, size=None, name='Parameters'):
-    from ipywidgets import HTML, IntProgress, VBox
-
-    # c&p from https://github.com/kuk/log-progress
-    is_iterator = False
-    if size is None:
-        try:
-            size = len(sequence)
-        except TypeError:
-            is_iterator = True
-    if size is not None:
-        if every is None:
-            if size <= 200:
-                every = 1
-            else:
-                every = int(size / 200)     # every 0.5%
-    else:
-        assert every is not None, 'sequence is iterator, set every'
-
-    if is_iterator:
-        progress = IntProgress(min=0, max=1, value=1)
-        progress.bar_style = 'info'
-    else:
-        progress = IntProgress(min=0, max=size, value=0)
-    label = HTML()
-    box = VBox(children=[label, progress])
-    IPython.display.display(box)
-
-    index = 0
-    try:
-        for index, record in enumerate(sequence, 1):
-            if index == 1 or index % every == 0:
-                if is_iterator:
-                    label.value = '{name}: {index} / ?'.format(
-                        name=name,
-                        index=index
-                    )
-                else:
-                    progress.value = index
-                    label.value = u'{name}: {index} / {size}'.format(
-                        name=name,
-                        index=index,
-                        size=size
-                    )
-            yield record
-    except:
-        progress.bar_style = 'danger'
-        raise
-    else:
-        progress.bar_style = 'success'
-        progress.value = index
-        label.value = f"{name}: {str(index or '?')}"
 
 
 def load_ipython_extension(ipython):

--- a/src/pymor/discretizers/builtin/gui/jupyter/logging.py
+++ b/src/pymor/discretizers/builtin/gui/jupyter/logging.py
@@ -2,6 +2,12 @@
 # Copyright pyMOR developers and contributors. All rights reserved.
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
+from pymor.core.config import config
+
+config.require('IPYTHON')
+config.require('IPYWIDGETS')
+
+
 import logging
 
 import ipywidgets

--- a/src/pymor/parallel/ipython.py
+++ b/src/pymor/parallel/ipython.py
@@ -4,22 +4,19 @@
 
 from pymor.core.config import config
 
-config.require('IPYTHON')
+config.require('IPYPARALLEL')
 
 
 import os
 import time
 from itertools import chain
 
+from ipyparallel import Client, TimeoutError
+
 from pymor.core import defaults
 from pymor.core.base import BasicObject
 from pymor.parallel.basic import WorkerPoolBase
 from pymor.tools.counter import Counter
-
-try:
-    from ipyparallel import Client, TimeoutError
-except ImportError:
-    from IPython.parallel import Client, TimeoutError
 
 
 class new_ipcluster_pool(BasicObject):  # noqa: N801


### PR DESCRIPTION
These are some leftovers from some last-minute work for the CSE minitutorial.

- The unused `distcretizeris.builtin.gui.jupyter.progress_bar` is removed.
- `is_jupyter()` returns `True` when running under `pyolite`.
- the `IPYTHON` config item is split into `IPYTHON` and `IPYPARALLEL`.