### PR TITLE
Add housekeeping scripts for docs.pymor.org

### DIFF
--- a/.ci/gitlab/docs_housekeeping.sh
+++ b/.ci/gitlab/docs_housekeeping.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+# This script is periodically executed on docs.pymor.org.
+
+BASEDIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+
+# remove documentation from merge queue builds
+find /var/www/docs.pymor.org -maxdepth 1 -type d -name 'gh-readonly-queue-*' -exec rm -r '{}' \;
+
+# remove old documentation
+find /var/www/docs.pymor.org -maxdepth 1 -type d -mtime +90 -not -name '20??-*-*' -not -name '20??.*.*' -not -name '0.?.?' -not -name 'main' -exec rm -r '{}' \;
+
+# rebuild https://docs.pymor.org/list.html
+$BASEDIR/docs_makeindex.py /var/www/docs.pymor.org
+
+# update version information
+$BASEDIR/docs_update_versions.py

--- a/.ci/gitlab/docs_makeindex.py
+++ b/.ci/gitlab/docs_makeindex.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# This script is periodically executed on docs.pymor.org.
 
 import sys
 from pathlib import Path

--- a/.ci/gitlab/docs_update_versions.py
+++ b/.ci/gitlab/docs_update_versions.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+# This script is periodically executed on docs.pymor.org.
+
+# Regenerate versions.json, badge.json and index.html
+
+import json
+import re
+from collections import OrderedDict
+from pathlib import Path
+
+base_path = Path('/var/www/docs.pymor.org/')
+
+def versions():
+    pattern = re.compile(r'20\d\d-\d-\d')
+
+    for d in base_path.iterdir():
+        if not d.is_dir():
+            continue
+        if not pattern.match(d.name):
+            continue
+        dir_name = d.name
+        version_name = '.'.join(dir_name.split('-')[:2])
+        yield version_name, dir_name
+
+versions_dict = OrderedDict()
+for v, d in sorted(versions(), reverse=True):
+    if v not in versions_dict:
+        versions_dict[v] = d
+versions_dict['development'] = 'main'
+current_version, current_version_dir = next(iter(versions_dict.items()))
+
+versions_file = base_path / 'versions.json'
+versions_file.write_text(json.dumps(versions_dict))
+
+badge_data = {'schemaVersion': 1,
+              'label': 'docs',
+              'message': current_version_dir.replace('-', '.'),
+              'color': 'green'}
+badge_file = base_path / 'badge.json'
+badge_file.write_text(json.dumps(badge_data))
+
+index_html = f"""
+<head>
+  <!-- This should always redirect to the last release -->
+  <!-- this file is deployed to the pages root from CI -->
+  <meta http-equiv="refresh" content="0; URL=https://docs.pymor.org/{current_version_dir}/index.html" />
+</head>
+"""[1:]
+with open('/var/www/docs.pymor.org/index.html', 'w') as f:
+    f.write(index_html)


### PR DESCRIPTION
This adds the housekeeping scripts executed on docs.pymor.org (every five minutes ATM). After this PR has been merged, the scripts will be executed from a git checkout of the pyMOR repo such that changes here will be automatically deployed.