### PR TITLE
Unindent dictionary key listings to avoid confusion with quotes

### DIFF
--- a/src/pymor/algorithms/adaptivegreedy.py
+++ b/src/pymor/algorithms/adaptivegreedy.py
@@ -67,16 +67,25 @@ def adaptive_weak_greedy(surrogate, parameter_space, target_error=None, max_exte
 
     Returns
     -------
-    Dict with the following fields:
+    data
+        Dict with the following fields:
 
-    :extensions:             Number of greedy iterations.
-    :max_errs:               Sequence of maximum errors during the greedy run.
-    :max_err_mus:            The parameters corresponding to `max_errs`.
-    :max_val_errs:           Sequence of maximum errors on the validation set.
-    :max_val_err_mus:        The parameters corresponding to `max_val_errs`.
-    :refinements:            Number of refinements made in each extension step.
-    :training_set_sizes:     The final size of the training set in each extension step.
-    :time:                   Duration of the algorithm.
+        :extensions:
+            Number of greedy iterations.
+        :max_errs:
+            Sequence of maximum errors during the greedy run.
+        :max_err_mus:
+            The parameters corresponding to `max_errs`.
+        :max_val_errs:
+            Sequence of maximum errors on the validation set.
+        :max_val_err_mus:
+            The parameters corresponding to `max_val_errs`.
+        :refinements:
+            Number of refinements made in each extension step.
+        :training_set_sizes:
+            The final size of the training set in each extension step.
+        :time:
+            Duration of the algorithm.
     """
     logger = getLogger('pymor.algorithms.adaptivegreedy.adaptive_weak_greedy')
 
@@ -272,18 +281,27 @@ def rb_adaptive_greedy(fom, reductor, parameter_space,
 
     Returns
     -------
-    Dict with the following fields:
+    data
+        Dict with the following fields:
 
-    :rom:                    The reduced |Model| obtained for the
-                                computed basis.
-    :extensions:             Number of greedy iterations.
-    :max_errs:               Sequence of maximum errors during the greedy run.
-    :max_err_mus:            The parameters corresponding to `max_errs`.
-    :max_val_errs:           Sequence of maximum errors on the validation set.
-    :max_val_err_mus:        The parameters corresponding to `max_val_errs`.
-    :refinements:            Number of refinements made in each extension step.
-    :training_set_sizes:     The final size of the training set in each extension step.
-    :time:                   Duration of the algorithm.
+        :rom:
+            The reduced |Model| obtained for the computed basis.
+        :extensions:
+            Number of greedy iterations.
+        :max_errs:
+            Sequence of maximum errors during the greedy run.
+        :max_err_mus:
+            The parameters corresponding to `max_errs`.
+        :max_val_errs:
+            Sequence of maximum errors on the validation set.
+        :max_val_err_mus:
+            The parameters corresponding to `max_val_errs`.
+        :refinements:
+            Number of refinements made in each extension step.
+        :training_set_sizes:
+            The final size of the training set in each extension step.
+        :time:
+            Duration of the algorithm.
     """
     surrogate = RBSurrogate(fom, reductor, use_error_estimator, error_norm, extension_params, pool or dummy_pool)
 

--- a/src/pymor/algorithms/adaptivegreedy.py
+++ b/src/pymor/algorithms/adaptivegreedy.py
@@ -69,14 +69,14 @@ def adaptive_weak_greedy(surrogate, parameter_space, target_error=None, max_exte
     -------
     Dict with the following fields:
 
-        :extensions:             Number of greedy iterations.
-        :max_errs:               Sequence of maximum errors during the greedy run.
-        :max_err_mus:            The parameters corresponding to `max_errs`.
-        :max_val_errs:           Sequence of maximum errors on the validation set.
-        :max_val_err_mus:        The parameters corresponding to `max_val_errs`.
-        :refinements:            Number of refinements made in each extension step.
-        :training_set_sizes:     The final size of the training set in each extension step.
-        :time:                   Duration of the algorithm.
+    :extensions:             Number of greedy iterations.
+    :max_errs:               Sequence of maximum errors during the greedy run.
+    :max_err_mus:            The parameters corresponding to `max_errs`.
+    :max_val_errs:           Sequence of maximum errors on the validation set.
+    :max_val_err_mus:        The parameters corresponding to `max_val_errs`.
+    :refinements:            Number of refinements made in each extension step.
+    :training_set_sizes:     The final size of the training set in each extension step.
+    :time:                   Duration of the algorithm.
     """
     logger = getLogger('pymor.algorithms.adaptivegreedy.adaptive_weak_greedy')
 
@@ -274,16 +274,16 @@ def rb_adaptive_greedy(fom, reductor, parameter_space,
     -------
     Dict with the following fields:
 
-        :rom:                    The reduced |Model| obtained for the
-                                 computed basis.
-        :extensions:             Number of greedy iterations.
-        :max_errs:               Sequence of maximum errors during the greedy run.
-        :max_err_mus:            The parameters corresponding to `max_errs`.
-        :max_val_errs:           Sequence of maximum errors on the validation set.
-        :max_val_err_mus:        The parameters corresponding to `max_val_errs`.
-        :refinements:            Number of refinements made in each extension step.
-        :training_set_sizes:     The final size of the training set in each extension step.
-        :time:                   Duration of the algorithm.
+    :rom:                    The reduced |Model| obtained for the
+                                computed basis.
+    :extensions:             Number of greedy iterations.
+    :max_errs:               Sequence of maximum errors during the greedy run.
+    :max_err_mus:            The parameters corresponding to `max_errs`.
+    :max_val_errs:           Sequence of maximum errors on the validation set.
+    :max_val_err_mus:        The parameters corresponding to `max_val_errs`.
+    :refinements:            Number of refinements made in each extension step.
+    :training_set_sizes:     The final size of the training set in each extension step.
+    :time:                   Duration of the algorithm.
     """
     surrogate = RBSurrogate(fom, reductor, use_error_estimator, error_norm, extension_params, pool or dummy_pool)
 

--- a/src/pymor/algorithms/bfgs.py
+++ b/src/pymor/algorithms/bfgs.py
@@ -82,14 +82,14 @@ def error_aware_bfgs(model, parameter_space=None, initial_guess=None, miniter=0,
     data
         Dict containing the following fields:
 
-            :mus:                       `list` of |parameter values| after each iteration.
-            :foc_norms:                 |NumPy array| of the first order criticality norms
-                                        after each iteration.
-            :update_norms:              |NumPy array| of the norms of the update vectors
-                                        after each iteration.
-            :iterations:                Number of total BFGS iterations.
-            :line_search_iterations:    |NumPy array| of the number of line search
-                                        iterations per BFGS iteration.
+        :mus:                       `list` of |parameter values| after each iteration.
+        :foc_norms:                 |NumPy array| of the first order criticality norms
+                                    after each iteration.
+        :update_norms:              |NumPy array| of the norms of the update vectors
+                                    after each iteration.
+        :iterations:                Number of total BFGS iterations.
+        :line_search_iterations:    |NumPy array| of the number of line search
+                                    iterations per BFGS iteration.
 
     Raises
     ------

--- a/src/pymor/algorithms/bfgs.py
+++ b/src/pymor/algorithms/bfgs.py
@@ -82,14 +82,16 @@ def error_aware_bfgs(model, parameter_space=None, initial_guess=None, miniter=0,
     data
         Dict containing the following fields:
 
-        :mus:                       `list` of |parameter values| after each iteration.
-        :foc_norms:                 |NumPy array| of the first order criticality norms
-                                    after each iteration.
-        :update_norms:              |NumPy array| of the norms of the update vectors
-                                    after each iteration.
-        :iterations:                Number of total BFGS iterations.
-        :line_search_iterations:    |NumPy array| of the number of line search
-                                    iterations per BFGS iteration.
+        :mus:
+            `list` of |parameter values| after each iteration.
+        :foc_norms:
+            |NumPy array| of the first order criticality norms after each iteration.
+        :update_norms:
+            |NumPy array| of the norms of the update vectors after each iteration.
+        :iterations:
+            Number of total BFGS iterations.
+        :line_search_iterations:
+            |NumPy array| of the number of line search iterations per BFGS iteration.
 
     Raises
     ------

--- a/src/pymor/algorithms/ei.py
+++ b/src/pymor/algorithms/ei.py
@@ -71,15 +71,18 @@ def ei_greedy(U, error_norm=None, atol=None, rtol=None, max_interpolation_dofs=N
     data
         Dict containing the following fields:
 
-        :errors:                Sequence of maximum approximation errors during
-                                greedy search.
-        :triangularity_errors:  Sequence of maximum absolute values of interpolation
-                                matrix coefficients in the upper triangle (should
-                                be near zero).
-        :coefficients:          |NumPy array| of coefficients such that `collateral_basis`
-                                is given by `U.lincomb(coefficients)`.
-        :interpolation_matrix:  The interpolation matrix, i.e., the evaluation of
-                                `collateral_basis` at `interpolation_dofs`.
+        :errors:
+            Sequence of maximum approximation errors during greedy search.
+        :triangularity_errors:
+            Sequence of maximum absolute values of interpolation
+            matrix coefficients in the upper triangle (should
+            be near zero).
+        :coefficients:
+            |NumPy array| of coefficients such that `collateral_basis`
+            is given by `U.lincomb(coefficients)`.
+        :interpolation_matrix:
+            The interpolation matrix, i.e., the evaluation of
+            `collateral_basis` at `interpolation_dofs`.
     """
     assert not isinstance(error_norm, str) or error_norm == 'sup'
     if pool:  # dispatch to parallel implementation
@@ -212,7 +215,8 @@ def deim(U, modes=None, pod=True, atol=None, rtol=None, product=None, pod_option
     data
         Dict containing the following fields:
 
-        :svals: POD singular values.
+        :svals:
+            POD singular values.
     """
     assert isinstance(U, VectorArray)
 
@@ -312,8 +316,10 @@ def interpolate_operators(fom, operator_names, parameter_sample, error_norm=None
     data
         Dict containing the following fields:
 
-        :dofs:     |NumPy array| of the DOFs at which the |Operators| have to be evaluated.
-        :basis:    |VectorArray| containing the generated collateral basis.
+        :dofs:
+            |NumPy array| of the DOFs at which the |Operators| have to be evaluated.
+        :basis:
+            |VectorArray| containing the generated collateral basis.
 
         In addition, `data` contains the fields of the `data` `dict` returned by
         :func:`ei_greedy`/:func:`deim`.

--- a/src/pymor/algorithms/ei.py
+++ b/src/pymor/algorithms/ei.py
@@ -71,15 +71,15 @@ def ei_greedy(U, error_norm=None, atol=None, rtol=None, max_interpolation_dofs=N
     data
         Dict containing the following fields:
 
-            :errors:                Sequence of maximum approximation errors during
-                                    greedy search.
-            :triangularity_errors:  Sequence of maximum absolute values of interpolation
-                                    matrix coefficients in the upper triangle (should
-                                    be near zero).
-            :coefficients:          |NumPy array| of coefficients such that `collateral_basis`
-                                    is given by `U.lincomb(coefficients)`.
-            :interpolation_matrix:  The interpolation matrix, i.e., the evaluation of
-                                    `collateral_basis` at `interpolation_dofs`.
+        :errors:                Sequence of maximum approximation errors during
+                                greedy search.
+        :triangularity_errors:  Sequence of maximum absolute values of interpolation
+                                matrix coefficients in the upper triangle (should
+                                be near zero).
+        :coefficients:          |NumPy array| of coefficients such that `collateral_basis`
+                                is given by `U.lincomb(coefficients)`.
+        :interpolation_matrix:  The interpolation matrix, i.e., the evaluation of
+                                `collateral_basis` at `interpolation_dofs`.
     """
     assert not isinstance(error_norm, str) or error_norm == 'sup'
     if pool:  # dispatch to parallel implementation
@@ -212,7 +212,7 @@ def deim(U, modes=None, pod=True, atol=None, rtol=None, product=None, pod_option
     data
         Dict containing the following fields:
 
-            :svals: POD singular values.
+        :svals: POD singular values.
     """
     assert isinstance(U, VectorArray)
 
@@ -312,8 +312,8 @@ def interpolate_operators(fom, operator_names, parameter_sample, error_norm=None
     data
         Dict containing the following fields:
 
-            :dofs:     |NumPy array| of the DOFs at which the |Operators| have to be evaluated.
-            :basis:    |VectorArray| containing the generated collateral basis.
+        :dofs:     |NumPy array| of the DOFs at which the |Operators| have to be evaluated.
+        :basis:    |VectorArray| containing the generated collateral basis.
 
         In addition, `data` contains the fields of the `data` `dict` returned by
         :func:`ei_greedy`/:func:`deim`.

--- a/src/pymor/algorithms/error.py
+++ b/src/pymor/algorithms/error.py
@@ -79,55 +79,84 @@ def reduction_error_analysis(rom, fom, reductor, test_mus,
 
     Returns
     -------
-    Dict with the following fields:
+    data
+        Dict with the following fields:
 
-    :mus:                       The test |Parameters| which have been considered.
-    :basis_sizes:               The reduced basis dimensions which have been considered.
-    :norms:                     |Array| of the norms of the high-dimensional solutions
-                                w.r.t. all given test |Parameters| and norms in `error_norms`.
-                                (Only present when `error_norms` has been specified.)
-    :max_norms:                 Maxima of `norms` over the given test |Parameters|.
-    :max_norm_mus:              |Parameters| corresponding to `max_norms`.
-    :errors:                    |Array| of the norms of the model reduction errors
-                                w.r.t. all given test |Parameters|, reduced basis
-                                dimensions and norms in `error_norms`.
-                                (Only present when `error_norms` has been specified.)
-    :max_errors:                Maxima of `errors` over the given test |Parameters|.
-    :max_error_mus:             |Parameters| corresponding to `max_errors`.
-    :rel_errors:                `errors` divided by `norms`.
-                                (Only present when `error_norms` has been specified.)
-    :max_rel_errors:            Maxima of `rel_errors` over the given test |Parameters|.
-    :max_rel_error_mus:         |Parameters| corresponding to `max_rel_errors`.
-    :error_norm_names:          Names of the given `error_norms`.
-                                (Only present when `error_norms` has been specified.)
-    :error_estimates:           |Array| of the model reduction error estimates
-                                w.r.t. all given test |Parameters| and reduced basis
-                                dimensions.
-                                (Only present when `error_estimator` is `True`.)
-    :max_error_estimate:        Maxima of `error_estimates` over the given test |Parameters|.
-    :max_error_estimate_mus:    |Parameters| corresponding to `max_error_estimates`.
-    :effectivities:             `errors` divided by `error_estimates`.
-                                (Only present when `error_estimator` is `True` and `error_norms`
-                                has been specified.)
-    :min_effectivities:         Minima of `effectivities` over the given test |Parameters|.
-    :min_effectivity_mus:       |Parameters| corresponding to `min_effectivities`.
-    :max_effectivities:         Maxima of `effectivities` over the given test |Parameters|.
-    :max_effectivity_mus:       |Parameters| corresponding to `max_effectivities`.
-    :errors:                    |Array| of the reduced system matrix conditions
-                                w.r.t. all given test |Parameters| and reduced basis
-                                dimensions.
-                                (Only present when `conditions` is `True`.)
-    :max_conditions:            Maxima of `conditions` over the given test |Parameters|.
-    :max_condition_mus:         |Parameters| corresponding to `max_conditions`.
-    :custom_values:             |Array| of custom function evaluations
-                                w.r.t. all given test |Parameters|, reduced basis
-                                dimensions and functions in `custom`.
-                                (Only present when `custom` has been specified.)
-    :max_custom_values:         Maxima of `custom_values` over the given test |Parameters|.
-    :max_custom_values_mus:     |Parameters| corresponding to `max_custom_values`.
-    :time:                      Time (in seconds) needed for the error analysis.
-    :summary:                   String containing a summary of all computed quantities for
-                                the largest (last) considered basis size.
+        :mus:
+            The test |Parameters| which have been considered.
+        :basis_sizes:
+            The reduced basis dimensions which have been considered.
+        :norms:
+            |Array| of the norms of the high-dimensional solutions
+            w.r.t. all given test |Parameters| and norms in `error_norms`.
+            (Only present when `error_norms` has been specified.)
+        :max_norms:
+            Maxima of `norms` over the given test |Parameters|.
+        :max_norm_mus:
+            |Parameters| corresponding to `max_norms`.
+        :errors:
+            |Array| of the norms of the model reduction errors
+            w.r.t. all given test |Parameters|, reduced basis
+            dimensions and norms in `error_norms`.
+            (Only present when `error_norms` has been specified.)
+        :max_errors:
+            Maxima of `errors` over the given test |Parameters|.
+        :max_error_mus:
+            |Parameters| corresponding to `max_errors`.
+        :rel_errors:
+            `errors` divided by `norms`.
+            (Only present when `error_norms` has been specified.)
+        :max_rel_errors:
+            Maxima of `rel_errors` over the given test |Parameters|.
+        :max_rel_error_mus:
+            |Parameters| corresponding to `max_rel_errors`.
+        :error_norm_names:
+            Names of the given `error_norms`.
+            (Only present when `error_norms` has been specified.)
+        :error_estimates:
+            |Array| of the model reduction error estimates
+            w.r.t. all given test |Parameters| and reduced basis
+            dimensions.
+            (Only present when `error_estimator` is `True`.)
+        :max_error_estimate:
+            Maxima of `error_estimates` over the given test |Parameters|.
+        :max_error_estimate_mus:
+            |Parameters| corresponding to `max_error_estimates`.
+        :effectivities:
+            `errors` divided by `error_estimates`.
+            (Only present when `error_estimator` is `True` and `error_norms`
+            has been specified.)
+        :min_effectivities:
+            Minima of `effectivities` over the given test |Parameters|.
+        :min_effectivity_mus:
+            |Parameters| corresponding to `min_effectivities`.
+        :max_effectivities:
+            Maxima of `effectivities` over the given test |Parameters|.
+        :max_effectivity_mus:
+            |Parameters| corresponding to `max_effectivities`.
+        :errors:
+            |Array| of the reduced system matrix conditions
+            w.r.t. all given test |Parameters| and reduced basis
+            dimensions.
+            (Only present when `conditions` is `True`.)
+        :max_conditions:
+            Maxima of `conditions` over the given test |Parameters|.
+        :max_condition_mus:
+            |Parameters| corresponding to `max_conditions`.
+        :custom_values:
+            |Array| of custom function evaluations
+            w.r.t. all given test |Parameters|, reduced basis
+            dimensions and functions in `custom`.
+            (Only present when `custom` has been specified.)
+        :max_custom_values:
+            Maxima of `custom_values` over the given test |Parameters|.
+        :max_custom_values_mus:
+            |Parameters| corresponding to `max_custom_values`.
+        :time:
+            Time (in seconds) needed for the error analysis.
+        :summary:
+            String containing a summary of all computed quantities for
+            the largest (last) considered basis size.
     """
     assert not error_norms or (fom and reductor)
     assert error_norm_names is None or len(error_norm_names) == len(error_norms)

--- a/src/pymor/algorithms/error.py
+++ b/src/pymor/algorithms/error.py
@@ -81,80 +81,53 @@ def reduction_error_analysis(rom, fom, reductor, test_mus,
     -------
     Dict with the following fields:
 
-        :mus:                       The test |Parameters| which have been considered.
-
-        :basis_sizes:               The reduced basis dimensions which have been considered.
-
-        :norms:                     |Array| of the norms of the high-dimensional solutions
-                                    w.r.t. all given test |Parameters| and norms in `error_norms`.
-                                    (Only present when `error_norms` has been specified.)
-
-        :max_norms:                 Maxima of `norms` over the given test |Parameters|.
-
-        :max_norm_mus:              |Parameters| corresponding to `max_norms`.
-
-        :errors:                    |Array| of the norms of the model reduction errors
-                                    w.r.t. all given test |Parameters|, reduced basis
-                                    dimensions and norms in `error_norms`.
-                                    (Only present when `error_norms` has been specified.)
-
-        :max_errors:                Maxima of `errors` over the given test |Parameters|.
-
-        :max_error_mus:             |Parameters| corresponding to `max_errors`.
-
-        :rel_errors:                `errors` divided by `norms`.
-                                    (Only present when `error_norms` has been specified.)
-
-        :max_rel_errors:            Maxima of `rel_errors` over the given test |Parameters|.
-
-        :max_rel_error_mus:         |Parameters| corresponding to `max_rel_errors`.
-
-        :error_norm_names:          Names of the given `error_norms`.
-                                    (Only present when `error_norms` has been specified.)
-
-        :error_estimates:           |Array| of the model reduction error estimates
-                                    w.r.t. all given test |Parameters| and reduced basis
-                                    dimensions.
-                                    (Only present when `error_estimator` is `True`.)
-
-        :max_error_estimate:        Maxima of `error_estimates` over the given test |Parameters|.
-
-        :max_error_estimate_mus:    |Parameters| corresponding to `max_error_estimates`.
-
-        :effectivities:             `errors` divided by `error_estimates`.
-                                    (Only present when `error_estimator` is `True` and `error_norms`
-                                    has been specified.)
-
-        :min_effectivities:         Minima of `effectivities` over the given test |Parameters|.
-
-        :min_effectivity_mus:       |Parameters| corresponding to `min_effectivities`.
-
-        :max_effectivities:         Maxima of `effectivities` over the given test |Parameters|.
-
-        :max_effectivity_mus:       |Parameters| corresponding to `max_effectivities`.
-
-        :errors:                    |Array| of the reduced system matrix conditions
-                                    w.r.t. all given test |Parameters| and reduced basis
-                                    dimensions.
-                                    (Only present when `conditions` is `True`.)
-
-        :max_conditions:            Maxima of `conditions` over the given test |Parameters|.
-
-        :max_condition_mus:         |Parameters| corresponding to `max_conditions`.
-
-        :custom_values:             |Array| of custom function evaluations
-                                    w.r.t. all given test |Parameters|, reduced basis
-                                    dimensions and functions in `custom`.
-                                    (Only present when `custom` has been specified.)
-
-        :max_custom_values:         Maxima of `custom_values` over the given test |Parameters|.
-
-        :max_custom_values_mus:     |Parameters| corresponding to `max_custom_values`.
-
-        :time:                      Time (in seconds) needed for the error analysis.
-
-        :summary:                   String containing a summary of all computed quantities for
-                                    the largest (last) considered basis size.
+    :mus:                       The test |Parameters| which have been considered.
+    :basis_sizes:               The reduced basis dimensions which have been considered.
+    :norms:                     |Array| of the norms of the high-dimensional solutions
+                                w.r.t. all given test |Parameters| and norms in `error_norms`.
+                                (Only present when `error_norms` has been specified.)
+    :max_norms:                 Maxima of `norms` over the given test |Parameters|.
+    :max_norm_mus:              |Parameters| corresponding to `max_norms`.
+    :errors:                    |Array| of the norms of the model reduction errors
+                                w.r.t. all given test |Parameters|, reduced basis
+                                dimensions and norms in `error_norms`.
+                                (Only present when `error_norms` has been specified.)
+    :max_errors:                Maxima of `errors` over the given test |Parameters|.
+    :max_error_mus:             |Parameters| corresponding to `max_errors`.
+    :rel_errors:                `errors` divided by `norms`.
+                                (Only present when `error_norms` has been specified.)
+    :max_rel_errors:            Maxima of `rel_errors` over the given test |Parameters|.
+    :max_rel_error_mus:         |Parameters| corresponding to `max_rel_errors`.
+    :error_norm_names:          Names of the given `error_norms`.
+                                (Only present when `error_norms` has been specified.)
+    :error_estimates:           |Array| of the model reduction error estimates
+                                w.r.t. all given test |Parameters| and reduced basis
+                                dimensions.
+                                (Only present when `error_estimator` is `True`.)
+    :max_error_estimate:        Maxima of `error_estimates` over the given test |Parameters|.
+    :max_error_estimate_mus:    |Parameters| corresponding to `max_error_estimates`.
+    :effectivities:             `errors` divided by `error_estimates`.
+                                (Only present when `error_estimator` is `True` and `error_norms`
+                                has been specified.)
+    :min_effectivities:         Minima of `effectivities` over the given test |Parameters|.
+    :min_effectivity_mus:       |Parameters| corresponding to `min_effectivities`.
+    :max_effectivities:         Maxima of `effectivities` over the given test |Parameters|.
+    :max_effectivity_mus:       |Parameters| corresponding to `max_effectivities`.
+    :errors:                    |Array| of the reduced system matrix conditions
+                                w.r.t. all given test |Parameters| and reduced basis
+                                dimensions.
+                                (Only present when `conditions` is `True`.)
+    :max_conditions:            Maxima of `conditions` over the given test |Parameters|.
+    :max_condition_mus:         |Parameters| corresponding to `max_conditions`.
+    :custom_values:             |Array| of custom function evaluations
+                                w.r.t. all given test |Parameters|, reduced basis
+                                dimensions and functions in `custom`.
+                                (Only present when `custom` has been specified.)
+    :max_custom_values:         Maxima of `custom_values` over the given test |Parameters|.
+    :max_custom_values_mus:     |Parameters| corresponding to `max_custom_values`.
+    :time:                      Time (in seconds) needed for the error analysis.
+    :summary:                   String containing a summary of all computed quantities for
+                                the largest (last) considered basis size.
     """
     assert not error_norms or (fom and reductor)
     assert error_norm_names is None or len(error_norm_names) == len(error_norms)

--- a/src/pymor/algorithms/greedy.py
+++ b/src/pymor/algorithms/greedy.py
@@ -49,10 +49,10 @@ def weak_greedy(surrogate, training_set, atol=None, rtol=None, max_extensions=No
     -------
     Dict with the following fields:
 
-        :max_errs:               Sequence of maximum estimated errors during the greedy run.
-        :max_err_mus:            The parameters corresponding to `max_errs`.
-        :extensions:             Number of performed basis extensions.
-        :time:                   Total runtime of the algorithm.
+    :max_errs:               Sequence of maximum estimated errors during the greedy run.
+    :max_err_mus:            The parameters corresponding to `max_errs`.
+    :extensions:             Number of performed basis extensions.
+    :time:                   Total runtime of the algorithm.
     """
     logger = getLogger('pymor.algorithms.greedy.weak_greedy')
     training_set = list(training_set)
@@ -190,12 +190,12 @@ def rb_greedy(fom, reductor, training_set, use_error_estimator=True, error_norm=
     -------
     Dict with the following fields:
 
-        :rom:                    The reduced |Model| obtained for the
-                                 computed basis.
-        :max_errs:               Sequence of maximum errors during the greedy run.
-        :max_err_mus:            The parameters corresponding to `max_errs`.
-        :extensions:             Number of performed basis extensions.
-        :time:                   Total runtime of the algorithm.
+    :rom:                    The reduced |Model| obtained for the
+                                computed basis.
+    :max_errs:               Sequence of maximum errors during the greedy run.
+    :max_err_mus:            The parameters corresponding to `max_errs`.
+    :extensions:             Number of performed basis extensions.
+    :time:                   Total runtime of the algorithm.
     """
     surrogate = RBSurrogate(fom, reductor, use_error_estimator, error_norm, extension_params, pool or dummy_pool)
 

--- a/src/pymor/algorithms/greedy.py
+++ b/src/pymor/algorithms/greedy.py
@@ -47,12 +47,17 @@ def weak_greedy(surrogate, training_set, atol=None, rtol=None, max_extensions=No
 
     Returns
     -------
-    Dict with the following fields:
+    data
+        Dict with the following fields:
 
-    :max_errs:               Sequence of maximum estimated errors during the greedy run.
-    :max_err_mus:            The parameters corresponding to `max_errs`.
-    :extensions:             Number of performed basis extensions.
-    :time:                   Total runtime of the algorithm.
+        :max_errs:
+            Sequence of maximum estimated errors during the greedy run.
+        :max_err_mus:
+            The parameters corresponding to `max_errs`.
+        :extensions:
+            Number of performed basis extensions.
+        :time:
+            Total runtime of the algorithm.
     """
     logger = getLogger('pymor.algorithms.greedy.weak_greedy')
     training_set = list(training_set)
@@ -188,14 +193,19 @@ def rb_greedy(fom, reductor, training_set, use_error_estimator=True, error_norm=
 
     Returns
     -------
-    Dict with the following fields:
+    data
+        Dict with the following fields:
 
-    :rom:                    The reduced |Model| obtained for the
-                                computed basis.
-    :max_errs:               Sequence of maximum errors during the greedy run.
-    :max_err_mus:            The parameters corresponding to `max_errs`.
-    :extensions:             Number of performed basis extensions.
-    :time:                   Total runtime of the algorithm.
+        :rom:
+            The reduced |Model| obtained for the computed basis.
+        :max_errs:
+            Sequence of maximum errors during the greedy run.
+        :max_err_mus:
+            The parameters corresponding to `max_errs`.
+        :extensions:
+            Number of performed basis extensions.
+        :time:
+            Total runtime of the algorithm.
     """
     surrogate = RBSurrogate(fom, reductor, use_error_estimator, error_norm, extension_params, pool or dummy_pool)
 

--- a/src/pymor/algorithms/newton.py
+++ b/src/pymor/algorithms/newton.py
@@ -85,11 +85,16 @@ def newton(operator, rhs, initial_guess=None, mu=None, range_product=None, sourc
     data
         Dict containing the following fields:
 
-        :solution_norms:  |NumPy array| of the solution norms after each iteration.
-        :update_norms:    |NumPy array| of the norms of the update vectors for each iteration.
-        :residual_norms:  |NumPy array| of the residual norms after each iteration.
-        :stages:          See `return_stages`.
-        :residuals:       See `return_residuals`.
+        :solution_norms:
+            |NumPy array| of the solution norms after each iteration.
+        :update_norms:
+            |NumPy array| of the norms of the update vectors for each iteration.
+        :residual_norms:
+            |NumPy array| of the residual norms after each iteration.
+        :stages:
+            See `return_stages`.
+        :residuals:
+            See `return_residuals`.
 
     Raises
     ------

--- a/src/pymor/algorithms/newton.py
+++ b/src/pymor/algorithms/newton.py
@@ -85,11 +85,11 @@ def newton(operator, rhs, initial_guess=None, mu=None, range_product=None, sourc
     data
         Dict containing the following fields:
 
-            :solution_norms:  |NumPy array| of the solution norms after each iteration.
-            :update_norms:    |NumPy array| of the norms of the update vectors for each iteration.
-            :residual_norms:  |NumPy array| of the residual norms after each iteration.
-            :stages:          See `return_stages`.
-            :residuals:       See `return_residuals`.
+        :solution_norms:  |NumPy array| of the solution norms after each iteration.
+        :update_norms:    |NumPy array| of the norms of the update vectors for each iteration.
+        :residual_norms:  |NumPy array| of the residual norms after each iteration.
+        :stages:          See `return_stages`.
+        :residuals:       See `return_residuals`.
 
     Raises
     ------

--- a/src/pymor/analyticalproblems/elliptic.py
+++ b/src/pymor/analyticalproblems/elliptic.py
@@ -53,11 +53,12 @@ class StationaryProblem(ParametricObject):
         the corresponding coefficient function. Currently implemented `functional_types`
         are:
 
-            :l2:            Evaluate the l2-product with the given data function.
-            :l2_boundary:   Evaluate the l2-product with the given data function
-                            on the boundary.
-            :quadratic:     Evaluate the integral of the data function scaled by
-                            the squared solution (u, u).
+        :l2:
+            Evaluate the l2-product with the given data function.
+        :l2_boundary:
+            Evaluate the l2-product with the given data function on the boundary.
+        :quadratic:
+            Evaluate the integral of the data function scaled by the squared solution (u, u).
     parameter_ranges
         Ranges of interest for the |Parameters| of the problem.
     name

--- a/src/pymor/discretizers/builtin/cg.py
+++ b/src/pymor/discretizers/builtin/cg.py
@@ -978,10 +978,12 @@ def discretize_stationary_cg(analytical_problem, diameter=None, domain_discretiz
     data
         Dictionary with the following entries:
 
-            :grid:           The generated |Grid|.
-            :boundary_info:  The generated |BoundaryInfo|.
-            :unassembled_m:  In case `preassemble` is `True`, the generated |Model|
-                             before preassembling operators.
+        :grid:
+            The generated |Grid|.
+        :boundary_info:
+            The generated |BoundaryInfo|.
+        :unassembled_m:
+            In case `preassemble` is `True`, the generated |Model| before preassembling operators.
     """
     assert isinstance(analytical_problem, StationaryProblem)
     assert grid is None or boundary_info is not None
@@ -1276,10 +1278,12 @@ def discretize_instationary_cg(analytical_problem, diameter=None, domain_discret
     data
         Dictionary with the following entries:
 
-            :grid:           The generated |Grid|.
-            :boundary_info:  The generated |BoundaryInfo|.
-            :unassembled_m:  In case `preassemble` is `True`, the generated |Model|
-                             before preassembling operators.
+        :grid:
+            The generated |Grid|.
+        :boundary_info:
+            The generated |BoundaryInfo|.
+        :unassembled_m:
+            In case `preassemble` is `True`, the generated |Model| before preassembling operators.
     """
     assert isinstance(analytical_problem, InstationaryProblem)
     assert isinstance(analytical_problem.stationary_part, StationaryProblem)

--- a/src/pymor/discretizers/builtin/fv.py
+++ b/src/pymor/discretizers/builtin/fv.py
@@ -944,10 +944,12 @@ def discretize_stationary_fv(analytical_problem, diameter=None, domain_discretiz
     data
         Dictionary with the following entries:
 
-            :grid:           The generated |Grid|.
-            :boundary_info:  The generated |BoundaryInfo|.
-            :unassembled_m:  In case `preassemble` is `True`, the generated |Model|
-                             before preassembling operators.
+        :grid:
+            The generated |Grid|.
+        :boundary_info:
+            The generated |BoundaryInfo|.
+        :unassembled_m:
+            In case `preassemble` is `True`, the generated |Model| before preassembling operators.
     """
     assert isinstance(analytical_problem, StationaryProblem)
     assert grid is None or boundary_info is not None
@@ -1161,10 +1163,12 @@ def discretize_instationary_fv(analytical_problem, diameter=None, domain_discret
     data
         Dictionary with the following entries:
 
-            :grid:           The generated |Grid|.
-            :boundary_info:  The generated |BoundaryInfo|.
-            :unassembled_m:  In case `preassemble` is `True`, the generated |Model|
-                             before preassembling operators.
+        :grid:
+            The generated |Grid|.
+        :boundary_info:
+            The generated |BoundaryInfo|.
+        :unassembled_m:
+            In case `preassemble` is `True`, the generated |Model| before preassembling operators.
     """
     assert isinstance(analytical_problem, InstationaryProblem)
     assert isinstance(analytical_problem.stationary_part, StationaryProblem)

--- a/src/pymor/discretizers/fenics/cg.py
+++ b/src/pymor/discretizers/fenics/cg.py
@@ -40,12 +40,14 @@ def discretize_stationary_cg(analytical_problem, diameter=None, degree=1, preass
     data
         Dictionary with the following entries:
 
-            :mesh:             The generated dolfin mesh object.
-            :boundary_mask:    Codim-1 `MeshFunctionSizet` indicating which boundary type a
-                               boundary facet belongs to.
-            :boundary_ids:     Dict mapping boundary types to ids used in `boundary_mask`.
-            :unassembled_m:    In case `preassemble` is `True`, the generated |Model|
-                               before preassembling operators.
+        :mesh:
+            The generated dolfin mesh object.
+        :boundary_mask:
+            Codim-1 `MeshFunctionSizet` indicating which boundary type a boundary facet belongs to.
+        :boundary_ids:
+            Dict mapping boundary types to ids used in `boundary_mask`.
+        :unassembled_m:
+            In case `preassemble` is `True`, the generated |Model| before preassembling operators.
     """
     assert isinstance(analytical_problem, StationaryProblem)
 

--- a/src/pymor/discretizers/skfem/cg.py
+++ b/src/pymor/discretizers/skfem/cg.py
@@ -177,12 +177,16 @@ def discretize_stationary_cg(analytical_problem, diameter=None, mesh_type=None, 
     data
         Dictionary with the following entries:
 
-            :mesh:             The generated `skfem.Mesh`.
-            :basis:            The generated `skfem.Basis`.
-            :boundary_facets:  Dict of `boundary_facets` of `mesh` per boundary type.
-            :dirichlet_dofs:   DOFs of the `skfem.Basis` associated with the Dirichlet boundary.
-            :unassembled_m:    In case `preassemble` is `True`, the generated |Model|
-                               before preassembling operators.
+        :mesh:
+            The generated `skfem.Mesh`.
+        :basis:
+            The generated `skfem.Basis`.
+        :boundary_facets:
+            Dict of `boundary_facets` of `mesh` per boundary type.
+        :dirichlet_dofs:
+            DOFs of the `skfem.Basis` associated with the Dirichlet boundary.
+        :unassembled_m:
+            In case `preassemble` is `True`, the generated |Model| before preassembling operators.
     """
     assert isinstance(analytical_problem, StationaryProblem)
 


### PR DESCRIPTION
In [a discussion](https://github.com/pymor/pymor/pull/2027#discussion_r1288654992) for the PHDMD PR #2027, @pmli mentioned that the indentation for the dictionary key listings resemble quotes. To avoid this, I have unindented all the occurrences I am currently aware of. If there are any other docstrings where this occurs, please let me know.