### PR TITLE
Add QR and RRQR interface methods

### DIFF
--- a/src/pymor/algorithms/eigs.py
+++ b/src/pymor/algorithms/eigs.py
@@ -5,7 +5,7 @@
 import numpy as np
 import scipy.linalg as spla
 
-from pymor.algorithms.gram_schmidt import gram_schmidt
+from pymor.algorithms.qr import qr
 from pymor.core.logger import getLogger
 from pymor.operators.constructions import IdentityOperator, InverseOperator
 from pymor.operators.interface import Operator
@@ -207,7 +207,7 @@ def _arnoldi(A, l, b, complex_evp):
         v = A.apply(v)
         V.append(v)
 
-        _, R = gram_schmidt(V, return_R=True, atol=0, rtol=0, offset=len(V) - 1, copy=False)
+        _, R = qr(V, offset=len(V) - 1, copy=False)
         H[:i + 2, i] = R[:l, i + 1]
         v = V[-1]
 
@@ -230,7 +230,7 @@ def _extend_arnoldi(A, V, H, f, p):
     for i in range(k, k + p):
         v = A.apply(v)
         V.append(v)
-        _, R = gram_schmidt(V, return_R=True, atol=0, rtol=0, offset=len(V) - 1, copy=False)
+        _, R = qr(V, offset=len(V) - 1, copy=False)
         H[:i + 2, i] = R[:k + p, i + 1]
 
         v = V[-1]

--- a/src/pymor/algorithms/gram_schmidt.py
+++ b/src/pymor/algorithms/gram_schmidt.py
@@ -50,7 +50,7 @@ def gram_schmidt(A, product=None, return_R=False, atol=1e-13, rtol=1e-13, offset
     Q
         The orthonormalized |VectorArray|.
     R
-        The upper-triangular/trapezoidal matrix (if `compute_R` is `True`).
+        The upper-triangular/trapezoidal matrix (if `return_R` is `True`).
     """
     logger = getLogger('pymor.algorithms.gram_schmidt.gram_schmidt')
 

--- a/src/pymor/algorithms/image.py
+++ b/src/pymor/algorithms/image.py
@@ -2,7 +2,7 @@
 # Copyright pyMOR developers and contributors. All rights reserved.
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
-from pymor.algorithms.gram_schmidt import gram_schmidt
+from pymor.algorithms.qr import rrqr
 from pymor.algorithms.rules import RuleTable, match_class, match_generic
 from pymor.core.exceptions import ImageCollectionError, NoMatchingRuleError
 from pymor.core.logger import getLogger
@@ -106,7 +106,7 @@ def estimate_image(operators=(), vectors=(),
         image = product.apply_inverse(image)
 
     if orthonormalize:
-        gram_schmidt(image, product=product, copy=False)
+        rrqr(image, product=product, copy=False)
 
     return image
 
@@ -212,7 +212,7 @@ def estimate_image_hierarchical(operators=(), vectors=(), domain=None, extends=N
         image.append(new_image, remove_from_other=True)
         if orthonormalize:
             with logger.block('Orthonormalizing ...'):
-                gram_schmidt(image, offset=gram_schmidt_offset, product=product, copy=False)
+                rrqr(image, offset=gram_schmidt_offset, product=product, copy=False)
             image_dims.append(len(image))
 
     return image, image_dims

--- a/src/pymor/algorithms/krylov.py
+++ b/src/pymor/algorithms/krylov.py
@@ -4,7 +4,7 @@
 
 """Module for computing (rational) Krylov subspaces' bases."""
 
-from pymor.algorithms.gram_schmidt import gram_schmidt
+from pymor.algorithms.qr import qr
 
 
 def rational_arnoldi(A, E, b, sigma, trans=False):
@@ -95,11 +95,11 @@ def rational_arnoldi(A, E, b, sigma, trans=False):
             v = sEmA.apply_inverse_adjoint(v if len(V) == 0 else E.apply_adjoint(v))
         if sigma[i].imag == 0:
             V.append(v)
-            gram_schmidt(V, atol=0, rtol=0, offset=len(V) - 1, copy=False)
+            qr(V, offset=len(V) - 1, copy=False)
         else:
             V.append(v.real)
             V.append(v.imag)
-            gram_schmidt(V, atol=0, rtol=0, offset=len(V) - 2, copy=False)
+            qr(V, offset=len(V) - 2, copy=False)
         v = V[-1]
 
     return V
@@ -185,5 +185,5 @@ def tangential_rational_krylov(A, E, B, b, sigma, trans=False, orth=True):
             V.append(v.real)
             V.append(v.imag)
     if orth:
-        gram_schmidt(V, atol=0, rtol=0, copy=False)
+        qr(V, copy=False)
     return V

--- a/src/pymor/algorithms/lradi.py
+++ b/src/pymor/algorithms/lradi.py
@@ -7,8 +7,8 @@ import scipy.linalg as spla
 
 from pymor.algorithms.eigs import _arnoldi
 from pymor.algorithms.genericsolvers import _parse_options
-from pymor.algorithms.gram_schmidt import gram_schmidt
 from pymor.algorithms.lyapunov import _solve_lyap_lrcf_check_args
+from pymor.algorithms.qr import qr
 from pymor.core.defaults import defaults
 from pymor.core.logger import getLogger
 from pymor.operators.constructions import IdentityOperator, InverseOperator
@@ -192,7 +192,7 @@ def projection_shifts_init(A, E, B, shift_options):
     """
     rng = new_rng(0)
     for i in range(shift_options['init_maxiter']):
-        Q = gram_schmidt(B, atol=0, rtol=0)
+        Q, _ = qr(B)
         shifts = spla.eigvals(A.apply2(Q, Q), E.apply2(Q, Q))
         shifts = shifts[shifts.real < 0]
         if shifts.size == 0:
@@ -233,12 +233,12 @@ def projection_shifts(A, E, V, Z, prev_shifts, shift_options):
     """
     if shift_options['subspace_columns'] == 1:
         if prev_shifts[-1].imag != 0:
-            Q = gram_schmidt(cat_arrays([V.real, V.imag]), atol=0, rtol=0)
+            Q, _ = qr(cat_arrays([V.real, V.imag]))
         else:
-            Q = gram_schmidt(V, atol=0, rtol=0)
+            Q, _ = qr(V)
     else:
         num_columns = shift_options['subspace_columns'] * len(V)
-        Q = gram_schmidt(Z[-num_columns:], atol=0, rtol=0)
+        Q, _ = qr(Z[-num_columns:])
 
     shifts = spla.eigvals(A.apply2(Q, Q), E.apply2(Q, Q))
     shifts = shifts[shifts.real < 0]

--- a/src/pymor/algorithms/lrradi.py
+++ b/src/pymor/algorithms/lrradi.py
@@ -6,7 +6,7 @@ import numpy as np
 import scipy.linalg as spla
 
 from pymor.algorithms.genericsolvers import _parse_options
-from pymor.algorithms.gram_schmidt import gram_schmidt
+from pymor.algorithms.qr import qr
 from pymor.algorithms.riccati import _solve_ricc_check_args
 from pymor.core.defaults import defaults
 from pymor.core.logger import getLogger
@@ -231,7 +231,7 @@ def hamiltonian_shifts_init(A, E, B, C, shift_options):
     """
     rng = new_rng(0)
     for _ in range(shift_options['init_maxiter']):
-        Q = gram_schmidt(C, atol=0, rtol=0)
+        Q, _ = qr(C)
         Ap = A.apply2(Q, Q)
         QB = Q.inner(B)
         Gp = QB.dot(QB.T)
@@ -310,7 +310,7 @@ def hamiltonian_shifts(A, E, B, R, K, Z, shift_options):
     if len(Z) < l:
         l = len(Z)
 
-    Q = gram_schmidt(Z[-l:], atol=0, rtol=0)
+    Q, _ = qr(Z[-l:])
     Ap = A.apply2(Q, Q)
     KBp = Q.inner(K) @ Q.inner(B).T
     AAp = Ap - KBp

--- a/src/pymor/algorithms/pod.py
+++ b/src/pymor/algorithms/pod.py
@@ -4,7 +4,7 @@
 
 import numpy as np
 
-from pymor.algorithms.gram_schmidt import gram_schmidt
+from pymor.algorithms.qr import qr
 from pymor.algorithms.svd_va import method_of_snapshots, qr_svd
 from pymor.core.defaults import defaults
 from pymor.core.logger import getLogger
@@ -75,6 +75,6 @@ def pod(A, product=None, modes=None, rtol=1e-7, atol=0., l2_err=0.,
         err = np.max(np.abs(POD.inner(POD, product) - np.eye(len(POD))))
         if err >= orth_tol:
             logger.info('Reorthogonalizing POD modes ...')
-            gram_schmidt(POD, product=product, atol=0., rtol=0., copy=False)
+            qr(POD, product=product, copy=False)
 
     return POD, SVALS

--- a/src/pymor/algorithms/qr.py
+++ b/src/pymor/algorithms/qr.py
@@ -1,0 +1,57 @@
+# This file is part of the pyMOR project (https://www.pymor.org).
+# Copyright pyMOR developers and contributors. All rights reserved.
+# License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
+
+from pymor.algorithms.gram_schmidt import gram_schmidt
+
+
+def qr(A, product=None, offset=0, copy=True):
+    """Compute a QR decomposition.
+
+    Parameters
+    ----------
+    A
+        The |VectorArray| for which to compute the QR decomposition.
+    product
+        The inner product |Operator| w.r.t. which to orthonormalize.
+        If `None`, the Euclidean product is used.
+    offset
+        Assume that the first `offset` vectors are already orthonormal and start the
+        algorithm at the `offset + 1`-th vector.
+    copy
+        If `True`, create a copy of `A` instead of modifying `A` in-place.
+
+    Returns
+    -------
+    Q
+        The orthonormal |VectorArray| of the same length as `A`.
+    R
+        The upper-triangular/trapezoidal matrix.
+    """
+    return gram_schmidt(A, product=product, return_R=True, atol=0, rtol=0, offset=offset, copy=copy)
+
+
+def rrqr(A, product=None, offset=0, copy=True):
+    """Compute a rank-revealing QR (RRQR) decomposition.
+
+    Parameters
+    ----------
+    A
+        The |VectorArray| for which to compute the QR decomposition.
+    product
+        The inner product |Operator| w.r.t. which to orthonormalize.
+        If `None`, the Euclidean product is used.
+    offset
+        Assume that the first `offset` vectors are already orthonormal and start the
+        algorithm at the `offset + 1`-th vector.
+    copy
+        If `True`, create a copy of `A` instead of modifying `A` in-place.
+
+    Returns
+    -------
+    Q
+        The orthonormalized |VectorArray|.
+    R
+        The upper-triangular/trapezoidal matrix.
+    """
+    return gram_schmidt(A, product=product, return_R=True, offset=offset, copy=copy)

--- a/src/pymor/algorithms/qr.py
+++ b/src/pymor/algorithms/qr.py
@@ -5,7 +5,7 @@
 from pymor.algorithms.gram_schmidt import gram_schmidt
 
 
-def qr(A, product=None, offset=0, copy=True):
+def qr(A, product=None, offset=0, check=True, check_tol=1e-3, copy=True):
     """Compute a QR decomposition.
 
     Parameters
@@ -18,6 +18,10 @@ def qr(A, product=None, offset=0, copy=True):
     offset
         Assume that the first `offset` vectors are already orthonormal and start the
         algorithm at the `offset + 1`-th vector.
+    check
+        If `True`, check if the resulting |VectorArray| is really orthonormal.
+    check_tol
+        Tolerance for the check.
     copy
         If `True`, create a copy of `A` instead of modifying `A` in-place.
 
@@ -28,10 +32,11 @@ def qr(A, product=None, offset=0, copy=True):
     R
         The upper-triangular/trapezoidal matrix.
     """
-    return gram_schmidt(A, product=product, return_R=True, atol=0, rtol=0, offset=offset, copy=copy)
+    return gram_schmidt(A, product=product, return_R=True, atol=0, rtol=0, offset=offset,
+                        check=check, check_tol=check_tol, copy=copy)
 
 
-def rrqr(A, product=None, offset=0, copy=True):
+def rrqr(A, product=None, offset=0, check=True, check_tol=1e-3, copy=True):
     """Compute a rank-revealing QR (RRQR) decomposition.
 
     Parameters
@@ -44,6 +49,10 @@ def rrqr(A, product=None, offset=0, copy=True):
     offset
         Assume that the first `offset` vectors are already orthonormal and start the
         algorithm at the `offset + 1`-th vector.
+    check
+        If `True`, check if the resulting |VectorArray| is really orthonormal.
+    check_tol
+        Tolerance for the check.
     copy
         If `True`, create a copy of `A` instead of modifying `A` in-place.
 
@@ -54,4 +63,5 @@ def rrqr(A, product=None, offset=0, copy=True):
     R
         The upper-triangular/trapezoidal matrix.
     """
-    return gram_schmidt(A, product=product, return_R=True, offset=offset, copy=copy)
+    return gram_schmidt(A, product=product, return_R=True, offset=offset,
+                        check=check, check_tol=check_tol, copy=copy)

--- a/src/pymor/algorithms/rand_la.py
+++ b/src/pymor/algorithms/rand_la.py
@@ -7,7 +7,7 @@ from scipy.linalg import eigh, lu_factor, lu_solve, svd
 from scipy.sparse.linalg import LinearOperator, eigsh
 from scipy.special import erfinv
 
-from pymor.algorithms.gram_schmidt import gram_schmidt
+from pymor.algorithms.qr import qr, rrqr
 from pymor.core.defaults import defaults
 from pymor.core.logger import getLogger
 from pymor.operators.constructions import IdentityOperator, InverseOperator
@@ -89,7 +89,7 @@ def adaptive_rrf(A, source_product=None, range_product=None, tol=1e-4,
         if iscomplex:
             v += 1j*A.source.random(distribution='normal')
         B.append(A.apply(v))
-        gram_schmidt(B, range_product, atol=0, rtol=0, offset=basis_length, copy=False)
+        qr(B, product=range_product, offset=basis_length, copy=False)
         M -= B.lincomb(B.inner(M, range_product).T)
         maxnorm = np.max(M.norm(range_product))
 
@@ -150,14 +150,14 @@ def rrf(A, source_product=None, range_product=None, q=2, l=8, return_rand=False,
         R += 1j*A.source.random(l, distribution='normal')
 
     Q = A.apply(R)
-    gram_schmidt(Q, range_product, atol=0, rtol=0, copy=False)
+    qr(Q, product=range_product, copy=False)
 
     for i in range(q):
         Q = A.apply_adjoint(range_product.apply(Q))
         Q = source_product.apply_inverse(Q)
-        gram_schmidt(Q, source_product, atol=0, rtol=0, copy=False)
+        qr(Q, product=source_product, copy=False)
         Q = A.apply(Q)
-        gram_schmidt(Q, range_product, atol=0, rtol=0, copy=False)
+        qr(Q, product=range_product, copy=False)
 
     if return_rand:
         return Q, R
@@ -240,7 +240,7 @@ def random_generalized_svd(A, range_product=None, source_product=None, modes=6, 
 
     Q = rrf(A, source_product=source_product, range_product=range_product, q=q, l=modes+p)
     B = A.apply_adjoint(range_product.apply(Q))
-    Q_B, R_B = gram_schmidt(source_product.apply_inverse(B), product=source_product, return_R=True)
+    Q_B, R_B = rrqr(source_product.apply_inverse(B), product=source_product)
     U_b, s, Vh_b = svd(R_B.T, full_matrices=False)
 
     with logger.block(f'Computing generalized left-singular vectors ({modes} vectors) ...'):
@@ -321,14 +321,14 @@ def random_ghep(A, E=None, modes=6, p=20, q=2, single_pass=False):
         Omega = A.source.random(modes+p, distribution='normal')
         Y_bar = A.apply(Omega)
         Y = E.apply_inverse(Y_bar)
-        Q, R = gram_schmidt(Y, product=E, return_R=True)
+        Q, R = rrqr(Y, product=E)
         X = E.apply2(Omega, Q)
         X_lu = lu_factor(X)
         T = lu_solve(X_lu, lu_solve(X_lu, Omega.inner(Y_bar)).T).T
     else:
         C = InverseOperator(E) @ A
         Y, Omega = rrf(C, q=q, l=modes+p, return_rand=True)
-        Q = gram_schmidt(Y, product=E)
+        Q = rrqr(Y, product=E)
         T = A.apply2(Q, Q)
 
     w, S = eigh(T)

--- a/src/pymor/algorithms/samdp.py
+++ b/src/pymor/algorithms/samdp.py
@@ -5,7 +5,7 @@
 import numpy as np
 import scipy.linalg as spla
 
-from pymor.algorithms.gram_schmidt import gram_schmidt
+from pymor.algorithms.qr import qr
 from pymor.core.defaults import defaults
 from pymor.core.logger import getLogger
 from pymor.operators.constructions import IdentityOperator
@@ -147,8 +147,8 @@ def samdp(A, E, B, C, nwanted, init_shifts=None, which='NR', tol=1e-10, imagtol=
 
         X.append(x)
         V.append(v)
-        gram_schmidt(V, atol=0, rtol=0, copy=False)
-        gram_schmidt(X, atol=0, rtol=0, copy=False)
+        qr(V, copy=False)
+        qr(X, copy=False)
 
         AX.append(A.apply(X[k-1]))
 
@@ -238,8 +238,8 @@ def samdp(A, E, B, C, nwanted, init_shifts=None, which='NR', tol=1e-10, imagtol=
                     V = A.source.empty()
 
                 if np.abs(np.imag(theta)) / np.abs(theta) < imagtol:
-                    gram_schmidt(V, atol=0, rtol=0, copy=False)
-                    gram_schmidt(X, atol=0, rtol=0, copy=False)
+                    qr(V, copy=False)
+                    qr(X, copy=False)
 
                 B_defl -= E.apply(Q[-1].lincomb(Qt[-1].inner(B_defl).T))
                 C_defl -= E.apply_adjoint(Qt[-1].lincomb(Q[-1].inner(C_defl).T))
@@ -271,8 +271,8 @@ def samdp(A, E, B, C, nwanted, init_shifts=None, which='NR', tol=1e-10, imagtol=
                         Q[-1].scal(1 / nqqt)
                         Qs[-1].scal(1 / nqqt)
 
-                        gram_schmidt(V, atol=0, rtol=0, copy=False)
-                        gram_schmidt(X, atol=0, rtol=0, copy=False)
+                        qr(V, copy=False)
+                        qr(X, copy=False)
 
                         B_defl -= E.apply(Q[-1].lincomb(Qt[-1].inner(B_defl).T))
                         C_defl -= E.apply_adjoint(Qt[-1].lincomb(Q[-1].inner(C_defl).T))
@@ -308,8 +308,8 @@ def samdp(A, E, B, C, nwanted, init_shifts=None, which='NR', tol=1e-10, imagtol=
                 X = X.lincomb(UR[:, minidx])
                 V = V.lincomb(URt[:, minidx])
 
-                gram_schmidt(V, atol=0, rtol=0, copy=False)
-                gram_schmidt(X, atol=0, rtol=0, copy=False)
+                qr(V, copy=False)
+                qr(X, copy=False)
 
                 G = V.inner(E.apply(X))
                 AX = A.apply(X)
@@ -327,8 +327,8 @@ def samdp(A, E, B, C, nwanted, init_shifts=None, which='NR', tol=1e-10, imagtol=
             X = X.lincomb(UR[:, minidx])
             V = V.lincomb(URt[:, minidx])
 
-            gram_schmidt(V, atol=0, rtol=0, copy=False)
-            gram_schmidt(X, atol=0, rtol=0, copy=False)
+            qr(V, copy=False)
+            qr(X, copy=False)
 
             G = V.inner(E.apply(X))
             AX = A.apply(X)

--- a/src/pymor/algorithms/svd_va.py
+++ b/src/pymor/algorithms/svd_va.py
@@ -7,7 +7,7 @@
 import numpy as np
 import scipy.linalg as spla
 
-from pymor.algorithms.gram_schmidt import gram_schmidt
+from pymor.algorithms.qr import rrqr
 from pymor.core.defaults import defaults
 from pymor.core.logger import getLogger
 from pymor.operators.interface import Operator
@@ -161,7 +161,7 @@ def qr_svd(A, product=None, modes=None, rtol=4e-8, atol=0., l2_err=0.):
     logger = getLogger('pymor.algorithms.svd_va.qr_svd')
 
     with logger.block('Computing QR decomposition ...'):
-        Q, R = gram_schmidt(A, product=product, return_R=True, check=False)
+        Q, R = rrqr(A, product=product, check=False)
 
     with logger.block('Computing SVD of R ...'):
         U2, s, Vh = spla.svd(R, lapack_driver='gesvd')

--- a/src/pymor/basic.py
+++ b/src/pymor/basic.py
@@ -19,6 +19,7 @@ from pymor.algorithms.newton import newton
 from pymor.algorithms.pod import pod
 from pymor.algorithms.preassemble import preassemble
 from pymor.algorithms.projection import project, project_to_subbasis
+from pymor.algorithms.qr import qr, rrqr
 from pymor.algorithms.simplify import expand
 from pymor.analyticalproblems.burgers import burgers_problem, burgers_problem_2d
 from pymor.analyticalproblems.domaindescriptions import (

--- a/src/pymor/reductors/basic.py
+++ b/src/pymor/reductors/basic.py
@@ -7,9 +7,9 @@ from numbers import Number
 import numpy as np
 
 from pymor.algorithms.basic import almost_equal
-from pymor.algorithms.gram_schmidt import gram_schmidt
 from pymor.algorithms.pod import pod
 from pymor.algorithms.projection import project, project_to_subbasis
+from pymor.algorithms.qr import rrqr
 from pymor.core.base import BasicObject, abstractmethod
 from pymor.core.defaults import defaults
 from pymor.core.exceptions import AccuracyError, ExtensionError
@@ -476,14 +476,14 @@ def extend_basis(U, basis, product=None, method='gram_schmidt', pod_modes=1, pod
                      remove_from_other=(not copy_U))
     elif method == 'gram_schmidt':
         basis.append(U, remove_from_other=(not copy_U))
-        gram_schmidt(basis, offset=basis_length, product=product, copy=False, check=False)
+        rrqr(basis, offset=basis_length, product=product, copy=False, check=False)
     elif method == 'pod':
         U_proj_err = U - basis.lincomb(U.inner(basis, product))
 
         basis.append(pod(U_proj_err, modes=pod_modes, product=product, orth_tol=np.inf)[0])
 
         if pod_orthonormalize:
-            gram_schmidt(basis, offset=basis_length, product=product, copy=False, check=False)
+            rrqr(basis, offset=basis_length, product=product, copy=False, check=False)
 
     if len(basis) <= basis_length:
         raise ExtensionError

--- a/src/pymor/reductors/bt.py
+++ b/src/pymor/reductors/bt.py
@@ -4,7 +4,8 @@
 
 import numpy as np
 
-from pymor.algorithms.gram_schmidt import gram_schmidt, gram_schmidt_biorth
+from pymor.algorithms.gram_schmidt import gram_schmidt_biorth
+from pymor.algorithms.qr import qr
 from pymor.core.base import BasicObject
 from pymor.models.iosys import LTIModel
 from pymor.parameters.base import Mu
@@ -92,8 +93,8 @@ class GenericBTReductor(BasicObject):
             self.V.scal(alpha)
             self.W.scal(alpha)
         elif projection == 'bfsr':
-            gram_schmidt(self.V, atol=0, rtol=0, copy=False)
-            gram_schmidt(self.W, atol=0, rtol=0, copy=False)
+            qr(self.V, copy=False)
+            qr(self.W, copy=False)
         elif projection == 'biorth':
             gram_schmidt_biorth(self.V, self.W, product=self.fom.E, copy=False)
 

--- a/src/pymor/reductors/h2.py
+++ b/src/pymor/reductors/h2.py
@@ -9,8 +9,9 @@ from numbers import Integral, Real
 import numpy as np
 import scipy.linalg as spla
 
-from pymor.algorithms.gram_schmidt import gram_schmidt, gram_schmidt_biorth
+from pymor.algorithms.gram_schmidt import gram_schmidt_biorth
 from pymor.algorithms.krylov import tangential_rational_krylov
+from pymor.algorithms.qr import qr
 from pymor.algorithms.riccati import solve_ricc_dense
 from pymor.algorithms.sylvester import solve_sylv_schur
 from pymor.algorithms.to_matrix import to_matrix
@@ -411,15 +412,11 @@ class OneSidedIRKAReductor(GenericIRKAReductor):
         if self.version == 'V':
             self.V = tangential_rational_krylov(fom.A, fom.E, fom.B, fom.B.source.from_numpy(b), sigma,
                                                 orth=False)
-            gram_schmidt(self.V, atol=0, rtol=0,
-                         product=None if projection == 'orth' else fom.E,
-                         copy=False)
+            qr(self.V, product=None if projection == 'orth' else fom.E, copy=False)
         else:
             self.V = tangential_rational_krylov(fom.A, fom.E, fom.C, fom.C.range.from_numpy(c), sigma, trans=True,
                                                 orth=False)
-            gram_schmidt(self.V, atol=0, rtol=0,
-                         product=None if projection == 'orth' else fom.E,
-                         copy=False)
+            qr(self.V, product=None if projection == 'orth' else fom.E, copy=False)
         self.W = self.V
         self._pg_reductor = LTIPGReductor(fom, self.V, self.V,
                                           projection == 'Eorth')
@@ -541,8 +538,8 @@ class TSIAReductor(GenericIRKAReductor):
                                           B=fom.B, Br=rom.B,
                                           C=fom.C, Cr=rom.C)
         if projection == 'orth':
-            gram_schmidt(self.V, atol=0, rtol=0, copy=False)
-            gram_schmidt(self.W, atol=0, rtol=0, copy=False)
+            qr(self.V, copy=False)
+            qr(self.W, copy=False)
         elif projection == 'biorth':
             gram_schmidt_biorth(self.V, self.W, product=fom.E, copy=False)
         self._pg_reductor = LTIPGReductor(fom, self.W, self.V,

--- a/src/pymor/reductors/interpolation.py
+++ b/src/pymor/reductors/interpolation.py
@@ -6,8 +6,9 @@ from abc import abstractmethod
 
 import numpy as np
 
-from pymor.algorithms.gram_schmidt import gram_schmidt, gram_schmidt_biorth
+from pymor.algorithms.gram_schmidt import gram_schmidt_biorth
 from pymor.algorithms.krylov import rational_arnoldi
+from pymor.algorithms.qr import qr
 from pymor.core.base import BasicObject
 from pymor.models.iosys import LinearDelayModel, LTIModel, SecondOrderModel
 from pymor.models.transfer_function import TransferFunction
@@ -142,8 +143,8 @@ class GenericBHIReductor(BasicObject):
                 self.W.append(w.real)
                 self.W.append(w.imag)
         if projection == 'orth':
-            gram_schmidt(self.V, atol=0, rtol=0, copy=False)
-            gram_schmidt(self.W, atol=0, rtol=0, copy=False)
+            qr(self.V, copy=False)
+            qr(self.W, copy=False)
         elif projection == 'biorth':
             gram_schmidt_biorth(self.V, self.W, product=self._product, copy=False)
 

--- a/src/pymor/reductors/mt.py
+++ b/src/pymor/reductors/mt.py
@@ -7,7 +7,8 @@ import bisect
 import numpy as np
 import scipy.linalg as spla
 
-from pymor.algorithms.gram_schmidt import gram_schmidt, gram_schmidt_biorth
+from pymor.algorithms.gram_schmidt import gram_schmidt_biorth
+from pymor.algorithms.qr import qr
 from pymor.algorithms.samdp import samdp
 from pymor.algorithms.to_matrix import to_matrix
 from pymor.core.base import BasicObject
@@ -200,8 +201,8 @@ class MTReductor(BasicObject):
         self.W.append(lev[complex_index].imag)
 
         if projection == 'orth':
-            gram_schmidt(self.V, atol=0, rtol=0, copy=False)
-            gram_schmidt(self.W, atol=0, rtol=0, copy=False)
+            qr(self.V, copy=False)
+            qr(self.W, copy=False)
         elif projection == 'biorth':
             gram_schmidt_biorth(self.V, self.W, product=fom.E, copy=False)
 

--- a/src/pymor/reductors/ph/ph_irka.py
+++ b/src/pymor/reductors/ph/ph_irka.py
@@ -2,8 +2,8 @@
 # Copyright pyMOR developers and contributors. All rights reserved.
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
-from pymor.algorithms.gram_schmidt import gram_schmidt
 from pymor.algorithms.krylov import tangential_rational_krylov
+from pymor.algorithms.qr import qr
 from pymor.models.iosys import PHLTIModel
 from pymor.reductors.h2 import GenericIRKAReductor
 from pymor.reductors.ph.basic import PHLTIPGReductor
@@ -121,6 +121,6 @@ class PHIRKAReductor(GenericIRKAReductor):
         fom = self._assemble_fom()
         self.V = tangential_rational_krylov(fom.A, fom.E, fom.B, fom.B.source.from_numpy(b), sigma, orth=False)
         product = None if projection == 'orth' else fom.Q.H @ fom.E
-        gram_schmidt(self.V, atol=0, rtol=0, product=product, copy=False)
+        qr(self.V, product=product, copy=False)
         self._pg_reductor = PHLTIPGReductor(fom, self.V, projection == 'QTEorth')
         self.W = self._pg_reductor.bases['W']

--- a/src/pymor/reductors/sobt.py
+++ b/src/pymor/reductors/sobt.py
@@ -5,8 +5,9 @@
 import numpy as np
 import scipy.linalg as spla
 
-from pymor.algorithms.gram_schmidt import gram_schmidt, gram_schmidt_biorth
+from pymor.algorithms.gram_schmidt import gram_schmidt_biorth
 from pymor.algorithms.projection import project
+from pymor.algorithms.qr import qr
 from pymor.core.base import BasicObject
 from pymor.models.iosys import SecondOrderModel
 from pymor.operators.constructions import IdentityOperator
@@ -85,8 +86,8 @@ class GenericSOBTpvReductor(BasicObject):
             self.V.scal(alpha)
             self.W.scal(alpha)
         elif projection == 'bfsr':
-            gram_schmidt(self.V, atol=0, rtol=0, copy=False)
-            gram_schmidt(self.W, atol=0, rtol=0, copy=False)
+            qr(self.V, copy=False)
+            qr(self.W, copy=False)
         elif projection == 'biorth':
             gram_schmidt_biorth(self.V, self.W, product=self.fom.M, copy=False)
 
@@ -275,9 +276,9 @@ class SOBTfvReductor(BasicObject):
             alpha = 1 / np.sqrt(sp[:r])
             self.V.scal(alpha)
         elif projection == 'bfsr':
-            gram_schmidt(self.V, atol=0, rtol=0, copy=False)
+            qr(self.V, copy=False)
         elif projection == 'biorth':
-            gram_schmidt(self.V, product=self.fom.M, atol=0, rtol=0, copy=False)
+            qr(self.V, product=self.fom.M, copy=False)
         self.W = self.V
 
         # find the reduced model
@@ -375,10 +376,10 @@ class SOBTReductor(BasicObject):
             W1TV1invW1TV2 = self.W1.inner(self.V2)
             projected_ops = {'M': IdentityOperator(NumpyVectorSpace(r))}
         elif projection == 'bfsr':
-            gram_schmidt(self.V1, atol=0, rtol=0, copy=False)
-            gram_schmidt(self.W1, atol=0, rtol=0, copy=False)
-            gram_schmidt(self.V2, atol=0, rtol=0, copy=False)
-            gram_schmidt(self.W2, atol=0, rtol=0, copy=False)
+            qr(self.V1, copy=False)
+            qr(self.W1, copy=False)
+            qr(self.V2, copy=False)
+            qr(self.W2, copy=False)
             W1TV1invW1TV2 = spla.solve(self.W1.inner(self.V1), self.W1.inner(self.V2))
             projected_ops = {'M': project(self.fom.M, range_basis=self.W2, source_basis=self.V2)}
         elif projection == 'biorth':


### PR DESCRIPTION
- adds `pymor.algorithms.qr` module with `qr` and `rrqr` methods
- replaces most usage of `gram_schmidt` in `pymor/src` (the exception is `VectorArrayOperator.apply_inverse`, because it uses `reiterate=False`, and it should anyway probably use an SVD method)
- parameter `copy` in `qr` and `rrqr` is commonly used, parameter `check` is only used in `reductors.basic` and `algorithms.svd_va`