### PR TITLE
fix misleading `from_points` classmethod

### DIFF
--- a/src/pymor/models/transforms.py
+++ b/src/pymor/models/transforms.py
@@ -48,7 +48,7 @@ class MoebiusTransformation(ImmutableObject):
         self.__auto_init(locals())
 
     @classmethod
-    def from_points(cls, w, z=(0, 1, np.inf), name=None):
+    def from_points(cls, z, w=(0, 1, np.inf), name=None):
         """Constructs a Moebius transformation from three points and their images.
 
         A Moebius transformation is completely determined by the images of three distinct points on
@@ -56,10 +56,10 @@ class MoebiusTransformation(ImmutableObject):
 
         Parameters
         ----------
-        w
-            A tuple, list or |NumPy array| of three complex numbers that are transformed.
         z
-            A tuple, list or |NumPy array| of three complex numbers represent the images of `w`.
+            A tuple, list or |NumPy array| of three complex numbers that are transformed.
+        w
+            A tuple, list or |NumPy array| of three complex numbers represent the images of `z`.
             Defaults to `(0, 1, np.inf)`.
         name
             Name of the transformation.
@@ -67,7 +67,7 @@ class MoebiusTransformation(ImmutableObject):
         Returns
         -------
         M
-            The corresponding |MoebiusTransformation|.
+            The corresponding |MoebiusTransformation| that fulfills M(z)=w.
         """
         assert len(z) == 3
         assert len(w) == 3

--- a/src/pymortests/models/transforms.py
+++ b/src/pymortests/models/transforms.py
@@ -64,16 +64,16 @@ def test_normalization(m1):
 @pytest.mark.parametrize('p2', points_list)
 def test_from_points(p1, p2):
     p1, p2 = np.asarray(p1), np.asarray(p2)
-    M1 = MoebiusTransformation.from_points(p1, z=p2)
-    m1 = M1(p2)
+    M1 = MoebiusTransformation.from_points(p1, w=p2)
+    m1 = M1(p1)
 
     for i in range(3):
-        if np.isinf(p1[i]):
-            assert np.isinf(m1[i]) or np.abs(m1[i]) >= 1e+15 or np.allclose(p1[i], m1[i])
+        if np.isinf(p2[i]):
+            assert np.isinf(m1[i]) or np.abs(m1[i]) >= 1e+15 or np.allclose(p2[i], m1[i])
         elif np.isinf(m1[i]):
-            assert np.abs(p1[i]) >= 1e+15 or np.allclose(p1[i], m1[i])
+            assert np.abs(p2[i]) >= 1e+15 or np.allclose(p2[i], m1[i])
         else:
-            assert np.allclose(p1[i], m1[i])
+            assert np.allclose(p2[i], m1[i])
 
 
 @pytest.mark.parametrize('sampling_time', sampling_time_list)


### PR DESCRIPTION
I just found an error in the classmethod that constructs a Moebius transformation from three points. The pre-images and images were interchanged. I've fixed it and made the docsting more descriptive to avoid confusions.

@lbalicki Maybe we can still add this to the next release although we are in soft-freeze. If you agree, feel free to change the milestone.