### PR TITLE
Ensure that notebook for getting_started.md is built

### DIFF
--- a/docs/source/getting_started.md
+++ b/docs/source/getting_started.md
@@ -286,3 +286,7 @@ Should you have any problems regarding pyMOR, questions or
 do not hesitate to contact us via
 [GitHub discussions](https://github.com/pymor/pymor/discussions)
 or [email](mailto:main.developers@pymor.org)!
+
+Download the code:
+{download}`getting_started.md`
+{nb-download}`getting_started.ipynb`


### PR DESCRIPTION
Without the download links added in this PR, the jupyter notebook for `getting_started.md` isn't built, which causes the binder link to fail.