### PR TITLE
Improve jupyter logging widget

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -6,7 +6,7 @@
 # --keep-going lets sphinx process the full build instead of aborting on first warning
 #   this is esp. necessary for myst-nb code-cells that otherwise show no visible code error
 SPHINXOPTS    = -W --keep-going
-SPHINXBUILD   = PYMOR_FORCE_JUPYTER=1 sphinx-build -j auto -v source
+SPHINXBUILD   = sphinx-build -j auto -v source
 PAPER         =
 BUILDDIR      = _build
 

--- a/docs/source/jupyter_init.txt
+++ b/docs/source/jupyter_init.txt
@@ -2,10 +2,6 @@
     :hide-code:
     :hide-output:
 
-    from IPython import get_ipython
-    ip = get_ipython()
-    if ip is not None:
-        ip.run_line_magic('load_ext', 'pymor.tools.jupyter')
     %matplotlib inline
 
     import warnings

--- a/docs/source/jupyter_init.txt
+++ b/docs/source/jupyter_init.txt
@@ -5,7 +5,7 @@
     from IPython import get_ipython
     ip = get_ipython()
     if ip is not None:
-        ip.run_line_magic('load_ext', 'pymor.discretizers.builtin.gui.jupyter')
+        ip.run_line_magic('load_ext', 'pymor.tools.jupyter')
     %matplotlib inline
 
     import warnings

--- a/docs/source/myst_code_init.py
+++ b/docs/source/myst_code_init.py
@@ -7,7 +7,6 @@ import pymor.tools.random
 
 ip = get_ipython()
 if ip is not None:
-    ip.run_line_magic('load_ext', 'pymor.tools.jupyter')
     ip.run_line_magic('matplotlib', 'inline')
 
 warnings.filterwarnings('ignore', category=UserWarning, module='torch')

--- a/docs/source/myst_code_init.py
+++ b/docs/source/myst_code_init.py
@@ -7,7 +7,7 @@ import pymor.tools.random
 
 ip = get_ipython()
 if ip is not None:
-    ip.run_line_magic('load_ext', 'pymor.discretizers.builtin.gui.jupyter')
+    ip.run_line_magic('load_ext', 'pymor.tools.jupyter')
     ip.run_line_magic('matplotlib', 'inline')
 
 warnings.filterwarnings('ignore', category=UserWarning, module='torch')

--- a/src/pymor/__init__.py
+++ b/src/pymor/__init__.py
@@ -48,8 +48,8 @@ def _init_mpi():
 
 _init_mpi()
 
-from pymor.core.config import config
-from pymor.core.defaults import load_defaults_from_file
+from pymor.core.config import config, is_jupyter
+from pymor.core.defaults import defaults, load_defaults_from_file
 
 if 'PYMOR_DEFAULTS' in os.environ:
     filename = os.environ['PYMOR_DEFAULTS']
@@ -75,6 +75,19 @@ from pymor.core.logger import set_log_format, set_log_levels
 
 set_log_levels()
 set_log_format()
+
+
+@defaults('enabled')
+def auto_load_jupyter_extension(enabled=True):
+    if not enabled:
+        return
+    if is_jupyter():
+        from IPython import get_ipython
+        ip = get_ipython()
+        ip.run_line_magic('load_ext', 'pymor.tools.jupyter')
+
+auto_load_jupyter_extension()
+
 
 from pymor.tools import mpi
 

--- a/src/pymor/__init__.py
+++ b/src/pymor/__init__.py
@@ -81,7 +81,7 @@ set_log_format()
 def auto_load_jupyter_extension(enabled=True):
     if not enabled:
         return
-    if is_jupyter():
+    if is_jupyter() and config.HAVE_IPYWIDGETS:
         from IPython import get_ipython
         ip = get_ipython()
         ip.run_line_magic('load_ext', 'pymor.tools.jupyter')

--- a/src/pymor/discretizers/builtin/gui/jupyter/__init__.py
+++ b/src/pymor/discretizers/builtin/gui/jupyter/__init__.py
@@ -9,10 +9,6 @@ from packaging.version import parse as parse_version
 from pymor.core.config import config
 from pymor.core.defaults import defaults
 
-# AFAICT there is no robust way to query for loaded extensions
-# and we have to make sure we do not setup two redirects
-_extension_loaded = False
-
 
 @defaults('backend')
 def get_visualizer(backend='prefer_k3d'):
@@ -33,19 +29,3 @@ def get_visualizer(backend='prefer_k3d'):
     else:
         from pymor.discretizers.builtin.gui.jupyter.matplotlib import visualize_patch
         return visualize_patch
-
-
-def load_ipython_extension(ipython):
-    global _extension_loaded
-    from pymor.discretizers.builtin.gui.jupyter.logging import redirect_logging
-    ipython.events.register('pre_run_cell', redirect_logging.start)
-    ipython.events.register('post_run_cell', redirect_logging.stop)
-    _extension_loaded = True
-
-
-def unload_ipython_extension(ipython):
-    global _extension_loaded
-    from pymor.discretizers.builtin.gui.jupyter.logging import redirect_logging
-    ipython.events.unregister('pre_run_cell', redirect_logging.start)
-    ipython.events.unregister('post_run_cell', redirect_logging.stop)
-    _extension_loaded = False

--- a/src/pymor/discretizers/builtin/gui/jupyter/logging.py
+++ b/src/pymor/discretizers/builtin/gui/jupyter/logging.py
@@ -33,7 +33,7 @@ class LogViewer(logging.Handler):
                 display(self.accordion)
             self.first_emit = False
         record = self.formatter.format_html(record)
-        self.out.value += f'<p style="line-height:120%">{record}</p>'
+        self.out.value += f'<div style="font-family:monospace,monospace;line-height:120%">{record}<br></div>'
 
     @property
     def empty(self):

--- a/src/pymor/tools/jupyter.py
+++ b/src/pymor/tools/jupyter.py
@@ -96,3 +96,20 @@ class LoggingRedirector:
 
 
 redirect_logging = LoggingRedirector()
+
+# AFAICT there is no robust way to query for loaded extensions
+# and we have to make sure we do not setup two redirects
+_extension_loaded = False
+
+def load_ipython_extension(ipython):
+    global _extension_loaded
+    ipython.events.register('pre_run_cell', redirect_logging.start)
+    ipython.events.register('post_run_cell', redirect_logging.stop)
+    _extension_loaded = True
+
+
+def unload_ipython_extension(ipython):
+    global _extension_loaded
+    ipython.events.unregister('pre_run_cell', redirect_logging.start)
+    ipython.events.unregister('post_run_cell', redirect_logging.stop)
+    _extension_loaded = False


### PR DESCRIPTION
- Use monospace font and improve spacing in log output.
- Move code to `tools.jupyter`.
- Autoload extension when `is_jupyter()` is true.