### PR TITLE
Vectorize orthonormalization steps in gram_schmidt

### DIFF
--- a/src/pymor/algorithms/gram_schmidt.py
+++ b/src/pymor/algorithms/gram_schmidt.py
@@ -122,6 +122,123 @@ def gram_schmidt(A, product=None, return_R=False, atol=1e-13, rtol=1e-13, offset
         return A
 
 
+@defaults('atol', 'rtol', 'reiterate', 'reiteration_threshold', 'check', 'check_tol')
+def gram_schmidt_vec(A, product=None, return_R=False, atol=1e-13, rtol=1e-13, offset=0,
+                     reiterate=True, reiteration_threshold=9e-1, check=True, check_tol=1e-3,
+                     copy=True):
+    """Orthonormalize a |VectorArray| using the modified Gram-Schmidt algorithm.
+
+    Parameters
+    ----------
+    A
+        The |VectorArray| which is to be orthonormalized.
+    product
+        The inner product |Operator| w.r.t. which to orthonormalize.
+        If `None`, the Euclidean product is used.
+    return_R
+        If `True`, the R matrix from QR decomposition is returned.
+    atol
+        Vectors of norm smaller than `atol` are removed from the array.
+    rtol
+        Relative tolerance used to detect linear dependent vectors
+        (which are then removed from the array).
+    offset
+        Assume that the first `offset` vectors are already orthonormal and start the
+        algorithm at the `offset + 1`-th vector.
+    reiterate
+        If `True`, orthonormalize again if the norm of the orthogonalized vector is
+        much smaller than the norm of the original vector.
+    reiteration_threshold
+        If `reiterate` is `True`, re-orthonormalize if the ratio between the norms of
+        the orthogonalized vector and the original vector is smaller than this value.
+    check
+        If `True`, check if the resulting |VectorArray| is really orthonormal.
+    check_tol
+        Tolerance for the check.
+    copy
+        If `True`, create a copy of `A` instead of modifying `A` in-place.
+
+    Returns
+    -------
+    Q
+        The orthonormalized |VectorArray|.
+    R
+        The upper-triangular/trapezoidal matrix (if `compute_R` is `True`).
+    """
+    logger = getLogger('pymor.algorithms.gram_schmidt.gram_schmidt')
+
+    if copy:
+        A = A.copy()
+
+    # main loop
+    R = np.eye(len(A))
+    remove = []  # indices of to be removed vectors
+    initial_norms = A.norm(product)
+    for i in range(offset, len(A)):
+        # first calculate norm
+        initial_norm = initial_norms[i]
+        norm = initial_norm if i == 0 else A[i].norm(product)[0]
+
+        if norm <= atol:
+            logger.info(f'Removing vector {i} of norm {initial_norm}')
+            remove.append(i)
+            continue
+
+        # If reiterate is True, reiterate as long as the norm of the vector changes
+        # strongly during orthogonalization (due to Andreas Buhr).
+        old_norm = initial_norm
+        while reiterate and norm < reiteration_threshold * old_norm:
+            logger.info(f'Orthonormalizing vector {i} again')
+            # orthogonalize again to all vectors left
+            for j in range(i):
+                if j in remove:
+                    continue
+                p = A[j].pairwise_inner(A[i], product)[0]
+                A[i].axpy(-p, A[j])
+                common_dtype = np.promote_types(R.dtype, type(p))
+                R = R.astype(common_dtype, copy=False)
+                R[j, i] += p
+
+            # calculate new norm
+            old_norm, norm = norm, A[i].norm(product)[0]
+
+            # remove vector if it got too small
+            if norm <= rtol * initial_norm:
+                logger.info(f'Removing linearly dependent vector {i}')
+                remove.append(i)
+                break
+
+        if i in remove:
+            continue
+
+        A[i].scal(1 / norm)
+        R[i, i] = norm
+
+        # orthogonalize all vectors to the right
+        p = A[i].inner(A[i+1:], product).ravel()
+        A[i+1:].axpy(-p, A[i])
+        common_dtype = np.promote_types(R.dtype, type(p))
+        R = R.astype(common_dtype, copy=False)
+        R[i, i+1:] += p
+
+    if remove:
+        del A[remove]
+        R = np.delete(R, remove, axis=0)
+
+    if check:
+        error_matrix = A[offset:len(A)].inner(A, product)
+        error_matrix[:len(A) - offset, offset:len(A)] -= np.eye(len(A) - offset)
+        if error_matrix.size > 0:
+            err = np.max(np.abs(error_matrix))
+            if err >= check_tol:
+                raise AccuracyError(f'result not orthogonal (max err={err})')
+
+    if return_R:
+        return A, R
+    else:
+        return A
+
+
 def gram_schmidt_biorth(V, W, product=None,
                         reiterate=True, reiteration_threshold=1e-1, check=True, check_tol=1e-3,
                         copy=True):


### PR DESCRIPTION
This refactors the `gram_schmidt` algorithm to orthonormalize all vectors to the right in a single vectorized operation. Depending on the use case, this can lead to significant speedup for `VectorArrays` like `NumpyVectorArrays` that support efficient vectorized operations.