### PR TITLE
Add missing argument docstring in PHLTI Demo

### DIFF
--- a/src/pymordemos/phlti.py
+++ b/src/pymordemos/phlti.py
@@ -26,6 +26,8 @@ def msd(n=6, m=2, m_i=4, k_i=4, c_i=1, as_lti=False):
     ----------
     n
         The order of the model.
+    m
+        The number or inputs and outputs of the model.
     m_i
         The weight of the masses.
     k_i


### PR DESCRIPTION
The MSD model in the PHLTI demo so far does not document the parameter `m` in the docstring of `msd`, but just in the arguments of `main`.