### PR TITLE
Add orth interface function

### DIFF
--- a/src/pymor/algorithms/eigs.py
+++ b/src/pymor/algorithms/eigs.py
@@ -5,7 +5,7 @@
 import numpy as np
 import scipy.linalg as spla
 
-from pymor.algorithms.gram_schmidt import gram_schmidt
+from pymor.algorithms.qr import qr
 from pymor.core.logger import getLogger
 from pymor.operators.constructions import IdentityOperator, InverseOperator
 from pymor.operators.interface import Operator
@@ -207,7 +207,7 @@ def _arnoldi(A, l, b, complex_evp):
         v = A.apply(v)
         V.append(v)
 
-        _, R = gram_schmidt(V, return_R=True, atol=0, rtol=0, offset=len(V) - 1, copy=False)
+        _, R = qr(V, offset=len(V) - 1, copy=False)
         H[:i + 2, i] = R[:l, i + 1]
         v = V[-1]
 
@@ -230,7 +230,7 @@ def _extend_arnoldi(A, V, H, f, p):
     for i in range(k, k + p):
         v = A.apply(v)
         V.append(v)
-        _, R = gram_schmidt(V, return_R=True, atol=0, rtol=0, offset=len(V) - 1, copy=False)
+        _, R = qr(V, offset=len(V) - 1, copy=False)
         H[:i + 2, i] = R[:k + p, i + 1]
 
         v = V[-1]

--- a/src/pymor/algorithms/eigs.py
+++ b/src/pymor/algorithms/eigs.py
@@ -5,7 +5,7 @@
 import numpy as np
 import scipy.linalg as spla
 
-from pymor.algorithms.qr import qr
+from pymor.algorithms.orth import orth
 from pymor.core.logger import getLogger
 from pymor.operators.constructions import IdentityOperator, InverseOperator
 from pymor.operators.interface import Operator
@@ -207,7 +207,7 @@ def _arnoldi(A, l, b, complex_evp):
         v = A.apply(v)
         V.append(v)
 
-        _, R = qr(V, offset=len(V) - 1, copy=False)
+        R = orth(V, offset=len(V) - 1, hierarchical=True, pad=True, copy=False)[1].T
         H[:i + 2, i] = R[:l, i + 1]
         v = V[-1]
 
@@ -230,7 +230,7 @@ def _extend_arnoldi(A, V, H, f, p):
     for i in range(k, k + p):
         v = A.apply(v)
         V.append(v)
-        _, R = qr(V, offset=len(V) - 1, copy=False)
+        R = orth(V, offset=len(V) - 1, hierarchical=True, pad=True, copy=False)[1].T
         H[:i + 2, i] = R[:k + p, i + 1]
 
         v = V[-1]

--- a/src/pymor/algorithms/gram_schmidt.py
+++ b/src/pymor/algorithms/gram_schmidt.py
@@ -50,7 +50,7 @@ def gram_schmidt(A, product=None, return_R=False, atol=1e-13, rtol=1e-13, offset
     Q
         The orthonormalized |VectorArray|.
     R
-        The upper-triangular/trapezoidal matrix (if `compute_R` is `True`).
+        The upper-triangular/trapezoidal matrix (if `return_R` is `True`).
     """
     logger = getLogger('pymor.algorithms.gram_schmidt.gram_schmidt')
 

--- a/src/pymor/algorithms/gram_schmidt.py
+++ b/src/pymor/algorithms/gram_schmidt.py
@@ -2,6 +2,8 @@
 # Copyright pyMOR developers and contributors. All rights reserved.
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
+import warnings
+
 import numpy as np
 
 from pymor.core.defaults import defaults
@@ -109,6 +111,8 @@ def gram_schmidt(A, product=None, return_R=False, atol=1e-13, rtol=1e-13, offset
         R = np.delete(R, remove, axis=0)
 
     if check:
+        warnings.warn('check and check_tol are deprecated (use qr or rrqr from pymor.algorithms.qr)',
+                      DeprecationWarning, stacklevel=2)
         error_matrix = A[offset:len(A)].inner(A, product)
         error_matrix[:len(A) - offset, offset:len(A)] -= np.eye(len(A) - offset)
         if error_matrix.size > 0:

--- a/src/pymor/algorithms/image.py
+++ b/src/pymor/algorithms/image.py
@@ -2,7 +2,7 @@
 # Copyright pyMOR developers and contributors. All rights reserved.
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
-from pymor.algorithms.qr import rrqr
+from pymor.algorithms.orth import orth
 from pymor.algorithms.rules import RuleTable, match_class, match_generic
 from pymor.core.exceptions import ImageCollectionError, NoMatchingRuleError
 from pymor.core.logger import getLogger
@@ -106,7 +106,7 @@ def estimate_image(operators=(), vectors=(),
         image = product.apply_inverse(image)
 
     if orthonormalize:
-        rrqr(image, product=product, copy=False)
+        orth(image, product=product, copy=False)
 
     return image
 
@@ -212,7 +212,7 @@ def estimate_image_hierarchical(operators=(), vectors=(), domain=None, extends=N
         image.append(new_image, remove_from_other=True)
         if orthonormalize:
             with logger.block('Orthonormalizing ...'):
-                rrqr(image, offset=gram_schmidt_offset, product=product, copy=False)
+                orth(image, offset=gram_schmidt_offset, product=product, copy=False)
             image_dims.append(len(image))
 
     return image, image_dims

--- a/src/pymor/algorithms/image.py
+++ b/src/pymor/algorithms/image.py
@@ -2,7 +2,7 @@
 # Copyright pyMOR developers and contributors. All rights reserved.
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
-from pymor.algorithms.gram_schmidt import gram_schmidt
+from pymor.algorithms.qr import rrqr
 from pymor.algorithms.rules import RuleTable, match_class, match_generic
 from pymor.core.exceptions import ImageCollectionError, NoMatchingRuleError
 from pymor.core.logger import getLogger
@@ -106,7 +106,7 @@ def estimate_image(operators=(), vectors=(),
         image = product.apply_inverse(image)
 
     if orthonormalize:
-        gram_schmidt(image, product=product, copy=False)
+        rrqr(image, product=product, copy=False)
 
     return image
 
@@ -212,7 +212,7 @@ def estimate_image_hierarchical(operators=(), vectors=(), domain=None, extends=N
         image.append(new_image, remove_from_other=True)
         if orthonormalize:
             with logger.block('Orthonormalizing ...'):
-                gram_schmidt(image, offset=gram_schmidt_offset, product=product, copy=False)
+                rrqr(image, offset=gram_schmidt_offset, product=product, copy=False)
             image_dims.append(len(image))
 
     return image, image_dims

--- a/src/pymor/algorithms/krylov.py
+++ b/src/pymor/algorithms/krylov.py
@@ -4,7 +4,7 @@
 
 """Module for computing (rational) Krylov subspaces' bases."""
 
-from pymor.algorithms.qr import qr
+from pymor.algorithms.orth import orth
 
 
 def rational_arnoldi(A, E, b, sigma, trans=False):
@@ -95,11 +95,11 @@ def rational_arnoldi(A, E, b, sigma, trans=False):
             v = sEmA.apply_inverse_adjoint(v if len(V) == 0 else E.apply_adjoint(v))
         if sigma[i].imag == 0:
             V.append(v)
-            qr(V, offset=len(V) - 1, copy=False)
+            orth(V, offset=len(V) - 1, pad=True, copy=False)
         else:
             V.append(v.real)
             V.append(v.imag)
-            qr(V, offset=len(V) - 2, copy=False)
+            orth(V, offset=len(V) - 2, pad=True, copy=False)
         v = V[-1]
 
     return V
@@ -185,5 +185,5 @@ def tangential_rational_krylov(A, E, B, b, sigma, trans=False, orth=True):
             V.append(v.real)
             V.append(v.imag)
     if orth:
-        qr(V, copy=False)
+        orth(V, pad=True, copy=False)
     return V

--- a/src/pymor/algorithms/krylov.py
+++ b/src/pymor/algorithms/krylov.py
@@ -4,7 +4,7 @@
 
 """Module for computing (rational) Krylov subspaces' bases."""
 
-from pymor.algorithms.gram_schmidt import gram_schmidt
+from pymor.algorithms.qr import qr
 
 
 def rational_arnoldi(A, E, b, sigma, trans=False):
@@ -95,11 +95,11 @@ def rational_arnoldi(A, E, b, sigma, trans=False):
             v = sEmA.apply_inverse_adjoint(v if len(V) == 0 else E.apply_adjoint(v))
         if sigma[i].imag == 0:
             V.append(v)
-            gram_schmidt(V, atol=0, rtol=0, offset=len(V) - 1, copy=False)
+            qr(V, offset=len(V) - 1, copy=False)
         else:
             V.append(v.real)
             V.append(v.imag)
-            gram_schmidt(V, atol=0, rtol=0, offset=len(V) - 2, copy=False)
+            qr(V, offset=len(V) - 2, copy=False)
         v = V[-1]
 
     return V
@@ -185,5 +185,5 @@ def tangential_rational_krylov(A, E, B, b, sigma, trans=False, orth=True):
             V.append(v.real)
             V.append(v.imag)
     if orth:
-        gram_schmidt(V, atol=0, rtol=0, copy=False)
+        qr(V, copy=False)
     return V

--- a/src/pymor/algorithms/lradi.py
+++ b/src/pymor/algorithms/lradi.py
@@ -7,8 +7,8 @@ import scipy.linalg as spla
 
 from pymor.algorithms.eigs import _arnoldi
 from pymor.algorithms.genericsolvers import _parse_options
-from pymor.algorithms.gram_schmidt import gram_schmidt
 from pymor.algorithms.lyapunov import _solve_lyap_lrcf_check_args
+from pymor.algorithms.qr import qr
 from pymor.core.defaults import defaults
 from pymor.core.logger import getLogger
 from pymor.operators.constructions import IdentityOperator, InverseOperator
@@ -192,7 +192,7 @@ def projection_shifts_init(A, E, B, shift_options):
     """
     rng = new_rng(0)
     for i in range(shift_options['init_maxiter']):
-        Q = gram_schmidt(B, atol=0, rtol=0)
+        Q, _ = qr(B)
         shifts = spla.eigvals(A.apply2(Q, Q), E.apply2(Q, Q))
         shifts = shifts[shifts.real < 0]
         if shifts.size == 0:
@@ -233,12 +233,12 @@ def projection_shifts(A, E, V, Z, prev_shifts, shift_options):
     """
     if shift_options['subspace_columns'] == 1:
         if prev_shifts[-1].imag != 0:
-            Q = gram_schmidt(cat_arrays([V.real, V.imag]), atol=0, rtol=0)
+            Q, _ = qr(cat_arrays([V.real, V.imag]))
         else:
-            Q = gram_schmidt(V, atol=0, rtol=0)
+            Q, _ = qr(V)
     else:
         num_columns = shift_options['subspace_columns'] * len(V)
-        Q = gram_schmidt(Z[-num_columns:], atol=0, rtol=0)
+        Q, _ = qr(Z[-num_columns:])
 
     shifts = spla.eigvals(A.apply2(Q, Q), E.apply2(Q, Q))
     shifts = shifts[shifts.real < 0]

--- a/src/pymor/algorithms/lradi.py
+++ b/src/pymor/algorithms/lradi.py
@@ -8,7 +8,7 @@ import scipy.linalg as spla
 from pymor.algorithms.eigs import _arnoldi
 from pymor.algorithms.genericsolvers import _parse_options
 from pymor.algorithms.lyapunov import _solve_lyap_lrcf_check_args
-from pymor.algorithms.qr import qr
+from pymor.algorithms.orth import orth
 from pymor.core.defaults import defaults
 from pymor.core.logger import getLogger
 from pymor.operators.constructions import IdentityOperator, InverseOperator
@@ -192,7 +192,7 @@ def projection_shifts_init(A, E, B, shift_options):
     """
     rng = new_rng(0)
     for i in range(shift_options['init_maxiter']):
-        Q, _ = qr(B)
+        Q, _ = orth(B, pad=True)
         shifts = spla.eigvals(A.apply2(Q, Q), E.apply2(Q, Q))
         shifts = shifts[shifts.real < 0]
         if shifts.size == 0:
@@ -233,12 +233,12 @@ def projection_shifts(A, E, V, Z, prev_shifts, shift_options):
     """
     if shift_options['subspace_columns'] == 1:
         if prev_shifts[-1].imag != 0:
-            Q, _ = qr(cat_arrays([V.real, V.imag]))
+            Q, _ = orth(cat_arrays([V.real, V.imag]), pad=True)
         else:
-            Q, _ = qr(V)
+            Q, _ = orth(V, pad=True)
     else:
         num_columns = shift_options['subspace_columns'] * len(V)
-        Q, _ = qr(Z[-num_columns:])
+        Q, _ = orth(Z[-num_columns:], pad=True)
 
     shifts = spla.eigvals(A.apply2(Q, Q), E.apply2(Q, Q))
     shifts = shifts[shifts.real < 0]

--- a/src/pymor/algorithms/lrradi.py
+++ b/src/pymor/algorithms/lrradi.py
@@ -6,7 +6,7 @@ import numpy as np
 import scipy.linalg as spla
 
 from pymor.algorithms.genericsolvers import _parse_options
-from pymor.algorithms.qr import qr
+from pymor.algorithms.orth import orth
 from pymor.algorithms.riccati import _solve_ricc_check_args
 from pymor.core.defaults import defaults
 from pymor.core.logger import getLogger
@@ -231,7 +231,7 @@ def hamiltonian_shifts_init(A, E, B, C, shift_options):
     """
     rng = new_rng(0)
     for _ in range(shift_options['init_maxiter']):
-        Q, _ = qr(C)
+        Q, _ = orth(C, pad=True)
         Ap = A.apply2(Q, Q)
         QB = Q.inner(B)
         Gp = QB.dot(QB.T)
@@ -310,7 +310,7 @@ def hamiltonian_shifts(A, E, B, R, K, Z, shift_options):
     if len(Z) < l:
         l = len(Z)
 
-    Q, _ = qr(Z[-l:])
+    Q, _ = orth(Z[-l:], pad=True)
     Ap = A.apply2(Q, Q)
     KBp = Q.inner(K) @ Q.inner(B).T
     AAp = Ap - KBp

--- a/src/pymor/algorithms/lrradi.py
+++ b/src/pymor/algorithms/lrradi.py
@@ -6,7 +6,7 @@ import numpy as np
 import scipy.linalg as spla
 
 from pymor.algorithms.genericsolvers import _parse_options
-from pymor.algorithms.gram_schmidt import gram_schmidt
+from pymor.algorithms.qr import qr
 from pymor.algorithms.riccati import _solve_ricc_check_args
 from pymor.core.defaults import defaults
 from pymor.core.logger import getLogger
@@ -231,7 +231,7 @@ def hamiltonian_shifts_init(A, E, B, C, shift_options):
     """
     rng = new_rng(0)
     for _ in range(shift_options['init_maxiter']):
-        Q = gram_schmidt(C, atol=0, rtol=0)
+        Q, _ = qr(C)
         Ap = A.apply2(Q, Q)
         QB = Q.inner(B)
         Gp = QB.dot(QB.T)
@@ -310,7 +310,7 @@ def hamiltonian_shifts(A, E, B, R, K, Z, shift_options):
     if len(Z) < l:
         l = len(Z)
 
-    Q = gram_schmidt(Z[-l:], atol=0, rtol=0)
+    Q, _ = qr(Z[-l:])
     Ap = A.apply2(Q, Q)
     KBp = Q.inner(K) @ Q.inner(B).T
     AAp = Ap - KBp

--- a/src/pymor/algorithms/orth.py
+++ b/src/pymor/algorithms/orth.py
@@ -1,0 +1,200 @@
+# This file is part of the pyMOR project (https://www.pymor.org).
+# Copyright pyMOR developers and contributors. All rights reserved.
+# License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
+
+from numbers import Integral, Real
+
+import numpy as np
+
+from pymor.algorithms.gram_schmidt import gram_schmidt
+from pymor.algorithms.qr import _check_qr
+from pymor.algorithms.svd_va import method_of_snapshots
+from pymor.core.defaults import defaults
+from pymor.core.exceptions import LinAlgError
+from pymor.operators.interface import Operator
+from pymor.vectorarrays.interface import VectorArray
+
+
+@defaults('atol', 'rtol', 'check', 'check_orth_tol', 'check_recon_tol')
+def orth(V, product=None,
+         hierarchical=False, pad=False, allow_truncation=True,
+         offset=0, copy=True,
+         atol=1e-13, rtol=1e-13,
+         check=True, check_orth_tol=1e-12, check_recon_tol=1e-12,
+         method=None, **kwargs):
+    """Compute an orthonormal basis.
+
+    Given a |VectorArray| `V` and inner product |Operator| `product`,
+    a `basis` for the span of the vectors in `V` is computed that is
+    orthonormal w.r.t. `product`. The coefficients of the vectors in
+    `V` w.r.t. the computed basis are returned as the second return
+    value. In particular, we have::
+
+        almost_equal(V, basis.lincomb(coeffs))
+
+    This method can be used to compute a QR decomposition of the
+    matrix of column vectors contained in `V` by setting
+    `hierarchical=True`. In this case, `coeffs.T` will be
+    upper-triangular (trapezoidal).
+
+    If the vectors in `V` are linearly dependent, then
+    `len(basis) < len(V)`. By setting `pad=True`, one can ensure that
+    `len(basis) == len(V)`. Depending on the used orthogonalization
+    algorithm, this is realized by padding `basis` with random vectors
+    and orthonormalizing these again.
+
+    Parameters
+    ----------
+    V
+        The |VectorArray| for which an orthonoral basis is computed.
+    product
+        The inner product |Operator| w.r.t. which `Q` is orthonormal.
+        If `None`, the Euclidean product is used.
+    hierarchical
+        If `True`, ensure that the span of the k vectors in `V` is
+        contained in the span of the first k vectors in `basis`.
+    pad
+        If `False`, then span the vectors in `basis` agrees, up to
+        nuerical accuracy, with the span of the vectors in `V`.
+        Hence, if the vectors in `V` are (numerically) linearly
+        dependent, `basis` will contain less vectors than `V`.
+        By setting `pad` to `True` the span of `V` is exteneded
+        to ensure `len(V) == len(basis)`.
+    allow_truncation
+        If `False`, raise an `LinAlgError` when the vectors in `V`
+        are detected to be linearly dependent.
+    offset
+        Assume that the first `offset` vectors are already orthonormal.
+        Those vectors will not be changed.
+    copy
+        If `True`, create a copy of `V` instead of modifying `V` in-place.
+    check
+        If `True`, check if the resulting `basis` is orthonormal and
+        if `basis.lincomb(coeffs)` approximates `V`.
+    atol
+        Absolute tolerance used to detect linearly dependent vectors
+        (exact meaning depends on the `method`).
+    rtol
+        Relative tolerance used to detect linearly dependent vectors
+        (exact meaning depends on the `method`).
+    check_orth_tol
+        Tolerance for the orthogonality check:
+        `frobenius_norm(basis.gramian(product) - np.eye(len(Q))) <= orth_tol`.
+    check_recon_tol
+        Tolerance for the reconstruction check:
+        `norm((V - basis.lincomb(coeffs)).norm(product)) <= recon_tol * norm(V.norm(product))`.
+    method
+        Orthonormalization method (currently only `'gram_schmidt', 'method_of_snapshots'`).
+    kwargs
+        Keyword arguments specific to the used orthonormalization method.
+
+    Returns
+    -------
+    basis
+        The computed orthonormal basis.
+    coefficients
+        `(len(V), len(basis))`-shaped array containing the coefficients of the
+        vectors in `V` w.r.t. the vectors in `basis`.
+
+    Raises
+    ------
+    AccuracyError
+        If the orthogonality or reconstruction check fail.
+    LinAlgError
+        If the vectors in `V` are detected to be linearly dependent.
+
+    See Also
+    --------
+    :func:`~pymor.algorithms.qr.rrqr` : Rank-revealing QR decomposition with truncation.
+    """
+    assert isinstance(V, VectorArray)
+    if product is not None:
+        assert isinstance(product, Operator)
+        assert product.source == product.range
+        assert not product.parametric
+        assert V in product.source
+    assert isinstance(atol, Real)
+    assert atol >= 0
+    assert isinstance(rtol, Real)
+    assert rtol >= 0
+    assert isinstance(offset, Integral)
+    assert offset >= 0
+    assert isinstance(check_orth_tol, Real)
+    assert check_orth_tol > 0
+    assert isinstance(check_recon_tol, Real)
+    assert check_recon_tol > 0
+    assert allow_truncation or not pad
+    if method is None:
+        method = default_orth_method(hierarchical)
+    if method not in {'gram_schmidt', 'method_of_snapshots'}:
+        raise ValueError(f'Unknown QR method {method}')
+    if hierarchical and method in {'method_of_snapshots'}:
+        raise ValueError(f'{method} cannot yield hierarchical basis')
+
+    if check and np.isfinite(check_recon_tol) and not copy:
+        V_orig = V.copy()
+    else:
+        V_orig = V
+
+    def _pad_vectors(basis, coeffs):
+        missing_vectors = len(V_orig) - len(basis)
+        basis.append(basis.random(missing_vectors))
+        gram_schmidt(
+            basis, product=product, atol=0, rtol=0, offset=len(V_orig)-missing_vectors,
+            check=False, copy=False,
+        )
+        coeffs = np.hstack([coeffs, np.zeros((len(V_orig), missing_vectors))])
+        return coeffs
+
+    if method == 'gram_schmidt':
+        basis = V.copy() if copy else V
+        _, coeffs = gram_schmidt(
+            basis, product=product, return_R=True, atol=atol, rtol=rtol, offset=offset,
+            check=False, copy=False, **kwargs
+        )
+        coeffs = coeffs.T
+        if len(basis) < len(V_orig) and pad:
+            coeffs = _pad_vectors(basis, coeffs)
+    elif method == 'method_of_snapshots':
+        if offset > 0:
+            coeffs_0 = V[offset:].inner(V[:offset], product=product)
+            VV = V[offset:] - V[:offset].lincomb(coeffs_0)
+        else:
+            VV = V
+        U, s, v = method_of_snapshots(
+            VV, product=product, atol=atol, rtol=rtol
+        )
+
+        if copy:
+            if offset > 0:
+                basis = V[:offset].copy()
+                basis.append(U)
+            else:
+                basis = U
+        else:
+            del V[offset + len(basis):]
+            V[offset:].scal(0.)
+            V[offset:] += basis
+            basis = V
+        coeffs = s * v.T
+
+        if len(basis) < len(V_orig) and pad:
+            coeffs = _pad_vectors(basis, coeffs)
+
+        if offset > 0:
+            coeffs = np.vstack([np.zeros((offset, len(V_orig))), np.hstack([coeffs_0, coeffs])])
+            coeffs[:offset, :offset] = np.eye(offset)
+
+    if not allow_truncation and len(basis) < len(V_orig):
+        raise LinAlgError('The VectorArray has linearly dependent vectors.')
+
+    if check:
+        _check_qr(V_orig, basis, coeffs.T, product, offset, check_orth_tol, check_recon_tol)
+    return basis, coeffs
+
+
+@defaults('hierarchical', 'non_hierarchical')
+def default_orth_method(is_hierarchical,
+                        hierarchical='gram_schmidt',
+                        non_hierarchical='gram_schmidt'):
+    return hierarchical if is_hierarchical else non_hierarchical

--- a/src/pymor/algorithms/pod.py
+++ b/src/pymor/algorithms/pod.py
@@ -4,7 +4,7 @@
 
 import numpy as np
 
-from pymor.algorithms.gram_schmidt import gram_schmidt
+from pymor.algorithms.qr import qr
 from pymor.algorithms.svd_va import method_of_snapshots, qr_svd
 from pymor.core.defaults import defaults
 from pymor.core.logger import getLogger
@@ -75,6 +75,6 @@ def pod(A, product=None, modes=None, rtol=1e-7, atol=0., l2_err=0.,
         err = np.max(np.abs(POD.inner(POD, product) - np.eye(len(POD))))
         if err >= orth_tol:
             logger.info('Reorthogonalizing POD modes ...')
-            gram_schmidt(POD, product=product, atol=0., rtol=0., copy=False)
+            qr(POD, product=product, copy=False)
 
     return POD, SVALS

--- a/src/pymor/algorithms/qr.py
+++ b/src/pymor/algorithms/qr.py
@@ -1,0 +1,57 @@
+# This file is part of the pyMOR project (https://www.pymor.org).
+# Copyright pyMOR developers and contributors. All rights reserved.
+# License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
+
+from pymor.algorithms.gram_schmidt import gram_schmidt
+
+
+def qr(A, product=None, offset=0, copy=True):
+    """Compute a QR decomposition.
+
+    Parameters
+    ----------
+    A
+        The |VectorArray| for which to compute the QR decomposition.
+    product
+        The inner product |Operator| w.r.t. which to orthonormalize.
+        If `None`, the Euclidean product is used.
+    offset
+        Assume that the first `offset` vectors are already orthonormal and start the
+        algorithm at the `offset + 1`-th vector.
+    copy
+        If `True`, create a copy of `A` instead of modifying `A` in-place.
+
+    Returns
+    -------
+    Q
+        The orthonormal |VectorArray| of the same length as `A`.
+    R
+        The upper-triangular/trapezoidal matrix.
+    """
+    return gram_schmidt(A, product=product, return_R=True, atol=0, rtol=0, offset=offset, copy=copy)
+
+
+def rrqr(A, product=None, offset=0, copy=True):
+    """Compute a rank-revealing QR (RRQR) decomposition.
+
+    Parameters
+    ----------
+    A
+        The |VectorArray| for which to compute the QR decomposition.
+    product
+        The inner product |Operator| w.r.t. which to orthonormalize.
+        If `None`, the Euclidean product is used.
+    offset
+        Assume that the first `offset` vectors are already orthonormal and start the
+        algorithm at the `offset + 1`-th vector.
+    copy
+        If `True`, create a copy of `A` instead of modifying `A` in-place.
+
+    Returns
+    -------
+    Q
+        The orthonormalized |VectorArray|.
+    R
+        The upper-triangular/trapezoidal matrix.
+    """
+    return gram_schmidt(A, product=product, return_R=True, offset=offset, copy=copy)

--- a/src/pymor/algorithms/qr.py
+++ b/src/pymor/algorithms/qr.py
@@ -11,15 +11,25 @@ from pymor.core.exceptions import AccuracyError
 
 
 @defaults('check', 'check_orth_tol', 'check_recon_tol', 'method')
-def qr(A, product=None, offset=0,
+def qr(V, product=None, offset=0,
        check=True, check_orth_tol=1e-3, check_recon_tol=1e-3,
        copy=True, method='gram_schmidt', **kwargs):
-    r"""Compute a QR decomposition.
+    r"""Compute a thin QR decomposition.
+
+    For a |VectorArray| `V` and inner product |Operator| `product`,
+    the thin QR decomposition of `V` is given by
+    orthonormal |VectorArray| `Q` and
+    upper-triangular matrix `R` such that
+    `V == Q.lincomb(R.T)` and `len(V) == len(Q)`.
+
+    .. note::
+        If the set of vectors in :math:`V` is linearly dependent,
+        the implementation may raise an exception (see below).
 
     Parameters
     ----------
-    A
-        The |VectorArray| for which to compute the QR decomposition.
+    V
+        The |VectorArray| for which to compute the thin QR decomposition.
     product
         The inner product |Operator| w.r.t. which to orthonormalize.
         If `None`, the Euclidean product is used.
@@ -27,15 +37,16 @@ def qr(A, product=None, offset=0,
         Assume that the first `offset` vectors are already orthonormal.
         Those vectors will not be changed even when `copy` is `False`.
     check
-        If `True`, check if the resulting |VectorArray| is really orthonormal.
+        If `True`, check if the resulting `Q` is orthonormal and
+        if `Q.lincomb(R.T)` approximates `V`.
     check_orth_tol
         Tolerance for the orthogonality check:
-        :math:`\lVert Q^H P Q - I \rVert_F \leqslant \mathtt{orth_tol}`.
+        :math:`\lVert Q^H P Q - I \rVert_F \leqslant \mathtt{orth\_tol}`.
     check_recon_tol
         Tolerance for the reconstruction check:
-        :math:`\lVert A - Q R \rVert_F \leqslant \mathtt{recon_tol} \lVert A \rVert_F`.
+        :math:`\lVert V - Q R \rVert_F \leqslant \mathtt{recon\_tol} \lVert A \rVert_F`.
     copy
-        If `True`, create a copy of `A` instead of modifying `A` in-place.
+        If `True`, create a copy of `V` instead of modifying `V` in-place.
     method
         QR decomposition method (currently only `'gram_schmidt'`).
     kwargs
@@ -44,42 +55,65 @@ def qr(A, product=None, offset=0,
     Returns
     -------
     Q
-        The orthonormal |VectorArray| of the same length as `A`.
+        The orthonormal |VectorArray| of the same length as `V`.
     R
         The upper-triangular/trapezoidal matrix.
+
+    Raises
+    ------
+    RuntimeError
+        If the vectors in `V` are detected to be linearly dependent.
     """
     assert method == 'gram_schmidt'
+    len_V = len(V)
     if check:
-        A_orig = A if copy else A.copy()
-    Q, R = gram_schmidt(A, product=product, return_R=True, atol=0, rtol=0, offset=offset,
+        V_orig = V if copy else V.copy()
+    Q, R = gram_schmidt(V, product=product, return_R=True, atol=0, rtol=0, offset=offset,
                         check=False, copy=copy, **kwargs)
-    if len(Q) < len(A):
+    if len(Q) < len_V:
         raise RuntimeError('Could not construct an orthonormal basis of full length.')
     if check:
-        _check_qr(A_orig, Q, R, product, check_orth_tol, check_recon_tol)
+        _check_qr(V_orig, Q, R, product, offset, check_orth_tol, check_recon_tol)
     return Q, R
 
 
-@defaults('check', 'check_orth_tol', 'check_recon_tol', 'method')
-def rrqr(A, product=None, offset=0,
+@defaults('atol', 'rtol', 'check', 'check_orth_tol', 'check_recon_tol', 'method')
+def rrqr(V, product=None, atol=1e-13, rtol=1e-13, offset=0,
          check=True, check_orth_tol=1e-3, check_recon_tol=1e-3,
          copy=True, method='gram_schmidt', **kwargs):
-    """Compute a rank-revealing QR (RRQR) decomposition.
+    r"""Compute a rank-revealing QR (RRQR) decomposition.
+
+    For a |VectorArray| `V` and inner product |Operator| `product`,
+    a rank-revealing QR decomposition of `V` is given by any
+    orthonormal |VectorArray| `Q` and
+    upper-triangular/trapezoidal matrix `R` such that
+    the norm of `V - Q.lincomb(R.T)` is "small" and
+    `len(Q) <= len(V)`.
 
     Parameters
     ----------
-    A
-        The |VectorArray| for which to compute the QR decomposition.
+    V
+        The |VectorArray| for which to compute the rank-revealing QR decomposition.
     product
         The inner product |Operator| w.r.t. which to orthonormalize.
         If `None`, the Euclidean product is used.
+    atol
+        Absolute tolerance used to detect linearly dependent vectors
+        (exact meaning depends on the `method`).
+    rtol
+        Relative tolerance used to detect linearly dependent vectors
+        (exact meaning depends on the `method`).
     offset
         Assume that the first `offset` vectors are already orthonormal.
         Those vectors will not be changed even when `copy` is `False`.
     check
-        If `True`, check if the resulting |VectorArray| is really orthonormal.
-    check_tol
-        Tolerance for the check.
+        If `True`, check if the resulting `Q` is orthonormal and if `Q*R` approximates `A`.
+    check_orth_tol
+        Tolerance for the orthogonality check:
+        :math:`\lVert Q^H P Q - I \rVert_F \leqslant \mathtt{orth\_tol}`.
+    check_recon_tol
+        Tolerance for the reconstruction check:
+        :math:`\lVert A - Q R \rVert_F \leqslant \mathtt{recon\_tol} \lVert A \rVert_F`.
     copy
         If `True`, create a copy of `A` instead of modifying `A` in-place.
     method
@@ -90,28 +124,29 @@ def rrqr(A, product=None, offset=0,
     Returns
     -------
     Q
-        The orthonormal |VectorArray| of the length less or equal to the length of `A`.
+        The orthonormal |VectorArray| such that `len(Q) <= len(V)`.
     R
         The upper-triangular/trapezoidal matrix.
     """
     assert method == 'gram_schmidt'
     if check:
-        A_orig = A if copy else A.copy()
-    Q, R = gram_schmidt(A, product=product, return_R=True, offset=offset,
+        V_orig = V if copy else V.copy()
+    Q, R = gram_schmidt(V, product=product, return_R=True, atol=atol, rtol=rtol, offset=offset,
                         check=False, copy=copy, **kwargs)
     if check:
-        _check_qr(A_orig, Q, R, product, check_orth_tol, check_recon_tol)
+        _check_qr(V_orig, Q, R, product, offset, check_orth_tol, check_recon_tol)
     return Q, R
 
 
-def _check_qr(A, Q, R, product, check_orth_tol, check_recon_tol):
-    orth_error_matrix = Q.gramian(product) - np.eye(len(Q))
+def _check_qr(V, Q, R, product, offset, check_orth_tol, check_recon_tol):
+    orth_error_matrix = Q[offset:].inner(Q, product)
+    orth_error_matrix[:, offset:] -= np.eye(len(Q) - offset)
     if orth_error_matrix.size > 0:
-        err = spla.norm(orth_error_matrix)
-        if err > check_orth_tol:
-            raise AccuracyError(f'Q not orthonormal (orth err={err})')
-    A_norm = spla.norm(A.norm())
-    recon_err = spla.norm((A - Q.lincomb(R.T)).norm())
-    recon_err_rel = recon_err / A_norm if A_norm > 0 else 0
-    if recon_err > check_recon_tol * A_norm:
+        orth_err = spla.norm(orth_error_matrix)
+        if orth_err > check_orth_tol:
+            raise AccuracyError(f'Q not orthonormal (orth err={orth_err})')
+    V_norm = spla.norm(V.norm())
+    recon_err = spla.norm((V - Q.lincomb(R.T)).norm())
+    recon_err_rel = recon_err / V_norm if V_norm > 0 else 0
+    if recon_err > check_recon_tol * V_norm:
         raise AccuracyError(f'QR not accurate (rel recon err={recon_err_rel})')

--- a/src/pymor/algorithms/qr.py
+++ b/src/pymor/algorithms/qr.py
@@ -53,6 +53,8 @@ def qr(A, product=None, offset=0,
         A_orig = A if copy else A.copy()
     Q, R = gram_schmidt(A, product=product, return_R=True, atol=0, rtol=0, offset=offset,
                         check=False, copy=copy, **kwargs)
+    if len(Q) < len(A):
+        raise RuntimeError('Could not construct an orthonormal basis of full length.')
     if check:
         _check_qr(A_orig, Q, R, product, check_orth_tol, check_recon_tol)
     return Q, R
@@ -110,6 +112,6 @@ def _check_qr(A, Q, R, product, check_orth_tol, check_recon_tol):
             raise AccuracyError(f'Q not orthonormal (orth err={err})')
     A_norm = spla.norm(A.norm())
     recon_err = spla.norm((A - Q.lincomb(R.T)).norm())
-    recon_err_rel = recon_err / A_norm
-    if recon_err_rel > check_recon_tol:
+    recon_err_rel = recon_err / A_norm if A_norm > 0 else 0
+    if recon_err > check_recon_tol * A_norm:
         raise AccuracyError(f'QR not accurate (rel recon err={recon_err_rel})')

--- a/src/pymor/algorithms/qr.py
+++ b/src/pymor/algorithms/qr.py
@@ -25,8 +25,14 @@ def qr(V, product=None, offset=0,
     the thin QR decomposition of `V` consists of the unique
     orthonormal |VectorArray| `Q` and
     upper-triangular matrix `R` such that
-    `V == Q.lincomb(R.T)`, `len(V) == len(Q)`, and
+    `V == Q.lincomb(R.T)`, `len(Q) == len(V)`, and
     `R` has positive diagonal entries.
+
+    The method assumes that `V` has linearly independent vectors and
+    may fail if linear dependence is detected
+    (it may or may not work for sets of vectors that are almost linearly dependent).
+    In particular, it will either return a `Q` such that `len(Q) == len(V)` or
+    raise an exception.
 
     Parameters
     ----------
@@ -67,6 +73,10 @@ def qr(V, product=None, offset=0,
         If the orthogonality or reconstruction check fail.
     LinAlgError
         If the vectors in `V` are detected to be linearly dependent.
+
+    See Also
+    --------
+    rrqr : Rank-revealing QR decomposition with truncation.
     """
     assert isinstance(V, VectorArray)
     if product is not None:
@@ -110,6 +120,8 @@ def rrqr(V, product=None, atol=1e-13, rtol=1e-13, offset=0,
     the norm of `V - Q.lincomb(R.T)` is "small" and
     `len(Q) <= len(V)`.
 
+    In particular, increasing `atol` and/or `rtol` should decrease the resulting `len(Q)`.
+
     Parameters
     ----------
     V
@@ -152,6 +164,10 @@ def rrqr(V, product=None, atol=1e-13, rtol=1e-13, offset=0,
     ------
     AccuracyError
         If the orthogonality or reconstruction check fail.
+
+    See Also
+    --------
+    qr : Thin QR decomposition without truncation.
     """
     assert isinstance(V, VectorArray)
     if product is not None:

--- a/src/pymor/algorithms/qr.py
+++ b/src/pymor/algorithms/qr.py
@@ -5,7 +5,7 @@
 from pymor.algorithms.gram_schmidt import gram_schmidt
 
 
-def qr(A, product=None, offset=0, copy=True):
+def qr(A, product=None, offset=0, check=True, check_tol=1e-3, copy=True):
     """Compute a QR decomposition.
 
     Parameters
@@ -18,6 +18,10 @@ def qr(A, product=None, offset=0, copy=True):
     offset
         Assume that the first `offset` vectors are already orthonormal and start the
         algorithm at the `offset + 1`-th vector.
+    check
+        If `True`, check if the resulting |VectorArray| is really orthonormal.
+    check_tol
+        Tolerance for the check.
     copy
         If `True`, create a copy of `A` instead of modifying `A` in-place.
 
@@ -28,10 +32,11 @@ def qr(A, product=None, offset=0, copy=True):
     R
         The upper-triangular/trapezoidal matrix.
     """
-    return gram_schmidt(A, product=product, return_R=True, atol=0, rtol=0, offset=offset, copy=copy)
+    return gram_schmidt(A, product=product, return_R=True, atol=0, rtol=0, offset=offset,
+                        check=check, check_tol=check_tol, copy=copy)
 
 
-def rrqr(A, product=None, offset=0, copy=True):
+def rrqr(A, product=None, offset=0, check=True, check_tol=1e-3, copy=True):
     """Compute a rank-revealing QR (RRQR) decomposition.
 
     Parameters
@@ -44,6 +49,10 @@ def rrqr(A, product=None, offset=0, copy=True):
     offset
         Assume that the first `offset` vectors are already orthonormal and start the
         algorithm at the `offset + 1`-th vector.
+    check
+        If `True`, check if the resulting |VectorArray| is really orthonormal.
+    check_tol
+        Tolerance for the check.
     copy
         If `True`, create a copy of `A` instead of modifying `A` in-place.
 
@@ -54,4 +63,5 @@ def rrqr(A, product=None, offset=0, copy=True):
     R
         The upper-triangular/trapezoidal matrix.
     """
-    return gram_schmidt(A, product=product, return_R=True, offset=offset, copy=copy)
+    return gram_schmidt(A, product=product, return_R=True, offset=offset,
+                        check=check, check_tol=check_tol, copy=copy)

--- a/src/pymor/algorithms/qr.py
+++ b/src/pymor/algorithms/qr.py
@@ -2,10 +2,16 @@
 # Copyright pyMOR developers and contributors. All rights reserved.
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
+import numpy as np
+import scipy.linalg as spla
+
 from pymor.algorithms.gram_schmidt import gram_schmidt
+from pymor.core.defaults import defaults
+from pymor.core.exceptions import AccuracyError
 
 
-def qr(A, product=None, offset=0, check=True, check_tol=1e-3, copy=True):
+@defaults('check', 'check_tol', 'method')
+def qr(A, product=None, offset=0, check=True, check_tol=1e-3, copy=True, method='gram_schmidt', **kwargs):
     """Compute a QR decomposition.
 
     Parameters
@@ -16,14 +22,18 @@ def qr(A, product=None, offset=0, check=True, check_tol=1e-3, copy=True):
         The inner product |Operator| w.r.t. which to orthonormalize.
         If `None`, the Euclidean product is used.
     offset
-        Assume that the first `offset` vectors are already orthonormal and start the
-        algorithm at the `offset + 1`-th vector.
+        Assume that the first `offset` vectors are already orthonormal.
+        Those vectors will not be changed even when `copy` is `False`.
     check
         If `True`, check if the resulting |VectorArray| is really orthonormal.
     check_tol
         Tolerance for the check.
     copy
         If `True`, create a copy of `A` instead of modifying `A` in-place.
+    method
+        QR decomposition method (currently only `'gram_schmidt'`).
+    kwargs
+        Keyword arguments specific to the method.
 
     Returns
     -------
@@ -32,11 +42,16 @@ def qr(A, product=None, offset=0, check=True, check_tol=1e-3, copy=True):
     R
         The upper-triangular/trapezoidal matrix.
     """
-    return gram_schmidt(A, product=product, return_R=True, atol=0, rtol=0, offset=offset,
-                        check=check, check_tol=check_tol, copy=copy)
+    assert method == 'gram_schmidt'
+    Q, R = gram_schmidt(A, product=product, return_R=True, atol=0, rtol=0, offset=offset,
+                        check=False, copy=copy, **kwargs)
+    if check:
+        _check_qr(A, product, offset, check_tol, Q, R)
+    return Q, R
 
 
-def rrqr(A, product=None, offset=0, check=True, check_tol=1e-3, copy=True):
+@defaults('check', 'check_tol', 'method')
+def rrqr(A, product=None, offset=0, check=True, check_tol=1e-3, copy=True, method='gram_schmidt', **kwargs):
     """Compute a rank-revealing QR (RRQR) decomposition.
 
     Parameters
@@ -47,21 +62,43 @@ def rrqr(A, product=None, offset=0, check=True, check_tol=1e-3, copy=True):
         The inner product |Operator| w.r.t. which to orthonormalize.
         If `None`, the Euclidean product is used.
     offset
-        Assume that the first `offset` vectors are already orthonormal and start the
-        algorithm at the `offset + 1`-th vector.
+        Assume that the first `offset` vectors are already orthonormal.
+        Those vectors will not be changed even when `copy` is `False`.
     check
         If `True`, check if the resulting |VectorArray| is really orthonormal.
     check_tol
         Tolerance for the check.
     copy
         If `True`, create a copy of `A` instead of modifying `A` in-place.
+    method
+        QR decomposition method (currently only `'gram_schmidt'`).
+    kwargs
+        Keyword arguments specific to the method.
 
     Returns
     -------
     Q
-        The orthonormalized |VectorArray|.
+        The orthonormal |VectorArray| of the length less or equal to the length of `A`.
     R
         The upper-triangular/trapezoidal matrix.
     """
-    return gram_schmidt(A, product=product, return_R=True, offset=offset,
-                        check=check, check_tol=check_tol, copy=copy)
+    assert method == 'gram_schmidt'
+    Q, R = gram_schmidt(A, product=product, return_R=True, offset=offset,
+                        check=False, copy=copy, **kwargs)
+    if check:
+        _check_qr(A, product, offset, check_tol, Q, R)
+    return Q, R
+
+
+def _check_qr(A, product, offset, check_tol, Q, R):
+    orth_error_matrix = A[offset:len(A)].inner(A, product)
+    orth_error_matrix[:len(A) - offset, offset:len(A)] -= np.eye(len(A) - offset)
+    if orth_error_matrix.size > 0:
+        err = np.max(np.abs(orth_error_matrix))
+        if err >= check_tol:
+            raise AccuracyError(f'Q not orthonormal (max err={err})')
+    A_norm = spla.norm(A.norm())
+    qr_error = spla.norm((A - Q.lincomb(R.T)).norm())
+    qr_error_rel = qr_error / A_norm
+    if qr_error_rel >= check_tol:
+        raise AccuracyError(f'QR not accurate (rel err={qr_error_rel})')

--- a/src/pymor/algorithms/qr.py
+++ b/src/pymor/algorithms/qr.py
@@ -191,8 +191,8 @@ def _check_qr(V, Q, R, product, offset, check_orth_tol, check_recon_tol):
         if orth_err > check_orth_tol:
             raise AccuracyError(f'Q not orthonormal (orth err={orth_err})')
     if np.isfinite(check_recon_tol):
-        V_norm = spla.norm(V.norm(product))
-        recon_err = spla.norm((V - Q.lincomb(R.T)).norm(product))
+        V_norm = np.linalg.norm(V.norm(product))
+        recon_err = np.linalg.norm((V - Q.lincomb(R.T)).norm(product))
         recon_err_rel = recon_err / V_norm if V_norm > 0 else 0
         if recon_err > check_recon_tol * V_norm:
             raise AccuracyError(f'QR not accurate (rel recon err={recon_err_rel})')

--- a/src/pymor/algorithms/qr.py
+++ b/src/pymor/algorithms/qr.py
@@ -2,36 +2,38 @@
 # Copyright pyMOR developers and contributors. All rights reserved.
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
+from numbers import Integral, Real
+
 import numpy as np
 import scipy.linalg as spla
 
 from pymor.algorithms.gram_schmidt import gram_schmidt
 from pymor.core.defaults import defaults
-from pymor.core.exceptions import AccuracyError
+from pymor.core.exceptions import AccuracyError, LinAlgError
+from pymor.operators.interface import Operator
+from pymor.vectorarrays.interface import VectorArray
 
 
 @defaults('check', 'check_orth_tol', 'check_recon_tol', 'method')
 def qr(V, product=None, offset=0,
        check=True, check_orth_tol=1e-3, check_recon_tol=1e-3,
        copy=True, method='gram_schmidt', **kwargs):
-    r"""Compute a thin QR decomposition.
+    """Compute a thin QR decomposition.
 
-    For a |VectorArray| `V` and inner product |Operator| `product`,
-    the thin QR decomposition of `V` is given by
+    For a |VectorArray| `V` of linearly independent vectors and
+    inner product |Operator| `product`,
+    the thin QR decomposition of `V` consists of the unique
     orthonormal |VectorArray| `Q` and
     upper-triangular matrix `R` such that
-    `V == Q.lincomb(R.T)` and `len(V) == len(Q)`.
-
-    .. note::
-        If the set of vectors in :math:`V` is linearly dependent,
-        the implementation may raise an exception (see below).
+    `V == Q.lincomb(R.T)`, `len(V) == len(Q)`, and
+    `R` has positive diagonal entries.
 
     Parameters
     ----------
     V
         The |VectorArray| for which to compute the thin QR decomposition.
     product
-        The inner product |Operator| w.r.t. which to orthonormalize.
+        The inner product |Operator| w.r.t. which `Q` is orthonormal.
         If `None`, the Euclidean product is used.
     offset
         Assume that the first `offset` vectors are already orthonormal.
@@ -41,10 +43,10 @@ def qr(V, product=None, offset=0,
         if `Q.lincomb(R.T)` approximates `V`.
     check_orth_tol
         Tolerance for the orthogonality check:
-        :math:`\lVert Q^H P Q - I \rVert_F \leqslant \mathtt{orth\_tol}`.
+        `frobenius_norm(Q.gramian(product) - np.eye(len(Q))) <= orth_tol`.
     check_recon_tol
         Tolerance for the reconstruction check:
-        :math:`\lVert V - Q R \rVert_F \leqslant \mathtt{recon\_tol} \lVert A \rVert_F`.
+        `norm((V - Q.lincomb(R.T)).norm(product)) <= recon_tol * norm(V.norm(product))`.
     copy
         If `True`, create a copy of `V` instead of modifying `V` in-place.
     method
@@ -57,21 +59,39 @@ def qr(V, product=None, offset=0,
     Q
         The orthonormal |VectorArray| of the same length as `V`.
     R
-        The upper-triangular/trapezoidal matrix.
+        The upper-triangular matrix.
 
     Raises
     ------
-    RuntimeError
+    AccuracyError
+        If the orthogonality or reconstruction check fail.
+    LinAlgError
         If the vectors in `V` are detected to be linearly dependent.
     """
-    assert method == 'gram_schmidt'
+    assert isinstance(V, VectorArray)
+    if product is not None:
+        assert isinstance(product, Operator)
+        assert product.source == product.range
+        assert not product.parametric
+        assert V in product.source
+    assert isinstance(offset, Integral)
+    assert offset >= 0
+    assert isinstance(check_orth_tol, Real)
+    assert check_orth_tol > 0
+    assert isinstance(check_recon_tol, Real)
+    assert check_recon_tol > 0
+    if method != 'gram_schmidt':
+        raise ValueError(f'Unknown QR method {method}')
+
     len_V = len(V)
-    if check:
+    if check and np.isfinite(check_recon_tol):
         V_orig = V if copy else V.copy()
+    else:
+        V_orig = None
     Q, R = gram_schmidt(V, product=product, return_R=True, atol=0, rtol=0, offset=offset,
                         check=False, copy=copy, **kwargs)
     if len(Q) < len_V:
-        raise RuntimeError('Could not construct an orthonormal basis of full length.')
+        raise LinAlgError('The VectorArray has linearly dependent vectors.')
     if check:
         _check_qr(V_orig, Q, R, product, offset, check_orth_tol, check_recon_tol)
     return Q, R
@@ -81,7 +101,7 @@ def qr(V, product=None, offset=0,
 def rrqr(V, product=None, atol=1e-13, rtol=1e-13, offset=0,
          check=True, check_orth_tol=1e-3, check_recon_tol=1e-3,
          copy=True, method='gram_schmidt', **kwargs):
-    r"""Compute a rank-revealing QR (RRQR) decomposition.
+    """Compute a rank-revealing QR (RRQR) decomposition.
 
     For a |VectorArray| `V` and inner product |Operator| `product`,
     a rank-revealing QR decomposition of `V` is given by any
@@ -95,7 +115,7 @@ def rrqr(V, product=None, atol=1e-13, rtol=1e-13, offset=0,
     V
         The |VectorArray| for which to compute the rank-revealing QR decomposition.
     product
-        The inner product |Operator| w.r.t. which to orthonormalize.
+        The inner product |Operator| w.r.t. which `Q` is orthonormal.
         If `None`, the Euclidean product is used.
     atol
         Absolute tolerance used to detect linearly dependent vectors
@@ -110,10 +130,10 @@ def rrqr(V, product=None, atol=1e-13, rtol=1e-13, offset=0,
         If `True`, check if the resulting `Q` is orthonormal and if `Q*R` approximates `A`.
     check_orth_tol
         Tolerance for the orthogonality check:
-        :math:`\lVert Q^H P Q - I \rVert_F \leqslant \mathtt{orth\_tol}`.
+        `frobenius_norm(Q.gramian(product) - np.eye(len(Q))) <= orth_tol`.
     check_recon_tol
         Tolerance for the reconstruction check:
-        :math:`\lVert A - Q R \rVert_F \leqslant \mathtt{recon\_tol} \lVert A \rVert_F`.
+        `(V - Q.lincomb(R.T)).norm(product) <= recon_tol * V.norm(product)`.
     copy
         If `True`, create a copy of `A` instead of modifying `A` in-place.
     method
@@ -127,10 +147,35 @@ def rrqr(V, product=None, atol=1e-13, rtol=1e-13, offset=0,
         The orthonormal |VectorArray| such that `len(Q) <= len(V)`.
     R
         The upper-triangular/trapezoidal matrix.
+
+    Raises
+    ------
+    AccuracyError
+        If the orthogonality or reconstruction check fail.
     """
-    assert method == 'gram_schmidt'
-    if check:
+    assert isinstance(V, VectorArray)
+    if product is not None:
+        assert isinstance(product, Operator)
+        assert product.source == product.range
+        assert not product.parametric
+        assert V in product.source
+    assert isinstance(atol, Real)
+    assert atol >= 0
+    assert isinstance(rtol, Real)
+    assert rtol >= 0
+    assert isinstance(offset, Integral)
+    assert offset >= 0
+    assert isinstance(check_orth_tol, Real)
+    assert check_orth_tol > 0
+    assert isinstance(check_recon_tol, Real)
+    assert check_recon_tol > 0
+    if method != 'gram_schmidt':
+        raise ValueError(f'Unknown QR method {method}')
+
+    if check and np.isfinite(check_recon_tol):
         V_orig = V if copy else V.copy()
+    else:
+        V_orig = None
     Q, R = gram_schmidt(V, product=product, return_R=True, atol=atol, rtol=rtol, offset=offset,
                         check=False, copy=copy, **kwargs)
     if check:
@@ -145,8 +190,9 @@ def _check_qr(V, Q, R, product, offset, check_orth_tol, check_recon_tol):
         orth_err = spla.norm(orth_error_matrix)
         if orth_err > check_orth_tol:
             raise AccuracyError(f'Q not orthonormal (orth err={orth_err})')
-    V_norm = spla.norm(V.norm())
-    recon_err = spla.norm((V - Q.lincomb(R.T)).norm())
-    recon_err_rel = recon_err / V_norm if V_norm > 0 else 0
-    if recon_err > check_recon_tol * V_norm:
-        raise AccuracyError(f'QR not accurate (rel recon err={recon_err_rel})')
+    if np.isfinite(check_recon_tol):
+        V_norm = spla.norm(V.norm(product))
+        recon_err = spla.norm((V - Q.lincomb(R.T)).norm(product))
+        recon_err_rel = recon_err / V_norm if V_norm > 0 else 0
+        if recon_err > check_recon_tol * V_norm:
+            raise AccuracyError(f'QR not accurate (rel recon err={recon_err_rel})')

--- a/src/pymor/algorithms/qr.py
+++ b/src/pymor/algorithms/qr.py
@@ -16,23 +16,17 @@ from pymor.vectorarrays.interface import VectorArray
 
 @defaults('check', 'check_orth_tol', 'check_recon_tol', 'method')
 def qr(V, product=None, offset=0,
-       check=True, check_orth_tol=1e-3, check_recon_tol=1e-3,
+       check=True, check_orth_tol=1e-12, check_recon_tol=1e-12,
        copy=True, method='gram_schmidt', **kwargs):
     """Compute a thin QR decomposition.
 
-    For a |VectorArray| `V` of linearly independent vectors and
-    inner product |Operator| `product`,
-    the thin QR decomposition of `V` consists of the unique
-    orthonormal |VectorArray| `Q` and
-    upper-triangular matrix `R` such that
-    `V == Q.lincomb(R.T)`, `len(Q) == len(V)`, and
-    `R` has positive diagonal entries.
+    For a |VectorArray| `V` and inner product |Operator| `product`,
+    a thin QR decomposition of `V` consists of
+    an orthonormal |VectorArray| `Q` and
+    an upper-triangular matrix `R` such that
+    `len(Q) == len(V)` and `V == Q.lincomb(R.T)`.
 
-    The method assumes that `V` has linearly independent vectors and
-    may fail if linear dependence is detected
-    (it may or may not work for sets of vectors that are almost linearly dependent).
-    In particular, it will either return a `Q` such that `len(Q) == len(V)` or
-    raise an exception.
+    The method may fail if `V` has linearly dependent vectors.
 
     Parameters
     ----------
@@ -76,7 +70,7 @@ def qr(V, product=None, offset=0,
 
     See Also
     --------
-    rrqr : Rank-revealing QR decomposition with truncation.
+    :func:`~pymor.algorithms.qr.rrqr` : Rank-revealing QR decomposition with truncation.
     """
     assert isinstance(V, VectorArray)
     if product is not None:
@@ -109,7 +103,7 @@ def qr(V, product=None, offset=0,
 
 @defaults('atol', 'rtol', 'check', 'check_orth_tol', 'check_recon_tol', 'method')
 def rrqr(V, product=None, atol=1e-13, rtol=1e-13, offset=0,
-         check=True, check_orth_tol=1e-3, check_recon_tol=1e-3,
+         check=True, check_orth_tol=1e-12, check_recon_tol=1e-12,
          copy=True, method='gram_schmidt', **kwargs):
     """Compute a rank-revealing QR (RRQR) decomposition.
 
@@ -167,7 +161,7 @@ def rrqr(V, product=None, atol=1e-13, rtol=1e-13, offset=0,
 
     See Also
     --------
-    qr : Thin QR decomposition without truncation.
+    :func:`~pymor.algorithms.qr.qr` : Thin QR decomposition without truncation.
     """
     assert isinstance(V, VectorArray)
     if product is not None:

--- a/src/pymor/algorithms/rand_la.py
+++ b/src/pymor/algorithms/rand_la.py
@@ -328,7 +328,7 @@ def random_ghep(A, E=None, modes=6, p=20, q=2, single_pass=False):
     else:
         C = InverseOperator(E) @ A
         Y, Omega = rrf(C, q=q, l=modes+p, return_rand=True)
-        Q = rrqr(Y, product=E)
+        Q = rrqr(Y, product=E)[0]
         T = A.apply2(Q, Q)
 
     w, S = eigh(T)

--- a/src/pymor/algorithms/rand_la.py
+++ b/src/pymor/algorithms/rand_la.py
@@ -7,7 +7,7 @@ from scipy.linalg import eigh, lu_factor, lu_solve, svd
 from scipy.sparse.linalg import LinearOperator, eigsh
 from scipy.special import erfinv
 
-from pymor.algorithms.gram_schmidt import gram_schmidt
+from pymor.algorithms.qr import qr, rrqr
 from pymor.core.defaults import defaults
 from pymor.core.logger import getLogger
 from pymor.operators.constructions import IdentityOperator, InverseOperator
@@ -89,7 +89,7 @@ def adaptive_rrf(A, source_product=None, range_product=None, tol=1e-4,
         if iscomplex:
             v += 1j*A.source.random(distribution='normal')
         B.append(A.apply(v))
-        gram_schmidt(B, range_product, atol=0, rtol=0, offset=basis_length, copy=False)
+        qr(B, product=range_product, offset=basis_length, copy=False)
         M -= B.lincomb(B.inner(M, range_product).T)
         maxnorm = np.max(M.norm(range_product))
 
@@ -150,14 +150,14 @@ def rrf(A, source_product=None, range_product=None, q=2, l=8, return_rand=False,
         R += 1j*A.source.random(l, distribution='normal')
 
     Q = A.apply(R)
-    gram_schmidt(Q, range_product, atol=0, rtol=0, copy=False)
+    qr(Q, product=range_product, copy=False)
 
     for i in range(q):
         Q = A.apply_adjoint(range_product.apply(Q))
         Q = source_product.apply_inverse(Q)
-        gram_schmidt(Q, source_product, atol=0, rtol=0, copy=False)
+        qr(Q, product=source_product, copy=False)
         Q = A.apply(Q)
-        gram_schmidt(Q, range_product, atol=0, rtol=0, copy=False)
+        qr(Q, product=range_product, copy=False)
 
     if return_rand:
         return Q, R
@@ -240,7 +240,7 @@ def random_generalized_svd(A, range_product=None, source_product=None, modes=6, 
 
     Q = rrf(A, source_product=source_product, range_product=range_product, q=q, l=modes+p)
     B = A.apply_adjoint(range_product.apply(Q))
-    Q_B, R_B = gram_schmidt(source_product.apply_inverse(B), product=source_product, return_R=True)
+    Q_B, R_B = rrqr(source_product.apply_inverse(B), product=source_product)
     U_b, s, Vh_b = svd(R_B.T, full_matrices=False)
 
     with logger.block(f'Computing generalized left-singular vectors ({modes} vectors) ...'):
@@ -321,14 +321,14 @@ def random_ghep(A, E=None, modes=6, p=20, q=2, single_pass=False):
         Omega = A.source.random(modes+p, distribution='normal')
         Y_bar = A.apply(Omega)
         Y = E.apply_inverse(Y_bar)
-        Q, R = gram_schmidt(Y, product=E, return_R=True)
+        Q, R = rrqr(Y, product=E)
         X = E.apply2(Omega, Q)
         X_lu = lu_factor(X)
         T = lu_solve(X_lu, lu_solve(X_lu, Omega.inner(Y_bar)).T).T
     else:
         C = InverseOperator(E) @ A
         Y, Omega = rrf(C, q=q, l=modes+p, return_rand=True)
-        Q = gram_schmidt(Y, product=E)
+        Q = rrqr(Y, product=E)
         T = A.apply2(Q, Q)
 
     w, S = eigh(T)

--- a/src/pymor/algorithms/rand_la.py
+++ b/src/pymor/algorithms/rand_la.py
@@ -7,7 +7,7 @@ from scipy.linalg import eigh, lu_factor, lu_solve, svd
 from scipy.sparse.linalg import LinearOperator, eigsh
 from scipy.special import erfinv
 
-from pymor.algorithms.qr import qr, rrqr
+from pymor.algorithms.orth import orth
 from pymor.core.defaults import defaults
 from pymor.core.logger import getLogger
 from pymor.operators.constructions import IdentityOperator, InverseOperator
@@ -89,7 +89,7 @@ def adaptive_rrf(A, source_product=None, range_product=None, tol=1e-4,
         if iscomplex:
             v += 1j*A.source.random(distribution='normal')
         B.append(A.apply(v))
-        qr(B, product=range_product, offset=basis_length, copy=False)
+        orth(B, product=range_product, offset=basis_length, copy=False)
         M -= B.lincomb(B.inner(M, range_product).T)
         maxnorm = np.max(M.norm(range_product))
 
@@ -150,14 +150,14 @@ def rrf(A, source_product=None, range_product=None, q=2, l=8, return_rand=False,
         R += 1j*A.source.random(l, distribution='normal')
 
     Q = A.apply(R)
-    qr(Q, product=range_product, copy=False)
+    orth(Q, product=range_product, copy=False)
 
     for i in range(q):
         Q = A.apply_adjoint(range_product.apply(Q))
         Q = source_product.apply_inverse(Q)
-        qr(Q, product=source_product, copy=False)
+        orth(Q, product=source_product, copy=False)
         Q = A.apply(Q)
-        qr(Q, product=range_product, copy=False)
+        orth(Q, product=range_product, copy=False)
 
     if return_rand:
         return Q, R
@@ -240,7 +240,7 @@ def random_generalized_svd(A, range_product=None, source_product=None, modes=6, 
 
     Q = rrf(A, source_product=source_product, range_product=range_product, q=q, l=modes+p)
     B = A.apply_adjoint(range_product.apply(Q))
-    Q_B, R_B = rrqr(source_product.apply_inverse(B), product=source_product)
+    Q_B, R_B = orth(source_product.apply_inverse(B), product=source_product)
     U_b, s, Vh_b = svd(R_B.T, full_matrices=False)
 
     with logger.block(f'Computing generalized left-singular vectors ({modes} vectors) ...'):
@@ -321,14 +321,14 @@ def random_ghep(A, E=None, modes=6, p=20, q=2, single_pass=False):
         Omega = A.source.random(modes+p, distribution='normal')
         Y_bar = A.apply(Omega)
         Y = E.apply_inverse(Y_bar)
-        Q, R = rrqr(Y, product=E)
+        Q, R = orth(Y, product=E, hierarchical=True)
         X = E.apply2(Omega, Q)
         X_lu = lu_factor(X)
         T = lu_solve(X_lu, lu_solve(X_lu, Omega.inner(Y_bar)).T).T
     else:
         C = InverseOperator(E) @ A
         Y, Omega = rrf(C, q=q, l=modes+p, return_rand=True)
-        Q = rrqr(Y, product=E)[0]
+        Q = orth(Y, product=E)[0]
         T = A.apply2(Q, Q)
 
     w, S = eigh(T)

--- a/src/pymor/algorithms/samdp.py
+++ b/src/pymor/algorithms/samdp.py
@@ -5,7 +5,7 @@
 import numpy as np
 import scipy.linalg as spla
 
-from pymor.algorithms.gram_schmidt import gram_schmidt
+from pymor.algorithms.qr import qr
 from pymor.core.defaults import defaults
 from pymor.core.logger import getLogger
 from pymor.operators.constructions import IdentityOperator
@@ -147,8 +147,8 @@ def samdp(A, E, B, C, nwanted, init_shifts=None, which='NR', tol=1e-10, imagtol=
 
         X.append(x)
         V.append(v)
-        gram_schmidt(V, atol=0, rtol=0, copy=False)
-        gram_schmidt(X, atol=0, rtol=0, copy=False)
+        qr(V, copy=False)
+        qr(X, copy=False)
 
         AX.append(A.apply(X[k-1]))
 
@@ -238,8 +238,8 @@ def samdp(A, E, B, C, nwanted, init_shifts=None, which='NR', tol=1e-10, imagtol=
                     V = A.source.empty()
 
                 if np.abs(np.imag(theta)) / np.abs(theta) < imagtol:
-                    gram_schmidt(V, atol=0, rtol=0, copy=False)
-                    gram_schmidt(X, atol=0, rtol=0, copy=False)
+                    qr(V, copy=False)
+                    qr(X, copy=False)
 
                 B_defl -= E.apply(Q[-1].lincomb(Qt[-1].inner(B_defl).T))
                 C_defl -= E.apply_adjoint(Qt[-1].lincomb(Q[-1].inner(C_defl).T))
@@ -271,8 +271,8 @@ def samdp(A, E, B, C, nwanted, init_shifts=None, which='NR', tol=1e-10, imagtol=
                         Q[-1].scal(1 / nqqt)
                         Qs[-1].scal(1 / nqqt)
 
-                        gram_schmidt(V, atol=0, rtol=0, copy=False)
-                        gram_schmidt(X, atol=0, rtol=0, copy=False)
+                        qr(V, copy=False)
+                        qr(X, copy=False)
 
                         B_defl -= E.apply(Q[-1].lincomb(Qt[-1].inner(B_defl).T))
                         C_defl -= E.apply_adjoint(Qt[-1].lincomb(Q[-1].inner(C_defl).T))
@@ -308,8 +308,8 @@ def samdp(A, E, B, C, nwanted, init_shifts=None, which='NR', tol=1e-10, imagtol=
                 X = X.lincomb(UR[:, minidx])
                 V = V.lincomb(URt[:, minidx])
 
-                gram_schmidt(V, atol=0, rtol=0, copy=False)
-                gram_schmidt(X, atol=0, rtol=0, copy=False)
+                qr(V, copy=False)
+                qr(X, copy=False)
 
                 G = V.inner(E.apply(X))
                 AX = A.apply(X)
@@ -327,8 +327,8 @@ def samdp(A, E, B, C, nwanted, init_shifts=None, which='NR', tol=1e-10, imagtol=
             X = X.lincomb(UR[:, minidx])
             V = V.lincomb(URt[:, minidx])
 
-            gram_schmidt(V, atol=0, rtol=0, copy=False)
-            gram_schmidt(X, atol=0, rtol=0, copy=False)
+            qr(V, copy=False)
+            qr(X, copy=False)
 
             G = V.inner(E.apply(X))
             AX = A.apply(X)

--- a/src/pymor/algorithms/samdp.py
+++ b/src/pymor/algorithms/samdp.py
@@ -5,7 +5,7 @@
 import numpy as np
 import scipy.linalg as spla
 
-from pymor.algorithms.qr import qr
+from pymor.algorithms.orth import orth
 from pymor.core.defaults import defaults
 from pymor.core.logger import getLogger
 from pymor.operators.constructions import IdentityOperator
@@ -147,8 +147,8 @@ def samdp(A, E, B, C, nwanted, init_shifts=None, which='NR', tol=1e-10, imagtol=
 
         X.append(x)
         V.append(v)
-        qr(V, copy=False)
-        qr(X, copy=False)
+        orth(V, pad=True, copy=False)
+        orth(X, pad=True, copy=False)
 
         AX.append(A.apply(X[k-1]))
 
@@ -238,8 +238,8 @@ def samdp(A, E, B, C, nwanted, init_shifts=None, which='NR', tol=1e-10, imagtol=
                     V = A.source.empty()
 
                 if np.abs(np.imag(theta)) / np.abs(theta) < imagtol:
-                    qr(V, copy=False)
-                    qr(X, copy=False)
+                    orth(V, pad=True, copy=False)
+                    orth(X, pad=True, copy=False)
 
                 B_defl -= E.apply(Q[-1].lincomb(Qt[-1].inner(B_defl).T))
                 C_defl -= E.apply_adjoint(Qt[-1].lincomb(Q[-1].inner(C_defl).T))
@@ -271,8 +271,8 @@ def samdp(A, E, B, C, nwanted, init_shifts=None, which='NR', tol=1e-10, imagtol=
                         Q[-1].scal(1 / nqqt)
                         Qs[-1].scal(1 / nqqt)
 
-                        qr(V, copy=False)
-                        qr(X, copy=False)
+                        orth(V, pad=True, copy=False)
+                        orth(X, pad=True, copy=False)
 
                         B_defl -= E.apply(Q[-1].lincomb(Qt[-1].inner(B_defl).T))
                         C_defl -= E.apply_adjoint(Qt[-1].lincomb(Q[-1].inner(C_defl).T))
@@ -308,8 +308,8 @@ def samdp(A, E, B, C, nwanted, init_shifts=None, which='NR', tol=1e-10, imagtol=
                 X = X.lincomb(UR[:, minidx])
                 V = V.lincomb(URt[:, minidx])
 
-                qr(V, copy=False)
-                qr(X, copy=False)
+                orth(V, pad=True, copy=False)
+                orth(X, pad=True, copy=False)
 
                 G = V.inner(E.apply(X))
                 AX = A.apply(X)
@@ -327,8 +327,8 @@ def samdp(A, E, B, C, nwanted, init_shifts=None, which='NR', tol=1e-10, imagtol=
             X = X.lincomb(UR[:, minidx])
             V = V.lincomb(URt[:, minidx])
 
-            qr(V, copy=False)
-            qr(X, copy=False)
+            orth(V, pad=True, copy=False)
+            orth(X, pad=True, copy=False)
 
             G = V.inner(E.apply(X))
             AX = A.apply(X)

--- a/src/pymor/algorithms/svd_va.py
+++ b/src/pymor/algorithms/svd_va.py
@@ -7,7 +7,7 @@
 import numpy as np
 import scipy.linalg as spla
 
-from pymor.algorithms.gram_schmidt import gram_schmidt
+from pymor.algorithms.qr import rrqr
 from pymor.core.defaults import defaults
 from pymor.core.logger import getLogger
 from pymor.operators.interface import Operator
@@ -161,7 +161,7 @@ def qr_svd(A, product=None, modes=None, rtol=4e-8, atol=0., l2_err=0.):
     logger = getLogger('pymor.algorithms.svd_va.qr_svd')
 
     with logger.block('Computing QR decomposition ...'):
-        Q, R = gram_schmidt(A, product=product, return_R=True, check=False)
+        Q, R = rrqr(A, product=product, check=False)
 
     with logger.block('Computing SVD of R ...'):
         U2, s, Vh = spla.svd(R, lapack_driver='gesvd')

--- a/src/pymor/basic.py
+++ b/src/pymor/basic.py
@@ -19,6 +19,7 @@ from pymor.algorithms.newton import newton
 from pymor.algorithms.pod import pod
 from pymor.algorithms.preassemble import preassemble
 from pymor.algorithms.projection import project, project_to_subbasis
+from pymor.algorithms.qr import qr, rrqr
 from pymor.algorithms.simplify import expand
 from pymor.analyticalproblems.burgers import burgers_problem, burgers_problem_2d
 from pymor.analyticalproblems.domaindescriptions import (

--- a/src/pymor/reductors/basic.py
+++ b/src/pymor/reductors/basic.py
@@ -7,9 +7,9 @@ from numbers import Number
 import numpy as np
 
 from pymor.algorithms.basic import almost_equal
-from pymor.algorithms.gram_schmidt import gram_schmidt
 from pymor.algorithms.pod import pod
 from pymor.algorithms.projection import project, project_to_subbasis
+from pymor.algorithms.qr import rrqr
 from pymor.core.base import BasicObject, abstractmethod
 from pymor.core.defaults import defaults
 from pymor.core.exceptions import AccuracyError, ExtensionError
@@ -476,14 +476,14 @@ def extend_basis(U, basis, product=None, method='gram_schmidt', pod_modes=1, pod
                      remove_from_other=(not copy_U))
     elif method == 'gram_schmidt':
         basis.append(U, remove_from_other=(not copy_U))
-        gram_schmidt(basis, offset=basis_length, product=product, copy=False, check=False)
+        rrqr(basis, offset=basis_length, product=product, copy=False, check=False)
     elif method == 'pod':
         U_proj_err = U - basis.lincomb(U.inner(basis, product))
 
         basis.append(pod(U_proj_err, modes=pod_modes, product=product, orth_tol=np.inf)[0])
 
         if pod_orthonormalize:
-            gram_schmidt(basis, offset=basis_length, product=product, copy=False, check=False)
+            rrqr(basis, offset=basis_length, product=product, copy=False, check=False)
 
     if len(basis) <= basis_length:
         raise ExtensionError

--- a/src/pymor/reductors/basic.py
+++ b/src/pymor/reductors/basic.py
@@ -9,7 +9,7 @@ import numpy as np
 from pymor.algorithms.basic import almost_equal
 from pymor.algorithms.pod import pod
 from pymor.algorithms.projection import project, project_to_subbasis
-from pymor.algorithms.qr import rrqr
+from pymor.algorithms.orth import orth
 from pymor.core.base import BasicObject, abstractmethod
 from pymor.core.defaults import defaults
 from pymor.core.exceptions import AccuracyError, ExtensionError
@@ -476,14 +476,15 @@ def extend_basis(U, basis, product=None, method='gram_schmidt', pod_modes=1, pod
                      remove_from_other=(not copy_U))
     elif method == 'gram_schmidt':
         basis.append(U, remove_from_other=(not copy_U))
-        rrqr(basis, offset=basis_length, product=product, copy=False, check=False)
+        orth(basis, hierarchical=True, offset=basis_length, product=product, copy=False, check=False,
+             method='gram_schmidt')
     elif method == 'pod':
         U_proj_err = U - basis.lincomb(U.inner(basis, product))
 
         basis.append(pod(U_proj_err, modes=pod_modes, product=product, orth_tol=np.inf)[0])
 
         if pod_orthonormalize:
-            rrqr(basis, offset=basis_length, product=product, copy=False, check=False)
+            orth(basis, offset=basis_length, product=product, copy=False, check=False)
 
     if len(basis) <= basis_length:
         raise ExtensionError

--- a/src/pymor/reductors/bt.py
+++ b/src/pymor/reductors/bt.py
@@ -5,7 +5,7 @@
 import numpy as np
 
 from pymor.algorithms.gram_schmidt import gram_schmidt_biorth
-from pymor.algorithms.qr import qr
+from pymor.algorithms.orth import orth
 from pymor.core.base import BasicObject
 from pymor.models.iosys import LTIModel
 from pymor.parameters.base import Mu
@@ -93,8 +93,8 @@ class GenericBTReductor(BasicObject):
             self.V.scal(alpha)
             self.W.scal(alpha)
         elif projection == 'bfsr':
-            qr(self.V, copy=False)
-            qr(self.W, copy=False)
+            orth(self.V, allow_truncation=False, copy=False)
+            orth(self.W, allow_truncation=False, copy=False)
         elif projection == 'biorth':
             gram_schmidt_biorth(self.V, self.W, product=self.fom.E, copy=False)
 

--- a/src/pymor/reductors/bt.py
+++ b/src/pymor/reductors/bt.py
@@ -4,7 +4,8 @@
 
 import numpy as np
 
-from pymor.algorithms.gram_schmidt import gram_schmidt, gram_schmidt_biorth
+from pymor.algorithms.gram_schmidt import gram_schmidt_biorth
+from pymor.algorithms.qr import qr
 from pymor.core.base import BasicObject
 from pymor.models.iosys import LTIModel
 from pymor.parameters.base import Mu
@@ -92,8 +93,8 @@ class GenericBTReductor(BasicObject):
             self.V.scal(alpha)
             self.W.scal(alpha)
         elif projection == 'bfsr':
-            gram_schmidt(self.V, atol=0, rtol=0, copy=False)
-            gram_schmidt(self.W, atol=0, rtol=0, copy=False)
+            qr(self.V, copy=False)
+            qr(self.W, copy=False)
         elif projection == 'biorth':
             gram_schmidt_biorth(self.V, self.W, product=self.fom.E, copy=False)
 

--- a/src/pymor/reductors/h2.py
+++ b/src/pymor/reductors/h2.py
@@ -9,8 +9,9 @@ from numbers import Integral, Real
 import numpy as np
 import scipy.linalg as spla
 
-from pymor.algorithms.gram_schmidt import gram_schmidt, gram_schmidt_biorth
+from pymor.algorithms.gram_schmidt import gram_schmidt_biorth
 from pymor.algorithms.krylov import tangential_rational_krylov
+from pymor.algorithms.qr import qr
 from pymor.algorithms.riccati import solve_ricc_dense
 from pymor.algorithms.sylvester import solve_sylv_schur
 from pymor.algorithms.to_matrix import to_matrix
@@ -411,15 +412,11 @@ class OneSidedIRKAReductor(GenericIRKAReductor):
         if self.version == 'V':
             self.V = tangential_rational_krylov(fom.A, fom.E, fom.B, fom.B.source.from_numpy(b), sigma,
                                                 orth=False)
-            gram_schmidt(self.V, atol=0, rtol=0,
-                         product=None if projection == 'orth' else fom.E,
-                         copy=False)
+            qr(self.V, product=None if projection == 'orth' else fom.E, copy=False)
         else:
             self.V = tangential_rational_krylov(fom.A, fom.E, fom.C, fom.C.range.from_numpy(c), sigma, trans=True,
                                                 orth=False)
-            gram_schmidt(self.V, atol=0, rtol=0,
-                         product=None if projection == 'orth' else fom.E,
-                         copy=False)
+            qr(self.V, product=None if projection == 'orth' else fom.E, copy=False)
         self.W = self.V
         self._pg_reductor = LTIPGReductor(fom, self.V, self.V,
                                           projection == 'Eorth')
@@ -541,8 +538,8 @@ class TSIAReductor(GenericIRKAReductor):
                                           B=fom.B, Br=rom.B,
                                           C=fom.C, Cr=rom.C)
         if projection == 'orth':
-            gram_schmidt(self.V, atol=0, rtol=0, copy=False)
-            gram_schmidt(self.W, atol=0, rtol=0, copy=False)
+            qr(self.V, copy=False)
+            qr(self.W, copy=False)
         elif projection == 'biorth':
             gram_schmidt_biorth(self.V, self.W, product=fom.E, copy=False)
         self._pg_reductor = LTIPGReductor(fom, self.W, self.V,

--- a/src/pymor/reductors/h2.py
+++ b/src/pymor/reductors/h2.py
@@ -11,7 +11,7 @@ import scipy.linalg as spla
 
 from pymor.algorithms.gram_schmidt import gram_schmidt_biorth
 from pymor.algorithms.krylov import tangential_rational_krylov
-from pymor.algorithms.qr import qr
+from pymor.algorithms.orth import orth
 from pymor.algorithms.riccati import solve_ricc_dense
 from pymor.algorithms.sylvester import solve_sylv_schur
 from pymor.algorithms.to_matrix import to_matrix
@@ -412,11 +412,11 @@ class OneSidedIRKAReductor(GenericIRKAReductor):
         if self.version == 'V':
             self.V = tangential_rational_krylov(fom.A, fom.E, fom.B, fom.B.source.from_numpy(b), sigma,
                                                 orth=False)
-            qr(self.V, product=None if projection == 'orth' else fom.E, copy=False)
+            orth(self.V, product=None if projection == 'orth' else fom.E, allow_truncation=False, copy=False)
         else:
             self.V = tangential_rational_krylov(fom.A, fom.E, fom.C, fom.C.range.from_numpy(c), sigma, trans=True,
                                                 orth=False)
-            qr(self.V, product=None if projection == 'orth' else fom.E, copy=False)
+            orth(self.V, product=None if projection == 'orth' else fom.E, allow_truncation=False, copy=False)
         self.W = self.V
         self._pg_reductor = LTIPGReductor(fom, self.V, self.V,
                                           projection == 'Eorth')
@@ -538,8 +538,8 @@ class TSIAReductor(GenericIRKAReductor):
                                           B=fom.B, Br=rom.B,
                                           C=fom.C, Cr=rom.C)
         if projection == 'orth':
-            qr(self.V, copy=False)
-            qr(self.W, copy=False)
+            orth(self.V, allow_truncation=False, copy=False)
+            orth(self.W, allow_truncation=False, copy=False)
         elif projection == 'biorth':
             gram_schmidt_biorth(self.V, self.W, product=fom.E, copy=False)
         self._pg_reductor = LTIPGReductor(fom, self.W, self.V,

--- a/src/pymor/reductors/interpolation.py
+++ b/src/pymor/reductors/interpolation.py
@@ -8,7 +8,7 @@ import numpy as np
 
 from pymor.algorithms.gram_schmidt import gram_schmidt_biorth
 from pymor.algorithms.krylov import rational_arnoldi
-from pymor.algorithms.qr import qr
+from pymor.algorithms.orth import orth
 from pymor.core.base import BasicObject
 from pymor.models.iosys import LinearDelayModel, LTIModel, SecondOrderModel
 from pymor.models.transfer_function import TransferFunction
@@ -143,8 +143,8 @@ class GenericBHIReductor(BasicObject):
                 self.W.append(w.real)
                 self.W.append(w.imag)
         if projection == 'orth':
-            qr(self.V, copy=False)
-            qr(self.W, copy=False)
+            orth(self.V, allow_truncation=False, copy=False)
+            orth(self.W, allow_truncation=False, copy=False)
         elif projection == 'biorth':
             gram_schmidt_biorth(self.V, self.W, product=self._product, copy=False)
 

--- a/src/pymor/reductors/interpolation.py
+++ b/src/pymor/reductors/interpolation.py
@@ -6,8 +6,9 @@ from abc import abstractmethod
 
 import numpy as np
 
-from pymor.algorithms.gram_schmidt import gram_schmidt, gram_schmidt_biorth
+from pymor.algorithms.gram_schmidt import gram_schmidt_biorth
 from pymor.algorithms.krylov import rational_arnoldi
+from pymor.algorithms.qr import qr
 from pymor.core.base import BasicObject
 from pymor.models.iosys import LinearDelayModel, LTIModel, SecondOrderModel
 from pymor.models.transfer_function import TransferFunction
@@ -142,8 +143,8 @@ class GenericBHIReductor(BasicObject):
                 self.W.append(w.real)
                 self.W.append(w.imag)
         if projection == 'orth':
-            gram_schmidt(self.V, atol=0, rtol=0, copy=False)
-            gram_schmidt(self.W, atol=0, rtol=0, copy=False)
+            qr(self.V, copy=False)
+            qr(self.W, copy=False)
         elif projection == 'biorth':
             gram_schmidt_biorth(self.V, self.W, product=self._product, copy=False)
 

--- a/src/pymor/reductors/mt.py
+++ b/src/pymor/reductors/mt.py
@@ -7,7 +7,8 @@ import bisect
 import numpy as np
 import scipy.linalg as spla
 
-from pymor.algorithms.gram_schmidt import gram_schmidt, gram_schmidt_biorth
+from pymor.algorithms.gram_schmidt import gram_schmidt_biorth
+from pymor.algorithms.qr import qr
 from pymor.algorithms.samdp import samdp
 from pymor.algorithms.to_matrix import to_matrix
 from pymor.core.base import BasicObject
@@ -200,8 +201,8 @@ class MTReductor(BasicObject):
         self.W.append(lev[complex_index].imag)
 
         if projection == 'orth':
-            gram_schmidt(self.V, atol=0, rtol=0, copy=False)
-            gram_schmidt(self.W, atol=0, rtol=0, copy=False)
+            qr(self.V, copy=False)
+            qr(self.W, copy=False)
         elif projection == 'biorth':
             gram_schmidt_biorth(self.V, self.W, product=fom.E, copy=False)
 

--- a/src/pymor/reductors/mt.py
+++ b/src/pymor/reductors/mt.py
@@ -8,7 +8,7 @@ import numpy as np
 import scipy.linalg as spla
 
 from pymor.algorithms.gram_schmidt import gram_schmidt_biorth
-from pymor.algorithms.qr import qr
+from pymor.algorithms.orth import orth
 from pymor.algorithms.samdp import samdp
 from pymor.algorithms.to_matrix import to_matrix
 from pymor.core.base import BasicObject
@@ -201,8 +201,8 @@ class MTReductor(BasicObject):
         self.W.append(lev[complex_index].imag)
 
         if projection == 'orth':
-            qr(self.V, copy=False)
-            qr(self.W, copy=False)
+            orth(self.V, allow_truncation=False, copy=False)
+            orth(self.W, allow_truncation=False, copy=False)
         elif projection == 'biorth':
             gram_schmidt_biorth(self.V, self.W, product=fom.E, copy=False)
 

--- a/src/pymor/reductors/ph/ph_irka.py
+++ b/src/pymor/reductors/ph/ph_irka.py
@@ -2,8 +2,8 @@
 # Copyright pyMOR developers and contributors. All rights reserved.
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
-from pymor.algorithms.gram_schmidt import gram_schmidt
 from pymor.algorithms.krylov import tangential_rational_krylov
+from pymor.algorithms.qr import qr
 from pymor.models.iosys import PHLTIModel
 from pymor.reductors.h2 import GenericIRKAReductor
 from pymor.reductors.ph.basic import PHLTIPGReductor
@@ -121,6 +121,6 @@ class PHIRKAReductor(GenericIRKAReductor):
         fom = self._assemble_fom()
         self.V = tangential_rational_krylov(fom.A, fom.E, fom.B, fom.B.source.from_numpy(b), sigma, orth=False)
         product = None if projection == 'orth' else fom.Q.H @ fom.E
-        gram_schmidt(self.V, atol=0, rtol=0, product=product, copy=False)
+        qr(self.V, product=product, copy=False)
         self._pg_reductor = PHLTIPGReductor(fom, self.V, projection == 'QTEorth')
         self.W = self._pg_reductor.bases['W']

--- a/src/pymor/reductors/ph/ph_irka.py
+++ b/src/pymor/reductors/ph/ph_irka.py
@@ -3,7 +3,7 @@
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
 from pymor.algorithms.krylov import tangential_rational_krylov
-from pymor.algorithms.qr import qr
+from pymor.algorithms.orth import orth
 from pymor.models.iosys import PHLTIModel
 from pymor.reductors.h2 import GenericIRKAReductor
 from pymor.reductors.ph.basic import PHLTIPGReductor
@@ -121,6 +121,6 @@ class PHIRKAReductor(GenericIRKAReductor):
         fom = self._assemble_fom()
         self.V = tangential_rational_krylov(fom.A, fom.E, fom.B, fom.B.source.from_numpy(b), sigma, orth=False)
         product = None if projection == 'orth' else fom.Q.H @ fom.E
-        qr(self.V, product=product, copy=False)
+        orth(self.V, product=product, copy=False)
         self._pg_reductor = PHLTIPGReductor(fom, self.V, projection == 'QTEorth')
         self.W = self._pg_reductor.bases['W']

--- a/src/pymor/reductors/sobt.py
+++ b/src/pymor/reductors/sobt.py
@@ -7,7 +7,7 @@ import scipy.linalg as spla
 
 from pymor.algorithms.gram_schmidt import gram_schmidt_biorth
 from pymor.algorithms.projection import project
-from pymor.algorithms.qr import qr
+from pymor.algorithms.orth import orth
 from pymor.core.base import BasicObject
 from pymor.models.iosys import SecondOrderModel
 from pymor.operators.constructions import IdentityOperator
@@ -86,8 +86,8 @@ class GenericSOBTpvReductor(BasicObject):
             self.V.scal(alpha)
             self.W.scal(alpha)
         elif projection == 'bfsr':
-            qr(self.V, copy=False)
-            qr(self.W, copy=False)
+            orth(self.V, allow_truncation=False, copy=False)
+            orth(self.W, allow_truncation=False, copy=False)
         elif projection == 'biorth':
             gram_schmidt_biorth(self.V, self.W, product=self.fom.M, copy=False)
 
@@ -276,9 +276,9 @@ class SOBTfvReductor(BasicObject):
             alpha = 1 / np.sqrt(sp[:r])
             self.V.scal(alpha)
         elif projection == 'bfsr':
-            qr(self.V, copy=False)
+            orth(self.V, allow_truncation=False, copy=False)
         elif projection == 'biorth':
-            qr(self.V, product=self.fom.M, copy=False)
+            orth(self.V, allow_truncation=False, product=self.fom.M, copy=False)
         self.W = self.V
 
         # find the reduced model
@@ -376,10 +376,10 @@ class SOBTReductor(BasicObject):
             W1TV1invW1TV2 = self.W1.inner(self.V2)
             projected_ops = {'M': IdentityOperator(NumpyVectorSpace(r))}
         elif projection == 'bfsr':
-            qr(self.V1, copy=False)
-            qr(self.W1, copy=False)
-            qr(self.V2, copy=False)
-            qr(self.W2, copy=False)
+            orth(self.V1, allow_truncation=False, copy=False)
+            orth(self.W1, allow_truncation=False, copy=False)
+            orth(self.V2, allow_truncation=False, copy=False)
+            orth(self.W2, allow_truncation=False, copy=False)
             W1TV1invW1TV2 = spla.solve(self.W1.inner(self.V1), self.W1.inner(self.V2))
             projected_ops = {'M': project(self.fom.M, range_basis=self.W2, source_basis=self.V2)}
         elif projection == 'biorth':

--- a/src/pymor/reductors/sobt.py
+++ b/src/pymor/reductors/sobt.py
@@ -5,8 +5,9 @@
 import numpy as np
 import scipy.linalg as spla
 
-from pymor.algorithms.gram_schmidt import gram_schmidt, gram_schmidt_biorth
+from pymor.algorithms.gram_schmidt import gram_schmidt_biorth
 from pymor.algorithms.projection import project
+from pymor.algorithms.qr import qr
 from pymor.core.base import BasicObject
 from pymor.models.iosys import SecondOrderModel
 from pymor.operators.constructions import IdentityOperator
@@ -85,8 +86,8 @@ class GenericSOBTpvReductor(BasicObject):
             self.V.scal(alpha)
             self.W.scal(alpha)
         elif projection == 'bfsr':
-            gram_schmidt(self.V, atol=0, rtol=0, copy=False)
-            gram_schmidt(self.W, atol=0, rtol=0, copy=False)
+            qr(self.V, copy=False)
+            qr(self.W, copy=False)
         elif projection == 'biorth':
             gram_schmidt_biorth(self.V, self.W, product=self.fom.M, copy=False)
 
@@ -275,9 +276,9 @@ class SOBTfvReductor(BasicObject):
             alpha = 1 / np.sqrt(sp[:r])
             self.V.scal(alpha)
         elif projection == 'bfsr':
-            gram_schmidt(self.V, atol=0, rtol=0, copy=False)
+            qr(self.V, copy=False)
         elif projection == 'biorth':
-            gram_schmidt(self.V, product=self.fom.M, atol=0, rtol=0, copy=False)
+            qr(self.V, product=self.fom.M, copy=False)
         self.W = self.V
 
         # find the reduced model
@@ -375,10 +376,10 @@ class SOBTReductor(BasicObject):
             W1TV1invW1TV2 = self.W1.inner(self.V2)
             projected_ops = {'M': IdentityOperator(NumpyVectorSpace(r))}
         elif projection == 'bfsr':
-            gram_schmidt(self.V1, atol=0, rtol=0, copy=False)
-            gram_schmidt(self.W1, atol=0, rtol=0, copy=False)
-            gram_schmidt(self.V2, atol=0, rtol=0, copy=False)
-            gram_schmidt(self.W2, atol=0, rtol=0, copy=False)
+            qr(self.V1, copy=False)
+            qr(self.W1, copy=False)
+            qr(self.V2, copy=False)
+            qr(self.W2, copy=False)
             W1TV1invW1TV2 = spla.solve(self.W1.inner(self.V1), self.W1.inner(self.V2))
             projected_ops = {'M': project(self.fom.M, range_basis=self.W2, source_basis=self.V2)}
         elif projection == 'biorth':

--- a/src/pymortests/algorithms/gram_schmidt.py
+++ b/src/pymortests/algorithms/gram_schmidt.py
@@ -4,10 +4,10 @@
 
 import numpy as np
 import pytest
-from hypothesis import assume, settings
+from hypothesis import settings
 
 import pymortests.strategies as pyst
-from pymor.algorithms.basic import almost_equal, contains_zero_vector
+from pymor.algorithms.basic import almost_equal
 from pymor.algorithms.gram_schmidt import gram_schmidt, gram_schmidt_biorth
 from pymor.core.logger import log_levels
 from pymortests.base import runmodule
@@ -16,18 +16,15 @@ from pymortests.base import runmodule
 @pyst.given_vector_arrays()
 def test_gram_schmidt(vector_array):
     U = vector_array
-    # TODO assumption here masks a potential issue with the algorithm
-    #      where it fails in del instead of a proper error
-    assume(len(U) > 1 or not contains_zero_vector(U))
 
     V = U.copy()
-    onb = gram_schmidt(U, copy=True)
+    onb = gram_schmidt(U, copy=True, check=False)
     assert np.all(almost_equal(U, V))
     assert np.allclose(onb.inner(onb), np.eye(len(onb)))
     # TODO maybe raise tolerances again
     assert np.all(almost_equal(U, onb.lincomb(onb.inner(U).T), atol=1e-13, rtol=1e-13))
 
-    onb2 = gram_schmidt(U, copy=False)
+    onb2 = gram_schmidt(U, copy=False, check=False)
     assert np.all(almost_equal(onb, onb2))
     assert np.all(almost_equal(onb, U))
 
@@ -36,12 +33,9 @@ def test_gram_schmidt(vector_array):
 @settings(deadline=None)
 def test_gram_schmidt_with_R(vector_array):
     U = vector_array
-    # TODO assumption here masks a potential issue with the algorithm
-    #      where it fails in del instead of a proper error
-    assume(len(U) > 1 or not contains_zero_vector(U))
 
     V = U.copy()
-    onb, R = gram_schmidt(U, return_R=True, copy=True)
+    onb, R = gram_schmidt(U, return_R=True, copy=True, check=False)
     assert np.all(almost_equal(U, V))
     assert np.allclose(onb.inner(onb), np.eye(len(onb)))
     lc = onb.lincomb(onb.inner(U).T)
@@ -49,7 +43,7 @@ def test_gram_schmidt_with_R(vector_array):
     assert np.all(almost_equal(U, lc, rtol=rtol, atol=atol))
     assert np.all(almost_equal(V, onb.lincomb(R.T), rtol=rtol, atol=atol))
 
-    onb2, R2 = gram_schmidt(U, return_R=True, copy=False)
+    onb2, R2 = gram_schmidt(U, return_R=True, copy=False, check=False)
     assert np.all(almost_equal(onb, onb2))
     assert np.all(R == R2)
     assert np.all(almost_equal(onb, U))
@@ -59,12 +53,12 @@ def test_gram_schmidt_with_product(operator_with_arrays_and_products):
     _, _, U, _, p, _ = operator_with_arrays_and_products
 
     V = U.copy()
-    onb = gram_schmidt(U, product=p, copy=True)
+    onb = gram_schmidt(U, product=p, copy=True, check=False)
     assert np.all(almost_equal(U, V))
     assert np.allclose(p.apply2(onb, onb), np.eye(len(onb)))
     assert np.all(almost_equal(U, onb.lincomb(p.apply2(onb, U).T), rtol=1e-13))
 
-    onb2 = gram_schmidt(U, product=p, copy=False)
+    onb2 = gram_schmidt(U, product=p, copy=False, check=False)
     assert np.all(almost_equal(onb, onb2))
     assert np.all(almost_equal(onb, U))
 
@@ -73,13 +67,13 @@ def test_gram_schmidt_with_product_and_R(operator_with_arrays_and_products):
     _, _, U, _, p, _ = operator_with_arrays_and_products
 
     V = U.copy()
-    onb, R = gram_schmidt(U, product=p, return_R=True, copy=True)
+    onb, R = gram_schmidt(U, product=p, return_R=True, copy=True, check=False)
     assert np.all(almost_equal(U, V))
     assert np.allclose(p.apply2(onb, onb), np.eye(len(onb)))
     assert np.all(almost_equal(U, onb.lincomb(p.apply2(onb, U).T), rtol=1e-13))
     assert np.all(almost_equal(U, onb.lincomb(R.T)))
 
-    onb2, R2 = gram_schmidt(U, product=p, return_R=True, copy=False)
+    onb2, R2 = gram_schmidt(U, product=p, return_R=True, copy=False, check=False)
     assert np.all(almost_equal(onb, onb2))
     assert np.all(R == R2)
     assert np.all(almost_equal(onb, U))
@@ -95,10 +89,10 @@ def test_gram_schmidt_biorth(vector_arrays):
             A1, A2 = gram_schmidt_biorth(U1, U2, copy=True)
         return
 
-    onb1 = gram_schmidt(U1)
+    onb1 = gram_schmidt(U1, check=False)
     if len(onb1) < len(U1):
         return
-    onb2 = gram_schmidt(U2)
+    onb2 = gram_schmidt(U2, check=False)
     if len(onb2) < len(U2):
         return
 

--- a/src/pymortests/algorithms/qr.py
+++ b/src/pymortests/algorithms/qr.py
@@ -7,26 +7,84 @@ import pytest
 from pymor.algorithms.qr import qr, rrqr
 from pymor.vectorarrays.numpy import NumpyVectorSpace
 
-
-def test_qr_random():
-    A = NumpyVectorSpace(5).random(3)
-    Q, R = qr(A)
-    assert len(A) == len(Q)
+pytestmark = pytest.mark.builtin
 
 
-def test_qr_zeros():
-    A = NumpyVectorSpace(5).zeros(2)
+@pytest.mark.parametrize('copy', [False, True])
+def test_qr_random(copy):
+    V = NumpyVectorSpace(5).random(3)
+    Q, R = qr(V, copy=copy)
+    assert len(V) == len(Q) == 3
+
+
+@pytest.mark.parametrize('copy', [False, True])
+def test_qr_random_offset(copy):
+    V = NumpyVectorSpace(5).random(3)
+    V[0].scal(1 / V[0].norm())
+    Q, R = qr(V, offset=1, copy=copy)
+    assert len(V) == len(Q) == 3
+
+
+@pytest.mark.parametrize('copy', [False, True])
+def test_qr_ones(copy):
+    V = NumpyVectorSpace(5).ones(2)
     with pytest.raises(RuntimeError):
-        Q, R = qr(A)
+        Q, R = qr(V, copy=copy)
 
 
-def test_rrqr_random():
-    A = NumpyVectorSpace(5).random(3)
-    Q, R = rrqr(A)
-    assert len(A) == len(Q)
+@pytest.mark.parametrize('copy', [False, True])
+def test_qr_zeros(copy):
+    V = NumpyVectorSpace(5).zeros(2)
+    with pytest.raises(RuntimeError):
+        Q, R = qr(V, copy=copy)
 
 
-def test_rrqr_zeros():
-    A = NumpyVectorSpace(5).zeros(2)
-    Q, R = rrqr(A)
+@pytest.mark.parametrize('copy', [False, True])
+def test_qr_empty(copy):
+    V = NumpyVectorSpace(5).empty(0)
+    Q, R = qr(V, copy=copy)
+    assert len(V) == len(Q) == 0
+
+
+@pytest.mark.parametrize('copy', [False, True])
+def test_rrqr_random(copy):
+    V = NumpyVectorSpace(5).random(3)
+    Q, R = rrqr(V, copy=copy)
+    assert len(V) == len(Q) == 3
+
+
+@pytest.mark.parametrize('copy', [False, True])
+def test_rrqr_random_offset(copy):
+    V = NumpyVectorSpace(5).random(3)
+    V[0].scal(1 / V[0].norm())
+    Q, R = rrqr(V, offset=1, copy=copy)
+    assert len(V) == len(Q) == 3
+
+
+@pytest.mark.parametrize('copy', [False, True])
+def test_rrqr_ones(copy):
+    V = NumpyVectorSpace(5).ones(2)
+    Q, R = rrqr(V, copy=copy)
+    if copy:
+        assert len(V) == 2
+    else:
+        assert len(V) == 1
+    assert len(Q) == 1
+
+
+@pytest.mark.parametrize('copy', [False, True])
+def test_rrqr_zeros(copy):
+    V = NumpyVectorSpace(5).zeros(2)
+    Q, R = rrqr(V, copy=copy)
+    if copy:
+        assert len(V) == 2
+    else:
+        assert len(V) == 0
     assert len(Q) == 0
+
+
+@pytest.mark.parametrize('copy', [False, True])
+def test_rrqr_empty(copy):
+    V = NumpyVectorSpace(5).empty(0)
+    Q, R = rrqr(V, copy=copy)
+    assert len(V) == len(Q) == 0

--- a/src/pymortests/algorithms/qr.py
+++ b/src/pymortests/algorithms/qr.py
@@ -2,89 +2,116 @@
 # Copyright pyMOR developers and contributors. All rights reserved.
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
+import numpy as np
 import pytest
 
 from pymor.algorithms.qr import qr, rrqr
+from pymor.operators.numpy import NumpyMatrixOperator
 from pymor.vectorarrays.numpy import NumpyVectorSpace
 
 pytestmark = pytest.mark.builtin
 
 
-@pytest.mark.parametrize('complex', [False, True])
-@pytest.mark.parametrize('copy', [False, True])
-def test_qr_random(copy, complex):
-    V = NumpyVectorSpace(5).random(3)
+def random_spd_operator(n, complex):
+    rng = np.random.default_rng(0)
+    P = rng.normal(size=(n, n))
     if complex:
-        V += 1j * NumpyVectorSpace(5).random(3)
-    Q, R = qr(V, copy=copy)
-    assert len(V) == len(Q) == 3
+        P = P + 1j * rng.normal(size=(n, n))
+    P = P @ P.conj().T
+    return NumpyMatrixOperator(P)
 
 
+@pytest.mark.parametrize('with_product', [False, True])
 @pytest.mark.parametrize('complex', [False, True])
 @pytest.mark.parametrize('copy', [False, True])
-def test_qr_random_offset(copy, complex):
-    V = NumpyVectorSpace(5).random(3)
+def test_qr_random(copy, complex, with_product):
+    n, m = 5, 3
+    V = NumpyVectorSpace(n).random(m)
     if complex:
-        V += 1j * NumpyVectorSpace(5).random(3)
-    V[0].scal(1 / V[0].norm())
-    Q, R = qr(V, offset=1, copy=copy)
-    assert len(V) == len(Q) == 3
+        V += 1j * NumpyVectorSpace(n).random(m)
+    product = random_spd_operator(n, complex) if with_product else None
+    Q, R = qr(V, product=product, copy=copy)
+    assert len(V) == len(Q) == m
+
+
+@pytest.mark.parametrize('with_product', [False, True])
+@pytest.mark.parametrize('complex', [False, True])
+@pytest.mark.parametrize('copy', [False, True])
+def test_qr_random_offset(copy, complex, with_product):
+    n, m = 5, 3
+    V = NumpyVectorSpace(n).random(m)
+    if complex:
+        V += 1j * NumpyVectorSpace(n).random(m)
+    product = random_spd_operator(n, complex) if with_product else None
+    V[0].scal(1 / V[0].norm(product=product))
+    Q, R = qr(V, product=product, offset=1, copy=copy)
+    assert len(V) == len(Q) == m
 
 
 @pytest.mark.parametrize('complex', [False, True])
 @pytest.mark.parametrize('copy', [False, True])
 def test_qr_ones(copy, complex):
-    V = NumpyVectorSpace(5).ones(2)
+    n, m = 5, 3
+    V = NumpyVectorSpace(n).ones(m)
     if complex:
-        V += 1j * NumpyVectorSpace(5).ones(2)
+        V += 1j * NumpyVectorSpace(n).ones(m)
     with pytest.raises(RuntimeError):
         Q, R = qr(V, copy=copy)
 
 
 @pytest.mark.parametrize('copy', [False, True])
 def test_qr_zeros(copy):
-    V = NumpyVectorSpace(5).zeros(2)
+    n, m = 5, 3
+    V = NumpyVectorSpace(n).zeros(m)
     with pytest.raises(RuntimeError):
         Q, R = qr(V, copy=copy)
 
 
 @pytest.mark.parametrize('copy', [False, True])
 def test_qr_empty(copy):
-    V = NumpyVectorSpace(5).empty(0)
+    n = 5
+    V = NumpyVectorSpace(n).empty(0)
     Q, R = qr(V, copy=copy)
     assert len(V) == len(Q) == 0
 
 
+@pytest.mark.parametrize('with_product', [False, True])
 @pytest.mark.parametrize('complex', [False, True])
 @pytest.mark.parametrize('copy', [False, True])
-def test_rrqr_random(copy, complex):
-    V = NumpyVectorSpace(5).random(3)
+def test_rrqr_random(copy, complex, with_product):
+    n, m = 5, 3
+    V = NumpyVectorSpace(n).random(m)
     if complex:
-        V += 1j * NumpyVectorSpace(5).random(3)
-    Q, R = rrqr(V, copy=copy)
-    assert len(V) == len(Q) == 3
+        V += 1j * NumpyVectorSpace(n).random(m)
+    product = random_spd_operator(n, complex) if with_product else None
+    Q, R = rrqr(V, product=product, copy=copy)
+    assert len(V) == len(Q) == m
 
 
+@pytest.mark.parametrize('with_product', [False, True])
 @pytest.mark.parametrize('complex', [False, True])
 @pytest.mark.parametrize('copy', [False, True])
-def test_rrqr_random_offset(copy, complex):
-    V = NumpyVectorSpace(5).random(3)
+def test_rrqr_random_offset(copy, complex, with_product):
+    n, m = 5, 3
+    V = NumpyVectorSpace(n).random(m)
     if complex:
-        V += 1j * NumpyVectorSpace(5).random(3)
-    V[0].scal(1 / V[0].norm())
-    Q, R = rrqr(V, offset=1, copy=copy)
-    assert len(V) == len(Q) == 3
+        V += 1j * NumpyVectorSpace(n).random(m)
+    product = random_spd_operator(n, complex) if with_product else None
+    V[0].scal(1 / V[0].norm(product=product))
+    Q, R = rrqr(V, product=product, offset=1, copy=copy)
+    assert len(V) == len(Q) == m
 
 
 @pytest.mark.parametrize('complex', [False, True])
 @pytest.mark.parametrize('copy', [False, True])
 def test_rrqr_ones(copy, complex):
-    V = NumpyVectorSpace(5).ones(2)
+    n, m = 5, 2
+    V = NumpyVectorSpace(n).ones(m)
     if complex:
-        V += 1j * NumpyVectorSpace(5).ones(2)
+        V += 1j * NumpyVectorSpace(n).ones(m)
     Q, R = rrqr(V, copy=copy)
     if copy:
-        assert len(V) == 2
+        assert len(V) == m
     else:
         assert len(V) == 1
     assert len(Q) == 1
@@ -92,10 +119,11 @@ def test_rrqr_ones(copy, complex):
 
 @pytest.mark.parametrize('copy', [False, True])
 def test_rrqr_zeros(copy):
-    V = NumpyVectorSpace(5).zeros(2)
+    n, m = 5, 2
+    V = NumpyVectorSpace(n).zeros(m)
     Q, R = rrqr(V, copy=copy)
     if copy:
-        assert len(V) == 2
+        assert len(V) == m
     else:
         assert len(V) == 0
     assert len(Q) == 0
@@ -103,6 +131,7 @@ def test_rrqr_zeros(copy):
 
 @pytest.mark.parametrize('copy', [False, True])
 def test_rrqr_empty(copy):
-    V = NumpyVectorSpace(5).empty(0)
+    n = 5
+    V = NumpyVectorSpace(n).empty(0)
     Q, R = rrqr(V, copy=copy)
     assert len(V) == len(Q) == 0

--- a/src/pymortests/algorithms/qr.py
+++ b/src/pymortests/algorithms/qr.py
@@ -6,6 +6,7 @@ import numpy as np
 import pytest
 
 from pymor.algorithms.qr import qr, rrqr
+from pymor.core.exceptions import LinAlgError
 from pymor.operators.numpy import NumpyMatrixOperator
 from pymor.vectorarrays.numpy import NumpyVectorSpace
 
@@ -55,7 +56,7 @@ def test_qr_ones(copy, complex):
     V = NumpyVectorSpace(n).ones(m)
     if complex:
         V += 1j * NumpyVectorSpace(n).ones(m)
-    with pytest.raises(RuntimeError):
+    with pytest.raises(LinAlgError):
         Q, R = qr(V, copy=copy)
 
 
@@ -63,7 +64,7 @@ def test_qr_ones(copy, complex):
 def test_qr_zeros(copy):
     n, m = 5, 3
     V = NumpyVectorSpace(n).zeros(m)
-    with pytest.raises(RuntimeError):
+    with pytest.raises(LinAlgError):
         Q, R = qr(V, copy=copy)
 
 

--- a/src/pymortests/algorithms/qr.py
+++ b/src/pymortests/algorithms/qr.py
@@ -10,24 +10,33 @@ from pymor.vectorarrays.numpy import NumpyVectorSpace
 pytestmark = pytest.mark.builtin
 
 
+@pytest.mark.parametrize('complex', [False, True])
 @pytest.mark.parametrize('copy', [False, True])
-def test_qr_random(copy):
+def test_qr_random(copy, complex):
     V = NumpyVectorSpace(5).random(3)
+    if complex:
+        V += 1j * NumpyVectorSpace(5).random(3)
     Q, R = qr(V, copy=copy)
     assert len(V) == len(Q) == 3
 
 
+@pytest.mark.parametrize('complex', [False, True])
 @pytest.mark.parametrize('copy', [False, True])
-def test_qr_random_offset(copy):
+def test_qr_random_offset(copy, complex):
     V = NumpyVectorSpace(5).random(3)
+    if complex:
+        V += 1j * NumpyVectorSpace(5).random(3)
     V[0].scal(1 / V[0].norm())
     Q, R = qr(V, offset=1, copy=copy)
     assert len(V) == len(Q) == 3
 
 
+@pytest.mark.parametrize('complex', [False, True])
 @pytest.mark.parametrize('copy', [False, True])
-def test_qr_ones(copy):
+def test_qr_ones(copy, complex):
     V = NumpyVectorSpace(5).ones(2)
+    if complex:
+        V += 1j * NumpyVectorSpace(5).ones(2)
     with pytest.raises(RuntimeError):
         Q, R = qr(V, copy=copy)
 
@@ -46,24 +55,33 @@ def test_qr_empty(copy):
     assert len(V) == len(Q) == 0
 
 
+@pytest.mark.parametrize('complex', [False, True])
 @pytest.mark.parametrize('copy', [False, True])
-def test_rrqr_random(copy):
+def test_rrqr_random(copy, complex):
     V = NumpyVectorSpace(5).random(3)
+    if complex:
+        V += 1j * NumpyVectorSpace(5).random(3)
     Q, R = rrqr(V, copy=copy)
     assert len(V) == len(Q) == 3
 
 
+@pytest.mark.parametrize('complex', [False, True])
 @pytest.mark.parametrize('copy', [False, True])
-def test_rrqr_random_offset(copy):
+def test_rrqr_random_offset(copy, complex):
     V = NumpyVectorSpace(5).random(3)
+    if complex:
+        V += 1j * NumpyVectorSpace(5).random(3)
     V[0].scal(1 / V[0].norm())
     Q, R = rrqr(V, offset=1, copy=copy)
     assert len(V) == len(Q) == 3
 
 
+@pytest.mark.parametrize('complex', [False, True])
 @pytest.mark.parametrize('copy', [False, True])
-def test_rrqr_ones(copy):
+def test_rrqr_ones(copy, complex):
     V = NumpyVectorSpace(5).ones(2)
+    if complex:
+        V += 1j * NumpyVectorSpace(5).ones(2)
     Q, R = rrqr(V, copy=copy)
     if copy:
         assert len(V) == 2

--- a/src/pymortests/algorithms/qr.py
+++ b/src/pymortests/algorithms/qr.py
@@ -1,0 +1,32 @@
+# This file is part of the pyMOR project (https://www.pymor.org).
+# Copyright pyMOR developers and contributors. All rights reserved.
+# License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
+
+import pytest
+
+from pymor.algorithms.qr import qr, rrqr
+from pymor.vectorarrays.numpy import NumpyVectorSpace
+
+
+def test_qr_random():
+    A = NumpyVectorSpace(5).random(3)
+    Q, R = qr(A)
+    assert len(A) == len(Q)
+
+
+def test_qr_zeros():
+    A = NumpyVectorSpace(5).zeros(2)
+    with pytest.raises(RuntimeError):
+        Q, R = qr(A)
+
+
+def test_rrqr_random():
+    A = NumpyVectorSpace(5).random(3)
+    Q, R = rrqr(A)
+    assert len(A) == len(Q)
+
+
+def test_rrqr_zeros():
+    A = NumpyVectorSpace(5).zeros(2)
+    Q, R = rrqr(A)
+    assert len(Q) == 0


### PR DESCRIPTION
This PR can be seen as an alternative approach to #2211. It adds an `orth` interface function that orthonormalizes a `VectorArray` by dispatching to various orthonormalization algorithms.

Main characteristics:

- If `pad=False` (which is the default), the spans of `V` and the computed `basis` are supposed to agree. Thus, `len(basis) <= len(V)`. By setting `pad=True`, it is ensured that `len(basis) == len(V)`, potentially by adding random vectors to the span.
- If `hierarchical` is `True`, the span of the first k vectors in `V` agrees with the span of the first k vectors in `basis`. I.e., we obtain a QR decomposition. Since `orth` returns the coefficients of `V` in the new basis as expected by `lincomb`, the returned array has to be transposed in order to get a QR decomposition.

The approach is based on the general observation that (more or less) everywhere in pyMOR, where `qr` (or `gram_schmidt`) is called, we actually want to orthonormalize a basis and do not care so much about the actual algorithm. Also, I think that `orth` fits better with the notion of a `VectorArrray` then QR decomposition. As such, I have replaced all calls to `qr` with `orth`. I wasn't always sure, of the resulting basis were needed. I see it as a feature of this approach that this has to be made explicit in `orth` calls. I also believe that a `qr` function would not really be needed in this case, or would act as an alias for `orth`.

This is meant as a basis for discussion. The implementation is ad-hoc and not fully tested. Argument names or their precise semantics, as well as the name of the function itself could be changed. 