### PR TITLE
Fix NumPy scalar conversion DeprecationWarning in ParabolicRBEstimator

### DIFF
--- a/src/pymor/reductors/parabolic.py
+++ b/src/pymor/reductors/parabolic.py
@@ -122,7 +122,7 @@ class ParabolicRBEstimator(ImmutableObject):
             for n in range(1, m.time_stepper.nt + 1):
                 t += dt
                 mu = mu.with_(t=t)
-                est[n] = self.residual.apply(U[n], U[n-1], mu=mu).norm2()
+                est[n] = self.residual.apply(U[n], U[n-1], mu=mu).norm2()[0]
         else:
             est[1:] = self.residual.apply(U[1:], U[:-1], mu=mu).norm2()
         est[1:] *= (dt/C**2)


### PR DESCRIPTION
To check the change, run, e.g.,

```bash
python -W always parabolic_mor.py pymor greedy 2 3 1
```

Edit: this happens with NumPy 1.25.