### PR TITLE
Simplify and clarify Model interface

### DIFF
--- a/docs/source/tutorial_optimization.md
+++ b/docs/source/tutorial_optimization.md
@@ -560,19 +560,16 @@ already available in pyMOR.
 
 ## Optimizing using a gradient in FOM
 
-We can easily include a function to compute the gradient to {func}`~scipy.optimize.minimize`.
-Since we use a linear operator and a linear objective functional, the `use_adjoint` argument
-is automatically enabled.
-Note that using the (more general) implementation `use_adjoint=False` results
-in the exact same gradient but lacks computational speed.
-Moreover, the function `output_d_mu` returns a dict w.r.t. the parameters.
-In order to use the output for {func}`~scipy.optimize.minimize` we thus its
-{meth}`~pymor.models.interface.OutputDMuResult.to_numpy` method to convert the values to a
-NumPy array.
+We can easily include a function to compute the gradient to {func}`~scipy.optimize.minimize`
+by using the {meth}`~pymor.models.interface.Model.output_d_mu` method.
+However, this method returns a dict w.r.t. the parameters.
+In order to use the output for {func}`~scipy.optimize.minimize` we use the output's
+{meth}`~pymor.models.interface.OutputDMuResult.to_numpy` method
+to convert the values to a single NumPy array.
 
 ```{code-cell}
 def fom_gradient_of_functional(mu):
-    return fom.output_d_mu(fom.parameters.parse(mu), use_adjoint=True).to_numpy()
+    return fom.output_d_mu(fom.parameters.parse(mu)).to_numpy()
 
 opt_fom_minimization_data = prepare_data()
 
@@ -600,7 +597,7 @@ output functional.
 
 ```{code-cell}
 def rom_gradient_of_functional(mu):
-    return rom.output_d_mu(rom.parameters.parse(mu), use_adjoint=True).to_numpy()
+    return rom.output_d_mu(rom.parameters.parse(mu)).to_numpy()
 
 opt_rom_minimization_data = prepare_data(offline_time=RB_greedy_data['time'])
 
@@ -662,7 +659,7 @@ def enrich_and_compute_objective_function(mu, data, opt_dict):
 
 def compute_gradient_with_opt_rom(opt_dict, mu):
     opt_rom = opt_dict['opt_rom']
-    return opt_rom.output_d_mu(opt_rom.parameters.parse(mu), use_adjoint=True).to_numpy()
+    return opt_rom.output_d_mu(opt_rom.parameters.parse(mu)).to_numpy()
 ```
 
 With this definitions, we can start the optimization method.

--- a/docs/source/tutorial_optimization.md
+++ b/docs/source/tutorial_optimization.md
@@ -565,12 +565,14 @@ Since we use a linear operator and a linear objective functional, the `use_adjoi
 is automatically enabled.
 Note that using the (more general) implementation `use_adjoint=False` results
 in the exact same gradient but lacks computational speed.
-Moreover, the function `output_d_mu` returns a dict w.r.t. the parameters as default.
-In order to use the output for {func}`~scipy.optimize.minimize` we thus use the `return_array=True` argument.
+Moreover, the function `output_d_mu` returns a dict w.r.t. the parameters.
+In order to use the output for {func}`~scipy.optimize.minimize` we thus its
+{meth}`~pymor.models.interface.OutputDMuResult.to_numpy` method to convert the values to a
+NumPy array.
 
 ```{code-cell}
 def fom_gradient_of_functional(mu):
-    return fom.output_d_mu(fom.parameters.parse(mu), return_array=True, use_adjoint=True)
+    return fom.output_d_mu(fom.parameters.parse(mu), use_adjoint=True).to_numpy()
 
 opt_fom_minimization_data = prepare_data()
 
@@ -598,7 +600,7 @@ output functional.
 
 ```{code-cell}
 def rom_gradient_of_functional(mu):
-    return rom.output_d_mu(rom.parameters.parse(mu), return_array=True, use_adjoint=True)
+    return rom.output_d_mu(rom.parameters.parse(mu), use_adjoint=True).to_numpy()
 
 opt_rom_minimization_data = prepare_data(offline_time=RB_greedy_data['time'])
 
@@ -660,7 +662,7 @@ def enrich_and_compute_objective_function(mu, data, opt_dict):
 
 def compute_gradient_with_opt_rom(opt_dict, mu):
     opt_rom = opt_dict['opt_rom']
-    return opt_rom.output_d_mu(opt_rom.parameters.parse(mu), return_array=True, use_adjoint=True)
+    return opt_rom.output_d_mu(opt_rom.parameters.parse(mu), use_adjoint=True).to_numpy()
 ```
 
 With this definitions, we can start the optimization method.

--- a/src/pymor/algorithms/bfgs.py
+++ b/src/pymor/algorithms/bfgs.py
@@ -126,12 +126,12 @@ def error_aware_bfgs(model, parameter_space=None, initial_guess=None, miniter=0,
     assert model.dim_output == 1
     output = lambda m: model.output(m)[0, 0]
 
-    # make sure the model is instationary by checking length of output vectorarray
+    # make sure the model output does not depend on time by checking length of output vectorarray
     temp_output = model.output(mu)
     assert len(temp_output) == 1
     current_output = temp_output[0, 0].item()
 
-    gradient = model.parameters.parse(model.output_d_mu(mu)).to_numpy()
+    gradient = model.output_d_mu(mu).to_numpy().ravel()
     eps = np.linalg.norm(gradient)
 
     # compute norms
@@ -197,7 +197,7 @@ def error_aware_bfgs(model, parameter_space=None, initial_guess=None, miniter=0,
 
         # update gradient
         old_gradient = gradient.copy()
-        gradient = model.parameters.parse(model.output_d_mu(mu)).to_numpy()
+        gradient = model.output_d_mu(mu).to_numpy().ravel()
         first_order_criticality = np.linalg.norm(mu - parameter_space.clip(mu - gradient).to_numpy())
         foc_norms.append(first_order_criticality)
 

--- a/src/pymor/algorithms/error.py
+++ b/src/pymor/algorithms/error.py
@@ -416,7 +416,7 @@ def _compute_errors(mu, fom, reductor, error_estimator, error_norms, condition, 
         u = result['solution']
         if error_estimator:
             e = result['solution_error_estimate']
-            e = e[0] if hasattr(e, '__len__') else e
+            e = np.max(e)
             error_estimates[i_N] = e
         if fom and reductor:
             URB = reductor.reconstruct(u)

--- a/src/pymor/algorithms/greedy.py
+++ b/src/pymor/algorithms/greedy.py
@@ -277,7 +277,7 @@ def _rb_surrogate_evaluate(rom=None, fom=None, reductor=None, mus=None, error_no
             return -1., None
 
     if fom is None:
-        errors = [rom.estimate_error(mu) for mu in mus]
+        errors = [np.max(rom.estimate_error(mu)) for mu in mus]
     elif error_norm is not None:
         errors = [error_norm(fom.solve(mu) - reductor.reconstruct(rom.solve(mu))) for mu in mus]
     else:

--- a/src/pymor/algorithms/tr.py
+++ b/src/pymor/algorithms/tr.py
@@ -238,7 +238,7 @@ def trust_region(fom, surrogate, parameter_space=None, initial_guess=None, beta=
 
                 with logger.block('Computing first order criticality...'):
                     # fom.output_d_mu is potentially for free after enrichment, e.g. using caching
-                    gradient = fom.parameters.parse(fom.output_d_mu(mu)).to_numpy()
+                    gradient = fom.parameters.parse(fom.output_d_mu(mu).to_numpy())
                     first_order_criticality = np.linalg.norm(mu - parameter_space.clip(mu - gradient).to_numpy())
                     foc_norms.append(first_order_criticality)
 

--- a/src/pymor/models/basic.py
+++ b/src/pymor/models/basic.py
@@ -278,8 +278,6 @@ class InstationaryModel(Model):
         Name of the model.
     """
 
-    _compute_allowed_kwargs = frozenset({'return_error_sequence'})
-
     def __init__(self, T, initial_data, operator, rhs, mass=None, time_stepper=None, num_values=None,
                  output_functional=None, products=None, error_estimator=None, visualizer=None, name=None):
 

--- a/src/pymor/models/basic.py
+++ b/src/pymor/models/basic.py
@@ -89,7 +89,7 @@ class StationaryModel(Model):
             f'    dim_output:      {self.dim_output}'
         )
 
-    def _compute_solution(self, mu=None, **kwargs):
+    def _compute_solution(self, mu=None):
         return self.operator.apply_inverse(self.rhs.as_range_array(mu), mu=mu)
 
     def _compute_solution_d_mu_single_direction(self, parameter, index, solution, mu):
@@ -324,7 +324,7 @@ class InstationaryModel(Model):
     def with_time_stepper(self, **kwargs):
         return self.with_(time_stepper=self.time_stepper.with_(**kwargs))
 
-    def _compute_solution(self, mu=None, **kwargs):
+    def _compute_solution(self, mu=None):
         mu = mu.with_(t=0.)
         U0 = self.initial_data.as_range_array(mu)
         U = self.time_stepper.solve(operator=self.operator,

--- a/src/pymor/models/interface.py
+++ b/src/pymor/models/interface.py
@@ -60,7 +60,7 @@ class Model(CacheableObject, ParametricObject):
                  mu=None, **kwargs):
         return {}
 
-    def _compute_solution(self, mu=None, **kwargs):
+    def _compute_solution(self, mu=None):
         """Compute the model's solution for |parameter values| `mu`.
 
         This method is called by the default implementation of :meth:`compute`
@@ -70,9 +70,6 @@ class Model(CacheableObject, ParametricObject):
         ----------
         mu
             |Parameter values| for which to compute the solution.
-        kwargs
-            Additional keyword arguments to select further quantities that should
-            be computed.
 
         Returns
         -------
@@ -81,7 +78,7 @@ class Model(CacheableObject, ParametricObject):
         """
         raise NotImplementedError
 
-    def _compute_output(self, solution, mu=None, **kwargs):
+    def _compute_output(self, solution, mu=None):
         """Compute the model's output for |parameter values| `mu`.
 
         This method is called by the default implementation of :meth:`compute`
@@ -102,9 +99,6 @@ class Model(CacheableObject, ParametricObject):
             Internal model state for the given |parameter values|.
         mu
             |Parameter values| for which to compute the output.
-        kwargs
-            Additional keyword arguments to select further quantities that should
-            be computed.
 
         Returns
         -------
@@ -191,7 +185,7 @@ class Model(CacheableObject, ParametricObject):
                 sensitivities[parameter, index] = output_d_mu
         return OutputDMuResult(sensitivities)
 
-    def _compute_solution_error_estimate(self, solution, mu=None, **kwargs):
+    def _compute_solution_error_estimate(self, solution, mu=None):
         """Compute an error estimate for the computed internal state.
 
         This method is called by the default implementation of :meth:`compute`
@@ -204,7 +198,7 @@ class Model(CacheableObject, ParametricObject):
 
             The default implementation calls the `estimate_error` method of the object
             given by the :attr:`error_estimator` attribute, passing `solution`,
-            `mu`, `self` and `**kwargs`.
+            `mu` and `self`.
 
         Parameters
         ----------
@@ -212,9 +206,6 @@ class Model(CacheableObject, ParametricObject):
             Internal model state for the given |parameter values|.
         mu
             |Parameter values| for which to compute the error estimate.
-        kwargs
-            Additional keyword arguments to select further quantities that should
-            be computed.
 
         Returns
         -------
@@ -223,9 +214,9 @@ class Model(CacheableObject, ParametricObject):
         """
         if self.error_estimator is None:
             raise ValueError('Model has no error estimator')
-        return self.error_estimator.estimate_error(solution, mu, self, **kwargs)
+        return self.error_estimator.estimate_error(solution, mu, self)
 
-    def _compute_output_error_estimate(self, solution, mu=None, **kwargs):
+    def _compute_output_error_estimate(self, solution, mu=None):
         """Compute an error estimate for the computed model output.
 
         This method is called by the default implementation of :meth:`compute`
@@ -238,7 +229,7 @@ class Model(CacheableObject, ParametricObject):
 
             The default implementation calls the `estimate_output_error` method of the object
             given by the :attr:`error_estimator` attribute, passing `solution`,
-            `mu`, `self` and `**kwargs`.
+            `mu` and `self`.
 
         Parameters
         ----------
@@ -246,9 +237,6 @@ class Model(CacheableObject, ParametricObject):
             Internal model state for the given |parameter values|.
         mu
             |Parameter values| for which to compute the error estimate.
-        kwargs
-            Additional keyword arguments to select further quantities that should
-            be computed.
 
         Returns
         -------
@@ -257,7 +245,7 @@ class Model(CacheableObject, ParametricObject):
         """
         if self.error_estimator is None:
             raise ValueError('Model has no error estimator')
-        return self.error_estimator.estimate_output_error(solution, mu, self, **kwargs)
+        return self.error_estimator.estimate_output_error(solution, mu, self)
 
     _compute_allowed_kwargs = frozenset()
 
@@ -340,7 +328,7 @@ class Model(CacheableObject, ParametricObject):
 
         if (solution or solution_error_estimate or solution_d_mu) and 'solution' not in data \
            or (output or output_error_estimate or output_d_mu) and 'output' not in data:
-            retval = self.cached_method_call(self._compute_solution, mu=mu, **kwargs)
+            retval = self.cached_method_call(self._compute_solution, mu=mu)
             if isinstance(retval, dict):
                 assert 'solution' in retval
                 data.update(retval)
@@ -349,7 +337,7 @@ class Model(CacheableObject, ParametricObject):
 
         if output and 'output' not in data:
             # TODO: use caching here (requires skipping args in key generation)
-            retval = self._compute_output(data['solution'], mu=mu, **kwargs)
+            retval = self._compute_output(data['solution'], mu=mu)
             if isinstance(retval, dict):
                 assert 'output' in retval
                 data.update(retval)
@@ -367,7 +355,7 @@ class Model(CacheableObject, ParametricObject):
 
         if solution_error_estimate and 'solution_error_estimate' not in data:
             # TODO: use caching here (requires skipping args in key generation)
-            retval = self._compute_solution_error_estimate(data['solution'], mu=mu, **kwargs)
+            retval = self._compute_solution_error_estimate(data['solution'], mu=mu)
             if isinstance(retval, dict):
                 assert 'solution_error_estimate' in retval
                 data.update(retval)
@@ -376,8 +364,7 @@ class Model(CacheableObject, ParametricObject):
 
         if output_error_estimate and 'output_error_estimate' not in data:
             # TODO: use caching here (requires skipping args in key generation)
-            retval = self._compute_output_error_estimate(
-                data['solution'], mu=mu, **kwargs)
+            retval = self._compute_output_error_estimate(data['solution'], mu=mu)
             if isinstance(retval, dict):
                 assert 'output_error_estimate' in retval
                 data.update(retval)

--- a/src/pymor/models/interface.py
+++ b/src/pymor/models/interface.py
@@ -71,8 +71,8 @@ class Model(CacheableObject, ParametricObject):
         mu
             |Parameter values| for which to compute the solution.
         kwargs
-            Additional keyword arguments to customize how the solution is
-            computed or to select additional data to be returned.
+            Additional keyword arguments to select further quantities that should
+            be computed.
 
         Returns
         -------
@@ -103,8 +103,8 @@ class Model(CacheableObject, ParametricObject):
         mu
             |Parameter values| for which to compute the output.
         kwargs
-            Additional keyword arguments to customize how the output is
-            computed or to select additional data to be returned.
+            Additional keyword arguments to select further quantities that should
+            be computed.
 
         Returns
         -------
@@ -211,8 +211,8 @@ class Model(CacheableObject, ParametricObject):
         mu
             |Parameter values| for which to compute the error estimate.
         kwargs
-            Additional keyword arguments to customize how the error estimate is
-            computed or to select additional data to be returned.
+            Additional keyword arguments to select further quantities that should
+            be computed.
 
         Returns
         -------
@@ -245,8 +245,8 @@ class Model(CacheableObject, ParametricObject):
         mu
             |Parameter values| for which to compute the error estimate.
         kwargs
-            Additional keyword arguments to customize how the error estimate is
-            computed or to select additional data to be returned.
+            Additional keyword arguments to select further quantities that should
+            be computed.
 
         Returns
         -------
@@ -303,8 +303,8 @@ class Model(CacheableObject, ParametricObject):
             can be used to instantiate an |ExpressionFunction| of this type.
             Can be `None` if `self.dim_input == 0`.
         kwargs
-            Further keyword arguments to select further quantities that should
-            be returned or to customize how the values are computed.
+            Additional keyword arguments to select further quantities that should
+            be computed.
 
         Returns
         -------
@@ -396,7 +396,7 @@ class Model(CacheableObject, ParametricObject):
 
         return data
 
-    def solve(self, mu=None, input=None, return_error_estimate=False, **kwargs):
+    def solve(self, mu=None, input=None, return_error_estimate=False):
         """Solve the discrete problem for the |parameter values| `mu`.
 
         This method returns a |VectorArray| with a internal state
@@ -419,9 +419,6 @@ class Model(CacheableObject, ParametricObject):
             Can be `None` if `self.dim_input == 0`.
         return_error_estimate
             If `True`, also return an error estimate for the computed solution.
-        kwargs
-            Additional keyword arguments passed to :meth:`compute` that
-            might affect how the solution is computed.
 
         Returns
         -------
@@ -433,14 +430,13 @@ class Model(CacheableObject, ParametricObject):
             solution_error_estimate=return_error_estimate,
             mu=mu,
             input=input,
-            **kwargs
         )
         if return_error_estimate:
             return data['solution'], data['solution_error_estimate']
         else:
             return data['solution']
 
-    def output(self, mu=None, input=None, return_error_estimate=False, **kwargs):
+    def output(self, mu=None, input=None, return_error_estimate=False):
         """Return the model output for given |parameter values| `mu`.
 
         This method is a convenience wrapper around :meth:`compute`.
@@ -457,9 +453,6 @@ class Model(CacheableObject, ParametricObject):
             Can be `None` if `self.dim_input == 0`.
         return_error_estimate
             If `True`, also return an error estimate for the computed output.
-        kwargs
-            Additional keyword arguments passed to :meth:`compute` that
-            might affect how the solution is computed.
 
         Returns
         -------
@@ -475,14 +468,13 @@ class Model(CacheableObject, ParametricObject):
             output_error_estimate=return_error_estimate,
             mu=mu,
             input=input,
-            **kwargs
         )
         if return_error_estimate:
             return data['output'], data['output_error_estimate']
         else:
             return data['output']
 
-    def solve_d_mu(self, parameter, index, mu=None, input=None, **kwargs):
+    def solve_d_mu(self, parameter, index, mu=None, input=None):
         """Solve for the partial derivative of the solution w.r.t. a parameter index.
 
         Parameters
@@ -508,11 +500,10 @@ class Model(CacheableObject, ParametricObject):
             solution_d_mu=(parameter, index),
             mu=mu,
             input=input,
-            **kwargs
         )
         return data['solution_d_mu']
 
-    def output_d_mu(self, mu=None, input=None, **kwargs):
+    def output_d_mu(self, mu=None, input=None):
         """Compute the gradient w.r.t. the parameter of the output functional.
 
         Parameters
@@ -538,11 +529,10 @@ class Model(CacheableObject, ParametricObject):
             output_d_mu=True,
             mu=mu,
             input=input,
-            **kwargs
         )
         return data['output_d_mu']
 
-    def estimate_error(self, mu=None, input=None, **kwargs):
+    def estimate_error(self, mu=None, input=None):
         """Estimate the error for the computed internal state.
 
         For given |parameter values| `mu` this method returns an
@@ -564,9 +554,6 @@ class Model(CacheableObject, ParametricObject):
             mapping time to input, or a `str` expression with `t` as variable that
             can be used to instantiate an |ExpressionFunction| of this type.
             Can be `None` if `self.dim_input == 0`.
-        kwargs
-            Additional keyword arguments passed to :meth:`compute` that
-            might affect how the error estimate (or the solution) is computed.
 
         Returns
         -------
@@ -580,10 +567,9 @@ class Model(CacheableObject, ParametricObject):
             solution_error_estimate=True,
             mu=mu,
             input=input,
-            **kwargs
         )['solution_error_estimate']
 
-    def estimate_output_error(self, mu=None, input=None, **kwargs):
+    def estimate_output_error(self, mu=None, input=None):
         """Estimate the error for the computed output.
 
         For given |parameter values| `mu` this method returns an
@@ -605,9 +591,6 @@ class Model(CacheableObject, ParametricObject):
             mapping time to input, or a `str` expression with `t` as variable that
             can be used to instantiate an |ExpressionFunction| of this type.
             Can be `None` if `self.dim_input == 0`.
-        kwargs
-            Additional keyword arguments passed to :meth:`compute` that
-            might affect how the error estimate (or the output) is computed.
 
         Returns
         -------
@@ -620,8 +603,7 @@ class Model(CacheableObject, ParametricObject):
         return self.compute(
             output_error_estimate=True,
             mu=mu,
-            input=input,
-            **kwargs
+            input=input
         )['output_error_estimate']
 
     def visualize(self, U, **kwargs):

--- a/src/pymor/models/interface.py
+++ b/src/pymor/models/interface.py
@@ -634,3 +634,6 @@ class OutputDMuResult(FrozenDict):
         ordered by alphabetically ordered parameter name.
         """
         return np.vstack([v for k, v in sorted(self.items())])
+
+    def __repr__(self):
+        return f'OutputDMuResult({dict(sorted(self.items()))})'

--- a/src/pymor/models/interface.py
+++ b/src/pymor/models/interface.py
@@ -166,7 +166,7 @@ class Model(CacheableObject, ParametricObject):
         Returns
         -------
         The output sensitivities as a dict `{(parameter, index): sensitivity}` where
-        `sensitivity` is a 2D |NumPy arrays| with axis 0 corresponding to time and axis 1
+        `sensitivity` is a 2D |NumPy array| with axis 0 corresponding to time and axis 1
         corresponding to the output component.
         The returned :class:`OutputDMuResult` object has a `meth`:~OutputDMuResult.to_numpy`
         method to convert it into a single NumPy array, e.g., for use in optimization

--- a/src/pymor/models/interface.py
+++ b/src/pymor/models/interface.py
@@ -606,12 +606,12 @@ class OutputDMuResult(FrozenDict):
     """Immutable dict of gradients returned by :meth:`~Model.output_d_mu`."""
 
     def to_numpy(self):
-        """Return gradients as a single 2D NumPy array.
+        """Return gradients as a single 3D NumPy array.
 
-        The array is obtained by stacking the individual arrays along axis 0,
-        ordered by alphabetically ordered parameter name.
+        The array is obtained by stacking the individual arrays along an
+        additional axis 0, ordered by alphabetically ordered parameter name.
         """
-        return np.vstack([v for k, v in sorted(self.items())])
+        return np.array([v for k, v in sorted(self.items())])
 
     def __repr__(self):
         return f'OutputDMuResult({dict(sorted(self.items()))})'

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -676,7 +676,7 @@ class LTIModel(Model):
             _mmwrite(Path(files_basename + '.E'), E)
 
     def _compute(self, solution=False, output=False, solution_d_mu=False, output_d_mu=False,
-                 solution_error_estimate=False, output_error_estimate=False, output_d_mu_return_array=False,
+                 solution_error_estimate=False, output_error_estimate=False,
                  mu=None, **kwargs):
 
         assert self.T is not None

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -677,7 +677,7 @@ class LTIModel(Model):
 
     def _compute(self, solution=False, output=False, solution_d_mu=False, output_d_mu=False,
                  solution_error_estimate=False, output_error_estimate=False, output_d_mu_return_array=False,
-                 output_error_estimate_return_vector=False, mu=None, **kwargs):
+                 mu=None, **kwargs):
 
         assert self.T is not None
 

--- a/src/pymor/models/mpi.py
+++ b/src/pymor/models/mpi.py
@@ -27,8 +27,8 @@ class MPIModel:
     Instead, you should use :func:`mpi_wrap_model`.
     """
 
-    def __init__(self, obj_id, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, obj_id, *args):
+        super().__init__(*args)
         self.obj_id = obj_id
         m = mpi.get_object(obj_id)
         self.parameters = m.parameters
@@ -36,9 +36,9 @@ class MPIModel:
         self.parameters_internal = m.parameters_internal
         self.visualizer = MPIVisualizer(obj_id)
 
-    def _compute_solution(self, mu=None, **kwargs):
+    def _compute_solution(self, mu=None):
         return self.solution_space.make_array(
-            mpi.call(mpi.method_call_manage, self.obj_id, '_compute_solution', mu=mu, **kwargs)
+            mpi.call(mpi.method_call_manage, self.obj_id, '_compute_solution', mu=mu)
         )
 
     def visualize(self, U, **kwargs):

--- a/src/pymor/models/neural_network.py
+++ b/src/pymor/models/neural_network.py
@@ -99,7 +99,7 @@ class NeuralNetworkModel(BaseNeuralNetworkModel):
         assert self.output_functional.source == self.solution_space
         self.dim_output = self.output_functional.range.dim
 
-    def _compute_solution(self, mu=None, **kwargs):
+    def _compute_solution(self, mu=None):
 
         # convert the parameter `mu` into a form that is usable in PyTorch
         converted_input = torch.DoubleTensor(mu.to_numpy())
@@ -229,7 +229,7 @@ class NeuralNetworkInstationaryModel(BaseNeuralNetworkModel):
         assert output_functional.source == self.solution_space
         self.dim_output = output_functional.range.dim
 
-    def _compute_solution(self, mu=None, **kwargs):
+    def _compute_solution(self, mu=None):
         # collect all inputs in a single tensor
         inputs = self._scale_input(torch.DoubleTensor(np.array([mu.with_(t=t).to_numpy()
                                                                 for t in np.linspace(0., self.T, self.nt)])))

--- a/src/pymor/models/neural_network.py
+++ b/src/pymor/models/neural_network.py
@@ -154,8 +154,7 @@ class NeuralNetworkStatefreeOutputModel(BaseNeuralNetworkModel):
         self.__auto_init(locals())
 
     def _compute(self, solution=False, output=False, solution_d_mu=False, output_d_mu=False,
-                 solution_error_estimate=False, output_error_estimate=False,
-                 output_d_mu_return_array=False, mu=None, **kwargs):
+                 solution_error_estimate=False, output_error_estimate=False, mu=None, **kwargs):
         if output:
             converted_input = torch.from_numpy(mu.to_numpy()).double()
             converted_input = self._scale_input(converted_input)
@@ -285,8 +284,7 @@ class NeuralNetworkInstationaryStatefreeOutputModel(BaseNeuralNetworkModel):
         self.__auto_init(locals())
 
     def _compute(self, solution=False, output=False, solution_d_mu=False, output_d_mu=False,
-                 solution_error_estimate=False, output_error_estimate=False,
-                 output_d_mu_return_array=False, mu=None, **kwargs):
+                 solution_error_estimate=False, output_error_estimate=False, mu=None, **kwargs):
 
         if output:
             inputs = self._scale_input(torch.DoubleTensor(np.array([mu.with_(t=t).to_numpy()

--- a/src/pymor/reductors/coercive.py
+++ b/src/pymor/reductors/coercive.py
@@ -83,17 +83,14 @@ class CoerciveRBEstimator(ImmutableObject):
             est /= self.coercivity_estimator(mu)
         return est
 
-    def estimate_output_error(self, U, mu, m, return_vector=False):
+    def estimate_output_error(self, U, mu, m):
         if self.projected_output_adjoint is None:
             raise NotImplementedError
         estimate = self.estimate_error(U, mu, m)
         # scale with dual norm of the output functional
         output_functional_norms = self.projected_output_adjoint.as_range_array(mu).norm()
         errs = estimate * output_functional_norms
-        if return_vector:
-            return errs
-        else:
-            return np.linalg.norm(errs)
+        return errs.reshape((1, -1))
 
     def restricted_to_subbasis(self, dim, m):
         if self.residual_range_dims:
@@ -286,7 +283,7 @@ class SimpleCoerciveRBEstimator(ImmutableObject):
 
         return est
 
-    def estimate_output_error(self, U, mu, m, return_vector=False):
+    def estimate_output_error(self, U, mu, m):
         if not self.output_estimator_matrices or not self.output_functional_coeffs:
             raise NotImplementedError
         estimate = self.estimate_error(U, mu, m)
@@ -296,10 +293,7 @@ class SimpleCoerciveRBEstimator(ImmutableObject):
         for d in range(m.dim_output):
             dual_norms.append(np.sqrt(coeff_vals.T@(self.output_estimator_matrices[d]@coeff_vals)))
         errs = estimate * dual_norms
-        if return_vector:
-            return errs
-        else:
-            return np.linalg.norm(errs)
+        return errs.reshape((-1, 1))
 
     def restricted_to_subbasis(self, dim, m):
         cr = 1 if not m.rhs.parametric else len(m.rhs.operators)

--- a/src/pymor/reductors/dwr.py
+++ b/src/pymor/reductors/dwr.py
@@ -223,14 +223,14 @@ class DWRCoerciveRBEstimator(ImmutableObject):
     def estimate_error(self, U, mu, m):
         return self.primal_estimator.estimate_error(U, mu, m)
 
-    def estimate_output_error(self, U, mu, m, return_vector=False):
-        est_pr = self.estimate_error(U, mu, m)
+    def estimate_output_error(self, U, mu, m):
+        est_pr = self.estimate_error(U, mu, m).item()
         est_dus = []
         for d in range(m.dim_output):
             dual_solution = self.dual_models[d].solve(mu)
-            est_dus.append(self.dual_estimators[d].estimate_error(dual_solution, mu, m))
-        ret = (est_pr * est_dus).T
-        return ret if return_vector else np.linalg.norm(ret)
+            est_dus.append(self.dual_estimators[d].estimate_error(dual_solution, mu, m).item())
+        ret = est_pr * np.array(est_dus).reshape((1, -1))
+        return ret
 
     def restricted_to_subbasis(self, dual_roms, primal_dim, dual_dims, m):
         primal_estimator = self.primal_estimator.restricted_to_subbasis(primal_dim, m)

--- a/src/pymordemos/linear_optimization.py
+++ b/src/pymordemos/linear_optimization.py
@@ -26,7 +26,7 @@ def main(
         return fom.output(mu)[0, 0]
 
     def fom_gradient_of_functional(mu):
-        return fom.output_d_mu(fom.parameters.parse(mu), return_array=True, use_adjoint=True)
+        return fom.output_d_mu(fom.parameters.parse(mu), use_adjoint=True).to_numpy()
 
     from functools import partial
     from time import perf_counter
@@ -65,7 +65,7 @@ def main(
         return rom.output(mu)[0, 0]
 
     def rom_gradient_of_functional(mu):
-        return rom.output_d_mu(fom.parameters.parse(mu), return_array=True, use_adjoint=True)
+        return rom.output_d_mu(fom.parameters.parse(mu), use_adjoint=True).to_numpy()
 
     opt_rom_minimization_data = {'num_evals': 0,
                                  'evaluations': [],

--- a/src/pymordemos/linear_optimization.py
+++ b/src/pymordemos/linear_optimization.py
@@ -26,7 +26,7 @@ def main(
         return fom.output(mu)[0, 0]
 
     def fom_gradient_of_functional(mu):
-        return fom.output_d_mu(fom.parameters.parse(mu), use_adjoint=True).to_numpy()
+        return fom.output_d_mu(fom.parameters.parse(mu)).to_numpy()
 
     from functools import partial
     from time import perf_counter
@@ -65,7 +65,7 @@ def main(
         return rom.output(mu)[0, 0]
 
     def rom_gradient_of_functional(mu):
-        return rom.output_d_mu(fom.parameters.parse(mu), use_adjoint=True).to_numpy()
+        return rom.output_d_mu(fom.parameters.parse(mu)).to_numpy()
 
     opt_rom_minimization_data = {'num_evals': 0,
                                  'evaluations': [],

--- a/src/pymordemos/output_error_estimation.py
+++ b/src/pymordemos/output_error_estimation.py
@@ -96,8 +96,8 @@ def main(
     results_full = {'fom': [], 'rom': [], 'err': [], 'est': []}
     for i, mu in enumerate(training_set):
         s_fom = fom_outputs[i]
-        s_rom, s_est = rom.output(return_error_estimate=True, mu=mu,
-                                  return_error_estimate_vector=False)
+        s_rom, s_est = rom.output(return_error_estimate=True, mu=mu)
+        s_est = np.linalg.norm(s_est[-1, :])
         results_full['fom'].append(s_fom)
         results_full['rom'].append(s_rom)
         results_full['err'].append(np.linalg.norm(np.abs(s_fom[-1]-s_rom[-1])))
@@ -105,22 +105,6 @@ def main(
 
         # just for testing purpose
         assert np.linalg.norm(np.abs(s_rom-s_fom)) <= s_est + 1e-8
-
-        # also test return_estimate_vector and return_error_sequence functionality but do not use it
-        s_rom_, s_est_ = rom.output(return_error_estimate=True, mu=mu,
-                                    return_error_estimate_vector=True)
-        assert np.allclose(s_rom, s_rom_)
-        assert np.allclose(s_est, np.linalg.norm(s_est_))
-
-        if fom_number in [3, 4]:
-            s_rom__, s_est__ = rom.output(return_error_estimate=True, mu=mu, return_error_sequence=True)
-            s_rom___, s_est___ = rom.output(return_error_estimate=True, mu=mu,
-                                            return_error_estimate_vector=True,
-                                            return_error_sequence=True)
-            # s_rom always stays the same
-            assert np.allclose(s_rom, s_rom__, s_rom___)
-            assert s_est__[-1] == s_est
-            assert np.allclose(s_est__, np.linalg.norm(s_est___, axis=1))
 
     # plot result
     plt.figure()
@@ -139,8 +123,7 @@ def main(
         for i, mu in enumerate(training_set):
             s_fom = fom_outputs[i]
             s_rom, s_est = rom.output(return_error_estimate=True, mu=mu)
-            if fom_number in [3, 4]:
-                s_est = s_est[0]
+            s_est = np.linalg.norm(s_est[-1, :])
             max_err = max(max_err, np.linalg.norm(np.abs(s_fom-s_rom)))
             max_est = max(max_est, s_est)
             min_err = min(min_err, np.linalg.norm(np.abs(s_fom-s_rom)))

--- a/src/pymordemos/output_error_estimation_with_dwr.py
+++ b/src/pymordemos/output_error_estimation_with_dwr.py
@@ -91,8 +91,8 @@ def main(
         results_full = {'fom': [], 'rom': [], 'err': [], 'est': []}
         for i, mu in enumerate(training_set):
             s_fom = fom_outputs[i]
-            s_rom, s_est = rom.output(return_error_estimate=True, mu=mu,
-                                      return_error_estimate_vector=False)
+            s_rom, s_est = rom.output(return_error_estimate=True, mu=mu)
+            s_est = np.linalg.norm(s_est[-1, :])
             results_full['fom'].append(s_fom)
             results_full['rom'].append(s_rom)
             results_full['err'].append(np.linalg.norm(np.abs(s_fom[-1]-s_rom[-1])))
@@ -136,6 +136,7 @@ def main(
             for i, mu in enumerate(training_set):
                 s_fom = fom_outputs[i]
                 s_rom, s_est = rom.output(return_error_estimate=True, mu=mu)
+                s_est = np.linalg.norm(s_est[-1, :])
                 max_err = max(max_err, np.linalg.norm(np.abs(s_fom-s_rom)))
                 max_est = max(max_est, s_est)
                 min_err = min(min_err, np.linalg.norm(np.abs(s_fom-s_rom)))

--- a/src/pymortests/parameters/mu_derivatives.py
+++ b/src/pymortests/parameters/mu_derivatives.py
@@ -287,7 +287,7 @@ def run_test_on_model(model, mu, parameter_name=None):
     assert np.allclose(gradient_with_adjoint_approach, gradient_with_sensitivities)
     if parameter_name is not None:
         u_d_mu = model.solve_d_mu(parameter_name, 1, mu=mu).to_numpy()
-        u_d_mu_ = model.compute(solution_d_mu=True, mu=mu)['solution_d_mu'][parameter_name][1].to_numpy()
+        u_d_mu_ = model.compute(solution_d_mu=True, mu=mu)['solution_d_mu'][parameter_name, 1].to_numpy()
         assert np.allclose(u_d_mu, u_d_mu_)
 
 

--- a/src/pymortests/parameters/mu_derivatives.py
+++ b/src/pymortests/parameters/mu_derivatives.py
@@ -280,8 +280,8 @@ def test_d_mu_of_LincombOperator():
 
 
 def run_test_on_model(model, mu, parameter_name=None):
-    gradient_with_adjoint_approach = model.output_d_mu(mu, return_array=True, use_adjoint=True)
-    gradient_with_sensitivities = model.output_d_mu(mu, return_array=True, use_adjoint=False)
+    gradient_with_adjoint_approach = model.output_d_mu(mu, use_adjoint=True).to_numpy()
+    gradient_with_sensitivities = model.output_d_mu(mu, use_adjoint=False).to_numpy()
     assert np.allclose(gradient_with_adjoint_approach, gradient_with_sensitivities)
     if parameter_name is not None:
         u_d_mu = model.solve_d_mu(parameter_name, 1, mu=mu).to_numpy()

--- a/src/pymortests/parameters/mu_derivatives.py
+++ b/src/pymortests/parameters/mu_derivatives.py
@@ -280,8 +280,10 @@ def test_d_mu_of_LincombOperator():
 
 
 def run_test_on_model(model, mu, parameter_name=None):
-    gradient_with_adjoint_approach = model.output_d_mu(mu, use_adjoint=True).to_numpy()
-    gradient_with_sensitivities = model.output_d_mu(mu, use_adjoint=False).to_numpy()
+    gradient_with_adjoint_approach = \
+        model.with_(output_d_mu_use_adjoint=True).output_d_mu(mu).to_numpy()
+    gradient_with_sensitivities = \
+        model.with_(output_d_mu_use_adjoint=False).output_d_mu(mu).to_numpy()
     assert np.allclose(gradient_with_adjoint_approach, gradient_with_sensitivities)
     if parameter_name is not None:
         u_d_mu = model.solve_d_mu(parameter_name, 1, mu=mu).to_numpy()


### PR DESCRIPTION
- `estimate_error` is required to always return a 1D NumPy array, where the index corresponds to time. For time-independent problems, the array always has length 1.
- `estimate_output_error` always returns a 2D numpy array, where axis 0 corresponds to time and axis 1 corresponds to the output component.  The `return_vector` parameter is removed.
- In order to have consistent behavior for time-dependent models, the `solution_d_mu` compute option now returns a dict of the form `{(parameter, index): sensitivity}` instead of appending solution sensitivities for different parameter indices to a single array. The value of `solution_d_mu` can now either be `True` to compute all sensitivities or a sequence of tuples `(parameter, index)` to select the parameters for which to compute sensitivities.
- `output_d_mu` now always returns a frozen dict the form `{(parameter, index): sensitivity}`, where `sensitivity` is a 2D numpy array with axis 0 corresponding to time and axis 1 corresponding to output component. This `OutputDMuResult` instance has a `to_numpy` method to convert it to a single array. The `return_array` parameter is removed.
- Only `compute` keeps `**kwargs`, which are only allowed to be used to select additional quantities that are to be computed. To change behavior of `solve`, etc., appropriate attributes of the `Model` instance have to be used in the future.

Apart from making the `Model` interface clearer, this change is necessary to improve caching in `compute` and related methods (#2277).