### PR TITLE
Implement __eq__, __hash__ for ReferenceElement

### DIFF
--- a/src/pymor/discretizers/builtin/grids/interfaces.py
+++ b/src/pymor/discretizers/builtin/grids/interfaces.py
@@ -139,6 +139,12 @@ class ReferenceElement(CacheableObject):
         o, _ = self.quadrature_info()
         return frozenset(o.keys())
 
+    def __eq__(self, other):
+        return type(self) == type(other)
+
+    def __hash__(self):
+        return hash(type(self).__name__)
+
 
 class Grid(CacheableObject):
     """Affine grid.


### PR DESCRIPTION
Make two `ReferenceElements` the equal if they are of the same type.

This fixes an issue with `discretizers.builtin.cg.LagrangeShapeFunctions` where the `ReferenceElement` instances defined in `discretizers.builtin.cg.grids.referenceelements` are used as keys: When a `Grid` is pickled and unpickled, it obtains a new `ReferenceElement` instance as an attribute, which no longer can used to look up shape functions in the `LagrangeShapeFunctions` dict. In particular this happens when `pymor.parallel` is used.

@niklasreich, this should fix the issue you were having.