### PR TITLE
fix `MoebiusTransformation`

### DIFF
--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -1458,17 +1458,15 @@ class LTIModel(Model):
         """
         assert isinstance(M, MoebiusTransformation)
 
-        a, b, c, d = M.coefficients
-        s = a * d - b * c
-        v = np.sqrt(np.abs(s))
+        a, b, c, d = MoebiusTransformation(M.coefficients, normalize=True).coefficients
 
-        Et = d * self.E + c * self.A
-        At = a * self.A + b * self.E
-        Bt = np.sign(s) * v * self.B
-        Ct = v * self.C @ InverseOperator(Et)
-        Dt = self.D - c * self.C @ InverseOperator(Et) @ self.B
+        Et = a * self.E - c * self.A
+        At = d * self.A - b * self.E
+        C = VectorArrayOperator(Et.apply_inverse_adjoint(self.C.H.as_range_array())).H
+        Ct = C @ self.E
+        Dt = self.D + c * C @ self.B
 
-        return LTIModel(At, Bt, Ct, D=Dt, E=Et, sampling_time=sampling_time)
+        return LTIModel(At, self.B, Ct, D=Dt, E=Et, sampling_time=sampling_time)
 
     def to_discrete(self, sampling_time, method='Tustin', w0=0):
         """Converts a continuous-time |LTIModel| to a discrete-time |LTIModel|.
@@ -1496,7 +1494,7 @@ class LTIModel(Model):
         assert sampling_time > 0
         assert isinstance(w0, Number)
         x = 2 / sampling_time if w0 == 0 else w0 / np.tan(w0 * sampling_time / 2)
-        c2d = BilinearTransformation(x).inverse()
+        c2d = BilinearTransformation(x)
         return self.moebius_substitution(c2d, sampling_time=sampling_time)
 
     def to_continuous(self, method='Tustin', w0=0):
@@ -1521,7 +1519,7 @@ class LTIModel(Model):
         assert self.sampling_time > 0
         assert isinstance(w0, Number)
         x = 2 / self.sampling_time if w0 == 0 else w0 / np.tan(w0 * self.sampling_time / 2)
-        d2c = BilinearTransformation(x)
+        d2c = BilinearTransformation(x).inverse()
         return self.moebius_substitution(d2c, sampling_time=0)
 
 

--- a/src/pymor/models/transforms.py
+++ b/src/pymor/models/transforms.py
@@ -35,15 +35,15 @@ class MoebiusTransformation(ImmutableObject):
     def __init__(self, coefficients, normalize=False, name=None):
         coefficients = np.array(coefficients)
         assert coefficients.shape == (4,)
-        assert coefficients[0]*coefficients[3] != coefficients[1]*coefficients[2]
+        assert not np.array_equal(coefficients[0]*coefficients[3], coefficients[1]*coefficients[2])
+        kappa = coefficients[0]*coefficients[3] -  coefficients[1]*coefficients[2]
 
         if normalize:
-            factor = coefficients[0]*coefficients[3]-coefficients[1]*coefficients[2]
             if np.isrealobj(coefficients):
-                coefficients, factor = np.asarray(coefficients, dtype=float), np.abs(factor)
-
-            coefficients /= np.sqrt(factor)
-            coefficients *= np.sign(coefficients[0])
+                coefficients = np.asarray(coefficients, dtype=float)
+                coefficients /= np.sqrt(np.abs(kappa)) / np.sign(coefficients[0])
+            else:
+                coefficients /= np.sqrt(np.abs(kappa)) / np.exp(-1j * np.angle(coefficients[0]))
 
         self.__auto_init(locals())
 
@@ -83,7 +83,7 @@ class MoebiusTransformation(ImmutableObject):
             else:
                 A[i] = [z[i], 1, -w[i]*z[i], -w[i]]
 
-        return cls(null_space(A).ravel(), name=name)
+        return cls(null_space(A).ravel(), normalize=True, name=name)
 
     def inverse(self, normalize=False):
         """Returns the inverse Moebius transformation by applying the inversion formula.

--- a/src/pymortests/models/transforms.py
+++ b/src/pymortests/models/transforms.py
@@ -10,7 +10,7 @@ import pytest
 from pymor.models.iosys import LTIModel
 from pymor.models.transforms import BilinearTransformation, CayleyTransformation, MoebiusTransformation
 
-type_list = ['BilinearTransformation', 'CayleyTransformation', 'MoebiusTransformation']
+type_list = ['BilinearTransformation', 'CayleyTransformation', 'MoebiusTransformation-real', 'MoebiusTransformation-complex']
 points_list = list(combinations([0, 1, -1, 1j, -1j, np.inf], 3))
 sampling_time_list = [0, 1/100, 2]
 
@@ -22,7 +22,9 @@ def get_transformation(name):
         return BilinearTransformation(2)
     elif name == 'CayleyTransformation':
         return CayleyTransformation()
-    elif name == 'MoebiusTransformation':
+    elif name == 'MoebiusTransformation-real':
+        return MoebiusTransformation([1, 2, 3, 4])
+    elif name == 'MoebiusTransformation-complex':
         return MoebiusTransformation([1+2j, 2+3j, 4+5j, 6+7j])
     else:
         raise KeyError
@@ -34,6 +36,8 @@ def test_inv(m):
     m_inv = m.inverse()
     mm_inv = MoebiusTransformation((m @ m_inv).coefficients, normalize=True)
     m_invm = MoebiusTransformation((m_inv @ m).coefficients, normalize=True)
+    print(mm_inv.coefficients)
+    print(m_invm.coefficients)
     assert np.allclose(np.eye(2).ravel(), mm_inv.coefficients)
     assert np.allclose(np.eye(2).ravel(), m_invm.coefficients)
 
@@ -46,6 +50,16 @@ def test_matmul(m1, m2):
     m = m1 @ m2
     assert np.allclose(m.coefficients.reshape(2, 2), m1.coefficients.reshape(2, 2) @ m2.coefficients.reshape(2, 2))
 
+
+@pytest.mark.parametrize('m1', type_list)
+def test_normalization(m1):
+    m1 = get_transformation(m1)
+    m2 = MoebiusTransformation(m1.coefficients, normalize=True)
+    a, b, c, d = m2.coefficients
+    assert np.isrealobj(m1.coefficients) == np.isrealobj(m2.coefficients)
+    assert np.allclose(m1(0), m2(0))
+    assert np.allclose(m1(1), m2(1))
+    assert np.allclose(m1(np.inf), m2(np.inf))
 
 @pytest.mark.parametrize('p1', points_list)
 @pytest.mark.parametrize('p2', points_list)
@@ -64,13 +78,26 @@ def test_from_points(p1, p2):
 
 
 @pytest.mark.parametrize('sampling_time', sampling_time_list)
-def test_substitution(sampling_time):
-    sys1 = LTIModel.from_matrices(np.array([-1]), np.array([[1]]), np.array([[1]]), sampling_time=sampling_time)
+def test_tustin(sampling_time):
+    sys1 = LTIModel.from_matrices(np.array([1]), np.array([[1]]), np.array([[1]]), sampling_time=sampling_time)
     if sampling_time:
         sys2 = sys1.to_continuous()
         assert isinstance(sys2, LTIModel)
         assert sys2.sampling_time == 0
+        A2, B2, C2, D2, E2 = sys2.to_discrete(sampling_time).to_matrices()
     else:
         sys2 = sys1.to_discrete(1)
         assert isinstance(sys2, LTIModel)
         assert sys2.sampling_time == 1
+        A2, B2, C2, D2, E2 = sys2.to_continuous().to_matrices()
+
+    D2 = np.zeros((C2.shape[0], B2.shape[1])) if D2 is None else D2
+    E2 = np.eye(A2.shape[0]) if E2 is None else E2
+    A1, B1, C1, D1, E1 = sys1.to_matrices()
+    D1 = np.zeros((C1.shape[0], B1.shape[1])) if D1 is None else D1
+    E1 = np.eye(A1.shape[0]) if E1 is None else E1
+    assert np.allclose(A1, A2)
+    assert np.allclose(B1, B2)
+    assert np.allclose(C1, C2)
+    assert np.allclose(D1, D2)
+    assert np.allclose(E1, E2)

--- a/src/pymortests/models/transforms.py
+++ b/src/pymortests/models/transforms.py
@@ -10,7 +10,8 @@ import pytest
 from pymor.models.iosys import LTIModel
 from pymor.models.transforms import BilinearTransformation, CayleyTransformation, MoebiusTransformation
 
-type_list = ['BilinearTransformation', 'CayleyTransformation', 'MoebiusTransformation-real', 'MoebiusTransformation-complex']
+type_list = ['BilinearTransformation', 'CayleyTransformation', 'MoebiusTransformation-real',
+             'MoebiusTransformation-complex']
 points_list = list(combinations([0, 1, -1, 1j, -1j, np.inf], 3))
 sampling_time_list = [0, 1/100, 2]
 

--- a/src/pymortests/models/transforms.py
+++ b/src/pymortests/models/transforms.py
@@ -36,8 +36,6 @@ def test_inv(m):
     m_inv = m.inverse()
     mm_inv = MoebiusTransformation((m @ m_inv).coefficients, normalize=True)
     m_invm = MoebiusTransformation((m_inv @ m).coefficients, normalize=True)
-    print(mm_inv.coefficients)
-    print(m_invm.coefficients)
     assert np.allclose(np.eye(2).ravel(), mm_inv.coefficients)
     assert np.allclose(np.eye(2).ravel(), m_invm.coefficients)
 


### PR DESCRIPTION
This PR fixes the normalization of `MoebiusTransformations` and improves the `LTIModel.moebius_substitution` method to avoid the use of `InverseOperator`.