### PR TITLE
Edit release checklist

### DIFF
--- a/docs/NEW_MAIN_DEVS.md
+++ b/docs/NEW_MAIN_DEVS.md
@@ -1,8 +1,8 @@
 # New main developer checklist
 
-- [ ] update pyMOR org admins and teams
-- [ ] announce in the next release notes
-- [ ] update `AUTHORS.md`
-- [ ] update `CITATION.cff`
-- [ ] update PyPI and TestPyPI project collaborators
-- [ ] update [conda recipe maintainers](https://github.com/conda-forge/pymor-feedstock/blob/main/recipe/meta.yaml)
+- [ ] Update pyMOR org admins and teams.
+- [ ] Announce in the next release notes.
+- [ ] Update `AUTHORS.md`.
+- [ ] Update `CITATION.cff`.
+- [ ] Update PyPI and TestPyPI project collaborators.
+- [ ] Update [conda recipe maintainers](https://github.com/conda-forge/pymor-feedstock/blob/main/recipe/meta.yaml).

--- a/docs/NEW_MAIN_DEVS.md
+++ b/docs/NEW_MAIN_DEVS.md
@@ -1,0 +1,8 @@
+# New main developer checklist
+
+- [ ] update pyMOR org admins and teams
+- [ ] announce in the next release notes
+- [ ] update `AUTHORS.md`
+- [ ] update `CITATION.cff`
+- [ ] update PyPI and TestPyPI project collaborators
+- [ ] update [conda recipe maintainers](https://github.com/conda-forge/pymor-feedstock/blob/main/recipe/meta.yaml)

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -28,7 +28,8 @@ Replace `RELEASE_TAG` below with the actual release tag.
       Should have a `.x` as the last part of the branch name in contrast
       to the `RELEASE_TAG`.
       (Omit in case of a bugfix release.)
-- [ ] Use `hatch version` to update `__version__` in `sr/pymor/__init__.py`. Merge into release branch.
+- [ ] Use `hatch version RELEASE_TAG` to update `__version__` in `src/pymor/__init__.py`.
+      Merge into release branch.
 - [ ] Run
 
     ```bash
@@ -41,7 +42,10 @@ Replace `RELEASE_TAG` below with the actual release tag.
       Use an annotated tag (`git tag -a RELEASE_TAG -m RELEASE_TAG`) with the
       annotation being `RELEASE_TAG`.
       Push `RELEASE_TAG` to GitHub.
-- [ ] Wait for CI build for tagged commit to finish.
+- [ ] Wait for CI build for tagged commit to finish (see the list of pipelines at
+      [zivgitlab](https://zivgitlab.uni-muenster.de/pymor/pymor/-/pipelines)).
+- [ ] Merge the automatic PR at [`pymor/docs`](https://github.com/pymor/docs) and
+      wait for the CI build to finish.
 - [ ] Check again that documentation for tagged commit (not release branch) is built correctly.
       Check that binder links work and `.binder/Dockerfile` in `pymor/docs@RELEASE_TAG` uses the
       correctly tagged base image.

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -49,6 +49,6 @@ The release manager is responsible for ensuring that the following steps are per
 - [ ] At the day of the release:
   - [ ] Follow the steps outlined in [`RELEASE_CHECKLIST`](RELEASE_CHECKLIST.md).
 - [ ] In the first community meeting after the release:
-  - [ ] Select a new release manager for the next release.
+  - [ ] Select a new release manager for the next release and set the release day.
         However, the current release manager is still responsible for all point releases until the next release.
   - [ ] Assign a couple of issues (about 2 or 3) to each main developer and give them the milestone of the next release.


### PR DESCRIPTION
Some edits after the last release.

A bunch of things happen after a new tag is pushed, and I forgot how many CI cycles I had to wait for (either on `pymor/pymor` or `pymor/docs`) before documentation showed up online. I tried to add some pointers.

For conda feedstock, there was no automatic PR, so I did it by hand. It would be good to fix the automatization.