### PR TITLE
FAQs

### DIFF
--- a/docs/source/getting_started.md
+++ b/docs/source/getting_started.md
@@ -250,27 +250,6 @@ err_lti = fom_lti - rom_lti
 _ = err_lti.transfer_function.mag_plot(w)
 ```
 
-## Running Demo Scripts
-
-pyMOR ships several example scripts that showcase various features of the library.
-While many features are also covered in our {doc}`tutorials`, the demos are more extensive
-and often have various command-line flags which allow to run the script for different
-parameters or problems.
-All demos can be found in the [src/pymordemos](https://github.com/pymor/pymor/tree/main/src/pymordemos)
-directory of the source repository.
-
-The demo scripts can be launched directly from the source tree:
-
-```
-./thermalblock.py --plot-err --plot-solutions 3 2 3 32
-```
-
-or by using the `pymor-demo` script that is installed with pyMOR:
-
-```
-pymor-demo thermalblock --plot-err --plot-solutions 3 2 3 32
-```
-
 ## Learning More
 
 You can find more details on the above approaches,

--- a/docs/source/guide_demos.md
+++ b/docs/source/guide_demos.md
@@ -1,0 +1,20 @@
+# How to Run Demo Scripts?
+
+pyMOR ships several example scripts that showcase various features of the library.
+While many features are also covered in our {doc}`tutorials`, the demos are more extensive
+and often have various command-line flags which allow to run the script for different
+parameters or problems.
+All demos can be found in the [src/pymordemos](https://github.com/pymor/pymor/tree/main/src/pymordemos)
+directory of the source repository.
+
+The demo scripts can be launched directly from the source tree:
+
+```
+./thermalblock.py --plot-err --plot-solutions 3 2 3 32
+```
+
+or by using the `pymor-demo` script that is installed with pyMOR:
+
+```
+pymor-demo thermalblock --plot-err --plot-solutions 3 2 3 32
+```

--- a/docs/source/guide_numpyvectorarray.md
+++ b/docs/source/guide_numpyvectorarray.md
@@ -1,0 +1,51 @@
+---
+jupytext:
+  text_representation:
+   format_name: myst
+jupyter:
+  jupytext:
+    cell_metadata_filter: -all
+    formats: ipynb,myst
+    main_language: python
+    text_representation:
+      format_name: myst
+      extension: .md
+      format_version: '1.3'
+      jupytext_version: 1.11.2
+kernelspec:
+  display_name: Python 3
+  name: python3
+---
+
+```{code-cell}
+:load: myst_code_init.py
+:tags: [remove-cell]
+
+```
+
+# How to Convert NumPy Arrays to pyMOR VectorArrays?
+
+You may have a 2D NumPy array `X`,
+where rows correspond to high-dimensional snapshots,
+and you want to convert it to a {{VectorArray}}
+to be able to pass it to pyMOR's algorithms.
+
+As an example, let us use
+
+```{code-cell}
+import numpy as np
+X = np.ones((5, 100))
+X.shape
+```
+
+Then use the following to convert it to a pyMOR {{NumpyVectorArray}}:
+
+```{code-cell}
+from pymor.vectorarrays.numpy import NumpyVectorSpace
+V = NumpyVectorSpace.from_numpy(X)
+len(V), V.dim
+```
+
+In particular, note that {{VectorSpace}} subclasses
+(in this case, {{NumpyVectorSpace}})
+should be used to build {{VectorArrays}}.

--- a/docs/source/guides.md
+++ b/docs/source/guides.md
@@ -1,0 +1,5 @@
+# How-to Guides
+
+```{toctree}
+guide_demos
+```

--- a/docs/source/guides.md
+++ b/docs/source/guides.md
@@ -2,4 +2,5 @@
 
 ```{toctree}
 guide_demos
+guide_numpyvectorarray
 ```

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -13,6 +13,7 @@ from NumPy/SciPy to external partial differential equation solver packages.
 
 getting_started
 tutorials
+guides
 /autoapi/index
 technical_overview
 release_notes/all.rst

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -12,11 +12,11 @@ from NumPy/SciPy to external partial differential equation solver packages.
 :maxdepth: 6
 
 getting_started
-technical_overview
-environment
 tutorials
-release_notes/all.rst
-bibliography
-developer_docs
 /autoapi/index
+technical_overview
+release_notes/all.rst
+developer_docs
+environment
+bibliography
 ```

--- a/docs/source/tutorials.md
+++ b/docs/source/tutorials.md
@@ -1,4 +1,4 @@
-# pyMOR Tutorials
+# Tutorials
 
 ```{toctree}
 tutorial_builtin_discretizer


### PR DESCRIPTION
**This PR predates #2405 and may need to be updated to reflect the VectorArray interface changes in #2405.**

- adds two how-to guides (about running demos and converting NumPy arrays to `NumpyVectorArrays`)
- removes "running demos" section from Getting Started
- reorders docs sections
- renames "pyMOR Tutorials" to "Tutorials"