### PR TITLE
Self-documenting help target for Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,19 +19,16 @@ ifeq ($(PANDOC_MAJOR),1)
 	PANDOC_FORMAT=-f markdown_github
 endif
 
-.PHONY: README.html README test docs help
-
-default: help
+.PHONY: README test docs help
 
 # The following self-documenting help target is inspired by https://marmelab.com/blog/2016/02/29/auto-documented-makefile.html.
 help: ## print this help prompt
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "%-30s %s\n", $$1, $$2}'
 
-# I want HTML (to preview the formatting :))
 README.html: README.md
 	pandoc $(PANDOC_FORMAT) -t html $< > $@
 
-README: README.html ## generate the README for the docs
+README: README.html ## convert README.md to other formats
 
 test: ## run tests
 	xvfb-run pytest

--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ ci_conda_requirements:
 	conda-lock --micromamba -c conda-forge --filter-extras --no-dev-dependencies $(CONDA_EXTRAS) -f conda-base.yml -f pyproject.toml
 	conda-lock render $(CONDA_EXTRAS)
 
-ci_requirements: ci_current_requirements ci_oldest_requirements ci_fenics_requirements ci_conda_requirements ## run the Docker CI images
+ci_requirements: ci_current_requirements ci_oldest_requirements ci_fenics_requirements ci_conda_requirements ## build the CI requirement files
 
 ci_current_image:
 	$(DOCKER) build -t pymor/ci-current:$(CI_CURRENT_IMAGE_TAG) -f $(THIS_DIR)/docker/Dockerfile.ci-current $(THIS_DIR)
@@ -138,7 +138,7 @@ ci_oldest_image_pull:
 ci_fenics_image_pull:
 	$(DOCKER) pull zivgitlab.wwu.io/pymor/pymor/ci-fenics:$(CI_FENICS_IMAGE_TAG)
 
-ci_images_pull: ci_current_image_pull ci_oldest_image_pull ci_fenics_image_pull ## pull the Docker CI images
+ci_images_pull: ci_current_image_pull ci_oldest_image_pull ci_fenics_image_pull ## run the Docker CI images
 
 
 ci_current_image_push:

--- a/Makefile
+++ b/Makefile
@@ -19,18 +19,24 @@ ifeq ($(PANDOC_MAJOR),1)
 	PANDOC_FORMAT=-f markdown_github
 endif
 
-.PHONY: README.html README test docs
+.PHONY: README.html README test docs help
+
+default: help
+
+# The following self-documenting help target is inspired by https://marmelab.com/blog/2016/02/29/auto-documented-makefile.html.
+help: ## print this help prompt
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "%-30s %s\n", $$1, $$2}'
 
 # I want HTML (to preview the formatting :))
 README.html: README.md
 	pandoc $(PANDOC_FORMAT) -t html $< > $@
 
-README: README.html
+README: README.html ## generate the README for the docs
 
-test:
+test: ## run tests
 	xvfb-run pytest
 
-docs:
+docs: ## build the docs
 	PYTHONPATH=${PWD}/src/:${PYTHONPATH} make -C docs html
 	./docs/fix_myst_in_notebooks.sh
 
@@ -109,7 +115,7 @@ ci_conda_requirements:
 	conda-lock --micromamba -c conda-forge --filter-extras --no-dev-dependencies $(CONDA_EXTRAS) -f conda-base.yml -f pyproject.toml
 	conda-lock render $(CONDA_EXTRAS)
 
-ci_requirements: ci_current_requirements ci_oldest_requirements ci_fenics_requirements ci_conda_requirements
+ci_requirements: ci_current_requirements ci_oldest_requirements ci_fenics_requirements ci_conda_requirements ## run the Docker CI images
 
 ci_current_image:
 	$(DOCKER) build -t pymor/ci-current:$(CI_CURRENT_IMAGE_TAG) -f $(THIS_DIR)/docker/Dockerfile.ci-current $(THIS_DIR)
@@ -120,7 +126,7 @@ ci_oldest_image:
 ci_fenics_image:
 	$(DOCKER) build -t pymor/ci-fenics:$(CI_FENICS_IMAGE_TAG) -f $(THIS_DIR)/docker/Dockerfile.ci-fenics $(THIS_DIR)
 
-ci_images: ci_current_image ci_oldest_image ci_fenics_image
+ci_images: ci_current_image ci_oldest_image ci_fenics_image ## build the Docker CI images
 
 
 ci_current_image_pull:
@@ -132,7 +138,7 @@ ci_oldest_image_pull:
 ci_fenics_image_pull:
 	$(DOCKER) pull zivgitlab.wwu.io/pymor/pymor/ci-fenics:$(CI_FENICS_IMAGE_TAG)
 
-ci_images_pull: ci_current_image_pull ci_oldest_image_pull ci_fenics_image_pull
+ci_images_pull: ci_current_image_pull ci_oldest_image_pull ci_fenics_image_pull ## pull the Docker CI images
 
 
 ci_current_image_push:
@@ -155,7 +161,7 @@ ci_preflight_image_push:
 	$(DOCKER) push pymor/ci-preflight \
 		zivgitlab.wwu.io/pymor/pymor/ci-preflight
 
-ci_images_push: ci_current_image_push ci_oldest_image_push ci_fenics_image_push
+ci_images_push: ci_current_image_push ci_oldest_image_push ci_fenics_image_push ## push the Docker CI images
 
 
 ci_current_image_run:

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ docs: ## build the docs
 	PYTHONPATH=${PWD}/src/:${PYTHONPATH} make -C docs html
 	./docs/fix_myst_in_notebooks.sh
 
-ci_preflight_image:
+ci_preflight_image: ## build CI image used in preflight stage
 	$(DOCKER) build -t pymor/ci-preflight -f $(THIS_DIR)/docker/Dockerfile.ci-preflight $(THIS_DIR)
 
 CI_EXTRAS= \
@@ -126,16 +126,16 @@ ci_fenics_image:
 ci_images: ci_current_image ci_oldest_image ci_fenics_image ## build the Docker CI images
 
 
-ci_current_image_pull:
+ci_current_image_pull:  ## pull 'current' CI image from zivgitlab.wwu.io
 	$(DOCKER) pull zivgitlab.wwu.io/pymor/pymor/ci-current:$(CI_CURRENT_IMAGE_TAG)
 
-ci_oldest_image_pull:
+ci_oldest_image_pull:  ## pull 'oldest' CI image from zivgitlab.wwu.io
 	$(DOCKER) pull zivgitlab.wwu.io/pymor/pymor/ci-oldest:$(CI_OLDEST_IMAGE_TAG)
 
-ci_fenics_image_pull:
+ci_fenics_image_pull:  ## pull 'fenics' CI image from zivgitlab.wwu.io
 	$(DOCKER) pull zivgitlab.wwu.io/pymor/pymor/ci-fenics:$(CI_FENICS_IMAGE_TAG)
 
-ci_images_pull: ci_current_image_pull ci_oldest_image_pull ci_fenics_image_pull ## run the Docker CI images
+ci_images_pull: ci_current_image_pull ci_oldest_image_pull ci_fenics_image_pull  ## pull all CI images from zivgitlab.wwu.io
 
 
 ci_current_image_push:
@@ -158,23 +158,23 @@ ci_preflight_image_push:
 	$(DOCKER) push pymor/ci-preflight \
 		zivgitlab.wwu.io/pymor/pymor/ci-preflight
 
-ci_images_push: ci_current_image_push ci_oldest_image_push ci_fenics_image_push ## push the Docker CI images
+ci_images_push: ci_current_image_push ci_oldest_image_push ci_fenics_image_push ## push the CI images to zivgitlab.wwu.io
 
 
-ci_current_image_run:
+ci_current_image_run:  ## run the 'current' CI image (needs to be pulled first)
 	$(DOCKER) run --rm -it -v=$(THIS_DIR):/src pymor/ci-current:$(CI_CURRENT_IMAGE_TAG)
 
-ci_oldest_image_run:
+ci_oldest_image_run:  ## run the 'oldest' CI image (needs to be pulled first)
 	$(DOCKER) run --rm -it -v=$(THIS_DIR):/src pymor/ci-oldest:$(CI_OLDEST_IMAGE_TAG)
 
-ci_fenics_image_run:
+ci_fenics_image_run:  ## run the 'fenics' CI image (needs to be pulled first)
 	$(DOCKER) run --rm -it -v=$(THIS_DIR):/src pymor/ci-fenics:$(CI_FENICS_IMAGE_TAG)
 
 
-ci_current_image_run_notebook:
+ci_current_image_run_notebook:  ## run jupyter in 'current' CI image (needs to be pulled first)
 	$(DOCKER) run --rm -it -p 8888:8888 -v=$(THIS_DIR):/src pymor/ci-current:$(CI_CURRENT_IMAGE_TAG) \
 		bash -c "pip install -e . && jupyter notebook --allow-root --ip=0.0.0.0"
 
-ci_oldest_image_run_notebook:
+ci_oldest_image_run_notebook:  ## run jupyter in 'oldest' CI image (needs to be pulled first)
 	$(DOCKER) run --rm -it -p 8888:8888 -v=$(THIS_DIR):/src pymor/ci-oldest:$(CI_OLDEST_IMAGE_TAG) \
 		bash -c "pip install -e . && jupyter notebook --allow-root --ip=0.0.0.0"


### PR DESCRIPTION
This PR proposes a default `help` target as mentioned in issue #2097. This target is self-documenting in the sense that any targets can be included in the generated help message by documenting it as follows:

```make
<target>: [dependencies] ## Target documentation
```

I've added basic docstrings for the targets where I could easily infer that they needed documentation and what their intended effects are, but this leaves out a number of other targets. Before converting this to a full PR, I would like some feedback on which targets still need documentation, as well as how to improve the current documentation.

Furthermore, I would like some feedback with regards to the formatting of the individual lines. Is some more spacing necessary? Should it include colour?