### PR TITLE
Pin numpy<2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 dependencies = [
   "diskcache",
   "matplotlib>=3.5.0",
-  "numpy>=1.20.3,!=1.25.0", # 1.25.0 crashes CI
+  "numpy>=1.20.3,!=1.25.0,<2", # 1.25.0 crashes CI, >=2 breaks API
   "packaging",
   "pillow",
   "pygments",


### PR DESCRIPTION
This addresses #2205 until numpy 2 support is tested in CI.