### PR TITLE
Bug Fix in FactorizedTransferFunction

### DIFF
--- a/src/pymor/models/transfer_function.py
+++ b/src/pymor/models/transfer_function.py
@@ -577,7 +577,7 @@ class FactorizedTransferFunction(TransferFunction):
                 Kinv_B = K.apply_inverse(B_vec, mu=mu)
                 res = C.apply(Kinv_B, mu=mu).to_numpy().T
             else:
-                C_vec_adj = C.as_source_array(mu=mu).conj()
+                C_vec_adj = C.as_source_array(mu=mu)
                 Kinvadj_Cadj = K.apply_inverse_adjoint(C_vec_adj, mu=mu)
                 res = B.apply_adjoint(Kinvadj_Cadj, mu=mu).to_numpy().conj()
             res += to_matrix(D, format='dense', mu=mu)


### PR DESCRIPTION
This fixes a bug in `FactorizedTransferFunction` where there was an unnecessary `conj`. The issue only occurs for complex system matrices and if `dim_input > dim_output`. Minimal example to make the issue appear:

```
import numpy as np
from pymor.models.iosys import LTIModel

A = np.array([[1]])
B = np.array([[1j, 1]])
C = np.array([[1j]])

fom = LTIModel.from_matrices(A,B,C)

fom.transfer_function.eval_tf(1j) - (C @ np.linalg.solve(1j - A, B))
```