### PR TITLE
Fix `return_fpeak` handling in `pymor.models.iosys`

### DIFF
--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -1184,11 +1184,19 @@ class LTIModel(Model):
         """
         if 'hinf_norm' in self.presets:
             hinf_norm = self.presets['hinf_norm']
+        elif not return_fpeak:
+            hinf_norm = self.linf_norm(mu=mu, ab13dd_equilibrate=ab13dd_equilibrate, tol=tol)
         else:
-            hinf_norm = self.linf_norm(mu=mu, return_fpeak=return_fpeak, ab13dd_equilibrate=ab13dd_equilibrate, tol=tol)
-        assert hinf_norm >= 0
+            hinf_norm, fpeak = self.linf_norm(
+                mu=mu, return_fpeak=return_fpeak, ab13dd_equilibrate=ab13dd_equilibrate, tol=tol
+            )
 
-        return hinf_norm
+        if return_fpeak:
+            assert isinstance(fpeak, Number) and hinf_norm >= 0
+            return hinf_norm, fpeak
+        else:
+            assert hinf_norm >= 0
+            return hinf_norm
 
     def hankel_norm(self, mu=None):
         """Compute the Hankel-norm of the |LTIModel|.

--- a/src/pymortests/models/iosys_norm.py
+++ b/src/pymortests/models/iosys_norm.py
@@ -1,0 +1,18 @@
+import pytest
+
+from pymortests.models.iosys_add_sub_mul import get_model
+
+
+@pytest.mark.parametrize('parametric', [False, True])
+def test_hinf_norm(parametric):
+    m = get_model('LTIModel', 0, parametric)
+
+    if parametric:
+        mu = m.parameters.parse([-1.])
+    else:
+        mu = None
+
+    hinf_norm = m.hinf_norm(mu=mu)
+    hinf_norm_f, fpeak = m.hinf_norm(mu=mu, return_fpeak=True)
+
+    assert hinf_norm == hinf_norm_f

--- a/src/pymortests/models/iosys_norm.py
+++ b/src/pymortests/models/iosys_norm.py
@@ -1,6 +1,12 @@
+# This file is part of the pyMOR project (https://www.pymor.org).
+# Copyright pyMOR developers and contributors. All rights reserved.
+# License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
+
 import pytest
 
 from pymortests.models.iosys_add_sub_mul import get_model
+
+pytestmark = pytest.mark.builtin
 
 
 @pytest.mark.parametrize('parametric', [False, True])


### PR DESCRIPTION
This is a proposed fix to issue #2133.