### PR TITLE
AAAReductor

### DIFF
--- a/docs/source/bibliography.bib
+++ b/docs/source/bibliography.bib
@@ -22,6 +22,14 @@
   editor        = {Mohammadpour, J. and Grigoriadis, K. M.},
 }
 
+@article{AG23,
+  title         = {Practical challenges in data-driven interpolation: Dealing with noise, enforcing stability, and computing realizations},
+  author        = {Q. Aumann and I. V. Gosea},
+  year          = 2023,
+  journal       = {International Journal of Adaptive Control and Signal Processing},
+  doi           = {10.1002/acs.3691},
+}
+
 @incollection{ALI17,
   title         = {A Tutorial Introduction to the {L}oewner Framework for Model Reduction},
   author        = {A. C. Antoulas and S. Lefteriu and A. C. Ionita},

--- a/src/pymor/reductors/aaa.py
+++ b/src/pymor/reductors/aaa.py
@@ -456,8 +456,13 @@ def make_bary_func(itpl_nodes, itpl_vals, coefs, removable_singularity_tol=1e-14
 class AAAReductor(BasicObject):
     """Reductor implementing the AAA algorithm.
 
-    See :cite:`NST18` for the algorithm. This version uses a strictly proper barycentric form
-    as the rational approximant.
+    See :cite:`NST18` for the algorithm. This reductor uses a strictly proper barycentric form
+    as the rational approximant and allows for computing the ROM as an |LTIModel|. See :cite:`AG23`
+    for this version of the algorithm.
+
+    .. note::
+       In order to apply the AAA algorithm with a proper barycentric form the
+       :class:`~pymor.reductors.aaa.PAAAReductor` can be used.
 
     Parameters
     ----------
@@ -515,7 +520,7 @@ class AAAReductor(BasicObject):
 
         self.__auto_init(locals())
 
-    def reduce(self, tol=1e-7, itpl_part=None, rom_form='LTI',  max_itpl=None):
+    def reduce(self, tol=1e-7, itpl_part=None, max_itpl=None, rom_form='LTI'):
         """Reduce using AAA.
 
         Parameters
@@ -532,6 +537,9 @@ class AAAReductor(BasicObject):
             Maximum number of interpolation points to use with respect to each
             variable. Should be `None` or a list such that `self.num_vars == len(max_itpl)`.
             If `None` `max_itpl[i]` will be set to `len(self.sampling_values[i]) - 1`.
+        rom_form
+            Can either be `'barycentric'` or `'lti'`. In the first case the returned reduced
+            model is a |TransferFunction| in the latter case the reduced model is an |LTIModel|.
 
         Returns
         -------

--- a/src/pymor/reductors/aaa.py
+++ b/src/pymor/reductors/aaa.py
@@ -8,6 +8,7 @@ import numpy as np
 import scipy.linalg as spla
 
 from pymor.core.base import BasicObject
+from pymor.models.iosys import LTIModel
 from pymor.models.transfer_function import TransferFunction
 from pymor.tools.random import new_rng
 
@@ -449,5 +450,233 @@ def make_bary_func(itpl_nodes, itpl_vals, coefs, removable_singularity_tol=1e-14
         denom = np.sum(coefs_pd)
         nd = num / denom
         return np.atleast_2d(nd)
+
+    return bary_func
+
+class AAAReductor(BasicObject):
+    """Reductor implementing the AAA algorithm.
+
+    See :cite:`NST18` for the algorithm. This version uses a strictly proper barycentric form
+    as the rational approximant.
+
+    Parameters
+    ----------
+    s
+        |Numpy Array| of shape (n,) containing the frequencies.
+    Hs
+        |Numpy Array| of shape (n, p, m) for MIMO systems with p outputs and m inputs or
+        |Numpy Array| of shape (n,) for SISO systems where the |Numpy Arrays| resemble the transfer
+        function samples. Alternatively, |TransferFunction| or `Model` with `transfer_function`
+        attribute.
+    conjugate
+        If `True` complex samples will always be interpolated in complex conjugate pairs. This
+        allows for constructing real-valued state-space representations.
+    """
+
+    def __init__(self, s, Hs, conjugate=True):
+        assert isinstance(s, np.ndarray)
+        if hasattr(Hs, 'transfer_function'):
+            Hs = Hs.transfer_function
+        assert isinstance(Hs, (TransferFunction, np.ndarray, list))
+
+        if isinstance(Hs, TransferFunction):
+            Hss = np.empty((len(s), Hs.dim_output, Hs.dim_input), dtype=s[0].dtype)
+            for i, ss in enumerate(s):
+                Hss[i] = Hs.eval_tf(ss)
+            if Hs.dim_output == 1 and Hs.dim_input == 1:
+                Hss = np.squeeze(Hss)
+            Hs = Hss
+        else:
+            assert Hs.shape[0] == len(s)
+
+        # ensure that complex sampling values appear in complex conjugate pairs
+        if conjugate:
+            for i, ss in enumerate(s):
+                if np.conj(ss) not in s:
+                    s = np.append(s, np.conj(ss))
+                    Hs = np.append(Hs, np.conj(Hs[i])[np.newaxis, ...], axis=0)
+
+        if len(Hs.shape) > 1:
+            self._dim_output = Hs.shape[1]
+            self._dim_input = Hs.shape[2]
+            rng = new_rng(0)
+            if any(np.iscomplex(s)):
+                w = 1j * rng.normal(scale=np.sqrt(2)/2, size=(self._dim_output,)) \
+                    + rng.normal(scale=np.sqrt(2)/2, size=(self._dim_output,))
+                v = 1j * rng.normal(scale=np.sqrt(2)/2, size=(self._dim_input,)) \
+                    + rng.normal(scale=np.sqrt(2)/2, size=(self._dim_input,))
+            else:
+                w = rng.normal(size=(self._dim_output,))
+                v = rng.normal(size=(self._dim_input,))
+            w /= np.linalg.norm(w)
+            v /= np.linalg.norm(v)
+            self.MIMO_Hs = Hs
+            self.Hs = Hs @ v @ w
+        else:
+            self._dim_input = 1
+            self._dim_output = 1
+
+        if self._dim_input == self._dim_output == 1:
+            Hs = np.squeeze(Hs)
+
+        self.__auto_init(locals())
+
+    def reduce(self, tol=1e-7, itpl_part=None, rom_form='LTI',  max_itpl=None):
+        """Reduce using AAA.
+
+        Parameters
+        ----------
+        tol
+            Convergence tolerance for relative error of `rom` over the set of samples.
+        itpl_part
+            Initial partition for interpolation values. Should be `None` or a nested list
+            such that `itpl_part[i]` corresponds to indices of interpolated values with
+            respect to the `i`-th variable. I.e., `self.sampling_values[i][itpl_part[i]]`
+            represents a list of all initially interpolated samples of the `i`-th variable.
+            If `None` p-AAA will start with no interpolated values.
+        max_itpl
+            Maximum number of interpolation points to use with respect to each
+            variable. Should be `None` or a list such that `self.num_vars == len(max_itpl)`.
+            If `None` `max_itpl[i]` will be set to `len(self.sampling_values[i]) - 1`.
+
+        Returns
+        -------
+        rom
+            Reduced |TransferFunction| or |LTIModel| instance.
+        """
+        if itpl_part is None:
+            self.itpl_part = []
+        else:
+            self.itpl_part = itpl_part
+
+        if max_itpl is None or max_itpl > len(self.s)-1:
+            max_itpl = len(self.s)-1
+
+        max_Hs = np.max(np.abs(self.Hs))
+        rel_tol = tol * max_Hs
+
+        err = np.inf
+
+        # Define ROM with constant output
+        tf = np.vectorize(lambda s: np.mean(self.Hs))
+
+        self.itpl_part = []
+        ls_part = range(len(self.s))
+
+        j = 0
+        r = 0
+
+        while len(self.itpl_part) < max_itpl:
+
+            # compute approximation error over LS partiation of sampled data
+            errs = np.empty(len(ls_part))
+            for i, ls_s in enumerate(self.s[ls_part]):
+                errs[i] = np.abs(tf(ls_s) - self.Hs[ls_part[i]])
+
+            # errors for greedy selection
+            ls_part_idx = np.argmax(errs)
+            greedy_val = self.s[ls_part][ls_part_idx]
+            greedy_idx = int(np.argwhere(self.s == greedy_val)[0])
+
+            err = np.max(errs)
+
+            j += 1
+            self.logger.info(f'Step {j} relative H(s) error: {err / max_Hs:.5e}, interpolation points {r}')
+
+            if err < rel_tol:
+                break
+
+            # add greedy search result to interpolation set
+            self.itpl_part.append(greedy_idx)
+            if self.conjugate and np.imag(self.s[greedy_idx]) != 0:
+                conj_sample = np.conj(self.s[greedy_idx])
+                conj_idx = np.argwhere(self.s == conj_sample)[0]
+                self.itpl_part.append(int(conj_idx))
+
+            ls_part = sorted(set(range(len(self.s))) - set(self.itpl_part))
+            r = len(self.itpl_part)
+
+            # compute Loewner matrices
+            L = nd_loewner(self.Hs, [self.s], [self.itpl_part])
+
+            # solve LS problem and define data for barycentric form
+            coefs = -spla.pinv(L) @ self.Hs[ls_part]
+            itpl_vals = self.Hs[self.itpl_part]
+            itpl_nodes = self.s[self.itpl_part]
+
+            tf = make_strictly_proper_bary_func(itpl_nodes, itpl_vals, coefs)
+
+        if rom_form == 'barycentric':
+            if self._dim_input != 1 or self._dim_output != 1:
+                itpl_vals = self.MIMO_Hs[self.itpl_part]
+                MIMO_tf = make_strictly_proper_bary_func(itpl_nodes, itpl_vals, coefs)
+                rom = TransferFunction(self._dim_input, self._dim_output, MIMO_tf)
+            else:
+                rom = TransferFunction(self._dim_input, self._dim_output, tf)
+        else:
+            if self._dim_input != 1 or self._dim_output != 1:
+                itpl_vals = self.MIMO_Hs[self.itpl_part]
+                r = len(self.itpl_part)
+                Im = np.eye(self._dim_input)
+                Br = np.kron(coefs, Im).T
+                Cr = np.empty((self._dim_output,r*self._dim_input), dtype=itpl_vals.dtype)
+                for i in range(r):
+                    Cr[:,self._dim_input*i:self._dim_input*(i+1)] = itpl_vals[i,:]
+                L = np.diag(itpl_nodes)
+                e = np.ones(r)
+                Ar = np.kron(L, Im) - Br @ (np.kron(e.T, Im))
+            else:
+                r = len(self.itpl_part)
+                b = coefs
+                Cr = itpl_vals
+                L = np.diag(itpl_nodes)
+                e = np.ones((1, r))
+                Ar = L - np.outer(b,e)
+                Br = b[:, np.newaxis]
+
+            if self.conjugate:
+                T = np.zeros((r, r), dtype=np.complex_)
+                for i in range(r):
+                    if self.s[self.itpl_part][i].imag == 0:
+                        T[i, i] = 1
+                    else:
+                        j = np.argmin(np.abs(self.s[self.itpl_part] - self.s[self.itpl_part][i].conjugate()))
+                        if i < j:
+                            T[i, i] = 1
+                            T[i, j] = 1
+                            T[j, i] = -1j
+                            T[j, j] = 1j
+
+                if self._dim_input != 1 or self._dim_output != 1:
+                    T = np.kron(T, Im)
+
+                Ar = 0.5 * (T @ Ar @ T.conj().T)
+                Br = (np.sqrt(2) / 2) * (T @ Br)
+                Cr = (np.sqrt(2) / 2) * (Cr @ T.conj().T)
+
+            rom = LTIModel.from_matrices(Ar, Br, Cr)
+
+        return rom
+
+def make_strictly_proper_bary_func(itpl_nodes, itpl_vals, coefs, removable_singularity_tol=1e-14):
+    r"""Return function for strictly proper barycentric form.
+
+    Returns
+    -------
+    bary_func
+        Rational function in strictly proper barycentric form.
+    """
+    def bary_func(s):
+        d = s - itpl_nodes
+        d_zero = d[np.abs(d) < removable_singularity_tol]
+        # if interpolation occurs simply return interpolation value
+        if len(d_zero) > 0:
+            d_min_idx = np.argmin(np.abs(d))
+            return np.atleast_2d(itpl_vals[d_min_idx])
+        di = 1 / d
+        coefs_di = coefs * di
+        N = np.tensordot(coefs_di,  itpl_vals, axes=1)
+        D = np.sum(coefs_di)
+        return np.atleast_2d(N / (D + 1))
 
     return bary_func

--- a/src/pymordemos/dd_heat.py
+++ b/src/pymordemos/dd_heat.py
@@ -14,7 +14,7 @@ from pymor.analyticalproblems.instationary import InstationaryProblem
 from pymor.core.logger import set_log_levels
 from pymor.discretizers.builtin import discretize_instationary_cg
 from pymor.models.transfer_function import TransferFunction
-from pymor.reductors.aaa import PAAAReductor
+from pymor.reductors.aaa import AAAReductor, PAAAReductor
 from pymor.reductors.loewner import LoewnerReductor
 
 
@@ -80,6 +80,7 @@ def main(
 
     ss = np.logspace(-1, 4, n)
 
+    run_mor_method_dd(lti, ss, AAAReductor, 'AAA Strictly Proper')
     run_mor_method_dd(lti, ss, PAAAReductor, 'AAA')
     run_mor_method_dd(lti, ss, LoewnerReductor, 'Loewner')
 


### PR DESCRIPTION
This PR adds the `AAAReductor`. Although we already have the `PAAAReductor` which can handle non-parametric problems, the new `AAAReductor` does a two things differently: First, it is based on strictly proper barycentric forms unlike the p-AAA implementation which uses just proper barycentric forms. Additionally, the `AAAReductor` allows for directly computing the ROM as an `LTIModel` rather than a `TransferFunction`.