### PR TITLE
Add 'from_file' and 'random' factory functions to BitmapFunction

### DIFF
--- a/docs/source/tutorial_builtin_discretizer.md
+++ b/docs/source/tutorial_builtin_discretizer.md
@@ -278,7 +278,7 @@ following graphic stored in `RB.png`:
 and a range of `[0.001 1]` we obtain:
 
 ```{code-cell}
-diffusion = BitmapFunction('RB.png', range=[0.001, 1])
+diffusion = BitmapFunction.from_file('RB.png', range=[0.001, 1])
 problem = StationaryProblem(
    domain=domain,
    diffusion=diffusion,
@@ -441,8 +441,8 @@ the following image files:
 ```
 
 ```{code-cell}
-f_R = BitmapFunction('R.png', range=[1, 0])
-f_B = BitmapFunction('B.png', range=[1, 0])
+f_R = BitmapFunction.from_file('R.png', range=[1, 0])
+f_B = BitmapFunction.from_file('B.png', range=[1, 0])
 ```
 
 Next we need to define the {{ ParameterFunctionals }}

--- a/src/pymor/analyticalproblems/functions.py
+++ b/src/pymor/analyticalproblems/functions.py
@@ -483,7 +483,7 @@ class BitmapFunction(Function):
         bounding_box
             Lower left and upper right coordinates of the domain of the function.
         range
-            Tuple of minimum and maximum functuion values.
+            Tuple of minimum and maximum function values.
         """
         a, b = range[0], range[1]
         random_field = get_rng().uniform(a, b, np.prod(shape)).reshape(shape)

--- a/src/pymor/analyticalproblems/functions.py
+++ b/src/pymor/analyticalproblems/functions.py
@@ -411,7 +411,7 @@ class BitmapFunction(Function):
     bounding_box
         Lower left and upper right coordinates of the domain of the function.
     range
-        Deprecated, only works in conjunction with filename). Don't use.
+        Deprecated, only works in conjunction with filename. Don't use.
     filename
         Deprecated, use :meth:`BitmapFunction.from_file` instead.
     """

--- a/src/pymor/analyticalproblems/functions.py
+++ b/src/pymor/analyticalproblems/functions.py
@@ -12,6 +12,7 @@ from pymor.core.base import abstractmethod
 from pymor.core.config import config
 from pymor.parameters.base import Mu, ParametricObject
 from pymor.parameters.functionals import ParameterFunctional
+from pymor.tools.random import get_rng
 
 
 class Function(ParametricObject):
@@ -401,23 +402,64 @@ class ProductFunction(Function):
 
 
 class BitmapFunction(Function):
-    """Define a 2D |Function| via a grayscale image.
+    """Define a piecewise constant 2D |Function| via a bitmap array.
 
     Parameters
     ----------
-    filename
-        Path of the image representing the function.
+    bitmap
+        2d |NumPy array| of the discrete function values.
     bounding_box
         Lower left and upper right coordinates of the domain of the function.
-    range
-        A pixel of value p is mapped to `(p / 255.) * range[1] + range[0]`.
     """
 
     dim_domain = 2
     shape_range = ()
 
-    def __init__(self, filename, bounding_box=None, range=None):
+    def __init__(self, bitmap=None, bounding_box=None, range=None, filename=None):
+        # TODO: remove entire if clause after release, remove range and filename args
+        if filename is not None or isinstance(bitmap, str):
+            import warnings
+            warnings.warn('DeprecationWarning. Call BitmapFunction.from_file to instantiate'
+                          'BitmapFunction from a graphics file')
+            if bitmap is not None and filename is not None:
+                raise ValueError
+            filename = bitmap if bitmap is not None else filename
+            assert isinstance(filename, str)
+            range = range or [0., 1.]
+            try:
+                from PIL import Image
+            except ImportError as e:
+                raise ImportError("PIL is needed for loading images. Try 'pip install pillow'") from e
+            img = Image.open(filename)
+            if not img.mode == 'L':
+                self.logger.warning('Image ' + filename + ' not in grayscale mode. Converting to grayscale.')
+                img = img.convert('L')
+            bitmap = np.array(img).T[:, ::-1]
+            bitmap = bitmap * ((range[1] - range[0]) / 255.)  # copy to change dtype
+            bitmap += range[0]
+            filename = None
+            range = None
+        assert isinstance(bitmap, np.ndarray)
+        assert range is None, 'only for deprecated interface'
+        assert filename is None, 'only for deprecated interface'
         bounding_box = bounding_box or [[0., 0.], [1., 1.]]
+        self.__auto_init(locals())
+        self.lower_left = np.array(bounding_box[0])
+        self.size = np.array(bounding_box[1] - self.lower_left)
+
+    @classmethod
+    def from_file(cls, filename, bounding_box=None, range=None):
+        """Create a |BitmapFunction| from a grayscale image file.
+
+        Parameters
+        ----------
+        filename
+            Path of the image representing the function.
+        bounding_box
+            Lower left and upper right coordinates of the domain of the function.
+        range
+            A pixel of value p is mapped to `(p / 255.) * range[1] + range[0]`.
+        """
         range = range or [0., 1.]
         try:
             from PIL import Image
@@ -425,19 +467,32 @@ class BitmapFunction(Function):
             raise ImportError("PIL is needed for loading images. Try 'pip install pillow'") from e
         img = Image.open(filename)
         if not img.mode == 'L':
-            self.logger.warning('Image ' + filename + ' not in grayscale mode. Converting to grayscale.')
+            cls._logger.warning('Image ' + filename + ' not in grayscale mode. Converting to grayscale.')
             img = img.convert('L')
-        self.__auto_init(locals())
-        self.bitmap = np.array(img).T[:, ::-1]
-        self.lower_left = np.array(bounding_box[0])
-        self.size = np.array(bounding_box[1] - self.lower_left)
+        bitmap = np.array(img).T[:, ::-1]
+        bitmap = bitmap * ((range[1] - range[0]) / 255.)  # copy to change dtype
+        bitmap += range[0]
+        return cls(bitmap, bounding_box=bounding_box)
+
+    @classmethod
+    def random(cls, shape=(1, 1), bounding_box=((0., 0.), (1., 1.)), range=(0., 1.)):
+        """Create a random |BitmapFunction| with uniform distribution of values.
+
+        Parameters
+        ----------
+        bounding_box
+            Lower left and upper right coordinates of the domain of the function.
+        range
+            Tuple of minimum and maximum functuion values.
+        """
+        a, b = range[0], range[1]
+        random_field = get_rng().uniform(a, b, np.prod(shape)).reshape(shape)
+        return cls(random_field, bounding_box=bounding_box)
 
     def evaluate(self, x, mu=None):
         indices = np.maximum(np.floor((x - self.lower_left) * np.array(self.bitmap.shape) / self.size).astype(int), 0)
-        F = (self.bitmap[np.minimum(indices[..., 0], self.bitmap.shape[0] - 1),
-                         np.minimum(indices[..., 1], self.bitmap.shape[1] - 1)]
-             * ((self.range[1] - self.range[0]) / 255.)
-             + self.range[0])
+        F = self.bitmap[np.minimum(indices[..., 0], self.bitmap.shape[0] - 1),
+                        np.minimum(indices[..., 1], self.bitmap.shape[1] - 1)]
         return F
 
 

--- a/src/pymor/analyticalproblems/functions.py
+++ b/src/pymor/analyticalproblems/functions.py
@@ -410,6 +410,10 @@ class BitmapFunction(Function):
         2d |NumPy array| of the discrete function values.
     bounding_box
         Lower left and upper right coordinates of the domain of the function.
+    range
+        Deprecated, only works in conjunction with filename). Don't use.
+    filename
+        Deprecated, use :meth:`BitmapFunction.from_file` instead.
     """
 
     dim_domain = 2

--- a/src/pymor/analyticalproblems/text.py
+++ b/src/pymor/analyticalproblems/text.py
@@ -45,7 +45,7 @@ def text_problem(text='pyMOR', font_name=None):
         # after leaving this 'with' block, the temporary file is automatically deleted
         with safe_temporary_filename(name='letter_bitmap.png') as f:
             img.save(f, format='png')
-            return BitmapFunction(f, bounding_box=[(0, 0), size], range=[0., 1.])
+            return BitmapFunction.from_file(f, bounding_box=[(0, 0), size], range=[0., 1.])
 
     # create BitmapFunctions for each character
     dfs = [make_bitmap_function(n) for n in range(len(text))]

--- a/src/pymortests/analyticalproblems/function.py
+++ b/src/pymortests/analyticalproblems/function.py
@@ -70,3 +70,14 @@ def test_pickle_by_evaluation(function):
 def test_invalid_expressions():
     with pytest.raises(TypeError):
         ExpressionFunction('(-1 < x[0]) and (x[0] < 1)', 1)
+
+
+def test_random_bitmap_function():
+    from pymor.analyticalproblems.functions import BitmapFunction
+    f = BitmapFunction.random(shape=(10, 10))
+    for i in range(9):
+        for j in range(9):
+            # all values are between 0 and 1
+            assert 0 <= f([i / 10., j / 10.]) <= 1
+            # all values are different
+            assert (f([i/10., j/10.]) != f([(i+1)/10., (j+1)/10.]))

--- a/src/pymortests/analyticalproblems/function.py
+++ b/src/pymortests/analyticalproblems/function.py
@@ -79,5 +79,7 @@ def test_random_bitmap_function():
         for j in range(9):
             # all values are between 0 and 1
             assert 0 <= f([i / 10., j / 10.]) <= 1
-            # all values are different
+            # neighboring cells have different values
             assert (f([i/10., j/10.]) != f([(i+1)/10., (j+1)/10.]))
+            # values in same cell are equal
+            assert (f([i/10., j/10.]) == f([(i+0.3)/10., (j+0.3)/10.]))

--- a/src/pymortests/fixtures/function.py
+++ b/src/pymortests/fixtures/function.py
@@ -5,9 +5,10 @@
 import numpy as np
 import pytest
 
-from pymor.analyticalproblems.functions import ConstantFunction, ExpressionFunction, GenericFunction
+from pymor.analyticalproblems.functions import BitmapFunction, ConstantFunction, ExpressionFunction, GenericFunction
 
 constant_functions = [
+    BitmapFunction.random((3,3)),
     ConstantFunction(),
     ConstantFunction(np.array([1., 2., 3.]), dim_domain=7),
     ConstantFunction(np.eye(27), dim_domain=2),


### PR DESCRIPTION
This adds the same features as #2050:

- `BitmapFunction.__init__` now expects a `bitmap` numpy array instead of a filename. (The old interface is still supported but deprecated.)
- `BitmapFunction.from_file` is used to load `bitmap` from a file and instantiates a `BitmapFunction` with it.
- `BitmapFunction.random` creates a random `bitmap` and instantiates a `BitmapFunction` with it.

I think this approach is preferable over the subclassing approach in #2050, as it is simpler and, IMHO, there is no need to differentiate different kinds of initialization via the function's type. Also, I really didn't like the name `DataFieldFunction`, but couldn't find a better one.