### PR TITLE
fix to prevent unnecessary copys in NumpyVectorArrayImpl functions

### DIFF
--- a/src/pymor/vectorarrays/numpy.py
+++ b/src/pymor/vectorarrays/numpy.py
@@ -70,7 +70,7 @@ class NumpyVectorArrayImpl(VectorArrayImpl):
 
         if len_other <= self._array.shape[0] - self._len:
             if self._array.dtype != other_array.dtype:
-                self._array = self._array.astype(np.promote_types(self._array.dtype, other_array.dtype))
+                self._array = self._array.astype(np.promote_types(self._array.dtype, other_array.dtype), copy=False)
             self._array[self._len:self._len + len_other] = other_array
         else:
             self._array = np.append(self._array[:self._len], other_array, axis=0)
@@ -87,7 +87,7 @@ class NumpyVectorArrayImpl(VectorArrayImpl):
         alpha_type = type(alpha)
         alpha_dtype = alpha.dtype if alpha_type is np.ndarray else alpha_type
         if self._array.dtype != alpha_dtype:
-            self._array = self._array.astype(np.promote_types(self._array.dtype, alpha_dtype))
+            self._array = self._array.astype(np.promote_types(self._array.dtype, alpha_dtype), copy=False)
         self._array[ind] *= alpha
 
     def scal_copy(self, alpha, ind):
@@ -109,7 +109,7 @@ class NumpyVectorArrayImpl(VectorArrayImpl):
         if self._array.dtype != alpha_dtype or self._array.dtype != B.dtype:
             dtype = np.promote_types(self._array.dtype, alpha_dtype)
             dtype = np.promote_types(dtype, B.dtype)
-            self._array = self._array.astype(dtype)
+            self._array = self._array.astype(dtype, copy=False)
 
         if type(alpha) is np.ndarray:
             alpha = alpha[:, np.newaxis]


### PR DESCRIPTION
numpy.ndarray.astype copies data even if the specified dtype is the same as the arrays dtype

e.g.
A.scal(2) or A.axpy(-1, B) where A and B are both NumpyVectorArray's with dtype 'float64' results in A being copied because '2' and '-1' are not of the same dtype
[https://numpy.org/doc/stable/reference/generated/numpy.ndarray.astype.html](
https://numpy.org/doc/stable/reference/generated/numpy.ndarray.astype.html)

Fixes #2259.