### PR TITLE
Remove unneeded metaclass features

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -16,7 +16,6 @@ if sphinx.__version__ < '3.4':
     raise RuntimeError('Sphinx 3.4 or newer required')
 
 needs_sphinx = '3.4'
-os.environ['PYMOR_WITH_SPHINX'] = '1'
 os.environ['PYBIND11_DIR'] = sysconfig.get_path('purelib')
 
 # -----------------------------------------------------------------------------

--- a/docs/source/environment.md
+++ b/docs/source/environment.md
@@ -54,8 +54,3 @@ is unset the value of `mpi4py.rc.finalize` remains unchanged, unless
 ```{envvar} PYMOR_MPI_INIT_THREAD
 Required threading level to require when pyMOR calls `mpi4py.MPI.Init_thread`.
 ```
-
-```{envvar} PYMOR_WITH_SPHINX
-This variable is set to `1` during API documentation generation
-using Sphinx.
-```

--- a/src/pymor/core/base.py
+++ b/src/pymor/core/base.py
@@ -264,11 +264,6 @@ class ImmutableMeta(UberMeta):
 
         c = UberMeta.__new__(cls, classname, bases, classdict)
 
-        c._implements_reduce = ('__reduce__' in classdict
-                                or '__reduce_ex__' in classdict
-                                or any(getattr(base, '_implements_reduce', False)
-                                       for base in bases))
-
         # set __signature__ attribute on newly created class c to ensure that
         # inspect.signature(c) returns the signature of its __init__ arguments and not
         # the signature of ImmutableMeta.__call__

--- a/src/pymor/core/base.py
+++ b/src/pymor/core/base.py
@@ -50,16 +50,13 @@ functionality:
 
 import abc
 import inspect
-import os
 import uuid
 from functools import wraps
-from types import FunctionType
 
 from pymor.core import logger
 from pymor.core.exceptions import ConstError
 from pymor.tools.formatrepr import _format_generic, format_repr
 
-DONT_COPY_DOCSTRINGS = int(os.environ.get('PYMOR_WITH_SPHINX', 0)) == 1
 NoneType = type(None)
 
 
@@ -95,29 +92,9 @@ class UberMeta(abc.ABCMeta):
         abc.ABCMeta.__init__(cls, name, bases, namespace)
 
     def __new__(cls, classname, bases, classdict):
-        """I copy docstrings from base class methods to deriving classes.
-
-        Copying of docstrings is disabled when the `PYMOR_WITH_SPHINX` environment
-        variable is set to `1`.
-        """
         for attr in ('_init_arguments', '_init_defaults'):
             if attr in classdict:
                 raise ValueError(attr + ' is a reserved class attribute for subclasses of BasicObject')
-
-        for attr, item in classdict.items():
-            if isinstance(item, FunctionType):
-                # first copy docs
-                base_doc = None
-                for base in bases:
-                    base_func = getattr(base, item.__name__, None)
-                    if not DONT_COPY_DOCSTRINGS:
-                        if base_func:
-                            base_doc = getattr(base_func, '__doc__', None)
-                        if base_doc:
-                            doc = getattr(item, '__doc__', '')
-                            if doc is not None:
-                                base_doc = doc
-                            item.__doc__ = base_doc
 
         def __auto_init(self, locals_):
             """Automatically assign __init__ arguments.


### PR DESCRIPTION
- Remove the unused `_implements_reduce` attribute of `ImmutableObjects`
- Do not copy method docstrings from base classes anymore. `help` and IPython's `?` nowadays automatically show to base class docstring.
- Remove `PYMOR_WITH_SPHINX` environment variable, which was only used to disable the copying of docstrings.