### PR TITLE
Document optional `asciitree` package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,12 +150,19 @@ scikit-fem = [
 ]
 
 
+## ASCII trees for rule printing
+
+asciitree = [
+    "asciitree",
+]
+
+
 ## Meta dependencies
 
 # install all optional dependencies, except those requiring a compiler toolchain to build
 # pymess is excluded here as installation from source is recommended by the developers
 full = [
-    "pymor[docs_additional,tests,dev,ann,ipyparallel,gui,jupyter,vtk,gmsh,dune,ngsolve,scikit-fem]",
+    "pymor[docs_additional,tests,dev,ann,ipyparallel,gui,jupyter,vtk,gmsh,dune,ngsolve,scikit-fem,asciitree]",
 ]
 
 # install all optional dependencies, including those requiring a compiler toolchain to build

--- a/src/pymor/algorithms/rules.py
+++ b/src/pymor/algorithms/rules.py
@@ -394,6 +394,11 @@ class RuleTable(BasicObject, metaclass=RuleTableMeta):
 
 
 def print_children(obj):
+    """Print tree of children of given object.
+
+    This method first tries to construct the tree with the :mod:`asciitree` package.
+    If this optional dependency is not installed, it defaults to :mod:`pprint`.
+    """
     def build_tree(obj):
 
         def process_child(child):


### PR DESCRIPTION
Documents the optional usage of the `asciitree` in `algorithms.rules` and adds the package to the `pyproject.toml` as mentioned in #2098.

@pmli: Is the additional dependency group okay? I didn't really see another group in which it would fit and created a new one.