### PR TITLE
`LTIModel` forced response computation

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -15,6 +15,7 @@
 
 * Art Pelling, a.pelling@tu-berlin.de
   * matrix-free implementation of circulant, Hankel and Toeplitz operators
+  * computation of an LTIModel's forced response
 
 ### pyMOR 2023.1
 

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -13,7 +13,7 @@
 
 ### pyMOR 2023.2
 
-* Art Pelling, a.pelling@tu-berlin.de
+* Art Pelling, @artpelling
   * matrix-free implementation of circulant, Hankel and Toeplitz operators
   * computation of an LTIModel's forced response
 

--- a/src/pymor/models/interface.py
+++ b/src/pymor/models/interface.py
@@ -352,7 +352,7 @@ class Model(CacheableObject, ParametricObject):
             self.logger.info(f'Solving {self.name} for {mu} ...')
 
         # first call _compute to give subclasses more control
-        data = self._compute(solution=solution, output=output, input=input,
+        data = self._compute(solution=solution, output=output,
                              solution_d_mu=solution_d_mu, output_d_mu=output_d_mu,
                              solution_error_estimate=solution_error_estimate,
                              output_error_estimate=output_error_estimate,

--- a/src/pymor/models/interface.py
+++ b/src/pymor/models/interface.py
@@ -352,15 +352,14 @@ class Model(CacheableObject, ParametricObject):
             self.logger.info(f'Solving {self.name} for {mu} ...')
 
         # first call _compute to give subclasses more control
-        data = self._compute(solution=solution, output=output,
+        data = self._compute(solution=solution, output=output, input=input,
                              solution_d_mu=solution_d_mu, output_d_mu=output_d_mu,
                              solution_error_estimate=solution_error_estimate,
                              output_error_estimate=output_error_estimate,
                              mu=mu, **kwargs)
 
-        if (solution or output or solution_error_estimate
-            or output_error_estimate or solution_d_mu or output_d_mu) \
-           and 'solution' not in data:
+        if (solution or solution_error_estimate or solution_d_mu) and 'solution' not in data \
+           or (output or output_error_estimate or output_d_mu) and 'output' not in data:
             retval = self.cached_method_call(self._compute_solution, mu=mu, **kwargs)
             if isinstance(retval, dict):
                 assert 'solution' in retval

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -671,10 +671,6 @@ class LTIModel(Model):
 
         assert self.T is not None
 
-        if any([solution_d_mu, output_d_mu, solution_error_estimate,
-                output_error_estimate, output_d_mu_return_array, output_error_estimate_return_vector]):
-            raise NotImplementedError
-
         if not solution and not output:
             return {}
 

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -667,11 +667,9 @@ class LTIModel(Model):
 
     def _compute(self, solution=False, output=False, solution_d_mu=False, output_d_mu=False,
                 solution_error_estimate=False, output_error_estimate=False, output_d_mu_return_array=False,
-                output_error_estimate_return_vector=False, mu=None, input=None, **kwargs):
+                 output_error_estimate_return_vector=False, mu=None, **kwargs):
 
         assert self.T is not None
-        assert kwargs.keys() <= self._compute_allowed_kwargs
-        assert input is not None or self.dim_input == 0
 
         if any([solution_d_mu, output_d_mu, solution_error_estimate,
                 output_error_estimate, output_d_mu_return_array, output_error_estimate_return_vector]):

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -665,37 +665,142 @@ class LTIModel(Model):
         if E is not None:
             _mmwrite(Path(files_basename + '.E'), E)
 
-    def _compute(self, solution=False, output=False, solution_d_mu=False, output_d_mu=False,
-                 solution_error_estimate=False, output_error_estimate=False,
-                 output_d_mu_return_array=False, mu=None):
+    def compute(self, solution=False, output=False, solution_d_mu=False, output_d_mu=False,
+                solution_error_estimate=False, output_error_estimate=False, output_d_mu_return_array=False,
+                output_error_estimate_return_vector=False, mu=None, input=None, **kwargs):
+        """Compute the solution of the model and associated quantities.
+
+        This method computes the output of the model, its internal state,
+        and various associated quantities for given |parameter values| `mu`.
+
+        Parameters
+        ----------
+        solution
+            If `True`, return the model's internal state.
+        output
+            If `True`, return the model output.
+        solution_d_mu
+            If not `False`, either `True` to return the derivative of the model's
+            internal state w.r.t. all parameter components or a tuple `(parameter, index)`
+            to return the derivative of a single parameter component.
+        output_d_mu
+            If `True`, return the gradient of the model output w.r.t. the |Parameter|.
+        solution_error_estimate
+            If `True`, return an error estimate for the computed internal state.
+        output_error_estimate
+            If `True`, return an error estimate for the computed output.
+        output_d_mu_return_array
+            If `True`, return the output gradient as a |NumPy array|.
+            Otherwise, return a dict of gradients for each |Parameter|.
+        output_error_estimate_return_vector
+            If `True`, return the output estimate as a |NumPy array|,
+            where each component corresponds to the respective component
+            of the :attr:`!output_functional`.
+            Otherwise, return the Euclidean norm of all components.
+        mu
+            |Parameter values| for which to compute the values.
+        input
+            The model input. Either a |NumPy array| of shape `(self.dim_input,)`,
+            a |Function| with `dim_domain == 1` and `shape_range == (self.dim_input,)`
+            mapping time to input, or a `str` expression with `t` as variable that
+            can be used to instantiate an |ExpressionFunction| of this type.
+            Can be `None` if `self.dim_input == 0`.
+        kwargs
+            Further keyword arguments to select further quantities that should
+            be returned or to customize how the values are computed.
+
+        Returns
+        -------
+        A dict with the computed values.
+        """
+        assert self.T is not None
+        assert kwargs.keys() <= self._compute_allowed_kwargs
+        assert input is not None or self.dim_input == 0
+
+        # parse parameter values
+        if not isinstance(mu, Mu):
+            mu = self.parameters.parse(mu)
+        assert self.parameters.assert_compatible(mu)
+
+        # parse input and add it to the parameter values
+        mu_input = Parameters(input=self.dim_input).parse(input)
+        input = mu_input.get_time_dependent_value('input') if mu_input.is_time_dependent('input') else mu_input['input']
+        mu = mu.with_(input=input)
+
         if not solution and not output:
             return {}
 
-        assert self.T is not None
-
-        if not isinstance(mu, Mu):
-            mu = self.parameters.parse(mu)
+        # explicitly checking if logging is disabled saves some cpu cycles
+        if not self.logging_disabled:
+            self.logger.info(f'Solving {self.name} for {mu} ...')
 
         # solution computation
-        mu = mu.with_(t=0)
-        X0 = self.initial_data.as_range_array(mu)
-        rhs = LinearInputOperator(self.B)
-        X = self.time_stepper.solve(
-            operator=-self.A,
-            rhs=rhs,
-            initial_data=X0,
+        n = self.num_values if self.num_values else self.time_stepper.estimate_time_step_count(0, self.T)
+        iterator = self.time_stepper.iterate(
+            0,  # initial_time
+            self.T,  # end_time
+            self.initial_data.as_range_array(mu),  # initial_data
+            -self.A,  # operator
+            rhs=LinearInputOperator(self.B),
             mass=None if isinstance(self.E, IdentityOperator) else self.E,
-            initial_time=0,
-            end_time=self.T,
-            mu=mu,
-            num_values=self.num_values,
+            mu=mu.with_(t=0),
+            num_values=n
         )
-        data = {'solution': X}
-
-        # output computation
+        data = {}
+        if solution:
+            data['solution'] = self.A.source.empty(reserve=n + 1)
         if output:
             D = LinearInputOperator(self.D)
-            data['output'] = self.C.apply(X, mu=mu).to_numpy() + D.apply(D.source.ones(1), mu=mu).to_numpy()
+            data['output'] = np.empty((n + 1, self.dim_output))
+        for i, (x, t) in enumerate(iterator):
+            if solution:
+                data['solution'].append(x)
+            if output:
+                data['output'][i] = self.C.apply(x, mu=mu).to_numpy() \
+                    + D.apply(D.source.ones(1), mu=mu.with_(t=t)).to_numpy()
+
+        if solution_d_mu:
+            if isinstance(solution_d_mu, tuple):
+                retval = self._compute_solution_d_mu_single_direction(
+                    solution_d_mu[0], solution_d_mu[1], data['solution'], mu=mu, **kwargs)
+            else:
+                retval = self._compute_solution_d_mu(data['solution'], mu=mu, **kwargs)
+            # retval is always a dict
+            if isinstance(retval, dict) and 'solution_d_mu' in retval:
+                data.update(retval)
+            else:
+                data['solution_d_mu'] = retval
+
+        if output_d_mu and 'output_d_mu' not in data:
+            # TODO use caching here (requires skipping args in key generation)
+            retval = self._compute_output_d_mu(data['solution'], mu=mu,
+                                               return_array=output_d_mu_return_array,
+                                               **kwargs)
+            # retval is always a dict
+            if isinstance(retval, dict) and 'output_d_mu' in retval:
+                data.update(retval)
+            else:
+                data['output_d_mu'] = retval
+
+        if solution_error_estimate and 'solution_error_estimate' not in data:
+            # TODO use caching here (requires skipping args in key generation)
+            retval = self._compute_solution_error_estimate(data['solution'], mu=mu, **kwargs)
+            if isinstance(retval, dict):
+                assert 'solution_error_estimate' in retval
+                data.update(retval)
+            else:
+                data['solution_error_estimate'] = retval
+
+        if output_error_estimate and 'output_error_estimate' not in data:
+            # TODO use caching here (requires skipping args in key generation)
+            retval = self._compute_output_error_estimate(
+                data['solution'], mu=mu,
+                return_vector=output_error_estimate_return_vector, **kwargs)
+            if isinstance(retval, dict):
+                assert 'output_error_estimate' in retval
+                data.update(retval)
+            else:
+                data['output_error_estimate'] = retval
 
         return data
 
@@ -799,7 +904,7 @@ class LTIModel(Model):
         """
         assert self.T is not None
 
-        n = self.time_stepper.estimate_time_step_count(0, self.T) + 1
+        n = (self.num_values if self.num_values else self.time_stepper.estimate_time_step_count(0, self.T)) + 1
         output = np.empty((n, self.dim_output, self.dim_input))
         if return_solution:
             solution = np.empty((n, self.dim_output, self.dim_input))
@@ -854,7 +959,7 @@ class LTIModel(Model):
         """
         assert self.T is not None
 
-        n = self.time_stepper.estimate_time_step_count(0, self.T) + 1
+        n = (self.num_values if self.num_values else self.time_stepper.estimate_time_step_count(0, self.T)) + 1
         output = np.empty((n, self.dim_output, self.dim_input))
         if return_solution:
             solution = np.empty((n, self.dim_output, self.dim_input))

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -810,7 +810,13 @@ class LTIModel(Model):
         """
         assert self.T is not None
 
-        n = (self.num_values if self.num_values else self.time_stepper.estimate_time_step_count(0, self.T)) + 1
+        if self.num_values is None:
+            try:
+                n = self.time_stepper.estimate_time_step_count(0, self.T) + 1
+            except NotImplementedError:
+                n = 0
+        else:
+            n = self.num_values + 1
         output = np.empty((n, self.dim_output, self.dim_input))
         if return_solution:
             solution = []
@@ -864,7 +870,13 @@ class LTIModel(Model):
         """
         assert self.T is not None
 
-        n = (self.num_values if self.num_values else self.time_stepper.estimate_time_step_count(0, self.T)) + 1
+        if self.num_values is None:
+            try:
+                n = self.time_stepper.estimate_time_step_count(0, self.T) + 1
+            except NotImplementedError:
+                n = 0
+        else:
+            n = self.num_values + 1
         output = np.empty((n, self.dim_output, self.dim_input))
         if return_solution:
             solution = []

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -698,12 +698,21 @@ class LTIModel(Model):
         if output:
             D = LinearInputOperator(self.D)
             data['output'] = np.empty((n, self.dim_output))
+            data_output_extra = []
         for i, (x, t) in enumerate(iterator):
             if solution:
                 data['solution'].append(x)
             if output:
-                data['output'][i] = (self.C.apply(x, mu=mu).to_numpy()
-                    + D.as_range_array(mu=mu.with_(t=t)).to_numpy())
+                y = self.C.apply(x, mu=mu).to_numpy() + D.as_range_array(mu=mu.with_(t=t)).to_numpy()
+                if i < n:
+                    data['output'][i] = y
+                else:
+                    data_output_extra.append(y)
+        if output:
+            if data_output_extra:
+                data['output'] = np.vstack((data['output'], data_output_extra))
+            if len(data['output']) < i + 1:
+                data['output'] = data['output'][:i + 1]
         return data
 
     def __add__(self, other):

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -665,54 +665,10 @@ class LTIModel(Model):
         if E is not None:
             _mmwrite(Path(files_basename + '.E'), E)
 
-    def compute(self, solution=False, output=False, solution_d_mu=False, output_d_mu=False,
+    def _compute(self, solution=False, output=False, solution_d_mu=False, output_d_mu=False,
                 solution_error_estimate=False, output_error_estimate=False, output_d_mu_return_array=False,
                 output_error_estimate_return_vector=False, mu=None, input=None, **kwargs):
-        """Compute the solution of the model and associated quantities.
 
-        This method computes the output of the model, its internal state,
-        and various associated quantities for given |parameter values| `mu`.
-
-        Parameters
-        ----------
-        solution
-            If `True`, return the model's internal state.
-        output
-            If `True`, return the model output.
-        solution_d_mu
-            If not `False`, either `True` to return the derivative of the model's
-            internal state w.r.t. all parameter components or a tuple `(parameter, index)`
-            to return the derivative of a single parameter component.
-        output_d_mu
-            If `True`, return the gradient of the model output w.r.t. the |Parameter|.
-        solution_error_estimate
-            If `True`, return an error estimate for the computed internal state.
-        output_error_estimate
-            If `True`, return an error estimate for the computed output.
-        output_d_mu_return_array
-            If `True`, return the output gradient as a |NumPy array|.
-            Otherwise, return a dict of gradients for each |Parameter|.
-        output_error_estimate_return_vector
-            If `True`, return the output estimate as a |NumPy array|,
-            where each component corresponds to the respective component
-            of the :attr:`!output_functional`.
-            Otherwise, return the Euclidean norm of all components.
-        mu
-            |Parameter values| for which to compute the values.
-        input
-            The model input. Either a |NumPy array| of shape `(self.dim_input,)`,
-            a |Function| with `dim_domain == 1` and `shape_range == (self.dim_input,)`
-            mapping time to input, or a `str` expression with `t` as variable that
-            can be used to instantiate an |ExpressionFunction| of this type.
-            Can be `None` if `self.dim_input == 0`.
-        kwargs
-            Further keyword arguments to select further quantities that should
-            be returned or to customize how the values are computed.
-
-        Returns
-        -------
-        A dict with the computed values.
-        """
         assert self.T is not None
         assert kwargs.keys() <= self._compute_allowed_kwargs
         assert input is not None or self.dim_input == 0
@@ -720,16 +676,6 @@ class LTIModel(Model):
         if any([solution_d_mu, output_d_mu, solution_error_estimate,
                 output_error_estimate, output_d_mu_return_array, output_error_estimate_return_vector]):
             raise NotImplementedError
-
-        # parse parameter values
-        if not isinstance(mu, Mu):
-            mu = self.parameters.parse(mu)
-        assert self.parameters.assert_compatible(mu)
-
-        # parse input and add it to the parameter values
-        mu_input = Parameters(input=self.dim_input).parse(input)
-        input = mu_input.get_time_dependent_value('input') if mu_input.is_time_dependent('input') else mu_input['input']
-        mu = mu.with_(input=input)
 
         if not solution and not output:
             return {}

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -666,7 +666,7 @@ class LTIModel(Model):
             _mmwrite(Path(files_basename + '.E'), E)
 
     def _compute(self, solution=False, output=False, solution_d_mu=False, output_d_mu=False,
-                solution_error_estimate=False, output_error_estimate=False, output_d_mu_return_array=False,
+                 solution_error_estimate=False, output_error_estimate=False, output_d_mu_return_array=False,
                  output_error_estimate_return_vector=False, mu=None, **kwargs):
 
         assert self.T is not None

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -20,7 +20,7 @@ from pymor.algorithms.riccati import solve_pos_ricc_dense, solve_pos_ricc_lrcf, 
 from pymor.algorithms.simplify import contract, expand
 from pymor.algorithms.timestepping import DiscreteTimeStepper, TimeStepper
 from pymor.algorithms.to_matrix import to_matrix
-from pymor.analyticalproblems.functions import ConstantFunction, GenericFunction
+from pymor.analyticalproblems.functions import GenericFunction
 from pymor.core.cache import cached
 from pymor.core.config import config
 from pymor.core.defaults import defaults
@@ -809,8 +809,7 @@ class LTIModel(Model):
 
         for i in range(self.dim_input):
             if self.sampling_time == 0:
-                input = ConstantFunction(np.zeros(self.dim_input))
-                data = self.with_(initial_data=initial_data[i]).compute(input=input,
+                data = self.with_(initial_data=initial_data[i]).compute(input=np.zeros(self.dim_input),
                                                                         output=True,
                                                                         solution=return_solution,
                                                                         mu=mu)

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -966,7 +966,7 @@ class LTIModel(Model):
         for i in range(self.dim_input):
             def input(t):
                 e = np.zeros(self.dim_input)
-                e[i] =  1 * self.sampling_time if self.sampling_time > 0 else 1  # noqa: B023
+                e[i] = self.sampling_time if self.sampling_time > 0 else 1  # noqa: B023
                 return e
 
             input = GenericFunction(mapping=input, shape_range=(self.dim_input,))

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -678,10 +678,6 @@ class LTIModel(Model):
         if not solution and not output:
             return {}
 
-        # explicitly checking if logging is disabled saves some cpu cycles
-        if not self.logging_disabled:
-            self.logger.info(f'Solving {self.name} for {mu} ...')
-
         # solution computation
         iterator = self.time_stepper.iterate(
             0,  # initial_time

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -665,7 +665,9 @@ class LTIModel(Model):
         if E is not None:
             _mmwrite(Path(files_basename + '.E'), E)
 
-    def compute(self, solution=False, output=False, mu=None, input=None):
+    def compute(self, solution=False, output=False, solution_d_mu=False, output_d_mu=False,
+                solution_error_estimate=False, output_error_estimate=False, output_d_mu_return_array=False,
+                output_error_estimate_return_vector=False, mu=None, input=None, **kwargs):
         """Compute the solution of the model and associated quantities.
 
         This method computes the output of the model, its internal state,
@@ -677,6 +679,24 @@ class LTIModel(Model):
             If `True`, return the model's internal state.
         output
             If `True`, return the model output.
+        solution_d_mu
+            If not `False`, either `True` to return the derivative of the model's
+            internal state w.r.t. all parameter components or a tuple `(parameter, index)`
+            to return the derivative of a single parameter component.
+        output_d_mu
+            If `True`, return the gradient of the model output w.r.t. the |Parameter|.
+        solution_error_estimate
+            If `True`, return an error estimate for the computed internal state.
+        output_error_estimate
+            If `True`, return an error estimate for the computed output.
+        output_d_mu_return_array
+            If `True`, return the output gradient as a |NumPy array|.
+            Otherwise, return a dict of gradients for each |Parameter|.
+        output_error_estimate_return_vector
+            If `True`, return the output estimate as a |NumPy array|,
+            where each component corresponds to the respective component
+            of the :attr:`!output_functional`.
+            Otherwise, return the Euclidean norm of all components.
         mu
             |Parameter values| for which to compute the values.
         input
@@ -685,12 +705,16 @@ class LTIModel(Model):
             mapping time to input, or a `str` expression with `t` as variable that
             can be used to instantiate an |ExpressionFunction| of this type.
             Can be `None` if `self.dim_input == 0`.
+        kwargs
+            Further keyword arguments to select further quantities that should
+            be returned or to customize how the values are computed.
 
         Returns
         -------
         A dict with the computed values.
         """
         assert self.T is not None
+        assert kwargs.keys() <= self._compute_allowed_kwargs
         assert input is not None or self.dim_input == 0
 
         # parse parameter values
@@ -734,6 +758,49 @@ class LTIModel(Model):
             if output:
                 data['output'][i] = (self.C.apply(x, mu=mu).to_numpy()
                     + D.as_range_array(mu=mu.with_(t=t)).to_numpy())
+
+        if solution_d_mu:
+            if isinstance(solution_d_mu, tuple):
+                retval = self._compute_solution_d_mu_single_direction(
+                    solution_d_mu[0], solution_d_mu[1], data['solution'], mu=mu, **kwargs)
+            else:
+                retval = self._compute_solution_d_mu(data['solution'], mu=mu, **kwargs)
+            # retval is always a dict
+            if isinstance(retval, dict) and 'solution_d_mu' in retval:
+                data.update(retval)
+            else:
+                data['solution_d_mu'] = retval
+
+        if output_d_mu and 'output_d_mu' not in data:
+            # TODO use caching here (requires skipping args in key generation)
+            retval = self._compute_output_d_mu(data['solution'], mu=mu,
+                                               return_array=output_d_mu_return_array,
+                                               **kwargs)
+            # retval is always a dict
+            if isinstance(retval, dict) and 'output_d_mu' in retval:
+                data.update(retval)
+            else:
+                data['output_d_mu'] = retval
+
+        if solution_error_estimate and 'solution_error_estimate' not in data:
+            # TODO use caching here (requires skipping args in key generation)
+            retval = self._compute_solution_error_estimate(data['solution'], mu=mu, **kwargs)
+            if isinstance(retval, dict):
+                assert 'solution_error_estimate' in retval
+                data.update(retval)
+            else:
+                data['solution_error_estimate'] = retval
+
+        if output_error_estimate and 'output_error_estimate' not in data:
+            # TODO use caching here (requires skipping args in key generation)
+            retval = self._compute_output_error_estimate(
+                data['solution'], mu=mu,
+                return_vector=output_error_estimate_return_vector, **kwargs)
+            if isinstance(retval, dict):
+                assert 'output_error_estimate' in retval
+                data.update(retval)
+            else:
+                data['output_error_estimate'] = retval
 
         return data
 


### PR DESCRIPTION
This PR will enable the computation of the outputs of an `LTIModel` given some inputs.

The `impulse_resp` and `step_resp` methods are refactored to call `LTIModel._compute`. This also fixes the bug where `step_resp` would not be scaled with the `sampling_time` and neglected `D`.