### PR TITLE
`Operator`-valued functions in `FactorizedTransferFunction`

### DIFF
--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -46,6 +46,7 @@ from pymor.operators.constructions import (
 )
 from pymor.operators.numpy import NumpyMatrixOperator
 from pymor.parameters.base import Mu, Parameters
+from pymor.parameters.functionals import ProjectionParameterFunctional
 from pymor.vectorarrays.block import BlockVectorSpace
 from pymor.vectorarrays.interface import VectorArray
 
@@ -225,15 +226,17 @@ class LTIModel(Model):
         self.solution_space = A.source
         self.dim_output = C.range.dim
 
-        K = lambda s: s * self.E - self.A
-        B = lambda s: self.B
-        C = lambda s: self.C
-        D = lambda s: self.D
-        dK = lambda s: self.E
-        dB = lambda s: ZeroOperator(self.B.range, self.B.source)
-        dC = lambda s: ZeroOperator(self.C.range, self.C.source)
-        dD = lambda s: ZeroOperator(self.D.range, self.D.source)
-        parameters = Parameters.of(self.A, self.B, self.C, self.D, self.E)
+        parameters = Parameters.of(self.A, self.B, self.C, self.D, self.E) | Mu({'s': 1}).parameters
+        s_func = ProjectionParameterFunctional('s')
+
+        K = s_func * self.E - self.A
+        B = self.B
+        C = self.C
+        D = self.D
+        dK = self.E
+        dB = ZeroOperator(self.B.range, self.B.source)
+        dC = ZeroOperator(self.C.range, self.C.source)
+        dD = ZeroOperator(self.D.range, self.D.source)
 
         self.transfer_function = FactorizedTransferFunction(
             self.dim_input, self.dim_output,

--- a/src/pymor/models/transfer_function.py
+++ b/src/pymor/models/transfer_function.py
@@ -554,13 +554,12 @@ class FactorizedTransferFunction(TransferFunction):
     """
 
     def __init__(self, dim_input, dim_output, K, B, C, D, dK=None, dB=None, dC=None, dD=None,
-                 parameters={'s': 1}, sampling_time=0, name=None):
+                 parameters={}, sampling_time=0, name=None):
         def tf(s, mu=None):
-            if mu is None:
-                mu = Mu({
-                    's': [s],
-                    **{ key: np.zeros(dim) for key, dim in parameters.items() }
-                })
+            mu = Mu({
+                's': [s],
+                **{ key: np.zeros(dim) for key, dim in parameters.items() }
+            })
             if dim_input <= dim_output:
                 B_vec = B.as_range_array(mu=mu)
                 Kinv_B = K.apply_inverse(B_vec, mu=mu)
@@ -576,11 +575,10 @@ class FactorizedTransferFunction(TransferFunction):
             dtf = None
         else:
             def dtf(s, mu=None):
-                if mu is None:
-                    mu = Mu({
-                        's': [s],
-                        **{ key: np.zeros(dim) for key, dim in parameters.items() }
-                    })
+                mu = Mu({
+                    's': [s],
+                    **{ key: np.zeros(dim) for key, dim in parameters.items() }
+                })
                 if dim_input <= dim_output:
                     B_vec = B.as_range_array(mu=mu)
                     Ki_B = K.apply_inverse(B_vec, mu=mu)

--- a/src/pymor/models/transfer_function.py
+++ b/src/pymor/models/transfer_function.py
@@ -556,10 +556,7 @@ class FactorizedTransferFunction(TransferFunction):
     def __init__(self, dim_input, dim_output, K, B, C, D, dK=None, dB=None, dC=None, dD=None,
                  parameters={}, sampling_time=0, name=None):
         def tf(s, mu=None):
-            mu = Mu({
-                's': [s],
-                **{ key: np.zeros(dim) for key, dim in parameters.items() }
-            })
+            mu = Mu({'s': [s]}) if mu is None else  Mu({'s': [s], **mu})
             if dim_input <= dim_output:
                 B_vec = B.as_range_array(mu=mu)
                 Kinv_B = K.apply_inverse(B_vec, mu=mu)

--- a/src/pymor/models/transfer_function.py
+++ b/src/pymor/models/transfer_function.py
@@ -556,7 +556,7 @@ class FactorizedTransferFunction(TransferFunction):
     def __init__(self, dim_input, dim_output, K, B, C, D, dK=None, dB=None, dC=None, dD=None,
                  parameters={}, sampling_time=0, name=None):
         def tf(s, mu=None):
-            mu = Mu({'s': [s]}) if mu is None else  Mu({'s': [s], **mu})
+            mu = Mu({'s': [s]}) if mu is None else mu.with_(s=s)
             if dim_input <= dim_output:
                 B_vec = B.as_range_array(mu=mu)
                 Kinv_B = K.apply_inverse(B_vec, mu=mu)
@@ -572,10 +572,7 @@ class FactorizedTransferFunction(TransferFunction):
             dtf = None
         else:
             def dtf(s, mu=None):
-                mu = Mu({
-                    's': [s],
-                    **{ key: np.zeros(dim) for key, dim in parameters.items() }
-                })
+                mu = Mu({'s': [s]}) if mu is None else mu.with_(s=s)
                 if dim_input <= dim_output:
                     B_vec = B.as_range_array(mu=mu)
                     Ki_B = K.apply_inverse(B_vec, mu=mu)

--- a/src/pymor/reductors/interpolation.py
+++ b/src/pymor/reductors/interpolation.py
@@ -68,16 +68,32 @@ class GenericBHIReductor(BasicObject):
         self._product = None
 
     def _B_apply(self, s, V):
-        return self.fom.transfer_function.B(s).apply(V, mu=self.mu)
+        mu = Mu({
+            's': [s],
+            **self.mu
+        })
+        return self.fom.transfer_function.B.apply(V, mu=mu)
 
     def _C_apply_adjoint(self, s, V):
-        return self.fom.transfer_function.C(s).apply_adjoint(V, mu=self.mu)
+        mu = Mu({
+            's': [s],
+            **self.mu
+        })
+        return self.fom.transfer_function.C.apply_adjoint(V, mu=mu)
 
     def _K_apply_inverse(self, s, V):
-        return self.fom.transfer_function.K(s).apply_inverse(V, mu=self.mu)
+        mu = Mu({
+            's': [s],
+            **self.mu
+        })
+        return self.fom.transfer_function.K.apply_inverse(V, mu=mu)
 
     def _K_apply_inverse_adjoint(self, s, V):
-        return self.fom.transfer_function.K(s).apply_inverse_adjoint(V, mu=self.mu)
+        mu = Mu({
+            's': [s],
+            **self.mu
+        })
+        return self.fom.transfer_function.K.apply_inverse_adjoint(V, mu=mu)
 
     @abstractmethod
     def _fom_assemble(self):

--- a/src/pymor/reductors/interpolation.py
+++ b/src/pymor/reductors/interpolation.py
@@ -68,10 +68,7 @@ class GenericBHIReductor(BasicObject):
         self._product = None
 
     def _B_apply(self, s, V):
-        mu = Mu({
-            's': [s],
-            **self.mu
-        })
+        mu = Mu({'s': [s], **self.mu})
         return self.fom.transfer_function.B.apply(V, mu=mu)
 
     def _C_apply_adjoint(self, s, V):

--- a/src/pymor/reductors/interpolation.py
+++ b/src/pymor/reductors/interpolation.py
@@ -68,28 +68,19 @@ class GenericBHIReductor(BasicObject):
         self._product = None
 
     def _B_apply(self, s, V):
-        mu = Mu({'s': [s], **self.mu})
+        mu = self.mu.with_(s=s)
         return self.fom.transfer_function.B.apply(V, mu=mu)
 
     def _C_apply_adjoint(self, s, V):
-        mu = Mu({
-            's': [s],
-            **self.mu
-        })
+        mu = self.mu.with_(s=s)
         return self.fom.transfer_function.C.apply_adjoint(V, mu=mu)
 
     def _K_apply_inverse(self, s, V):
-        mu = Mu({
-            's': [s],
-            **self.mu
-        })
+        mu = self.mu.with_(s=s)
         return self.fom.transfer_function.K.apply_inverse(V, mu=mu)
 
     def _K_apply_inverse_adjoint(self, s, V):
-        mu = Mu({
-            's': [s],
-            **self.mu
-        })
+        mu = self.mu.with_(s=s)
         return self.fom.transfer_function.K.apply_inverse_adjoint(V, mu=mu)
 
     @abstractmethod

--- a/src/pymortests/models/iosys_add_sub_mul.py
+++ b/src/pymortests/models/iosys_add_sub_mul.py
@@ -85,18 +85,19 @@ def get_model(name, sampling_time, parametric):
             dH = lambda s, mu: np.array([[-1 / (s + 1 + mu['mu'][0])**2]])
         return TransferFunction(1, 1, H, dH, sampling_time=sampling_time, parameters={'mu': 1} if parametric else {})
     elif name == 'FactorizedTransferFunction':
+        s = ProjectionParameterFunctional('s')
         if not parametric:
-            K = lambda s: NumpyMatrixOperator(np.array([[s + 1]]))
+            K = s * NumpyMatrixOperator(np.array([[1]])) + NumpyMatrixOperator(np.array([[1]]))
         else:
-            K = lambda s: (NumpyMatrixOperator(np.array([[s + 1]]))
-                           + ProjectionParameterFunctional('mu') * NumpyMatrixOperator(np.eye(1)))
-        B = lambda s: NumpyMatrixOperator(np.array([[1]]))
-        C = lambda s: NumpyMatrixOperator(np.array([[1]]))
-        D = lambda s: NumpyMatrixOperator(np.array([[1]]))
-        dK = lambda s: NumpyMatrixOperator(np.array([[1]]))
-        dB = lambda s: NumpyMatrixOperator(np.array([[0]]))
-        dC = lambda s: NumpyMatrixOperator(np.array([[0]]))
-        dD = lambda s: NumpyMatrixOperator(np.array([[0]]))
+            K = (s * NumpyMatrixOperator(np.array([[1]])) + NumpyMatrixOperator(np.array([[1]]))
+                 + ProjectionParameterFunctional('mu') * NumpyMatrixOperator(np.eye(1)))
+        B = NumpyMatrixOperator(np.array([[1]]))
+        C = NumpyMatrixOperator(np.array([[1]]))
+        D = NumpyMatrixOperator(np.array([[1]]))
+        dK = NumpyMatrixOperator(np.array([[1]]))
+        dB = NumpyMatrixOperator(np.array([[0]]))
+        dC = NumpyMatrixOperator(np.array([[0]]))
+        dD = NumpyMatrixOperator(np.array([[0]]))
         return FactorizedTransferFunction(1, 1, K, B, C, D, dK, dB, dC, dD, sampling_time=sampling_time,
                                           parameters={'mu': 1} if parametric else {})
 


### PR DESCRIPTION
This PR is a very crude proposal for #2122 I will continue working on this in the next few days.

Current problems:
- [x] LTI system matrices have to be initialized with `dtype=np.complex<size>` for the `FactorizedTransferFunction` to compute complex values.
- [x] No checks have been performed if complex-valued `ParameterFunctionals` mess up somewhere.
- [x] Not all systems in `pymor.models.iosys.py` are supported.
- [x] No tests have been updated.
- [x] Formatting may be off.
- [x] Parameter concatenation has been implemented using `Parameters` `__or__` operator. -> Is this correct?
- [x] Parameter creation for simple `s` value uses dictionary deconstruction.