### PR TITLE
Fix Slycot matrix mutation

### DIFF
--- a/src/pymor/bindings/pymess.py
+++ b/src/pymor/bindings/pymess.py
@@ -24,7 +24,7 @@ from pymor.bindings.scipy import _solve_ricc_check_args
 from pymor.core.defaults import defaults
 from pymor.core.logger import getLogger
 from pymor.operators.constructions import IdentityOperator
-from pymor.tools import Deprecated
+from pymor.tools.deprecated import Deprecated
 
 
 @defaults('adi_maxit', 'adi_memory_usage', 'adi_output', 'adi_rel_change_tol', 'adi_res2_tol', 'adi_res2c_tol',

--- a/src/pymor/bindings/slycot.py
+++ b/src/pymor/bindings/slycot.py
@@ -139,6 +139,7 @@ def solve_lyap_dense(A, E, B, trans=False, cont_time=True, options=None):
             uplo = 'L'
             Q = np.zeros((n, n))
             Z = np.zeros((n, n))
+            A, E = A.copy(), E.copy()  # avoid overwriting (see #2168)
             _, _, _, _, X, scale, sep, ferr, _, _, _ = slycot.sg03ad(dico, job, fact, trana, uplo,
                                                                      n, A, E,
                                                                      Q, Z, C)

--- a/src/pymor/bindings/slycot.py
+++ b/src/pymor/bindings/slycot.py
@@ -227,9 +227,14 @@ def solve_ricc_dense(A, E, B, C, R=None, S=None, trans=False, options=None):
         p = B.shape[1] if not trans else C.shape[0]
         if R is None:
             R = np.eye(m)
+        else:
+            R = R.copy()  # fix overwrite issue (#2200)
+        S = S.copy()  # fix overwrite issue (#2200)
         if trans:
+            C = C.copy()  # fix overwrite issue (#2200)
             X, rcond = slycot.sb02od(n, m, A, B, C, R, dico, p=p, L=S, fact='C')[:2]
         else:
+            B = B.copy()  # fix overwrite issue (#2200)
             X, rcond = slycot.sb02od(n, m, A.T, C.T, B.T, R, dico, p=p, L=S.T, fact='C')[:2]
         _ricc_rcond_check('slycot.sb02od', rcond)
     else:

--- a/src/pymortests/algorithms/lyapunov.py
+++ b/src/pymortests/algorithms/lyapunov.py
@@ -222,7 +222,7 @@ def test_disc_lrcf(n, m, with_E, trans, solver):
 def test_cont_dense(n, m, with_E, trans, solver):
     skip_if_missing_solver(solver)
 
-    A = np.random.randn(n, n)
+    A = np.asfortranarray(np.random.randn(n, n))
     E = np.eye(n) + np.random.randn(n, n) / n if with_E else None
     B = np.random.randn(n, m)
     if trans:
@@ -256,7 +256,7 @@ def test_cont_dense(n, m, with_E, trans, solver):
 def test_disc_dense(n, m, with_E, trans, solver):
     skip_if_missing_solver(solver)
 
-    A = np.random.randn(n, n)
+    A = np.asfortranarray(np.random.randn(n, n))
     E = np.eye(n) + np.random.randn(n, n) / n if with_E else None
     B = np.random.randn(n, m)
     if trans:

--- a/src/pymortests/algorithms/lyapunov.py
+++ b/src/pymortests/algorithms/lyapunov.py
@@ -134,14 +134,23 @@ def relative_residual(A, E, B, X, cont_time, trans=False):
 def test_cont_lrcf(n, m, with_E, trans, solver):
     skip_if_missing_solver(solver)
 
+    mat_old = []
+    mat_new = []
     if not with_E:
         A = conv_diff_1d_fd(n, 1, 0.1, cont_time=True)
         E = None
     else:
         A, E = conv_diff_1d_fem(n, 1, 0.1, cont_time=True)
+        mat_old.append(E.copy())
+        mat_new.append(E)
+    mat_old.append(A.copy())
+    mat_new.append(A)
+
     B = np.random.randn(n, m)
     if trans:
         B = B.T
+    mat_old.append(B.copy())
+    mat_new.append(B)
 
     Aop = NumpyMatrixOperator(A)
     Eop = NumpyMatrixOperator(E) if with_E else None
@@ -153,6 +162,13 @@ def test_cont_lrcf(n, m, with_E, trans, solver):
     Z = Zva.to_numpy().T
     assert relative_residual(A, E, B, Z @ Z.T, trans=trans, cont_time=True) < 1e-10
 
+    for mat1, mat2 in zip(mat_old, mat_new):
+        assert type(mat1) == type(mat2)
+        if sps.issparse(mat1):
+            mat1 = mat1.toarray()
+            mat2 = mat2.toarray()
+        assert np.all(mat1 == mat2)
+
 
 @pytest.mark.parametrize('n', n_list_small)
 @pytest.mark.parametrize('m', m_list)
@@ -162,15 +178,23 @@ def test_cont_lrcf(n, m, with_E, trans, solver):
 def test_disc_lrcf(n, m, with_E, trans, solver):
     skip_if_missing_solver(solver)
 
+    mat_old = []
+    mat_new = []
     if not with_E:
         A = conv_diff_1d_fd(n, 1, 0.1, cont_time=False)
         E = None
     else:
         A, E = conv_diff_1d_fem(n, 1, 0.1, cont_time=False)
+        mat_old.append(E.copy())
+        mat_new.append(E)
+    mat_old.append(A.copy())
+    mat_new.append(A)
 
     B = np.random.randn(n, m)
     if trans:
         B = B.T
+    mat_old.append(B.copy())
+    mat_new.append(B)
 
     Aop = NumpyMatrixOperator(A)
     Eop = NumpyMatrixOperator(E) if with_E else None
@@ -181,6 +205,13 @@ def test_disc_lrcf(n, m, with_E, trans, solver):
 
     Z = Zva.to_numpy().T
     assert relative_residual(A, E, B, Z @ Z.T, trans=trans, cont_time=False) < 1e-10
+
+    for mat1, mat2 in zip(mat_old, mat_new):
+        assert type(mat1) == type(mat2)
+        if sps.issparse(mat1):
+            mat1 = mat1.toarray()
+            mat2 = mat2.toarray()
+        assert np.all(mat1 == mat2)
 
 
 @pytest.mark.parametrize('n', n_list_small)
@@ -197,10 +228,24 @@ def test_cont_dense(n, m, with_E, trans, solver):
     if trans:
         B = B.T
 
+    mat_old = []
+    mat_new = []
+    if E is not None:
+        mat_old.append(E.copy())
+        mat_new.append(E)
+    mat_old.append(A.copy())
+    mat_new.append(A)
+    mat_old.append(B.copy())
+    mat_new.append(B)
+
     X = solve_cont_lyap_dense(A, E, B, trans=trans, options=solver)
     assert type(X) is np.ndarray
 
     assert relative_residual(A, E, B, X, trans=trans, cont_time=True) < 1e-10
+
+    for mat1, mat2 in zip(mat_old, mat_new):
+        assert type(mat1) == type(mat2)
+        assert np.all(mat1 == mat2)
 
 
 @pytest.mark.parametrize('n', n_list_small)
@@ -217,7 +262,21 @@ def test_disc_dense(n, m, with_E, trans, solver):
     if trans:
         B = B.T
 
+    mat_old = []
+    mat_new = []
+    if E is not None:
+        mat_old.append(E.copy())
+        mat_new.append(E)
+    mat_old.append(A.copy())
+    mat_new.append(A)
+    mat_old.append(B.copy())
+    mat_new.append(B)
+
     X = solve_disc_lyap_dense(A, E, B, trans=trans, options=solver)
     assert type(X) is np.ndarray
 
     assert relative_residual(A, E, B, X, trans=trans, cont_time=False) < 1e-10
+
+    for mat1, mat2 in zip(mat_old, mat_new):
+        assert type(mat1) == type(mat2)
+        assert np.all(mat1 == mat2)

--- a/src/pymortests/algorithms/riccati.py
+++ b/src/pymortests/algorithms/riccati.py
@@ -7,6 +7,7 @@ from itertools import chain, product
 import numpy as np
 import pytest
 import scipy.linalg as spla
+import scipy.sparse as sps
 
 from pymor.algorithms.lyapunov import _chol
 from pymor.algorithms.riccati import solve_pos_ricc_lrcf, solve_ricc_dense, solve_ricc_lrcf
@@ -138,13 +139,23 @@ def test_ricc_lrcf(n, m, p, with_E, with_R, with_S, trans, solver):
     if with_S and (solver.startswith('pymess') or solver == 'lrradi'):
         pytest.xfail('solver not implemented')
 
+    mat_old = []
+    mat_new = []
     if not with_E:
         A = conv_diff_1d_fd(n, 1, 1)
         E = None
     else:
         A, E = conv_diff_1d_fem(n, 1, 1)
+        mat_old.append(E.copy())
+        mat_new.append(E)
+    mat_old.append(A.copy())
+    mat_new.append(A)
     B = np.random.randn(n, m)
+    mat_old.append(B.copy())
+    mat_new.append(B)
     C = np.random.randn(p, n)
+    mat_old.append(C.copy())
+    mat_new.append(C)
     D = np.random.randn(p, m)
     if not trans:
         R0 = np.random.randn(p, p)
@@ -154,6 +165,12 @@ def test_ricc_lrcf(n, m, p, with_E, with_R, with_S, trans, solver):
         R0 = np.random.randn(m, m)
         R = D.T.dot(D) + R0.dot(R0.T) if with_R else None
         S = 1e-1 * C.T @ D if with_S else None
+    if with_R:
+        mat_old.append(R.copy())
+        mat_new.append(R)
+    if with_S:
+        mat_old.append(S.copy())
+        mat_new.append(S)
 
     Aop = NumpyMatrixOperator(A)
     Eop = NumpyMatrixOperator(E) if with_E else None
@@ -167,6 +184,13 @@ def test_ricc_lrcf(n, m, p, with_E, with_R, with_S, trans, solver):
 
     Z = Zva.to_numpy().T
     assert relative_residual(A, E, B, C, R, S, Z, trans) < 1e-8
+
+    for mat1, mat2 in zip(mat_old, mat_new):
+        assert type(mat1) == type(mat2)
+        if sps.issparse(mat1):
+            mat1 = mat1.toarray()
+            mat2 = mat2.toarray()
+        assert np.all(mat1 == mat2)
 
 
 @pytest.mark.parametrize('n', n_list_small)
@@ -182,13 +206,23 @@ def test_pos_ricc_lrcf(n, m, p, with_E, with_R, with_S, trans, solver):
     if with_S and solver.startswith('pymess'):
         pytest.xfail('solver not implemented')
 
+    mat_old = []
+    mat_new = []
     if not with_E:
         A = conv_diff_1d_fd(n, 1, 1)
         E = None
     else:
         A, E = conv_diff_1d_fem(n, 1, 1)
+        mat_old.append(E.copy())
+        mat_new.append(E)
+    mat_old.append(A.copy())
+    mat_new.append(A)
     B = np.random.randn(n, m)
+    mat_old.append(B.copy())
+    mat_new.append(B)
     C = np.random.randn(p, n)
+    mat_old.append(C.copy())
+    mat_new.append(C)
     D = np.random.randn(p, m)
     if not trans:
         R0 = np.random.randn(p, p)
@@ -198,6 +232,12 @@ def test_pos_ricc_lrcf(n, m, p, with_E, with_R, with_S, trans, solver):
         R0 = np.random.randn(m, m)
         R = D.T.dot(D) + 10 * R0.dot(R0.T) if with_R else None
         S = np.random.randn(n,m) if with_S else None
+    if with_R:
+        mat_old.append(R.copy())
+        mat_new.append(R)
+    if with_S:
+        mat_old.append(S.copy())
+        mat_new.append(S)
 
     Aop = NumpyMatrixOperator(A)
     Eop = NumpyMatrixOperator(E) if with_E else None
@@ -213,3 +253,10 @@ def test_pos_ricc_lrcf(n, m, p, with_E, with_R, with_S, trans, solver):
     if not with_R:
         R = np.eye(p if not trans else m)
     assert relative_residual(A, E, B, C, -R, S, Z, trans) < 1e-8
+
+    for mat1, mat2 in zip(mat_old, mat_new):
+        assert type(mat1) == type(mat2)
+        if sps.issparse(mat1):
+            mat1 = mat1.toarray()
+            mat2 = mat2.toarray()
+        assert np.all(mat1 == mat2)


### PR DESCRIPTION
- tests for matrix mutation in Lyapunov and Riccati solvers
- fixes the mutation issue with `sg03ad` and `sb02od`
- fixes `Deprecated` import in `pymess` bindings

Closes #2168.