### PR TITLE
Remove  coverage upload for weekly CI runs

### DIFF
--- a/.ci/gitlab/ci.yml
+++ b/.ci/gitlab/ci.yml
@@ -306,17 +306,6 @@ submit coverage:
         - preflight
     image: zivgitlab.wwu.io/pymor/pymor/ci-current:${CI_CURRENT_IMAGE_TAG}
 
-submit coverage weekly:
-    extends: .submit
-    rules:
-        - if: $CI_PIPELINE_SOURCE == "schedule"
-          when: always
-    environment:
-        name: safe
-    dependencies:
-        - vanilla current weekly
-    image: zivgitlab.wwu.io/pymor/pymor/ci-current:${CI_CURRENT_IMAGE_TAG}
-
 coverage html:
     extends: .submit
     needs: 

--- a/.ci/gitlab/ci.yml
+++ b/.ci/gitlab/ci.yml
@@ -348,6 +348,8 @@ docs:
 tag docker images:
     extends: .test_base
     rules:
+        - if: $CI_PIPELINE_SOURCE == "schedule"
+          when: never
         - if: $CI_COMMIT_TAG || ($CI_COMMIT_BRANCH == "main")
           when: on_success
         - when: never


### PR DESCRIPTION
Do not upload coverage reports to codecov for weekly CI runs, as coverage should depend on standard CI runs. Also, the current job description was broken.

Also prevent 'tag docker images' from running in weekly pipelines.