### PR TITLE
Add `check_finite` and `check_cond` in `NumpyMatrixOperator` and use SciPy solvers elsewhere

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -257,7 +257,7 @@ ignore = [
 # N806 same for variables in function
 
 [tool.ruff.flake8-import-conventions]
-banned-from = ["numpy.linalg"]
+banned-from = ["numpy.linalg"]  # avoids importing similar routines from numpy.linalg and scipy.linalg
 
 [tool.ruff.flake8-import-conventions.extend-aliases]
 scipy = ""  # don't import scipy directly

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -261,14 +261,7 @@ banned-from = ["numpy.linalg"]
 
 [tool.ruff.flake8-import-conventions.extend-aliases]
 scipy = ""  # don't import scipy directly
-"scipy.integrate" = "spint"
-"scipy.io" = "spio"
 "scipy.linalg" = "spla"
-"scipy.optimize" = "spopt"
-"scipy.sparse.linalg" = "spsla"
-"scipy.sparse" = "sps"
-"scipy.special" = "spsp"
-"scipy.stats" = "spst"
 
 [tool.ruff.flake8-quotes]
 inline-quotes = "single"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -257,6 +257,8 @@ ignore = [
 # N806 same for variables in function
 
 [tool.ruff.flake8-import-conventions]
+banned-from = ["numpy.linalg"]
+
 [tool.ruff.flake8-import-conventions.extend-aliases]
 scipy = ""  # don't import scipy directly
 "scipy.integrate" = "spint"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -258,7 +258,15 @@ ignore = [
 
 [tool.ruff.flake8-import-conventions]
 [tool.ruff.flake8-import-conventions.extend-aliases]
+scipy = ""  # don't import scipy directly
+"scipy.integrate" = "spint"
+"scipy.io" = "spio"
 "scipy.linalg" = "spla"
+"scipy.optimize" = "spopt"
+"scipy.sparse.linalg" = "spsla"
+"scipy.sparse" = "sps"
+"scipy.special" = "spsp"
+"scipy.stats" = "spst"
 
 [tool.ruff.flake8-quotes]
 inline-quotes = "single"

--- a/src/pymor/algorithms/basic.py
+++ b/src/pymor/algorithms/basic.py
@@ -5,7 +5,7 @@
 """Module containing some basic but generic linear algebra algorithms."""
 
 import numpy as np
-import scipy
+import scipy.linalg as spla
 
 from pymor.core.defaults import defaults
 from pymor.tools.floatcmp import float_cmp
@@ -92,7 +92,7 @@ def project_array(U, basis, product=None, orthonormal=True):
     else:
         gramian = basis.gramian(product)
         rhs = basis.inner(U, product)
-        coeffs = scipy.linalg.solve(gramian, rhs, assume_a='pos', overwrite_a=True, overwrite_b=True).T
+        coeffs = spla.solve(gramian, rhs, assume_a='pos', overwrite_a=True, overwrite_b=True).T
         return basis.lincomb(coeffs)
 
 

--- a/src/pymor/algorithms/ei.py
+++ b/src/pymor/algorithms/ei.py
@@ -14,7 +14,7 @@ a single function call.
 """
 
 import numpy as np
-from scipy.linalg import solve
+import scipy.linalg as spla
 
 from pymor.algorithms.pod import pod as pod_alg
 from pymor.analyticalproblems.functions import EmpiricalInterpolatedFunction, Function
@@ -167,7 +167,7 @@ def ei_greedy(U, error_norm=None, atol=None, rtol=None, max_interpolation_dofs=N
 
     if nodal_basis:
         logger.info('Building nodal basis.')
-        inv_interpolation_matrix = np.linalg.inv(interpolation_matrix)
+        inv_interpolation_matrix = spla.inv(interpolation_matrix)
         collateral_basis = collateral_basis.lincomb(inv_interpolation_matrix.T)
         coefficients = inv_interpolation_matrix.T @ coefficients
         interpolation_matrix = np.eye(len(collateral_basis))
@@ -238,8 +238,8 @@ def deim(U, modes=None, pod=True, atol=None, rtol=None, product=None, pod_option
         logger.info(f'Choosing interpolation point for basis vector {i}.')
 
         if len(interpolation_dofs) > 0:
-            coefficients = solve(interpolation_matrix,
-                                 collateral_basis[i].dofs(interpolation_dofs).T).T
+            coefficients = spla.solve(interpolation_matrix,
+                                      collateral_basis[i].dofs(interpolation_dofs).T).T
             U_interpolated = collateral_basis[:len(interpolation_dofs)].lincomb(coefficients)
             ERR = collateral_basis[i] - U_interpolated
         else:
@@ -518,7 +518,7 @@ def _parallel_ei_greedy(U, pool, error_norm=None, atol=None, rtol=None, max_inte
 
     if nodal_basis:
         logger.info('Building nodal basis.')
-        inv_interpolation_matrix = np.linalg.inv(interpolation_matrix)
+        inv_interpolation_matrix = spla.inv(interpolation_matrix)
         collateral_basis = collateral_basis.lincomb(inv_interpolation_matrix.T)
         coefficients = inv_interpolation_matrix.T @ coefficients
         interpolation_matrix = np.eye(len(collateral_basis))

--- a/src/pymor/algorithms/eigs.py
+++ b/src/pymor/algorithms/eigs.py
@@ -246,10 +246,10 @@ def _qr_iteration(H, shifts, complex_evp=False):
     while i < len(shifts) - 1:
         s = shifts[i]
         if not complex_evp and shifts[i].imag != 0:
-            Q, _ = np.linalg.qr(H @ H - 2 * s.real * H + np.abs(s)**2 * np.eye(len(H)))
+            Q, _ = spla.qr(H @ H - 2 * s.real * H + np.abs(s)**2 * np.eye(len(H)))
             i += 2
         else:
-            Q, _ = np.linalg.qr(H - s * np.eye(len(H)))
+            Q, _ = spla.qr(H - s * np.eye(len(H)))
             i += 1
         Qs = Qs @ Q
         H = Q.T @ H @ Q

--- a/src/pymor/algorithms/lrradi.py
+++ b/src/pymor/algorithms/lrradi.py
@@ -154,9 +154,9 @@ def solve_ricc_lrcf(A, E, B, C, R=None, S=None, trans=False, options=None):
             Yt = np.eye(len(C)) - (VB @ VB.T) / (2 * shifts[j_shift].real)
             Y = spla.block_diag(Y, Yt)
             if not trans:
-                EVYt = E.apply(V).lincomb(np.linalg.inv(Yt))
+                EVYt = E.apply(V).lincomb(spla.inv(Yt))
             else:
-                EVYt = E.apply_adjoint(V).lincomb(np.linalg.inv(Yt))
+                EVYt = E.apply_adjoint(V).lincomb(spla.inv(Yt))
             RF.axpy(np.sqrt(-2*shifts[j_shift].real), EVYt)
             K += EVYt.lincomb(VB.T)
             j += 1
@@ -184,9 +184,9 @@ def solve_ricc_lrcf(A, E, B, C, R=None, S=None, trans=False, options=None):
                 - (F3 @ F3.T) / 2
             Y = spla.block_diag(Y, Yt)
             if not trans:
-                EVYt = E.apply(cat_arrays([V.real, V.imag])).lincomb(np.linalg.inv(Yt))
+                EVYt = E.apply(cat_arrays([V.real, V.imag])).lincomb(spla.inv(Yt))
             else:
-                EVYt = E.apply_adjoint(cat_arrays([V.real, V.imag])).lincomb(np.linalg.inv(Yt))
+                EVYt = E.apply_adjoint(cat_arrays([V.real, V.imag])).lincomb(spla.inv(Yt))
             RF.axpy(np.sqrt(-2 * shifts[j_shift].real), EVYt[:len(C)])
             K += EVYt.lincomb(F2.T)
             j += 2

--- a/src/pymor/algorithms/rand_la.py
+++ b/src/pymor/algorithms/rand_la.py
@@ -3,8 +3,7 @@
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
 import numpy as np
-import scipy as sp
-from scipy.linalg import lu_factor, lu_solve
+from scipy.linalg import eigh, lu_factor, lu_solve, svd
 from scipy.sparse.linalg import LinearOperator, eigsh
 from scipy.special import erfinv
 
@@ -242,7 +241,7 @@ def random_generalized_svd(A, range_product=None, source_product=None, modes=6, 
     Q = rrf(A, source_product=source_product, range_product=range_product, q=q, l=modes+p)
     B = A.apply_adjoint(range_product.apply(Q))
     Q_B, R_B = gram_schmidt(source_product.apply_inverse(B), product=source_product, return_R=True)
-    U_b, s, Vh_b = sp.linalg.svd(R_B.T, full_matrices=False)
+    U_b, s, Vh_b = svd(R_B.T, full_matrices=False)
 
     with logger.block(f'Computing generalized left-singular vectors ({modes} vectors) ...'):
         U = Q.lincomb(U_b.T)
@@ -332,7 +331,7 @@ def random_ghep(A, E=None, modes=6, p=20, q=2, single_pass=False):
         Q = gram_schmidt(Y, product=E)
         T = A.apply2(Q, Q)
 
-    w, S = sp.linalg.eigh(T)
+    w, S = eigh(T)
     w = w[::-1]
     S = S[:, ::-1]
 

--- a/src/pymor/models/examples.py
+++ b/src/pymor/models/examples.py
@@ -3,6 +3,7 @@
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
 import numpy as np
+import scipy.linalg as spla
 
 
 def thermal_block_example():
@@ -142,7 +143,7 @@ def msd_example(n=6, m=2, m_i=4, k_i=4, c_i=1, as_lti=False):
         A[2 * i - 1, 2 * i - 2] = -2 * k_i
         A[2 * i - 1, 2 * i - 4] = k_i
 
-    Q = np.linalg.solve(J - R, A)
+    Q = spla.solve(J - R, A)
     G = B
     P = np.zeros(G.shape)
     D = np.zeros((m, m))

--- a/src/pymor/operators/constructions.py
+++ b/src/pymor/operators/constructions.py
@@ -830,11 +830,11 @@ class VectorArrayOperator(Operator):
 
         Q, R = gram_schmidt(self.array, return_R=True, reiterate=False)
         if self.adjoint:
-            v = np.linalg.lstsq(R.T.conj(), V.to_numpy().T, rcond=None)[0]
+            v = spla.lstsq(R.T.conj(), V.to_numpy().T)[0]
             U = Q.lincomb(v.T)
         else:
             v = Q.inner(V)
-            u = np.linalg.lstsq(R, v, rcond=None)[0]
+            u = spla.lstsq(R, v)[0]
             U = self.source.make_array(u.T)
 
         return U

--- a/src/pymor/operators/constructions.py
+++ b/src/pymor/operators/constructions.py
@@ -826,17 +826,15 @@ class VectorArrayOperator(Operator):
         if not least_squares and len(self.array) != self.array.dim:
             raise InversionError
 
-        from numpy.linalg import lstsq
-
         from pymor.algorithms.gram_schmidt import gram_schmidt
 
         Q, R = gram_schmidt(self.array, return_R=True, reiterate=False)
         if self.adjoint:
-            v = lstsq(R.T.conj(), V.to_numpy().T, rcond=None)[0]
+            v = np.linalg.lstsq(R.T.conj(), V.to_numpy().T, rcond=None)[0]
             U = Q.lincomb(v.T)
         else:
             v = Q.inner(V)
-            u = lstsq(R, v, rcond=None)[0]
+            u = np.linalg.lstsq(R, v, rcond=None)[0]
             U = self.source.make_array(u.T)
 
         return U

--- a/src/pymor/operators/numpy.py
+++ b/src/pymor/operators/numpy.py
@@ -18,7 +18,7 @@ This module provides the following |NumPy|-based |Operators|:
 from functools import reduce
 
 import numpy as np
-import scipy.sparse
+import scipy.sparse as sps
 from numpy.fft import fft, ifft, irfft, rfft
 from scipy.io import mmwrite, savemat
 from scipy.linalg import lu_factor, lu_solve
@@ -384,9 +384,9 @@ class NumpyMatrixOperator(NumpyMatrixBasedOperator):
                 identity_shift = identity_shift.real
             if operators[0].sparse:
                 try:
-                    matrix += (scipy.sparse.eye(matrix.shape[0]) * identity_shift)
+                    matrix += (sps.eye(matrix.shape[0]) * identity_shift)
                 except NotImplementedError:
-                    matrix = matrix + (scipy.sparse.eye(matrix.shape[0]) * identity_shift)
+                    matrix = matrix + (sps.eye(matrix.shape[0]) * identity_shift)
             else:
                 matrix += (np.eye(matrix.shape[0]) * identity_shift)
 

--- a/src/pymor/operators/numpy.py
+++ b/src/pymor/operators/numpy.py
@@ -328,7 +328,7 @@ class NumpyMatrixOperator(NumpyMatrixBasedOperator):
             else:
                 if not hasattr(self, '_lu_factor'):
                     try:
-                        self._lu_factor = lu_factor(self.matrix)
+                        self._lu_factor = lu_factor(self.matrix, check_finite=check_finite)
                     except np.linalg.LinAlgError as e:
                         raise InversionError(f'{str(type(e))}: {str(e)}') from e
                     gecon = get_lapack_funcs('gecon', self._lu_factor)
@@ -336,7 +336,7 @@ class NumpyMatrixOperator(NumpyMatrixBasedOperator):
                     if rcond < np.finfo(np.float64).eps:
                         self.logger.warning(f'Ill-conditioned matrix (rcond={rcond:.6g}) in apply_inverse: '
                                             'result may not be accurate.')
-                R = lu_solve(self._lu_factor, V.to_numpy().T).T
+                R = lu_solve(self._lu_factor, V.to_numpy().T, check_finite=check_finite).T
 
             if check_finite:
                 if not np.isfinite(np.sum(R)):

--- a/src/pymor/operators/numpy.py
+++ b/src/pymor/operators/numpy.py
@@ -18,6 +18,7 @@ This module provides the following |NumPy|-based |Operators|:
 from functools import reduce
 
 import numpy as np
+import scipy.linalg as spla
 import scipy.sparse as sps
 from numpy.fft import fft, ifft, irfft, rfft
 from scipy.io import mmwrite, savemat
@@ -320,7 +321,7 @@ class NumpyMatrixOperator(NumpyMatrixBasedOperator):
         else:
             if least_squares:
                 try:
-                    R, _, _, _ = np.linalg.lstsq(self.matrix, V.to_numpy().T, rcond=None)
+                    R, _, _, _ = spla.lstsq(self.matrix, V.to_numpy().T)
                 except np.linalg.LinAlgError as e:
                     raise InversionError(f'{str(type(e))}: {str(e)}') from e
                 R = R.T

--- a/src/pymor/operators/numpy.py
+++ b/src/pymor/operators/numpy.py
@@ -171,6 +171,12 @@ class NumpyMatrixBasedOperator(Operator):
 class NumpyMatrixOperator(NumpyMatrixBasedOperator):
     """Wraps a 2D |NumPy Array| or |SciPy spmatrix| as an |Operator|.
 
+    .. note::
+        In the case of a |NumPy array|, the `apply_inverse` method by default
+        uses `check_finite=True` and `check_cond=True`.
+        Setting them to `False` (e.g., via `defaults`) can significantly speed
+        up the computation, especially for smaller matrices.
+
     Parameters
     ----------
     matrix
@@ -273,7 +279,7 @@ class NumpyMatrixOperator(NumpyMatrixBasedOperator):
         check_finite
             Test if solution only contains finite values.
         check_cond
-            Check condition number.
+            Check condition number in case the matrix is a |NumPy array|.
         default_sparse_solver_backend
             Default sparse solver backend to use (scipy, generic).
 

--- a/src/pymor/operators/numpy.py
+++ b/src/pymor/operators/numpy.py
@@ -19,7 +19,7 @@ from functools import reduce
 
 import numpy as np
 import scipy.linalg as spla
-import scipy.sparse as sps
+import scipy.sparse
 from numpy.fft import fft, ifft, irfft, rfft
 from scipy.io import mmwrite, savemat
 from scipy.linalg import lu_factor, lu_solve
@@ -388,9 +388,9 @@ class NumpyMatrixOperator(NumpyMatrixBasedOperator):
                 identity_shift = identity_shift.real
             if operators[0].sparse:
                 try:
-                    matrix += (sps.eye(matrix.shape[0]) * identity_shift)
+                    matrix += (scipy.sparse.eye(matrix.shape[0]) * identity_shift)
                 except NotImplementedError:
-                    matrix = matrix + (sps.eye(matrix.shape[0]) * identity_shift)
+                    matrix = matrix + (scipy.sparse.eye(matrix.shape[0]) * identity_shift)
             else:
                 matrix += (np.eye(matrix.shape[0]) * identity_shift)
 

--- a/src/pymor/reductors/spectral_factor.py
+++ b/src/pymor/reductors/spectral_factor.py
@@ -3,6 +3,7 @@
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
 import numpy as np
+import scipy.linalg as spla
 
 from pymor.algorithms.lyapunov import _chol, solve_cont_lyap_dense
 from pymor.algorithms.to_matrix import to_matrix
@@ -110,7 +111,7 @@ class SpectralFactorReductor(BasicObject):
         C = to_matrix(self.fom.C, format='dense')
         D = to_matrix(self.fom.D, format='dense')
         M = _chol(D + D.T).T
-        L = np.linalg.solve(M.T, C - B.T @ X @ E)
+        L = spla.solve(M.T, C - B.T @ X @ E)
 
         if compute_errors:
             A = to_matrix(self.fom.A, format='dense')

--- a/src/pymortests/algorithms/rand_la.py
+++ b/src/pymortests/algorithms/rand_la.py
@@ -4,7 +4,7 @@
 
 import numpy as np
 import pytest
-import scipy as sp
+import scipy.linalg as spla
 from numpy.random import uniform
 
 from pymor.algorithms.rand_la import adaptive_rrf, random_generalized_svd, random_ghep, rrf
@@ -70,7 +70,7 @@ def test_random_generalized_svd():
 
     modes = 3
     U, s, Vh = random_generalized_svd(E_op, modes=modes, p=1)
-    U_real, s_real, Vh_real = sp.linalg.svd(E)
+    U_real, s_real, Vh_real = spla.svd(E)
 
     assert abs(np.linalg.norm(s-s_real[:modes])) <= 1e-2
     assert len(U) == modes
@@ -88,7 +88,7 @@ def test_random_ghep():
     modes = 3
     w1, V1 = random_ghep(D_op, modes=modes, p=1, single_pass=False)
     w2, V2 = random_ghep(D_op, modes=modes, p=1, single_pass=True)
-    w_real, V_real = sp.linalg.eigh(D)
+    w_real, V_real = spla.eigh(D)
     w_real = w_real[::-1]
     V_real = V_real[:, ::-1]
 

--- a/src/pymortests/operators/operators.py
+++ b/src/pymortests/operators/operators.py
@@ -512,7 +512,7 @@ def test_vectorarray_op_apply_inverse_lstsq():
     V = op.range.random()
     U = op.apply_inverse(V, least_squares=True)
     v = V.to_numpy()
-    u = np.linalg.lstsq(O.T, v.ravel(), rcond=None)[0]
+    u = spla.lstsq(O.T, v.ravel())[0]
     assert np.all(almost_equal(U, U.space.from_numpy(u)))
 
 
@@ -523,7 +523,7 @@ def test_adjoint_vectorarray_op_apply_inverse_lstsq():
     V = op.range.random()
     U = op.apply_inverse(V, least_squares=True)
     v = V.to_numpy()
-    u = np.linalg.lstsq(O, v.ravel(), rcond=None)[0]
+    u = spla.lstsq(O, v.ravel())[0]
     assert np.all(almost_equal(U, U.space.from_numpy(u)))
 
 

--- a/src/pymortests/operators/operators.py
+++ b/src/pymortests/operators/operators.py
@@ -4,6 +4,7 @@
 
 import numpy as np
 import pytest
+import scipy.linalg as spla
 
 from pymor.algorithms.basic import almost_equal
 from pymor.algorithms.projection import project
@@ -500,7 +501,7 @@ def test_vectorarray_op_apply_inverse():
     V = op.range.random()
     U = op.apply_inverse(V)
     v = V.to_numpy()
-    u = np.linalg.solve(O.T, v.ravel())
+    u = spla.solve(O.T, v.ravel())
     assert np.all(almost_equal(U, U.space.from_numpy(u), rtol=1e-10))
 
 

--- a/src/pymortests/reductors/spectral_factor.py
+++ b/src/pymortests/reductors/spectral_factor.py
@@ -4,6 +4,7 @@
 
 import numpy as np
 import pytest
+import scipy.linalg as spla
 
 from pymor.models.iosys import LTIModel
 from pymor.reductors.h2 import IRKAReductor
@@ -20,7 +21,7 @@ def test_spectral_factor():
 
     Z = fom.gramian('pr_o_lrcf').to_numpy()
     X = Z.T@Z
-    assert np.all(np.linalg.eigvals(X) > 0), 'Passive FOM expected.'
+    assert np.all(spla.eigvals(X) > 0), 'Passive FOM expected.'
 
     spectralFactor = SpectralFactorReductor(fom)
 
@@ -33,7 +34,7 @@ def test_spectral_factor():
     rom = rom.with_(solver_options={'ricc_pos_lrcf': 'slycot'})
     Z2 = rom.gramian('pr_o_lrcf').to_numpy()
     X2 = Z2.T@Z2
-    assert np.all(np.linalg.eigvals(X2) > 0), 'Passive ROM expected.'
+    assert np.all(spla.eigvals(X2) > 0), 'Passive ROM expected.'
 
 def test_spectral_factor_invertible_D_assertion():
     R = np.array([[1, 0], [0, 2]])

--- a/src/pymortests/vectorarray.py
+++ b/src/pymortests/vectorarray.py
@@ -205,12 +205,12 @@ def test_random_normal(vector_array, realizations, loc, scale):
     try:
         x = v.to_numpy()
         assert x.shape == (c, v.dim)
-        import scipy.stats as spst
+        import scipy.stats
         n = x.size
         if n == 0:
             return
         # test for expected value
-        norm = spst.norm()
+        norm = scipy.stats.norm()
         gamma = 1 - 1e-7
         alpha = 1 - gamma
         lower = np.sum(x)/n - norm.ppf(1 - alpha/2) * scale / np.sqrt(n)

--- a/src/pymortests/vectorarray.py
+++ b/src/pymortests/vectorarray.py
@@ -205,12 +205,12 @@ def test_random_normal(vector_array, realizations, loc, scale):
     try:
         x = v.to_numpy()
         assert x.shape == (c, v.dim)
-        import scipy.stats
+        import scipy.stats as spst
         n = x.size
         if n == 0:
             return
         # test for expected value
-        norm = scipy.stats.norm()
+        norm = spst.norm()
         gamma = 1 - 1e-7
         alpha = 1 - gamma
         lower = np.sum(x)/n - norm.ppf(1 - alpha/2) * scale / np.sqrt(n)


### PR DESCRIPTION
Closes #1052.

Since #1603, `NumpyMatrixOperator` caches the LU factorization and checks the condition number. To enable faster `apply_inverse`, especially for small matrices, this PR adds `check_finite` and `check_cond` default in `NumpyMatrixOperator.apply_inverse`.

Regarding the choice between NumPy and SciPy linalg routines, it seems that SciPy is used predominantly (see the two `grep`s below, which was enabled by forbidding `import scipy` and `from numpy.linalg import`). Therefore, this PR replaces NumPy's `solve`, `lstsq`, `inv`, `qr`, `eigvals` by SciPy's (in `src/`).

---

`NumpyMatrixOperator` uses `lu_factor` and `lu_solve`.

Places where `numpy.linalg.solve` is used:

```console
$ grep -rn 'np.linalg.solve(' src/
src/pymortests/operators/operators.py:503:    u = np.linalg.solve(O.T, v.ravel())
src/pymor/reductors/spectral_factor.py:113:        L = np.linalg.solve(M.T, C - B.T @ X @ E)
src/pymordemos/phlti.py:114:    Q = np.linalg.solve(J - R, A)
```

Places where `scipy.linalg.solve` is used:

```console
$ grep -rn 'spla.solve(' src/
src/pymortests/algorithms/riccati.py:65:        quadratic = quadratic @ spla.solve(R, quadratic.T)
src/pymortests/algorithms/to_matrix.py:116:    assert_type_and_allclose(spla.solve(S, A.T.dot(R)), Aadj, 'dense')
src/pymortests/algorithms/to_matrix.py:122:    assert_type_and_allclose(spla.solve(S, A.T.dot(R)), Aadj, 'dense')
src/pymortests/algorithms/to_matrix.py:128:    assert_type_and_allclose(spla.solve(S, A.T.dot(R)), Aadj, 'dense')
src/pymortests/algorithms/to_matrix.py:134:    assert_type_and_allclose(spla.solve(S, A.T.dot(R)), Aadj, 'sparse')
src/pymortests/algorithms/to_matrix.py:229:    assert_type_and_allclose(L @ spla.solve(C, R.T), LR, 'dense')
src/pymortests/operators/block.py:92:    assert np.allclose(spla.solve(C, v), w)
src/pymortests/operators/block.py:112:    assert np.allclose(spla.solve(C.T, v), w)
src/pymortests/operators/low_rank_op.py:40:                       L.to_numpy().T @ spla.solve(C, R.to_numpy() @ U.to_numpy().T))
src/pymortests/operators/low_rank_op.py:53:                       R.to_numpy().T @ spla.solve(C.T, L.to_numpy() @ V.to_numpy().T))
src/pymortests/operators/low_rank_op.py:63:    assert np.allclose(U.to_numpy().T, spla.solve(mat, V.to_numpy().T))
src/pymortests/operators/low_rank_op.py:68:    mat = A.matrix + L.to_numpy().T @ spla.solve(C, R.to_numpy())
src/pymortests/operators/low_rank_op.py:69:    assert np.allclose(U.to_numpy().T, spla.solve(mat, V.to_numpy().T))
src/pymortests/operators/low_rank_op.py:79:    assert np.allclose(V.to_numpy().T, spla.solve(mat.T, U.to_numpy().T))
src/pymortests/operators/low_rank_op.py:84:    mat = A.matrix + L.to_numpy().T @ spla.solve(C, R.to_numpy())
src/pymortests/operators/low_rank_op.py:85:    assert np.allclose(V.to_numpy().T, spla.solve(mat.T, U.to_numpy().T))
src/pymor/reductors/sobt.py:382:            W1TV1invW1TV2 = spla.solve(self.W1.inner(self.V1), self.W1.inner(self.V2))
src/pymor/reductors/h2.py:789:        b = spla.solve(EX, B)
src/pymor/algorithms/lrradi.py:148:            ImBNKL = spla.solve(ImBN, B.inner(L))
src/pymor/algorithms/basic.py:95:        coeffs = spla.solve(gramian, rhs, assume_a='pos', overwrite_a=True, overwrite_b=True).T
src/pymor/algorithms/to_matrix.py:126:                res = spla.solve(source_product, res)
src/pymor/algorithms/to_matrix.py:183:            res = op.left.to_numpy().T @ spla.solve(op.core, op.right.to_numpy())
src/pymor/operators/constructions.py:499:            V = spla.solve(self.core, V)
src/pymor/operators/constructions.py:508:            U = spla.solve(self.core.T.conj(), U)
src/pymor/operators/constructions.py:572:        U.axpy(-beta, AinvL.lincomb(spla.solve(mat, RhAinvV).T))
src/pymor/operators/constructions.py:590:        V.axpy(-beta, AinvhR.lincomb(spla.solve(mat, LhAinvhU).T))
src/pymor/bindings/pymess.py:499:        RinvC = spla.solve(R, C) if R is not None else C
src/pymor/bindings/pymess.py:502:        RinvBT = spla.solve(R, B.T) if R is not None else B.T
src/pymor/bindings/slycot.py:239:                G = B @ spla.solve(R, B.T)
src/pymor/bindings/slycot.py:246:                G = C.T @ spla.solve(R, C)
src/pymor/models/iosys.py:3121:    b = spla.solve(EX, B)
$ grep -rn 'from scipy.linalg import.*solve' src/
src/pymor/algorithms/ei.py:17:from scipy.linalg import solve
src/pymor/analyticalproblems/functions.py:8:from scipy.linalg import solve, solve_triangular
src/pymor/operators/numpy.py:24:from scipy.linalg import lu_factor, lu_solve
src/pymor/operators/ei.py:8:from scipy.linalg import solve, solve_triangular
src/pymor/bindings/scipy.py:7:from scipy.linalg import solve, solve_continuous_are, solve_continuous_lyapunov, solve_discrete_lyapunov
```