### PR TITLE
Allow time-dependent Mus as arguments of cached functions / make cache key generation more flexible

### DIFF
--- a/src/pymor/analyticalproblems/expressions.py
+++ b/src/pymor/analyticalproblems/expressions.py
@@ -288,6 +288,9 @@ class Expression(ParametricObject):
     def __bool__(self):
         raise TypeError("Cannot convert Expression to bool. (Don't use boolean operators or two-sided comparisons.)")
 
+    def _cache_key_reduce(self):
+        return self.numpy_expr()
+
 
 class BaseConstant(Expression):
     """A constant value."""

--- a/src/pymor/analyticalproblems/functions.py
+++ b/src/pymor/analyticalproblems/functions.py
@@ -276,6 +276,9 @@ class SymbolicExpressionFunction(GenericFunction):
         return (SymbolicExpressionFunction,
                 (self.expression_obj, self.dim_domain, self.variable, getattr(self, '_name', None)))
 
+    def _cache_key_reduce(self):
+        return (self.expression_obj, self.dim_domain, self.variable)
+
     def __str__(self):
         return f'{self.name}: {self.variable} -> {self.expression_obj}'
 

--- a/src/pymor/core/cache.py
+++ b/src/pymor/core/cache.py
@@ -389,14 +389,14 @@ def build_cache_key(obj):
 
     def transform_obj(obj):
         t = type(obj)
-        if t in (NoneType, bool, int, float, str, bytes):
+        if hasattr(obj, '_cache_key_reduce'):
+            return transform_obj(obj._cache_key_reduce())
+        elif t in (NoneType, bool, int, float, str, bytes):
             return obj
         elif t is np.ndarray:
             if obj.dtype == object:
                 raise CacheKeyGenerationError('Cannot generate cache key for provided arguments')
             return obj
-        elif t is Mu:
-            return transform_obj(obj._raw_values)
         elif t in (list, tuple):
             return tuple(transform_obj(o) for o in obj)
         elif t in (set, frozenset):

--- a/src/pymor/parameters/base.py
+++ b/src/pymor/parameters/base.py
@@ -466,6 +466,9 @@ class Mu(FrozenDict):
     def __repr__(self):
         return f'Mu({dict(sorted(self._raw_values.items()))})'
 
+    def _cache_key_reduce(self):
+        return self._raw_values
+
 
 class ParametricObject(ImmutableObject):
     """Base class for immutable mathematical entities depending on some |Parameters|.


### PR DESCRIPTION
Classes can now implement `_reduce_cache_key` to make them viable arguments for cached methods. This is used to allow time-dependent parameter values as arguments.

Fixes #1810.