### PR TITLE
shifted Cholesky QR algorithm

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -29,6 +29,8 @@ Linus Balicki <balicki@vt.edu> <linuxte@yahoo.de>
 Luca Mechelli <luca.mechelli@uni-konstanz.de>
 Lucas Camphausen <lucascamp@web.de>
 Magnus Ostertag <MagnusOstertag@users.noreply.github.com>
+Maximilian Bindhak <bindhak@mpi-magdeburg.mpg.de>
+Maximilian Bindhak <bindhak@mpi-magdeburg.mpg.de> <153179496+maxbindhak@users.noreply.github.com>
 Meret Behrens <mbehrens@mpi-magdeburg.mpg.de>
 Meret Behrens <mbehrens@mpi-magdeburg.mpg.de> <50019307+meretp@users.noreply.github.com>
 Mohamed Adel Naguib Ahmed <mohamedadel1551998@gmail.com>

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -11,6 +11,11 @@
 
 ## Contributors
 
+### pyMOR 2024.1
+
+* Art Pelling, a.pelling@tu-berlin.de
+  * shifted Cholesky-QR algorithm
+  
 ### pyMOR 2023.2
 
 * Steffen Müller, @steff-mueller

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -15,7 +15,10 @@
 
 * Art Pelling, a.pelling@tu-berlin.de
   * shifted Cholesky-QR algorithm
-  
+
+* Maximilian Bindhak, bindhak@mpi-magdeburg.mpg.de
+  * shifted Cholesky-QR algorithm
+
 ### pyMOR 2023.2
 
 * Steffen Müller, @steff-mueller

--- a/docs/source/bibliography.bib
+++ b/docs/source/bibliography.bib
@@ -253,7 +253,7 @@
 }
 
 @article{FKNYY20,
-  title         = {Shifted {{Cholesky QR}} for {{Computing}} the {{QR Factorization}} of {{Ill-Conditioned Matrices}}},
+  title         = {Shifted {C}holesky {QR} for Computing the {QR} Factorization of Ill-Conditioned Matrices},
   author        = {Fukaya, T. and Kannan, R. and Nakatsukasa, Y. and Yamamoto, Y. and Yanagisawa, Y.},
   year          = 2020,
   journal       = {SIAM Journal on Scientific Computing},

--- a/docs/source/bibliography.bib
+++ b/docs/source/bibliography.bib
@@ -252,6 +252,17 @@
   issue         = 37,
 }
 
+@article{FKNYY20,
+  title         = {Shifted {{Cholesky QR}} for {{Computing}} the {{QR Factorization}} of {{Ill-Conditioned Matrices}}},
+  author        = {Fukaya, T. and Kannan, R. and Nakatsukasa, Y. and Yamamoto, Y. and Yanagisawa, Y.},
+  year          = 2020,
+  journal       = {SIAM Journal on Scientific Computing},
+  volume        = 42,
+  number        = 1,
+  pages         = {477-503},
+  doi           = {10.1137/18M1218212},
+}
+
 @article{GA04,
   title         = {A survey of model reduction by balanced truncation and some new results},
   author        = {S. Gugercin and A. C. Antoulas},

--- a/docs/source/substitutions.py
+++ b/docs/source/substitutions.py
@@ -150,6 +150,7 @@ common = """
 .. |Array| replace:: :class:`NumPy array <numpy.ndarray>`
 
 .. |SciPy| replace:: :mod:`SciPy <scipy>`
+.. |SciPy linalg| replace:: :mod:`SciPy linalg <scipy.linalg>`
 .. |SciPy spmatrix| replace:: :class:`SciPy spmatrix <scipy.sparse.spmatrix>`
 .. |SciPy spmatrices| replace:: :class:`SciPy spmatrices <scipy.sparse.spmatrix>`
 .. |Scipy spmatrix| replace:: :class:`SciPy spmatrix <scipy.sparse.spmatrix>`

--- a/src/pymor/algorithms/chol_qr.py
+++ b/src/pymor/algorithms/chol_qr.py
@@ -93,6 +93,7 @@ def shifted_chol_qr(A, product=None, maxiter=3, offset=0, orth_tol=None, check_f
     iter = 1
     shift = None
     while iter <= maxiter:
+        shift = None
         with logger.block(f'Iteration {iter}'):
             # This will compute the Cholesky factor of the lower right block
             # and keep applying shifts if it breaks down.

--- a/src/pymor/algorithms/chol_qr.py
+++ b/src/pymor/algorithms/chol_qr.py
@@ -61,17 +61,20 @@ def shifted_chol_qr(A, product=None, maxiter=3, offset=0, orth_tol=None, check_f
     R
         The upper-triangular/trapezoidal matrix (if `compute_R` is `True`).
     """
-    assert 0 <= offset < len(A)
+    assert 0 <= offset <= len(A)
     assert 0 < maxiter
     assert orth_tol is None or 0 < orth_tol
+
+    if copy:
+        A = A.copy()
+
+    if len(A) == 0 or offset == len(A):
+        return A, np.eye(len(A))
 
     logger = getLogger('pymor.algorithms.chol_qr.shifted_chol_qr')
 
     if maxiter == 1:
         logger.warning('Single iteration shifted CholeskyQR can lead to poor orthogonality!')
-
-    if copy:
-        A = A.copy()
 
     B, X = np.split(A[offset:].inner(A, product=product), [offset], axis=1)
     B = B.conj()

--- a/src/pymor/algorithms/chol_qr.py
+++ b/src/pymor/algorithms/chol_qr.py
@@ -65,7 +65,7 @@ def shifted_chol_qr(A, product=None, maxiter=3, offset=0, orth_tol=None, check_f
     assert 0 < maxiter
     assert orth_tol is None or 0 < orth_tol
 
-    logger = getLogger('pymor.algorithms.cholesky_qr.shifted_chol_qr')
+    logger = getLogger('pymor.algorithms.chol_qr.shifted_chol_qr')
 
     if maxiter == 1:
         logger.warning('Single iteration shifted CholeskyQR can lead to poor orthogonality!')

--- a/src/pymor/algorithms/chol_qr.py
+++ b/src/pymor/algorithms/chol_qr.py
@@ -102,8 +102,8 @@ def shifted_chol_qr(A, product=None, maxiter=3, offset=0, orth_tol=None,
     else:
         if product_norm is None:
             from pymor.algorithms.eigs import eigs
-            product_norm = eigs(product, k=1)[0][0]
-        shift = (2*m*np.sqrt(m*n)+n*(n+1))*np.abs(product_norm)
+            product_norm = np.sqrt(np.abs(eigs(product, k=1)[0][0]))
+        shift *= (2*m*np.sqrt(m*n)+n*(n+1))*product_norm
         XX = A[offset:].gramian()
     try:
         shift *= spsla.eigsh(XX, k=1, tol=1e-2, return_eigenvectors=False)[0]

--- a/src/pymor/algorithms/chol_qr.py
+++ b/src/pymor/algorithms/chol_qr.py
@@ -117,7 +117,7 @@ def shifted_chol_qr(A, product=None, maxiter=3, offset=0, orth_tol=None, check_f
 
                         shift = 2*m*np.sqrt(m*n)+n*(n+1)*np.sqrt(np.abs(eig))
                         XX = A[offset:].gramian(product=product)
-                    shift *= 11*eps*spla.norm(XX, ord=2, check_finite=check_finite)
+                    shift *= 11*eps*spla.norm(XX, ord=2, check_finite=check_finite)**2
 
                 logger.info(f'Applying shift: {shift}')
                 idx = range(len(X))

--- a/src/pymor/algorithms/chol_qr.py
+++ b/src/pymor/algorithms/chol_qr.py
@@ -92,6 +92,7 @@ def shifted_chol_qr(A, product=None, maxiter=3, offset=0, orth_tol=None, check_f
 
     iter = 1
     shift = None
+    eig = None
     while iter <= maxiter:
         shift = None
         with logger.block(f'Iteration {iter}'):
@@ -111,7 +112,10 @@ def shifted_chol_qr(A, product=None, maxiter=3, offset=0, orth_tol=None, check_f
                         XX = X
                     else:
                         from pymor.algorithms.eigs import eigs
-                        shift = 2*m*np.sqrt(m*n)+n*(n+1)*np.sqrt(np.abs(eigs(product, k=1)[0][0]))
+                        if not eig:
+                            eig = eigs(product, k=1)[0][0]
+
+                        shift = 2*m*np.sqrt(m*n)+n*(n+1)*np.sqrt(np.abs(eig))
                         XX = A[offset:].gramian(product=product)
                     shift *= 11*eps*spla.norm(XX, ord=2, check_finite=check_finite)
 

--- a/src/pymor/algorithms/chol_qr.py
+++ b/src/pymor/algorithms/chol_qr.py
@@ -120,7 +120,7 @@ def shifted_chol_qr(A, product=None, maxiter=3, offset=0, orth_tol=None, check_f
                             from pymor.algorithms.eigs import eigs
                             eig = eigs(product, k=1)[0][0]
 
-                        shift = 2*m*np.sqrt(m*n)+n*(n+1)*np.sqrt(np.abs(eig))
+                        shift = 2*m*np.sqrt(m*n)+n*(n+1)*np.abs(eig)
                         XX = A[offset:].gramian(product=product)
                     shift *= 11*eps*spla.eigh(XX, eigvals_only=True, subset_by_index=[n-1, n-1], driver='evr')[0]**2
 

--- a/src/pymor/algorithms/chol_qr.py
+++ b/src/pymor/algorithms/chol_qr.py
@@ -122,7 +122,7 @@ def shifted_chol_qr(A, product=None, maxiter=3, offset=0, orth_tol=None, check_f
 
                         shift = 2*m*np.sqrt(m*n)+n*(n+1)*np.sqrt(np.abs(eig))
                         XX = A[offset:].gramian(product=product)
-                    shift *= 11*eps*spla.norm(XX, ord=2, check_finite=check_finite)**2
+                    shift *= 11*eps*spla.eigh(XX, eigvals_only=True, subset_by_index=[n-1, n-1], driver='evr')[0]**2
 
                 logger.info(f'Applying shift: {shift}')
                 idx = range(len(X))

--- a/src/pymor/algorithms/chol_qr.py
+++ b/src/pymor/algorithms/chol_qr.py
@@ -114,8 +114,8 @@ def shifted_chol_qr(A, product=None, maxiter=3, offset=0, orth_tol=None, check_f
                         shift = m*n+n*(n+1)
                         XX = X
                     else:
-                        from pymor.algorithms.eigs import eigs
                         if not eig:
+                            from pymor.algorithms.eigs import eigs
                             eig = eigs(product, k=1)[0][0]
 
                         shift = 2*m*np.sqrt(m*n)+n*(n+1)*np.sqrt(np.abs(eig))

--- a/src/pymor/algorithms/chol_qr.py
+++ b/src/pymor/algorithms/chol_qr.py
@@ -68,7 +68,10 @@ def shifted_chol_qr(A, product=None, maxiter=3, offset=0, orth_tol=None, check_f
     if copy:
         A = A.copy()
 
-    if len(A) == 0 or offset == len(A):
+    if len(A) == 0 or A.sup_norm().max() < 1e-16:
+        del A[:]
+        return A, np.eye(0)
+    elif offset == len(A):
         return A, np.eye(len(A))
 
     logger = getLogger('pymor.algorithms.chol_qr.shifted_chol_qr')

--- a/src/pymor/algorithms/chol_qr.py
+++ b/src/pymor/algorithms/chol_qr.py
@@ -96,7 +96,6 @@ def shifted_chol_qr(A, product=None, maxiter=3, offset=0, orth_tol=None, check_f
         xtrmm, xtrtri = spla.blas.ztrmm, spla.lapack.ztrtri
 
     iter = 1
-    shift = None
     eig = None
     while iter <= maxiter:
         shift = None
@@ -116,17 +115,16 @@ def shifted_chol_qr(A, product=None, maxiter=3, offset=0, orth_tol=None, check_f
                         shift = m*n+n*(n+1)
                         XX = X
                     else:
-                        if not eig:
+                        if eig is None:
                             from pymor.algorithms.eigs import eigs
                             eig = eigs(product, k=1)[0][0]
 
-                        shift = 2*m*np.sqrt(m*n)+n*(n+1)*np.abs(eig)
+                        shift = (2*m*np.sqrt(m*n)+n*(n+1))*np.abs(eig)
                         XX = A[offset:].gramian(product=product)
                     shift *= 11*eps*spla.eigh(XX, eigvals_only=True, subset_by_index=[n-1, n-1], driver='evr')[0]**2
 
                 logger.info(f'Applying shift: {shift}')
-                idx = range(len(X))
-                X[idx, idx] += shift
+                X[np.diag_indices_from(X)] += shift
 
             # orthogonalize
             Rinv = xtrtri(Rx)[0].T

--- a/src/pymor/algorithms/chol_qr.py
+++ b/src/pymor/algorithms/chol_qr.py
@@ -68,11 +68,13 @@ def shifted_chol_qr(A, product=None, maxiter=3, offset=0, orth_tol=None, check_f
     if copy:
         A = A.copy()
 
-    if len(A) == 0 or A.sup_norm().max() < 1e-16:
-        del A[:]
-        return A, np.eye(0)
-    elif offset == len(A):
+    if offset == len(A):
         return A, np.eye(len(A))
+    elif A.sup_norm().max() < 1e-16:
+        k = len(A)
+        del A[:]
+        R = np.empty([len(A), k])
+        return A, R
 
     logger = getLogger('pymor.algorithms.chol_qr.shifted_chol_qr')
 

--- a/src/pymor/algorithms/chol_qr.py
+++ b/src/pymor/algorithms/chol_qr.py
@@ -6,6 +6,7 @@ import numpy as np
 import scipy.linalg as spla
 import scipy.sparse.linalg as spsla
 
+from pymor.core.exceptions import AccuracyError
 from pymor.core.logger import getLogger
 
 
@@ -154,7 +155,7 @@ def shifted_chol_qr(A, product=None, maxiter=3, offset=0, orth_tol=None,
                 if res <= orth_tol*np.sqrt(len(A)):
                     break
                 elif iter == maxiter:
-                    logger.warning('Orthonormality could not be achieved within the given tolerance. \
+                    raise AccuracyError('Orthonormality could not be achieved within the given tolerance. \
                     Consider increasing maxiter.')
 
             iter += 1

--- a/src/pymor/algorithms/chol_qr.py
+++ b/src/pymor/algorithms/chol_qr.py
@@ -100,7 +100,7 @@ def shifted_chol_qr(A, product=None, maxiter=3, offset=0, orth_tol=None, check_f
             # and keep applying shifts if it breaks down.
             while True:
                 try:
-                    Rx = spla.cholesky(X, overwrite_a=True, check_finite=check_finite)
+                    Rx = spla.cholesky(X - B@B.T, overwrite_a=True, check_finite=check_finite)
                     break
                 except spla.LinAlgError:
                     pass

--- a/src/pymor/algorithms/chol_qr.py
+++ b/src/pymor/algorithms/chol_qr.py
@@ -76,11 +76,6 @@ def shifted_chol_qr(A, product=None, maxiter=3, offset=0, orth_tol=None,
 
     if offset == len(A):
         return A, np.eye(len(A))
-    elif A.sup_norm().max() < 1e-16:
-        k = len(A)
-        del A[:]
-        R = np.empty([len(A), k])
-        return A, R
 
     logger = getLogger('pymor.algorithms.chol_qr.shifted_chol_qr')
 
@@ -111,6 +106,7 @@ def shifted_chol_qr(A, product=None, maxiter=3, offset=0, orth_tol=None,
         logger.warning(f'ARPACK failed with: {e}')
         logger.info('Proceeding with dense solver.')
         shift *= spla.eigh(XX, eigvals_only=True, subset_by_index=[n-1, n-1], driver='evr')[0]
+    shift = max(shift, np.finfo(dtype).eps)  # ensure that shift is non-zero
 
     iter = 1
     while iter <= maxiter:

--- a/src/pymor/algorithms/chol_qr.py
+++ b/src/pymor/algorithms/chol_qr.py
@@ -114,11 +114,15 @@ def shifted_chol_qr(A, product=None, maxiter=3, offset=0, orth_tol=None,
             # This will compute the Cholesky factor of the lower right block
             # and keep applying shifts if it breaks down.
             X -= B@B.T
+            it = 0
             while True:
                 try:
                     Rx = spla.cholesky(X, overwrite_a=True, check_finite=check_finite)
                     break
                 except spla.LinAlgError:
+                    it += 1
+                    if it > 100:
+                        assert False
                     logger.warning('Cholesky factorization broke down! Matrix is ill-conditioned.')
                     logger.info(f'Applying shift: {shift}')
                     X[np.diag_indices_from(X)] += shift

--- a/src/pymor/algorithms/cholesky_qr.py
+++ b/src/pymor/algorithms/cholesky_qr.py
@@ -1,4 +1,6 @@
-#!/usr/bin/env python3
+# This file is part of the pyMOR project (https://www.pymor.org).
+# Copyright pyMOR developers and contributors. All rights reserved.
+# License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
 import numpy as np
 import scipy.linalg as spla

--- a/src/pymor/algorithms/cholesky_qr.py
+++ b/src/pymor/algorithms/cholesky_qr.py
@@ -91,22 +91,23 @@ def shifted_chol_qr(A, product=None, return_R=True, maxiter=3, offset=0, orth_to
                     Rx = spla.cholesky(X, overwrite_a=True, check_finite=check_finite)
                     break
                 except spla.LinAlgError:
-                    logger.warning('Cholesky factorization broke down! Matrix is ill-conditioned.')
-                    if shift is None:
-                        m, n = A.dim, len(A[offset:])
-                        if product is None:
-                            shift = m*n+n*(n+1)
-                            XX = X
-                        else:
-                            from pymor.algorithms.eigs import eigs
-                            shift = 2*m*np.sqrt(m*n)+n*(n+1)*np.sqrt(np.abs(eigs(product, k=1)[0][0]))
-                            XX = A[offset:].gramian(product=product)
-                        eps = np.finfo(XX.dtype).eps
-                        shift *= 11*eps*spla.norm(XX, ord=2, check_finite=check_finite)
+                    pass
+                logger.warning('Cholesky factorization broke down! Matrix is ill-conditioned.')
+                if shift is None:
+                    m, n = A.dim, len(A[offset:])
+                    if product is None:
+                        shift = m*n+n*(n+1)
+                        XX = X
+                    else:
+                        from pymor.algorithms.eigs import eigs
+                        shift = 2*m*np.sqrt(m*n)+n*(n+1)*np.sqrt(np.abs(eigs(product, k=1)[0][0]))
+                        XX = A[offset:].gramian(product=product)
+                    eps = np.finfo(XX.dtype).eps
+                    shift *= 11*eps*spla.norm(XX, ord=2, check_finite=check_finite)
 
-                    logger.info(f'Applying shift: {shift}')
-                    idx = range(len(X))
-                    X[idx, idx] += shift
+                logger.info(f'Applying shift: {shift}')
+                idx = range(len(X))
+                X[idx, idx] += shift
 
             # orthogonalize
             Rinv = spla.lapack.dtrtri(Rx)[0].T

--- a/src/pymor/algorithms/cholesky_qr.py
+++ b/src/pymor/algorithms/cholesky_qr.py
@@ -9,8 +9,8 @@ from pymor.core.logger import getLogger
 logger = getLogger('pymor.algorithms.cholesky_qr.cholesky_qr')
 
 
-def _chol_qr(V, product=None, gramian=None, check_finite=True):
-    X = V.gramian(product=product) if gramian is None else gramian
+def _chol_qr(A, product=None, gramian=None, check_finite=True):
+    X = A.gramian(product=product) if gramian is None else gramian
 
     while True:
         try:
@@ -18,42 +18,42 @@ def _chol_qr(V, product=None, gramian=None, check_finite=True):
             break
         except spla.LinAlgError:
             logger.warning('Cholesky factorization broke down! Matrix is ill-conditioned.')
-            m, n = V.dim, len(V)
+            m, n = A.dim, len(A)
             eps = np.finfo(X.dtype).eps
             s = m*n+n*(n+1) if product is None else 2*m*np.sqrt(m*n)+n*(n+1)*np.sqrt(np.abs(eigs(product, k=1)[0][0]))
             s *= 11*eps*spla.norm(X, ord=2, check_finite=check_finite)
             logger.info(f'Applying shift: {s}')
             np.fill_diagonal(X, np.diag(X)+s)
 
-    return V.lincomb(spla.lapack.dtrtri(R)[0].T), R
+    return A.lincomb(spla.lapack.dtrtri(R)[0].T), R
 
 
-def cholesky_qr(V, product=None, maxiter=3, tol=None, check_finite=True, return_R=True, copy=True):
+def cholesky_qr(A, product=None, maxiter=3, tol=None, check_finite=True, return_R=True, copy=True):
     if copy:
-        V = V.copy()
+        A = A.copy()
 
     iter = 1
     with logger.block(f'Iteration {iter}'):
-        Q, R = _chol_qr(V, product=product, gramian=None, check_finite=check_finite)
+        A, R = _chol_qr(A, product=product, gramian=None, check_finite=check_finite)
 
-    gramian = None
     while iter < maxiter:
         iter += 1
-
-        if tol is not None:
-            gramian = Q.gramian(product=product)
-            res = spla.norm(gramian - np.eye(len(V)), ord='fro', check_finite=check_finite)
+        if tol is None:
+            X = None
+        else:
+            X = A.gramian(product=product)
+            res = spla.norm(X - np.eye(len(A)), ord='fro', check_finite=check_finite)
             logger.info(f'Residual = {res}')
-            if res <= tol*np.sqrt(len(V)):
+            if res <= tol*np.sqrt(len(A)):
                 break
 
         with logger.block(f'Iteration {iter}'):
-            Q, S = _chol_qr(Q, product=product, gramian=gramian, check_finite=check_finite)
+            A, S = _chol_qr(A, product=product, gramian=X, check_finite=check_finite)
 
             if return_R:
                 spla.blas.dtrmm(1, S, R, overwrite_b=True)
 
     if return_R:
-        return Q, R
+        return A, R
     else:
-        return Q
+        return A

--- a/src/pymor/algorithms/cholesky_qr.py
+++ b/src/pymor/algorithms/cholesky_qr.py
@@ -103,7 +103,8 @@ def shifted_cholqr(A, product=None, return_R=True, maxiter=3, offset=0, orth_tol
                         shift *= 11*eps*spla.norm(XX, ord=2, check_finite=check_finite)
 
                     logger.info(f'Applying shift: {shift}')
-                    np.fill_diagonal(X, np.diag(X) + shift)
+                    idx = range(len(X))
+                    X[idx, idx] += shift
 
             # orthogonalize
             Rinv = spla.lapack.dtrtri(Rx)[0].T

--- a/src/pymor/algorithms/cholesky_qr.py
+++ b/src/pymor/algorithms/cholesky_qr.py
@@ -5,21 +5,21 @@ import scipy.linalg as spla
 
 from pymor.core.logger import getLogger
 
-logger = getLogger('pymor.algorithms.cholesky_qr.shifted_cholqr')
+logger = getLogger('pymor.algorithms.cholesky_qr.shifted_chol_qr')
 
 
-def shifted_cholqr(A, product=None, return_R=True, maxiter=3, offset=0, orth_tol=None, check_finite=True, copy=True):
+def shifted_chol_qr(A, product=None, return_R=True, maxiter=3, offset=0, orth_tol=None, check_finite=True, copy=True):
     r"""Orthonormalize a |VectorArray| using the shifted CholeskyQR algorithm.
 
     This method computes a QR decomposition of a |VectorArray| via Cholesky factorizations
     of its Gramian matrix according to :cite:`FKNYY20`. For ill-conditioned matrices, the Cholesky
     factorization will break down. In this case a diagonal shift will be applied to the Gramian.
 
-    - `shifted_cholqr(A, maxiter=3, orth_tol=None)` is equivalent to the shifted CholeskyQR3
+    - `shifted_chol_qr(A, maxiter=3, orth_tol=None)` is equivalent to the shifted CholeskyQR3
     algorithm (Algorithm 4.2 in :cite:`FKNYY20`).
-    - `shifted_cholqr(A, maxiter=np.inf, orth_tol=<some_number>)` is equivalent to the shifted
+    - `shifted_chol_qr(A, maxiter=np.inf, orth_tol=<some_number>)` is equivalent to the shifted
     CholeskyQR algorithm (Algorithm 4.1 in :cite:`FKNYY20`).
-    - `shifted_cholqr(A, product=<some_product>, maxiter=3, orth_tol=None)` is equivalent to the
+    - `shifted_chol_qr(A, product=<some_product>, maxiter=3, orth_tol=None)` is equivalent to the
     shifted CholeskyQR3 algorithm in an oblique inner product (Algorithm 5.1 in :cite:`FKNYY20`).
 
 

--- a/src/pymor/algorithms/cholesky_qr.py
+++ b/src/pymor/algorithms/cholesky_qr.py
@@ -23,8 +23,7 @@ def _chol_qr(V, product=None, gramian=None, check_finite=True):
             logger.info(f'Applying shift: {s}')
             np.fill_diagonal(X, np.diag(X)+s)
 
-    Q = spla.solve_triangular(R, V.to_numpy(), trans='T', overwrite_b=True, check_finite=check_finite)
-    return V.space.from_numpy(Q), R
+    return V.lincomb(spla.lapack.dtrtri(R)[0].T), R
 
 
 def cholesky_qr(V, product=None, maxiter=3, tol=None, check_finite=True, return_R=True, copy=True):

--- a/src/pymor/algorithms/cholesky_qr.py
+++ b/src/pymor/algorithms/cholesky_qr.py
@@ -70,6 +70,7 @@ def shifted_cholqr(A, product=None, return_R=True, maxiter=3, offset=0, check_to
     - `shifted_cholqr(A, product=<some_product>, maxiter=3, check_tol=None)` is equivalent to the
     shifted CholeskyQR3 algorithm in an oblique inner product (Algorithm 5.1 in :cite:`FKNYY20`).
 
+
     .. note::
         Note that the unshifted single iteration CholeskyQR algorithm is unstable.
         Setting `maxiter=1` will perform the simple shifted CholeskyQR algorithm (Algorithm 2.1

--- a/src/pymor/algorithms/cholesky_qr.py
+++ b/src/pymor/algorithms/cholesky_qr.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+
+import numpy as np
+import scipy.linalg as spla
+
+from pymor.core.logger import getLogger
+
+logger = getLogger('pymor.algorithms.cholesky_qr.cholesky_qr')
+
+
+def _chol_qr(V, product=None, gramian=None, check_finite=True):
+    X = V.gramian(product=product) if gramian is None else gramian
+
+    while True:
+        try:
+            R = spla.cholesky(X, overwrite_a=True, check_finite=check_finite)
+            break
+        except spla.LinAlgError:
+            logger.warning('Cholesky factorization broke down! Matrix is ill-conditioned.')
+            m, n = V.dim, len(V)
+            eps = 7. / 3 - 4. / 3 - 1
+            s = 11*(m*n + n*(n+1))*eps*spla.norm(V.to_numpy().T, ord=2, check_finite=check_finite)
+            logger.info(f'Applying shift: {s}')
+            np.fill_diagonal(X, np.diag(X)+s)
+
+    Q = spla.solve_triangular(R, V.to_numpy(), trans='T', overwrite_b=True, check_finite=check_finite)
+    return V.space.from_numpy(Q), R
+
+
+def cholesky_qr(V, product=None, maxiter=3, tol=None, check_finite=True, return_R=True, copy=True):
+    if copy:
+        V = V.copy()
+
+    iter = 1
+    with logger.block(f'Iteration {iter}'):
+        Q, R = _chol_qr(V, product=product, gramian=None, check_finite=check_finite)
+
+    gramian = None
+    while iter < maxiter:
+        iter += 1
+
+        if tol is not None:
+            gramian = Q.gramian(product=product)
+            res = spla.norm(gramian - np.eye(len(V)), ord='fro', check_finite=check_finite)
+            logger.info(f'Residual = {res}')
+            if res <= tol*np.sqrt(len(V)):
+                break
+
+        with logger.block(f'Iteration {iter}'):
+            Q, S = _chol_qr(Q, product=product, gramian=gramian, check_finite=check_finite)
+
+            if return_R:
+                spla.blas.dtrmm(1, S, R, overwrite_b=True)
+
+    if return_R:
+        return Q, R
+    else:
+        return Q

--- a/src/pymor/algorithms/cholesky_qr.py
+++ b/src/pymor/algorithms/cholesky_qr.py
@@ -8,7 +8,7 @@ import scipy.linalg as spla
 from pymor.core.logger import getLogger
 
 
-def shifted_chol_qr(A, product=None, return_R=True, maxiter=3, offset=0, orth_tol=None, check_finite=True, copy=True):
+def shifted_chol_qr(A, product=None, maxiter=3, offset=0, orth_tol=None, check_finite=True, copy=True):
     r"""Orthonormalize a |VectorArray| using the shifted CholeskyQR algorithm.
 
     This method computes a QR decomposition of a |VectorArray| via Cholesky factorizations
@@ -40,8 +40,6 @@ def shifted_chol_qr(A, product=None, return_R=True, maxiter=3, offset=0, orth_to
     product
         The inner product |Operator| w.r.t. which to orthonormalize.
         If `None`, the Euclidean product is used.
-    return_R
-        If `True`, the R matrix from QR decomposition is returned.
     maxiter
         Maximum number of iterations. Defaults to 3.
     offset
@@ -116,13 +114,12 @@ def shifted_chol_qr(A, product=None, return_R=True, maxiter=3, offset=0, orth_to
             A.append(A_todo)
 
             # update blocks of R
-            if return_R:
-                if iter == 1:
-                    Bi = B.T
-                    Ri = Rx
-                else:
-                    Bi += B.T @ Rx
-                    spla.blas.dtrmm(1, Rx, Ri, overwrite_b=True)
+            if iter == 1:
+                Bi = B.T
+                Ri = Rx
+            else:
+                Bi += B.T @ Rx
+                spla.blas.dtrmm(1, Rx, Ri, overwrite_b=True)
 
             # check orthonormality (for an iterative algorithm)
             if orth_tol is not None:
@@ -134,12 +131,9 @@ def shifted_chol_qr(A, product=None, return_R=True, maxiter=3, offset=0, orth_to
 
             iter += 1
 
-    return_args = [A]
-    if return_R:
-        # construct R from blocks
-        R = np.eye(len(A))
-        R[:offset, offset:] = Bi
-        R[offset:, offset:] = Ri
-        return_args.append(R)
+    # construct R from blocks
+    R = np.eye(len(A))
+    R[:offset, offset:] = Bi
+    R[offset:, offset:] = Ri
 
-    return tuple(return_args)
+    return A, R

--- a/src/pymor/algorithms/cholesky_qr.py
+++ b/src/pymor/algorithms/cholesky_qr.py
@@ -120,7 +120,7 @@ def shifted_cholqr(A, product=None, return_R=True, maxiter=3, offset=0, orth_tol
                     Bi += B.T @ Rx
                     spla.blas.dtrmm(1, Rx, Ri, overwrite_b=True)
 
-            # check orthogonality (for an iterative algorithm)
+            # check orthonormality (for an iterative algorithm)
             if orth_tol is not None:
                 B, X = np.split(A[offset:].inner(A, product=product), [offset], axis=1)
                 res = spla.norm(X - np.eye(len(A) - offset), ord='fro', check_finite=check_finite)
@@ -130,11 +130,12 @@ def shifted_cholqr(A, product=None, return_R=True, maxiter=3, offset=0, orth_tol
 
             iter += 1
 
+    return_args = [A]
     if return_R:
         # construct R from blocks
         R = np.eye(len(A))
         R[:offset, offset:] = Bi
         R[offset:, offset:] = Ri
-        return A, R
-    else:
-        return A
+        return_args.append(R)
+
+    return tuple(return_args)

--- a/src/pymor/algorithms/cholesky_qr.py
+++ b/src/pymor/algorithms/cholesky_qr.py
@@ -16,12 +16,11 @@ def shifted_chol_qr(A, product=None, maxiter=3, offset=0, orth_tol=None, check_f
     factorization will break down. In this case a diagonal shift will be applied to the Gramian.
 
     - `shifted_chol_qr(A, maxiter=3, orth_tol=None)` is equivalent to the shifted CholeskyQR3
-    algorithm (Algorithm 4.2 in :cite:`FKNYY20`).
+      algorithm (Algorithm 4.2 in :cite:`FKNYY20`).
     - `shifted_chol_qr(A, maxiter=np.inf, orth_tol=<some_number>)` is equivalent to the shifted
-    CholeskyQR algorithm (Algorithm 4.1 in :cite:`FKNYY20`).
+      CholeskyQR algorithm (Algorithm 4.1 in :cite:`FKNYY20`).
     - `shifted_chol_qr(A, product=<some_product>, maxiter=3, orth_tol=None)` is equivalent to the
-    shifted CholeskyQR3 algorithm in an oblique inner product (Algorithm 5.1 in :cite:`FKNYY20`).
-
+      shifted CholeskyQR3 algorithm in an oblique inner product (Algorithm 5.1 in :cite:`FKNYY20`).
 
     .. note::
         Note that the unshifted single iteration CholeskyQR algorithm is unstable.

--- a/src/pymor/algorithms/cholesky_qr.py
+++ b/src/pymor/algorithms/cholesky_qr.py
@@ -3,7 +3,6 @@
 import numpy as np
 import scipy.linalg as spla
 
-from pymor.algorithms.eigs import eigs
 from pymor.core.logger import getLogger
 
 logger = getLogger('pymor.algorithms.cholesky_qr.cholesky_qr')
@@ -20,10 +19,16 @@ def _chol_qr(A, product=None, gramian=None, check_finite=True):
             logger.warning('Cholesky factorization broke down! Matrix is ill-conditioned.')
             m, n = A.dim, len(A)
             eps = np.finfo(X.dtype).eps
-            s = m*n+n*(n+1) if product is None else 2*m*np.sqrt(m*n)+n*(n+1)*np.sqrt(np.abs(eigs(product, k=1)[0][0]))
-            s *= 11*eps*spla.norm(X, ord=2, check_finite=check_finite)
+            if product is None:
+                s = m*n+n*(n+1)
+                s *= 11*eps*spla.norm(X, ord=2, check_finite=check_finite)
+            else:
+                from pymor.algorithms.eigs import eigs
+                s = 2*m*np.sqrt(m*n)+n*(n+1)
+                s *= 11*eps*spla.norm(A, ord=2, check_finite=check_finite)**2
+                s *= np.sqrt(np.abs(eigs(product, k=1)[0][0]))
             logger.info(f'Applying shift: {s}')
-            np.fill_diagonal(X, np.diag(X)+s)
+            np.fill_diagonal(X, np.diag(X) + s)
 
     return A.lincomb(spla.lapack.dtrtri(R)[0].T), R
 

--- a/src/pymor/algorithms/cholesky_qr.py
+++ b/src/pymor/algorithms/cholesky_qr.py
@@ -5,8 +5,6 @@ import scipy.linalg as spla
 
 from pymor.core.logger import getLogger
 
-logger = getLogger('pymor.algorithms.cholesky_qr.shifted_chol_qr')
-
 
 def shifted_chol_qr(A, product=None, return_R=True, maxiter=3, offset=0, orth_tol=None, check_finite=True, copy=True):
     r"""Orthonormalize a |VectorArray| using the shifted CholeskyQR algorithm.
@@ -67,6 +65,8 @@ def shifted_chol_qr(A, product=None, return_R=True, maxiter=3, offset=0, orth_to
     assert 0 <= offset < len(A)
     assert 0 < maxiter
     assert orth_tol is None or 0 < orth_tol
+
+    logger = getLogger('pymor.algorithms.cholesky_qr.shifted_chol_qr')
 
     if maxiter == 1:
         logger.warning('Single iteration shifted CholeskyQR can lead to poor orthogonality!')

--- a/src/pymor/algorithms/cholesky_qr.py
+++ b/src/pymor/algorithms/cholesky_qr.py
@@ -3,57 +3,9 @@
 import numpy as np
 import scipy.linalg as spla
 
-from pymor.core.base import BasicObject
-from pymor.core.cache import CacheableObject, cached
 from pymor.core.logger import getLogger
 
 logger = getLogger('pymor.algorithms.cholesky_qr.shifted_cholqr')
-
-
-class _ProductNorm(CacheableObject):
-    cache_region = 'memory'
-
-    def __init__(self, product):
-        self.__auto_init(locals())
-
-    @cached
-    def norm(self):
-        if self.product is None:
-            return 1
-        else:
-            from pymor.algorithms.eigs import eigs
-            return np.sqrt(np.abs(eigs(self.product, k=1)[0][0]))
-
-
-class _CholeskyShifter(BasicObject):
-    def __init__(self, A, product, product_norm):
-        self.__auto_init(locals())
-
-    def compute_shift(self, X, check_finite=True):
-        m, n = self.A.dim, len(self.A)
-        if self.product is None:
-            s = m*n+n*(n+1)
-        else:
-            s = 2*m*np.sqrt(m*n)+n*(n+1)*self.product_norm.norm()
-            X = self.A.gramian(product=self.product)
-        eps = np.finfo(X.dtype).eps
-        s *= 11*eps*spla.norm(X, ord=2, check_finite=check_finite)
-        return s
-
-
-def _shifted_cholesky(X, shifter, check_finite=True):
-    """This will return the Cholesky factor and keep applying shifts if it breaks down."""
-    while True:
-        try:
-            R = spla.cholesky(X, overwrite_a=True, check_finite=check_finite)
-            break
-        except spla.LinAlgError:
-            logger.warning('Cholesky factorization broke down! Matrix is ill-conditioned.')
-            shift = shifter.compute_shift(X, check_finite=check_finite)
-            logger.info(f'Applying shift: {shift}')
-            np.fill_diagonal(X, np.diag(X) + shift)
-
-    return R
 
 
 def shifted_cholqr(A, product=None, return_R=True, maxiter=3, offset=0, check_tol=None, check_finite=True, copy=True):
@@ -124,16 +76,35 @@ def shifted_cholqr(A, product=None, return_R=True, maxiter=3, offset=0, check_to
         A = A.copy()
 
     iter = 1
-    product_norm = _ProductNorm(product)
+    shift = None
     while iter <= maxiter:
         with logger.block(f'Iteration {iter}'):
             if check_tol is None or iter == 1:
                 # compute only the necessary parts of the Gramian
                 B, X = np.split(A[offset:].inner(A, product=product), [offset], axis=1)
 
-            # compute Cholesky factor of lower right block
-            shifter = _CholeskyShifter(A[offset:], product, product_norm)
-            Rx = _shifted_cholesky(X, shifter, check_finite=check_finite)
+            # This will compute the Cholesky factor of the lower right block
+            # and keep applying shifts if it breaks down.
+            while True:
+                try:
+                    Rx = spla.cholesky(X, overwrite_a=True, check_finite=check_finite)
+                    break
+                except spla.LinAlgError:
+                    logger.warning('Cholesky factorization broke down! Matrix is ill-conditioned.')
+                    if shift is None:
+                        m, n = A.dim, len(A[offset:])
+                        if product is None:
+                            shift = m*n+n*(n+1)
+                            XX = X
+                        else:
+                            from pymor.algorithms.eigs import eigs
+                            shift = 2*m*np.sqrt(m*n)+n*(n+1)*np.sqrt(np.abs(eigs(product, k=1)[0][0]))
+                            XX = A[offset:].gramian(product=product)
+                        eps = np.finfo(XX.dtype).eps
+                        shift *= 11*eps*spla.norm(XX, ord=2, check_finite=check_finite)
+
+                    logger.info(f'Applying shift: {shift}')
+                    np.fill_diagonal(X, np.diag(X) + shift)
 
             # orthogonalize
             Rinv = spla.lapack.dtrtri(Rx)[0].T
@@ -150,7 +121,7 @@ def shifted_cholqr(A, product=None, return_R=True, maxiter=3, offset=0, check_to
                     Bi += B.T @ Rx
                     spla.blas.dtrmm(1, Rx, Ri, overwrite_b=True)
 
-            # check orthogonality
+            # check orthogonality (for an iterative algorithm)
             if check_tol is not None:
                 B, X = np.split(A[offset:].inner(A, product=product), [offset], axis=1)
                 res = spla.norm(X - np.eye(len(A) - offset), ord='fro', check_finite=check_finite)

--- a/src/pymor/algorithms/cholesky_qr.py
+++ b/src/pymor/algorithms/cholesky_qr.py
@@ -7,7 +7,7 @@ from pymor.core.base import BasicObject
 from pymor.core.cache import CacheableObject, cached
 from pymor.core.logger import getLogger
 
-logger = getLogger('pymor.algorithms.cholesky_qr.cholesky_qr')
+logger = getLogger('pymor.algorithms.cholesky_qr.shifted_cholqr')
 
 
 class _ProductNorm(CacheableObject):
@@ -56,30 +56,89 @@ def _shifted_cholesky(X, shifter, check_finite=True):
     return R
 
 
-def cholesky_qr(A, product=None, maxiter=5, tol=None, check_finite=True, return_R=True, offset=0):
-    """No copy kwarg, because we cannot work in place anyway."""
+def shifted_cholqr(A, product=None, return_R=True, maxiter=3, offset=0, check_tol=None, check_finite=True, copy=True):
+    r"""Orthonormalize a |VectorArray| using the shifted CholeskyQR algorithm.
+
+    This method computes a QR decomposition of a |VectorArray| via Cholesky factorizations
+    of its Gramian matrix according to :cite:`FKNYY20`. For ill-conditioned matrices, the Cholesky
+    factorization will break down. In this case a diagonal shift will be applied to the Gramian.
+
+    - `shifted_cholqr(A, maxiter=3, check_tol=None)` is equivalent to the shifted CholeskyQR3
+    algorithm (Algorithm 4.2 in :cite:`FKNYY20`).
+    - `shifted_cholqr(A, maxiter=np.inf, check_tol=<some_number>)` is equivalent to the shifted
+    CholeskyQR algorithm (Algorithm 4.1 in :cite:`FKNYY20`).
+    - `shifted_cholqr(A, product=<some_product>, maxiter=3, check_tol=None)` is equivalent to the
+    shifted CholeskyQR3 algorithm in an oblique inner product (Algorithm 5.1 in :cite:`FKNYY20`).
+
+    .. note::
+        Note that the unshifted single iteration CholeskyQR algorithm is unstable.
+        Setting `maxiter=1` will perform the simple shifted CholeskyQR algorithm (Algorithm 2.1
+        in :cite:`FKNYY20`) which is stable but leads to poor orthogonality in general, i.e.
+
+        .. math::
+            \lVert Q^TQ - I \rVert_2 < 2,
+
+        (see Lemma 3.1 in :cite:`FKNYY20`).
+
+    Parameters
+    ----------
+    A
+        The |VectorArray| which is to be orthonormalized.
+    product
+        The inner product |Operator| w.r.t. which to orthonormalize.
+        If `None`, the Euclidean product is used.
+    return_R
+        If `True`, the R matrix from QR decomposition is returned.
+    maxiter
+        Maximum number of iterations. Defaults to 3.
+    offset
+        Assume that the first `offset` vectors are already orthonormal and apply the
+        algorithm for the vectors starting at `offset + 1`.
+    check_tol
+        If not `None`, check if the resulting |VectorArray| is really orthornormal and
+        repeat the algorithm until the check passes
+        or `maxiter` is reached.
+    check_finite
+        This argument is passed down to |SciPy linalg| functions. Disabling may give a
+        performance gain, but may result in problems (crashes, non-termination) if the
+        inputs do contain infinities or NaNs.
+    copy
+        If `True`, create a copy of `A` instead of modifying `A` in-place.
+
+    Returns
+    -------
+    Q
+        The orthonormalized |VectorArray|.
+    R
+        The upper-triangular/trapezoidal matrix (if `compute_R` is `True`).
+    """
     assert 0 <= offset < len(A)
+    assert 0 < maxiter
+    assert check_tol is None or 0 < check_tol
+
+    if maxiter == 1:
+        logger.warning('Single iteration shifted CholeskyQR can lead to poor orthogonality!')
+
+    if copy:
+        A = A.copy()
 
     iter = 1
     product_norm = _ProductNorm(product)
     while iter <= maxiter:
         with logger.block(f'Iteration {iter}'):
-            if tol is None or iter == 1:
+            if check_tol is None or iter == 1:
                 # compute only the necessary parts of the Gramian
-                A_orth, A_todo = A[:offset].copy(), A[offset:]
-                B, X = np.split(A_todo.inner(A, product=product), [offset], axis=1)
+                B, X = np.split(A[offset:].inner(A, product=product), [offset], axis=1)
 
             # compute Cholesky factor of lower right block
-            shifter = _CholeskyShifter(A_todo, product, product_norm)
+            shifter = _CholeskyShifter(A[offset:], product, product_norm)
             Rx = _shifted_cholesky(X, shifter, check_finite=check_finite)
 
             # orthogonalize
             Rinv = spla.lapack.dtrtri(Rx)[0].T
-            if offset == 0:
-                A = A.lincomb(Rinv)
-            else:
-                A_orth.append(A_orth.lincomb(-Rinv@B) + A_todo.lincomb(Rinv))
-                A = A_orth
+            A_todo = A[:offset].lincomb(-Rinv@B) + A[offset:].lincomb(Rinv)
+            del A[offset:]
+            A.append(A_todo)
 
             # update blocks of R
             if return_R:
@@ -91,12 +150,11 @@ def cholesky_qr(A, product=None, maxiter=5, tol=None, check_finite=True, return_
                     spla.blas.dtrmm(1, Rx, Ri, overwrite_b=True)
 
             # check orthogonality
-            if tol is not None:
-                A_orth, A_todo = A[:offset].copy(), A[offset:]
-                B, X = np.split(A_todo.inner(A, product=product), [offset], axis=1)
-                res = spla.norm(X - np.eye(len(A_todo)), ord='fro', check_finite=check_finite)
+            if check_tol is not None:
+                B, X = np.split(A[offset:].inner(A, product=product), [offset], axis=1)
+                res = spla.norm(X - np.eye(len(A) - offset), ord='fro', check_finite=check_finite)
                 logger.info(f'Residual = {res}')
-                if res <= tol*np.sqrt(len(A)):
+                if res <= check_tol*np.sqrt(len(A)):
                     break
 
             iter += 1

--- a/src/pymor/algorithms/cholesky_qr.py
+++ b/src/pymor/algorithms/cholesky_qr.py
@@ -3,6 +3,7 @@
 import numpy as np
 import scipy.linalg as spla
 
+from pymor.algorithms.eigs import eigs
 from pymor.core.logger import getLogger
 
 logger = getLogger('pymor.algorithms.cholesky_qr.cholesky_qr')
@@ -18,8 +19,9 @@ def _chol_qr(V, product=None, gramian=None, check_finite=True):
         except spla.LinAlgError:
             logger.warning('Cholesky factorization broke down! Matrix is ill-conditioned.')
             m, n = V.dim, len(V)
-            eps = 7. / 3 - 4. / 3 - 1
-            s = 11*(m*n + n*(n+1))*eps*spla.norm(V.to_numpy().T, ord=2, check_finite=check_finite)
+            eps = np.finfo(X.dtype).eps
+            s = m*n+n*(n+1) if product is None else 2*m*np.sqrt(m*n)+n*(n+1)*np.sqrt(np.abs(eigs(product, k=1)[0][0]))
+            s *= 11*eps*spla.norm(X, ord=2, check_finite=check_finite)
             logger.info(f'Applying shift: {s}')
             np.fill_diagonal(X, np.diag(X)+s)
 

--- a/src/pymor/algorithms/eigs.py
+++ b/src/pymor/algorithms/eigs.py
@@ -116,6 +116,9 @@ def eigs(A, E=None, k=3, sigma=None, which='LM', b=None, l=None, maxiter=1000, t
     if l is None:
         l = min(n - 1, max(2 * k + 1, l_min))
 
+    if k == n:
+        return A.apply(E.apply_inverse(E.source.ones(1))).to_numpy()
+
     assert k < n
     assert l > k
 

--- a/src/pymor/algorithms/eigs.py
+++ b/src/pymor/algorithms/eigs.py
@@ -116,9 +116,6 @@ def eigs(A, E=None, k=3, sigma=None, which='LM', b=None, l=None, maxiter=1000, t
     if l is None:
         l = min(n - 1, max(2 * k + 1, l_min))
 
-    if k == n:
-        return A.apply(E.apply_inverse(E.source.ones(1))).to_numpy()
-
     assert k < n
     assert l > k
 

--- a/src/pymortests/algorithms/chol_qr.py
+++ b/src/pymortests/algorithms/chol_qr.py
@@ -1,0 +1,55 @@
+# This file is part of the pyMOR project (https://www.pymor.org).
+# Copyright pyMOR developers and contributors. All rights reserved.
+# License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
+
+import numpy as np
+from hypothesis import assume, settings
+
+import pymortests.strategies as pyst
+from pymor.algorithms.basic import almost_equal, contains_zero_vector
+from pymor.algorithms.chol_qr import shifted_chol_qr
+
+
+@pyst.given_vector_arrays()
+@settings(deadline=None)
+def test_shifted_chol_qr(vector_array):
+    U = vector_array
+
+    assume(len(U) > 1 or not contains_zero_vector(U))
+
+    V = U.copy()
+
+    onb, R = shifted_chol_qr(U, copy=True)
+    assert np.all(almost_equal(U, V))
+    assert np.allclose(onb.inner(onb), np.eye(len(onb)))
+    lc = onb.lincomb(onb.inner(U).T)
+    rtol = atol = 1e-13
+    assert np.all(almost_equal(U, lc, rtol=rtol, atol=atol))
+    assert np.all(almost_equal(V, onb.lincomb(R.T), rtol=rtol, atol=atol))
+
+    onb2, R2 = shifted_chol_qr(U, copy=False)
+    assert np.all(almost_equal(onb, onb2))
+    assert np.all(R == R2)
+    assert np.all(almost_equal(onb, U))
+
+
+def test_shifted_chol_qr_with_product(operator_with_arrays_and_products):
+    _, _, U, _, p, _ = operator_with_arrays_and_products
+
+    assume(len(U) > 1 or not contains_zero_vector(U))
+
+    if U.dim < len(U):
+        return
+
+    V = U.copy()
+
+    onb, R = shifted_chol_qr(U, product=p, copy=True)
+    assert np.all(almost_equal(U, V))
+    assert np.allclose(p.apply2(onb, onb), np.eye(len(onb)))
+    assert np.all(almost_equal(U, onb.lincomb(p.apply2(onb, U).T), rtol=1e-13))
+    assert np.all(almost_equal(U, onb.lincomb(R.T)))
+
+    onb2, R2 = shifted_chol_qr(U, product=p, copy=False)
+    assert np.all(almost_equal(onb, onb2))
+    assert np.all(R == R2)
+    assert np.all(almost_equal(onb, U))

--- a/src/pymortests/algorithms/chol_qr.py
+++ b/src/pymortests/algorithms/chol_qr.py
@@ -48,7 +48,7 @@ def test_shifted_chol_qr_with_product(operator_with_arrays_and_products):
     onb, R = shifted_chol_qr(U, product=p, copy=True)
     assert np.all(almost_equal(U, V))
     assert np.allclose(p.apply2(onb, onb), np.eye(len(onb)))
-    assert np.all(almost_equal(U, onb.lincomb(p.apply2(onb, U).T), rtol=1e-13))
+    assert np.all(almost_equal(U, onb.lincomb(p.apply2(onb, U).T), rtol=1e-12))
     assert np.all(almost_equal(U, onb.lincomb(R.T)))
 
     onb2, R2 = shifted_chol_qr(U, product=p, copy=False)

--- a/src/pymortests/algorithms/chol_qr.py
+++ b/src/pymortests/algorithms/chol_qr.py
@@ -3,11 +3,13 @@
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
 import numpy as np
+import pytest
 from hypothesis import assume, settings
 
 import pymortests.strategies as pyst
 from pymor.algorithms.basic import almost_equal, contains_zero_vector
 from pymor.algorithms.chol_qr import shifted_chol_qr
+from pymor.vectorarrays.numpy import NumpyVectorSpace
 
 
 @pyst.given_vector_arrays()
@@ -53,3 +55,33 @@ def test_shifted_chol_qr_with_product(operator_with_arrays_and_products):
     assert np.all(almost_equal(onb, onb2))
     assert np.all(R == R2)
     assert np.all(almost_equal(onb, U))
+
+
+@pytest.mark.parametrize('copy', [False, True])
+def test_chol_qr_zeros(copy):
+    n, m = 5, 2
+    V = NumpyVectorSpace(n).zeros(m)
+    Q, R = shifted_chol_qr(V, copy=copy)
+    if copy:
+        assert len(V) == m
+    else:
+        assert len(V) == 0
+    assert len(Q) == 0
+
+
+@pytest.mark.parametrize('copy', [False, True])
+def test_chol_qr_empty(copy):
+    n = 5
+    V = NumpyVectorSpace(n).empty(0)
+    Q, R = shifted_chol_qr(V, copy=copy)
+    assert len(V) == len(Q) == 0
+
+
+if __name__ == '__main__':
+    U = NumpyVectorSpace(5).empty()
+    V = U.copy()
+    onb, R = shifted_chol_qr(U, copy=False)
+
+    print(len(onb), R.shape)
+    print(len(onb.lincomb(R)))
+    almost_equal(V, onb.lincomb(R.T))

--- a/src/pymortests/algorithms/chol_qr.py
+++ b/src/pymortests/algorithms/chol_qr.py
@@ -75,13 +75,3 @@ def test_chol_qr_empty(copy):
     V = NumpyVectorSpace(n).empty(0)
     Q, R = shifted_chol_qr(V, copy=copy)
     assert len(V) == len(Q) == 0
-
-
-if __name__ == '__main__':
-    U = NumpyVectorSpace(5).empty()
-    V = U.copy()
-    onb, R = shifted_chol_qr(U, copy=False)
-
-    print(len(onb), R.shape)
-    print(len(onb.lincomb(R)))
-    almost_equal(V, onb.lincomb(R.T))

--- a/src/pymortests/algorithms/chol_qr.py
+++ b/src/pymortests/algorithms/chol_qr.py
@@ -60,7 +60,7 @@ def test_shifted_chol_qr_with_product(operator_with_arrays_and_products):
     onb, R = shifted_chol_qr(U, product=p, copy=True)
     assert np.all(almost_equal(U, V))
     assert np.allclose(p.apply2(onb, onb), np.eye(len(onb)))
-    assert np.all(almost_equal(U, onb.lincomb(p.apply2(onb, U).T), rtol=1e-13))
+    assert np.all(almost_equal(U, onb.lincomb(p.apply2(onb, U).T), rtol=1e-11))
     assert np.all(almost_equal(U, onb.lincomb(R.T)))
 
     onb2, R2 = shifted_chol_qr(U, product=p, copy=False)

--- a/src/pymortests/algorithms/chol_qr.py
+++ b/src/pymortests/algorithms/chol_qr.py
@@ -60,7 +60,7 @@ def test_shifted_chol_qr_with_product(operator_with_arrays_and_products):
     onb, R = shifted_chol_qr(U, product=p, copy=True)
     assert np.all(almost_equal(U, V))
     assert np.allclose(p.apply2(onb, onb), np.eye(len(onb)))
-    assert np.all(almost_equal(U, onb.lincomb(p.apply2(onb, U).T), rtol=1e-12))
+    assert np.all(almost_equal(U, onb.lincomb(p.apply2(onb, U).T), rtol=1e-13))
     assert np.all(almost_equal(U, onb.lincomb(R.T)))
 
     onb2, R2 = shifted_chol_qr(U, product=p, copy=False)

--- a/src/pymortests/algorithms/chol_qr.py
+++ b/src/pymortests/algorithms/chol_qr.py
@@ -20,7 +20,7 @@ from pymor.vectorarrays.numpy import NumpyVectorSpace
 def test_shifted_chol_qr(vector_array):
     U = vector_array
 
-    assume(len(U) > 1 or not contains_zero_vector(U))
+    assume(len(U) >= 1 and not contains_zero_vector(U))
 
     V = U.copy()
 
@@ -33,7 +33,7 @@ def test_shifted_chol_qr(vector_array):
     assert np.all(almost_equal(U, V))
     assert np.allclose(onb.inner(onb), np.eye(len(onb)))
     lc = onb.lincomb(onb.inner(U).T)
-    rtol = atol = 1e-13
+    rtol = atol = 1e-10
 
     assert np.all(almost_equal(U, lc, rtol=rtol, atol=atol))
     try:
@@ -50,7 +50,7 @@ def test_shifted_chol_qr(vector_array):
 def test_shifted_chol_qr_with_product(operator_with_arrays_and_products):
     _, _, U, _, p, _ = operator_with_arrays_and_products
 
-    assume(len(U) > 1 or not contains_zero_vector(U))
+    assume(len(U) >= 1 and not contains_zero_vector(U))
 
     if U.dim < len(U):
         return

--- a/src/pymortests/algorithms/chol_qr.py
+++ b/src/pymortests/algorithms/chol_qr.py
@@ -70,18 +70,6 @@ def test_shifted_chol_qr_with_product(operator_with_arrays_and_products):
 
 
 @pytest.mark.parametrize('copy', [False, True])
-def test_chol_qr_zeros(copy):
-    n, m = 5, 2
-    V = NumpyVectorSpace(n).zeros(m)
-    Q, R = shifted_chol_qr(V, copy=copy)
-    if copy:
-        assert len(V) == m
-    else:
-        assert len(V) == 0
-    assert len(Q) == 0
-
-
-@pytest.mark.parametrize('copy', [False, True])
 def test_chol_qr_empty(copy):
     n = 5
     V = NumpyVectorSpace(n).empty(0)


### PR DESCRIPTION
Adds the Cholesky based QR algorithm from [this paper](https://epubs.siam.org/doi/epdf/10.1137/18M1218212) with an oblique inner product.  Shifts are applied if necessary (see Algorithm 4.1 in the paper).

