### PR TITLE
Refactoring pH and matrix solvers 

### DIFF
--- a/src/pymor/algorithms/riccati.py
+++ b/src/pymor/algorithms/riccati.py
@@ -298,8 +298,8 @@ def solve_pos_ricc_lrcf(A, E, B, C, R=None, S=None, trans=False, options=None,
         The solver options to use.
         See:
 
-        - :func:`pymor.bindings.scipy.pos_ricc_lrcf_solver_options`,
-        - :func:`pymor.bindings.slycot.pos_ricc_lrcf_solver_options`,
+        - :func:`pymor.bindings.scipy.ricc_lrcf_solver_options`,
+        - :func:`pymor.bindings.slycot.ricc_lrcf_solver_options`,
         - :func:`pymor.bindings.pymess.pos_ricc_lrcf_solver_options`.
 
     default_dense_solver_backend

--- a/src/pymor/algorithms/riccati.py
+++ b/src/pymor/algorithms/riccati.py
@@ -243,9 +243,6 @@ def _solve_ricc_dense_check_args(A, E, B, C, R, S, trans):
             assert S.shape[1] == B.shape[1]
 
 
-_DEFAULT_POS_RICC_LRCF_DENSE_SOLVER_BACKEND = 'slycot' if config.HAVE_SLYCOT else 'scipy'
-
-
 @defaults('default_dense_solver_backend')
 def solve_pos_ricc_lrcf(A, E, B, C, R=None, S=None, trans=False, options=None,
                         default_dense_solver_backend=_DEFAULT_RICC_LRCF_DENSE_SOLVER_BACKEND):
@@ -277,6 +274,8 @@ def solve_pos_ricc_lrcf(A, E, B, C, R=None, S=None, trans=False, options=None,
 
     1. `slycot` (see :func:`pymor.bindings.slycot.solve_pos_ricc_lrcf`),
     2. `scipy` (see :func:`pymor.bindings.scipy.solve_pos_ricc_lrcf`).
+
+    Currently, only dense solvers are provided.
 
     Parameters
     ----------
@@ -327,6 +326,93 @@ def solve_pos_ricc_lrcf(A, E, B, C, R=None, S=None, trans=False, options=None,
     else:
         raise ValueError(f'Unknown solver backend ({backend}).')
     return solve_ricc_impl(A, E, B, C, R, S, trans=trans, options=options)
+
+
+@defaults('default_solver_backend')
+def solve_pos_ricc_dense(A, E, B, C, R=None, S=None, trans=False, options=None,
+                     default_solver_backend=_DEFAULT_RICC_DENSE_SOLVER_BACKEND):
+    """Compute the solution of a Riccati equation.
+
+    Returns the solution :math:`X` of a (generalized) continuous-time
+    algebraic Riccati equation:
+
+    - if trans is `False`
+
+      .. math::
+          A X E^T + E X A^T
+          + (E X C^T + S^T) R^{-1} (C X E^T + S)
+          + B B^T = 0.
+
+    - if trans is `True`
+
+      .. math::
+          A^T X E + E^T X A
+          + (E^T X B + S) R^{-1} (B^T X E + S^T)
+          + C^T C = 0.
+
+    If E is None, it is taken to be identity, and similarly for R.
+    If S is None, it is taken to be zero.
+
+    We assume:
+
+    - A, E, B, C, R, S are real |NumPy arrays|,
+    - E is nonsingular,
+    - (E, A, B, C) is stabilizable and detectable,
+    - R is symmetric positive definite, and
+    - :math:`B B^T - S^T R^{-1} S` (:math:`C^T C - S R^{-1} S^T`) is
+      positive semi-definite if trans is `False` (`True`).
+
+    If the solver is not specified using the options argument, a solver
+    backend is chosen based on availability in the following order:
+
+    1. `slycot` (see :func:`pymor.bindings.slycot.solve_ricc_dense`)
+    2. `scipy` (see :func:`pymor.bindings.scipy.solve_ricc_dense`)
+
+    Parameters
+    ----------
+    A
+        The matrix A as a 2D |NumPy array|.
+    E
+        The matrix E as a 2D |NumPy array| or `None`.
+    B
+        The matrix B as a 2D |NumPy array|.
+    C
+        The matrix C as a 2D |NumPy array|.
+    R
+        The matrix B as a 2D |NumPy array| or `None`.
+    S
+        The matrix S as a 2D |NumPy array| or `None`.
+    trans
+        Whether the first matrix in the Riccati equation is
+        transposed.
+    options
+        The solver options to use.
+        See:
+
+        - :func:`pymor.bindings.slycot.ricc_dense_solver_options`,
+        - :func:`pymor.bindings.scipy.ricc_dense_solver_options`.
+
+    default_solver_backend
+        Default solver backend to use (slycot, scipy).
+
+    Returns
+    -------
+    X
+        Riccati equation solution as a |NumPy array|.
+    """
+    _solve_ricc_dense_check_args(A, E, B, C, R, S, trans)
+    if options:
+        solver = options if isinstance(options, str) else options['type']
+        backend = solver.split('_')[0]
+    else:
+        backend = default_solver_backend
+    if backend == 'scipy':
+        from pymor.bindings.scipy import solve_pos_ricc_dense as solve_ricc_impl
+    elif backend == 'slycot':
+        from pymor.bindings.slycot import solve_pos_ricc_dense as solve_ricc_impl
+    else:
+        raise ValueError(f'Unknown solver backend ({backend}).')
+    return solve_ricc_impl(A, E, B, C, R, S, trans, options=options)
 
 
 def _solve_ricc_check_args(A, E, B, C, R, S, trans):

--- a/src/pymor/bindings/scipy.py
+++ b/src/pymor/bindings/scipy.py
@@ -557,6 +557,51 @@ def solve_ricc_dense(A, E, B, C, R=None, S=None, trans=False, options=None):
     return X
 
 
+def solve_pos_ricc_dense(A, E, B, C, R=None, S=None, trans=False, options=None):
+    """Compute the solution of a Riccati equation.
+
+    See :func:`pymor.algorithms.riccati.solve_pos_ricc_dense` for a general
+    description.
+
+    This function uses `scipy.linalg.solve_continuous_are`, which
+    is a dense solver.
+
+    Parameters
+    ----------
+    A
+        The matrix A as a 2D |NumPy array|.
+    E
+        The matrix E as a 2D |NumPy array| or `None`.
+    B
+        The matrix B as a 2D |NumPy array|.
+    C
+        The matrix C as a 2D |NumPy array|.
+    R
+        The matrix R as a 2D |NumPy array| or `None`.
+    S
+        The matrix S as a 2D |NumPy array| or `None`.
+    trans
+        Whether the first operator in the Riccati equation is
+        transposed.
+    options
+        The solver options to use (see
+        :func:`ricc_dense_solver_options`).
+
+    Returns
+    -------
+    X
+        Riccati equation solution as a |NumPy array|.
+    """
+    _solve_ricc_dense_check_args(A, E, B, C, R, S, trans)
+    options = _parse_options(options, ricc_dense_solver_options(), 'scipy', None, False)
+    if options['type'] != 'scipy':
+        raise ValueError(f"Unexpected Riccati equation solver ({options['type']}).")
+    
+    if R is None:
+        R = np.eye(np.shape(C)[0] if not trans else np.shape(B)[1])
+    return solve_ricc_dense(A, E, B, C, -R, S, trans, options)
+
+
 def pos_ricc_lrcf_solver_options():
     """Return available positive Riccati solvers with default options for the SciPy backend.
 

--- a/src/pymor/bindings/scipy.py
+++ b/src/pymor/bindings/scipy.py
@@ -596,7 +596,7 @@ def solve_pos_ricc_dense(A, E, B, C, R=None, S=None, trans=False, options=None):
     options = _parse_options(options, ricc_dense_solver_options(), 'scipy', None, False)
     if options['type'] != 'scipy':
         raise ValueError(f"Unexpected Riccati equation solver ({options['type']}).")
-    
+
     if R is None:
         R = np.eye(np.shape(C)[0] if not trans else np.shape(B)[1])
     return solve_ricc_dense(A, E, B, C, -R, S, trans, options)

--- a/src/pymor/bindings/scipy.py
+++ b/src/pymor/bindings/scipy.py
@@ -563,7 +563,7 @@ def solve_pos_ricc_dense(A, E, B, C, R=None, S=None, trans=False, options=None):
     See :func:`pymor.algorithms.riccati.solve_pos_ricc_dense` for a general
     description.
 
-    This function uses `scipy.linalg.solve_continuous_are`, which
+    This function uses :func:`scipy.linalg.solve_continuous_are`, which
     is a dense solver.
 
     Parameters

--- a/src/pymor/bindings/scipy.py
+++ b/src/pymor/bindings/scipy.py
@@ -602,16 +602,6 @@ def solve_pos_ricc_dense(A, E, B, C, R=None, S=None, trans=False, options=None):
     return solve_ricc_dense(A, E, B, C, -R, S, trans, options)
 
 
-def pos_ricc_lrcf_solver_options():
-    """Return available positive Riccati solvers with default options for the SciPy backend.
-
-    Returns
-    -------
-    A dict of available solvers with default solver options.
-    """
-    return {'scipy': {'type': 'scipy'}}
-
-
 def solve_pos_ricc_lrcf(A, E, B, C, R=None, S=None, trans=False, options=None):
     """Compute an approximate low-rank solution of a positive Riccati equation.
 
@@ -644,7 +634,7 @@ def solve_pos_ricc_lrcf(A, E, B, C, R=None, S=None, trans=False, options=None):
         transposed.
     options
         The solver options to use (see
-        :func:`pos_ricc_lrcf_solver_options`).
+        :func:`ricc_lrcf_solver_options`).
 
     Returns
     -------
@@ -653,7 +643,7 @@ def solve_pos_ricc_lrcf(A, E, B, C, R=None, S=None, trans=False, options=None):
         solution, |VectorArray| from `A.source`.
     """
     _solve_ricc_check_args(A, E, B, C, R, S, trans)
-    options = _parse_options(options, pos_ricc_lrcf_solver_options(), 'scipy', None, False)
+    options = _parse_options(options, ricc_lrcf_solver_options(), 'scipy', None, False)
     if options['type'] != 'scipy':
         raise ValueError(f"Unexpected positive Riccati equation solver ({options['type']}).")
 

--- a/src/pymor/bindings/slycot.py
+++ b/src/pymor/bindings/slycot.py
@@ -299,7 +299,7 @@ def solve_pos_ricc_dense(A, E, B, C, R=None, S=None, trans=False, options=None):
 
     if options['type'] != 'slycot':
         raise ValueError(f"Unexpected Riccati equation solver ({options['type']}).")
-    
+
     if R is None:
         R = np.eye(np.shape(C)[0] if not trans else np.shape(B)[1])
     return solve_ricc_dense(A, E, B, C, -R, S, trans, options)

--- a/src/pymor/bindings/slycot.py
+++ b/src/pymor/bindings/slycot.py
@@ -257,6 +257,54 @@ def solve_ricc_dense(A, E, B, C, R=None, S=None, trans=False, options=None):
     return X
 
 
+def solve_pos_ricc_dense(A, E, B, C, R=None, S=None, trans=False, options=None):
+    """Compute the solution of a Riccati equation.
+
+    See :func:`pymor.algorithms.riccati.solve_pos_ricc_dense` for a
+    general description.
+
+    This function uses `slycot.sb02md` (if `E is None and S is None`) which is based on
+    the Schur vector approach, and `slycot.sb02od` (if `E is None and S is not None`) or
+    `slycot.sg02ad` (if `E is not None`) which are both based on
+    the method of deflating subspaces.
+
+    Parameters
+    ----------
+    A
+        The matrix A as a 2D |NumPy array|.
+    E
+        The matrix E as a 2D |NumPy array| or `None`.
+    B
+        The matrix B as a 2D |NumPy array|.
+    C
+        The matrix C as a 2D |NumPy array|.
+    R
+        The matrix R as a 2D |NumPy array| or `None`.
+    S
+        The matrix S as a 2D |NumPy array| or `None`.
+    trans
+        Whether the first matrix in the Riccati equation is
+        transposed.
+    options
+        The solver options to use (see
+        :func:`ricc_dense_solver_options`).
+
+    Returns
+    -------
+    X
+        Riccati equation solution as a |NumPy array|.
+    """
+    _solve_ricc_dense_check_args(A, E, B, C, R, S, trans)
+    options = _parse_options(options, ricc_dense_solver_options(), 'slycot', None, False)
+
+    if options['type'] != 'slycot':
+        raise ValueError(f"Unexpected Riccati equation solver ({options['type']}).")
+    
+    if R is None:
+        R = np.eye(np.shape(C)[0] if not trans else np.shape(B)[1])
+    return solve_ricc_dense(A, E, B, C, -R, S, trans, options)
+
+
 def ricc_dense_solver_options():
     """Return available Riccati solvers with default options for the slycot backend.
 
@@ -349,16 +397,6 @@ def _ricc_rcond_check(solver, rcond):
                        f'Result may not be accurate.')
 
 
-def pos_ricc_lrcf_solver_options():
-    """Return available positive Riccati solvers with default options for the slycot backend.
-
-    Returns
-    -------
-    A dict of available solvers with default solver options.
-    """
-    return {'slycot': {'type': 'slycot'}}
-
-
 def solve_pos_ricc_lrcf(A, E, B, C, R=None, S=None, trans=False, options=None):
     """Compute an approximate low-rank solution of a positive Riccati equation.
 
@@ -391,7 +429,7 @@ def solve_pos_ricc_lrcf(A, E, B, C, R=None, S=None, trans=False, options=None):
         equation is transposed.
     options
         The solver options to use (see
-        :func:`pos_ricc_lrcf_solver_options`).
+        :func:`ricc_lrcf_solver_options`).
 
     Returns
     -------
@@ -400,7 +438,7 @@ def solve_pos_ricc_lrcf(A, E, B, C, R=None, S=None, trans=False, options=None):
         solution, |VectorArray| from `A.source`.
     """
     _solve_ricc_check_args(A, E, B, C, R, S, trans)
-    options = _parse_options(options, pos_ricc_lrcf_solver_options(), 'slycot', None, False)
+    options = _parse_options(options, ricc_lrcf_solver_options(), 'slycot', None, False)
     if options['type'] != 'slycot':
         raise ValueError(f"Unexpected positive Riccati equation solver ({options['type']}).")
 

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -340,8 +340,16 @@ class LTIModel(Model):
                    time_stepper=time_stepper, num_values=num_values, presets=presets,
                    solver_options=solver_options, error_estimator=error_estimator, visualizer=visualizer, name=name)
 
-    def to_matrices(self):
+    def to_matrices(self, format=None):
         """Return operators as matrices.
+
+        Parameters
+        ----------
+        format
+            Format of the resulting matrices: |NumPy array| if 'dense',
+            otherwise the appropriate |SciPy spmatrix|.
+            If `None`, a choice between dense and sparse format is
+            automatically made.
 
         Returns
         -------
@@ -356,11 +364,37 @@ class LTIModel(Model):
         E
             The |NumPy array| or |SciPy spmatrix| E or `None` (if E is an `IdentityOperator`).
         """
-        A = to_matrix(self.A)
-        B = to_matrix(self.B)
-        C = to_matrix(self.C)
-        D = None if isinstance(self.D, ZeroOperator) else to_matrix(self.D)
-        E = None if isinstance(self.E, IdentityOperator) else to_matrix(self.E)
+        return self.to_abcde_matrices(format)
+    
+    def to_abcde_matrices(self, format=None):
+        """Return A, B, C and D operators as matrices.
+
+        Parameters
+        ----------
+        format
+            Format of the resulting matrices: |NumPy array| if 'dense',
+            otherwise the appropriate |SciPy spmatrix|.
+            If `None`, a choice between dense and sparse format is
+            automatically made.
+
+        Returns
+        -------
+        A
+            The |NumPy array| or |SciPy spmatrix| A.
+        B
+            The |NumPy array| or |SciPy spmatrix| B.
+        C
+            The |NumPy array| or |SciPy spmatrix| C.
+        D
+            The |NumPy array| or |SciPy spmatrix| D or `None` (if D is a `ZeroOperator`).
+        E
+            The |NumPy array| or |SciPy spmatrix| E or `None` (if E is an `IdentityOperator`).
+        """
+        A = to_matrix(self.A, format)
+        B = to_matrix(self.B, format)
+        C = to_matrix(self.C, format)
+        D = None if isinstance(self.D, ZeroOperator) else to_matrix(self.D, format)
+        E = None if isinstance(self.E, IdentityOperator) else to_matrix(self.E, format)
         return A, B, C, D, E
 
     @classmethod
@@ -1817,8 +1851,16 @@ class PHLTIModel(LTIModel):
                    solver_options=solver_options, error_estimator=error_estimator, visualizer=visualizer,
                    name=name)
 
-    def to_matrices(self):
+    def to_matrices(self, format=None):
         """Return operators as matrices.
+
+        Parameters
+        ----------
+        format
+            Format of the resulting matrices: |NumPy array| if 'dense',
+            otherwise the appropriate |SciPy spmatrix|.
+            If `None`, a choice between dense and sparse format is
+            automatically made.
 
         Returns
         -------
@@ -1839,14 +1881,14 @@ class PHLTIModel(LTIModel):
         Q
             The |NumPy array| or |SciPy spmatrix| Q  or `None` (if Q is an `IdentityOperator`).
         """
-        J = to_matrix(self.J)
-        R = to_matrix(self.R)
-        G = to_matrix(self.G)
-        P = None if isinstance(self.P, ZeroOperator) else to_matrix(self.P)
-        S = None if isinstance(self.S, ZeroOperator) else to_matrix(self.S)
-        N = None if isinstance(self.N, ZeroOperator) else to_matrix(self.N)
-        E = None if isinstance(self.E, IdentityOperator) else to_matrix(self.E)
-        Q = None if isinstance(self.Q, IdentityOperator) else to_matrix(self.Q)
+        J = to_matrix(self.J, format)
+        R = to_matrix(self.R, format)
+        G = to_matrix(self.G, format)
+        P = None if isinstance(self.P, ZeroOperator) else to_matrix(self.P, format)
+        S = None if isinstance(self.S, ZeroOperator) else to_matrix(self.S, format)
+        N = None if isinstance(self.N, ZeroOperator) else to_matrix(self.N, format)
+        E = None if isinstance(self.E, IdentityOperator) else to_matrix(self.E, format)
+        Q = None if isinstance(self.Q, IdentityOperator) else to_matrix(self.Q, format)
 
         return J, R, G, P, S, N, E, Q
 

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -366,7 +366,7 @@ class LTIModel(Model):
         return self.to_abcde_matrices(format)
 
     def to_abcde_matrices(self, format=None):
-        """Return A, B, C and D operators as matrices.
+        """Return A, B, C, D, and E operators as matrices.
 
         Parameters
         ----------

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -39,6 +39,7 @@ from pymor.operators.constructions import (
     LincombOperator,
     LinearInputOperator,
     LowRankOperator,
+    VectorArrayOperator,
     VectorOperator,
     ZeroOperator,
 )

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -40,7 +40,6 @@ from pymor.operators.constructions import (
     LincombOperator,
     LinearInputOperator,
     LowRankOperator,
-    VectorArrayOperator,
     VectorOperator,
     ZeroOperator,
 )
@@ -365,7 +364,7 @@ class LTIModel(Model):
             The |NumPy array| or |SciPy spmatrix| E or `None` (if E is an `IdentityOperator`).
         """
         return self.to_abcde_matrices(format)
-    
+
     def to_abcde_matrices(self, format=None):
         """Return A, B, C and D operators as matrices.
 

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -36,7 +36,6 @@ from pymor.operators.block import (
 )
 from pymor.operators.constructions import (
     IdentityOperator,
-    InverseOperator,
     LincombOperator,
     LinearInputOperator,
     LowRankOperator,

--- a/src/pymor/reductors/spectral_factor.py
+++ b/src/pymor/reductors/spectral_factor.py
@@ -105,19 +105,15 @@ class SpectralFactorReductor(BasicObject):
             X = self.fom.gramian('pr_o_dense', mu=self.mu)
 
         # Compute Cholesky-like factorization of W(X)
-        E = to_matrix(self.fom.E, format='dense')
-        B = to_matrix(self.fom.B, format='dense')
-        C = to_matrix(self.fom.C, format='dense')
-        D = to_matrix(self.fom.D, format='dense')
+        A, B, C, D, E = self.fom.to_abcde_matrices()
         M = _chol(D + D.T).T
-        L = spla.solve(M.T, C - B.T @ X @ E)
+        L = spla.solve(M.T, C - B.T @ X if E is None else C - B.T @ X @ E)
 
         if compute_errors:
-            A = to_matrix(self.fom.A, format='dense')
-            LTL = -A.T @ X @ E - X @ A @ E
+            LTL = -A.T @ X - X @ A if E is None else -A.T @ X @ E - X @ A @ E
             relLTLerr = np.linalg.norm(L.T @ L - LTL) / np.linalg.norm(LTL)
             self.logger.info(f'Relative L^T*L error: {relLTLerr:.3e}')
-            LTM = C.T - E.T @ X @ B
+            LTM = C.T - X @ B if E is None else C.T - E.T @ X @ B
             relLTMerr = np.linalg.norm(L.T @ M - LTM) / np.linalg.norm(LTM)
             self.logger.info(f'Relative L^T*M error: {relLTMerr:.3e}')
 
@@ -126,28 +122,22 @@ class SpectralFactorReductor(BasicObject):
             NumpyMatrixOperator(M, source_id=self.fom.B.source.id),
             self.fom.E)
 
-        spectral_factor_reduced = r_fn(spectral_factor, self.mu)
+        spectral_factor_rom = r_fn(spectral_factor, self.mu)
 
         if compute_errors:
-            spectralH2err = spectral_factor_reduced - spectral_factor
+            spectralH2err = spectral_factor_rom - spectral_factor
             self.logger.info('Relative H2 error of reduced spectral factor: '
                 f'{spectralH2err.h2_norm() / spectral_factor.h2_norm():.3e}')
 
-        Er = to_matrix(spectral_factor_reduced.E, format='dense')
-        Ar = to_matrix(spectral_factor_reduced.A, format='dense')
-        Br = to_matrix(spectral_factor_reduced.B, format='dense')
-        Lr = to_matrix(spectral_factor_reduced.C, format='dense')
-        Mr = to_matrix(spectral_factor_reduced.D, format='dense')
-
         if check_stability:
-            largest_pole = spectral_factor_reduced.poles().real.max()
+            largest_pole = spectral_factor_rom.poles().real.max()
             if largest_pole > 0:
                 self.logger.warn('Reduced system for spectral factor is not stable. '
                                  f'Real value of largest pole is {largest_pole}.')
 
+        Ar, Br, Lr, Mr, Er = spectral_factor_rom.to_abcde_matrices()
         Dr = 0.5*(Mr.T @ Mr) + 0.5*(D-D.T)
-
         Xr = solve_cont_lyap_dense(A=Ar, E=Er, B=Lr, trans=True)
-        Cr = Br.T @ Xr @ Er + Mr.T @ Lr
+        Cr = Br.T @ Xr + Mr.T @ Lr if Er is None else Br.T @ Xr @ Er + Mr.T @ Lr
 
         return LTIModel.from_matrices(Ar, Br, Cr, Dr, Er)

--- a/src/pymor/reductors/spectral_factor.py
+++ b/src/pymor/reductors/spectral_factor.py
@@ -102,8 +102,7 @@ class SpectralFactorReductor(BasicObject):
         if X is None:
             # Compute minimal solution X to Riccati equation
             assert not isinstance(self.fom.D, ZeroOperator), 'D+D^T must be invertible.'
-            Z = self.fom.gramian('pr_o_lrcf', mu=self.mu).to_numpy()
-            X = Z.T @ Z
+            X = self.fom.gramian('pr_o_dense', mu=self.mu)
 
         # Compute Cholesky-like factorization of W(X)
         E = to_matrix(self.fom.E, format='dense')

--- a/src/pymor/reductors/spectral_factor.py
+++ b/src/pymor/reductors/spectral_factor.py
@@ -6,7 +6,6 @@ import numpy as np
 import scipy.linalg as spla
 
 from pymor.algorithms.lyapunov import _chol, solve_cont_lyap_dense
-from pymor.algorithms.to_matrix import to_matrix
 from pymor.core.base import BasicObject
 from pymor.models.iosys import LTIModel
 from pymor.operators.constructions import ZeroOperator

--- a/src/pymordemos/phlti.py
+++ b/src/pymordemos/phlti.py
@@ -67,6 +67,11 @@ def main(
         t0 = perf_counter()
         for j, r in enumerate(reduced_order):
             rom = reductors[name](r)
+
+            if name in ('PRBT', 'spectral_factor'):
+               print('Converting ROM to PHLTIModel.')
+               rom = PHLTIModel.from_passive_LTIModel(rom)
+
             h2_errors[i, j] = (rom - fom).h2_norm() / fom.h2_norm()
         t1 = perf_counter()
         timings[name] = t1 - t0

--- a/src/pymordemos/phlti.py
+++ b/src/pymordemos/phlti.py
@@ -31,7 +31,9 @@ def main(
     eps = 1e-12
     S += np.eye(S.shape[0]) * eps
 
-    fom = PHLTIModel.from_matrices(J, R, G, S=S, Q=Q, solver_options={'ricc_pos_lrcf': 'slycot'})
+    fom = PHLTIModel.from_matrices(J, R, G, S=S, Q=Q, solver_options={
+        'ricc_pos_lrcf': 'slycot', 'ricc_pos_dense': 'slycot'
+    })
 
     bt = BTReductor(fom).reduce
     prbt = PRBTReductor(fom).reduce

--- a/src/pymortests/algorithms/riccati.py
+++ b/src/pymortests/algorithms/riccati.py
@@ -137,16 +137,27 @@ def test_ricc_dense(n, m, p, with_E, with_R, with_S, trans, solver):
 def test_pos_ricc_dense(n, m, p, with_E, with_R, with_S, trans, solver):
     skip_if_missing_solver(solver)
 
+    mat_old = []
+    mat_new = []
     if not with_E:
         A = conv_diff_1d_fd(n, 1, 1)
-        A = A.todense()
+        A = A.toarray()
         E = None
     else:
         A, E = conv_diff_1d_fem(n, 1, 1)
-        A = A.todense()
-        E = E.todense()
+        A = A.toarray()
+        E = E.toarray()
+        mat_old.append(E.copy())
+        mat_new.append(E)
+    A = np.asfortranarray(A)
+    mat_old.append(A.copy())
+    mat_new.append(A)
     B = np.random.randn(n, m)
+    mat_old.append(B.copy())
+    mat_new.append(B)
     C = np.random.randn(p, n)
+    mat_old.append(C.copy())
+    mat_new.append(C)
     D = np.random.randn(p, m)
     if not trans:
         R0 = np.random.randn(p, p)
@@ -156,12 +167,22 @@ def test_pos_ricc_dense(n, m, p, with_E, with_R, with_S, trans, solver):
         R0 = np.random.randn(m, m)
         R = D.T.dot(D) + R0.dot(R0.T) if with_R else None
         S = 1e-1 * C.T @ D if with_S else None
+    if with_R:
+        mat_old.append(R.copy())
+        mat_new.append(R)
+    if with_S:
+        mat_old.append(S.copy())
+        mat_new.append(S)
 
     X = solve_pos_ricc_dense(A, E, B, C, R, S, trans=trans, options=solver)
 
     if not with_R:
         R = np.eye(p if not trans else m)
     assert relative_residual(A, E, B, C, -R, S, _chol(X), trans) < 1e-8
+
+    for mat1, mat2 in zip(mat_old, mat_new):
+        assert type(mat1) == type(mat2)
+        assert np.all(mat1 == mat2)
 
 
 @pytest.mark.parametrize('m', m_list)

--- a/src/pymortests/algorithms/riccati.py
+++ b/src/pymortests/algorithms/riccati.py
@@ -79,6 +79,7 @@ def relative_residual(A, E, B, C, R, S, Z, trans):
 @pytest.mark.parametrize('solver', ricc_dense_solver_list)
 def test_ricc_dense(n, m, p, with_E, with_R, with_S, trans, solver):
     skip_if_missing_solver(solver)
+    np.random.seed(0)
 
     mat_old = []
     mat_new = []
@@ -136,6 +137,7 @@ def test_ricc_dense(n, m, p, with_E, with_R, with_S, trans, solver):
 @pytest.mark.parametrize('solver', ricc_dense_solver_list)
 def test_pos_ricc_dense(n, m, p, with_E, with_R, with_S, trans, solver):
     skip_if_missing_solver(solver)
+    np.random.seed(0)
 
     mat_old = []
     mat_new = []
@@ -195,6 +197,7 @@ def test_pos_ricc_dense(n, m, p, with_E, with_R, with_S, trans, solver):
                                            product(n_list_big, ricc_lrcf_solver_list_big)))
 def test_ricc_lrcf(n, m, p, with_E, with_R, with_S, trans, solver):
     skip_if_missing_solver(solver)
+    np.random.seed(0)
     if with_S and (solver.startswith('pymess') or solver == 'lrradi'):
         pytest.xfail('solver not implemented')
 
@@ -262,6 +265,7 @@ def test_ricc_lrcf(n, m, p, with_E, with_R, with_S, trans, solver):
 @pytest.mark.parametrize('solver', ricc_lrcf_solver_list_small)
 def test_pos_ricc_lrcf(n, m, p, with_E, with_R, with_S, trans, solver):
     skip_if_missing_solver(solver)
+    np.random.seed(0)
     if with_S and solver.startswith('pymess'):
         pytest.xfail('solver not implemented')
 

--- a/src/pymortests/algorithms/riccati.py
+++ b/src/pymortests/algorithms/riccati.py
@@ -10,9 +10,7 @@ import scipy.linalg as spla
 import scipy.sparse as sps
 
 from pymor.algorithms.lyapunov import _chol
-from pymor.algorithms.riccati import (
-    solve_pos_ricc_dense, solve_pos_ricc_lrcf, solve_ricc_dense, solve_ricc_lrcf
-)
+from pymor.algorithms.riccati import solve_pos_ricc_dense, solve_pos_ricc_lrcf, solve_ricc_dense, solve_ricc_lrcf
 from pymor.operators.numpy import NumpyMatrixOperator
 from pymortests.algorithms.lyapunov import conv_diff_1d_fd, conv_diff_1d_fem, fro_norm, skip_if_missing_solver
 

--- a/src/pymortests/algorithms/riccati.py
+++ b/src/pymortests/algorithms/riccati.py
@@ -10,7 +10,9 @@ import scipy.linalg as spla
 import scipy.sparse as sps
 
 from pymor.algorithms.lyapunov import _chol
-from pymor.algorithms.riccati import solve_pos_ricc_lrcf, solve_ricc_dense, solve_ricc_lrcf
+from pymor.algorithms.riccati import (
+    solve_pos_ricc_dense, solve_pos_ricc_lrcf, solve_ricc_dense, solve_ricc_lrcf
+)
 from pymor.operators.numpy import NumpyMatrixOperator
 from pymortests.algorithms.lyapunov import conv_diff_1d_fd, conv_diff_1d_fem, fro_norm, skip_if_missing_solver
 
@@ -124,6 +126,44 @@ def test_ricc_dense(n, m, p, with_E, with_R, with_S, trans, solver):
     for mat1, mat2 in zip(mat_old, mat_new):
         assert type(mat1) == type(mat2)
         assert np.all(mat1 == mat2)
+
+
+@pytest.mark.parametrize('m', m_list)
+@pytest.mark.parametrize('p', p_list)
+@pytest.mark.parametrize('with_E', [False, True])
+@pytest.mark.parametrize('with_R', [False, True])
+@pytest.mark.parametrize('with_S', [False, True])
+@pytest.mark.parametrize('trans', [False, True])
+@pytest.mark.parametrize('n', n_list_small)
+@pytest.mark.parametrize('solver', ricc_dense_solver_list)
+def test_pos_ricc_dense(n, m, p, with_E, with_R, with_S, trans, solver):
+    skip_if_missing_solver(solver)
+
+    if not with_E:
+        A = conv_diff_1d_fd(n, 1, 1)
+        A = A.todense()
+        E = None
+    else:
+        A, E = conv_diff_1d_fem(n, 1, 1)
+        A = A.todense()
+        E = E.todense()
+    B = np.random.randn(n, m)
+    C = np.random.randn(p, n)
+    D = np.random.randn(p, m)
+    if not trans:
+        R0 = np.random.randn(p, p)
+        R = D.dot(D.T) + R0.dot(R0.T) if with_R else None
+        S = 1e-1 * D @ B.T if with_S else None
+    else:
+        R0 = np.random.randn(m, m)
+        R = D.T.dot(D) + R0.dot(R0.T) if with_R else None
+        S = 1e-1 * C.T @ D if with_S else None
+
+    X = solve_pos_ricc_dense(A, E, B, C, R, S, trans=trans, options=solver)
+
+    if not with_R:
+        R = np.eye(p if not trans else m)
+    assert relative_residual(A, E, B, C, -R, S, _chol(X), trans) < 1e-8
 
 
 @pytest.mark.parametrize('m', m_list)


### PR DESCRIPTION
- [riccati] Add `solve_pos_ricc_dense` and bindings for `scipy` and `slycot`
- [iosys] add `pr_c_dense` and `pr_o_dense` Gramians
- [spectral_factor] use `pr_o_dense` Gramian instead of `pr_o_lrcf` because we need the full dense solution anyway
- [iosys] use dense solvers in `from_passive_LTIModel` instead of lrcf ones
- [iosys] add `to_abcde_matrices` to `LTIModel` such that the standard ABCDE matrices can still be exported if a child class overrides `to_matrices` (like for instance `PHLTIModel`)
- [iosys] add `format` parameter to `to_matrices` methods
- [spectral_factor] use `LTIModel.to_abcde_matrices` instead of converting the matrices individually