### PR TITLE
Support NumPy 2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 dependencies = [
   "diskcache",
   "matplotlib>=3.5.0",
-  "numpy>=1.20.3,!=1.25.0,<2", # 1.25.0 crashes CI, >=2 breaks API
+  "numpy>=1.20.3,!=1.25.0", # 1.25.0 crashes CI
   "packaging",
   "pillow",
   "pygments",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,9 +51,9 @@ docs-additional = [
   "myst-nb>=0.16",
   "pybind11[global]",
   "python-slugify",
-  "sphinx-autoapi",
+  "sphinx-autoapi==3.1.2",
   "sphinx-material",
-  "sphinx",
+  "sphinx==7.3.7",
   "sphinxcontrib-bibtex",
 ]
 # additional dependencies for running tests via 'make tests'

--- a/requirements-ci-current.txt
+++ b/requirements-ci-current.txt
@@ -18,7 +18,7 @@ argon2-cffi-bindings==21.2.0
     # via argon2-cffi
 arrow==1.3.0
     # via isoduration
-astroid==3.2.2
+astroid==3.2.4
     # via sphinx-autoapi
 asttokens==2.4.1
     # via stack-data
@@ -64,7 +64,7 @@ comm==0.2.2
     #   ipywidgets
 contourpy==1.2.1
     # via matplotlib
-coverage[toml]==7.5.4
+coverage[toml]==7.6.0
     # via
     #   coverage
     #   pytest-cov
@@ -129,7 +129,7 @@ idna==3.7
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.0.0
+importlib-metadata==8.2.0
     # via
     #   jupyter-cache
     #   myst-nb
@@ -182,7 +182,7 @@ json5==0.9.25
     # via jupyterlab-server
 jsonpointer==3.0.0
     # via jsonschema
-jsonschema[format-nongpl]==4.22.0
+jsonschema[format-nongpl]==4.23.0
     # via
     #   jupyter-events
     #   jupyterlab-server
@@ -210,7 +210,7 @@ jupyter-events==0.10.0
     # via jupyter-server
 jupyter-lsp==2.2.5
     # via jupyterlab
-jupyter-server==2.14.1
+jupyter-server==2.14.2
     # via
     #   jupyter-lsp
     #   jupyter-server-mathjax
@@ -224,7 +224,7 @@ jupyter-server-mathjax==0.2.6
     # via nbdime
 jupyter-server-terminals==0.5.3
     # via jupyter-server
-jupyterlab==4.2.3
+jupyterlab==4.2.4
     # via
     #   notebook
     #   pymor (pyproject.toml)
@@ -232,7 +232,7 @@ jupyterlab-myst==2.4.2
     # via pymor (pyproject.toml)
 jupyterlab-pygments==0.3.0
     # via nbconvert
-jupyterlab-server==2.27.2
+jupyterlab-server==2.27.3
     # via
     #   jupyterlab
     #   notebook
@@ -275,7 +275,7 @@ mistune==3.0.2
     # via nbconvert
 mkl==2024.2.0
     # via ngsolve
-mpi4py==3.1.6
+mpi4py==4.0.0
     # via pymor (pyproject.toml)
 mpmath==1.3.0
     # via sympy
@@ -322,7 +322,7 @@ notebook-shim==0.2.4
     # via
     #   jupyterlab
     #   notebook
-numpy==1.26.4
+numpy==2.0.1
     # via
     #   contourpy
     #   hypothesis
@@ -378,7 +378,7 @@ ptyprocess==0.7.0
     # via
     #   pexpect
     #   terminado
-pure-eval==0.2.2
+pure-eval==0.2.3
     # via stack-data
 pybind11[global]==2.13.1
     # via pymor (pyproject.toml)
@@ -414,7 +414,7 @@ pyside6-essentials==6.7.2
     # via
     #   pyside6
     #   pyside6-addons
-pytest==8.2.2
+pytest==8.3.2
     # via
     #   hypothesis
     #   pymor (pyproject.toml)
@@ -477,11 +477,11 @@ rich==13.7.1
     # via
     #   meshio
     #   typer
-rpds-py==0.18.1
+rpds-py==0.19.1
     # via
     #   jsonschema
     #   referencing
-scikit-fem==9.1.1
+scikit-fem==10.0.0
     # via pymor (pyproject.toml)
 scipy==1.14.0
     # via
@@ -517,7 +517,7 @@ sortedcontainers==2.4.0
     # via hypothesis
 soupsieve==2.5
     # via beautifulsoup4
-sphinx==7.3.7
+sphinx==7.4.7
     # via
     #   myst-nb
     #   myst-parser
@@ -525,29 +525,29 @@ sphinx==7.3.7
     #   sphinx-autoapi
     #   sphinx-material
     #   sphinxcontrib-bibtex
-sphinx-autoapi==3.1.2
+sphinx-autoapi==3.2.1
     # via pymor (pyproject.toml)
 sphinx-material==0.0.36
     # via pymor (pyproject.toml)
-sphinxcontrib-applehelp==1.0.8
+sphinxcontrib-applehelp==2.0.0
     # via sphinx
 sphinxcontrib-bibtex==2.6.2
     # via pymor (pyproject.toml)
-sphinxcontrib-devhelp==1.0.6
+sphinxcontrib-devhelp==2.0.0
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.5
+sphinxcontrib-htmlhelp==2.1.0
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-qthelp==1.0.7
+sphinxcontrib-qthelp==2.0.0
     # via sphinx
-sphinxcontrib-serializinghtml==1.1.10
+sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
 sqlalchemy==2.0.31
     # via jupyter-cache
 stack-data==0.6.3
     # via ipython
-sympy==1.12.1
+sympy==1.13.1
     # via torch
 tabulate==0.9.0
     # via jupyter-cache
@@ -561,7 +561,7 @@ text-unidecode==1.3
     # via python-slugify
 tinycss2==1.3.0
     # via nbconvert
-torch==2.3.1+cpu
+torch==2.4.0+cpu
     # via pymor (pyproject.toml)
 tornado==6.4.1
     # via

--- a/requirements-ci-current.txt
+++ b/requirements-ci-current.txt
@@ -517,7 +517,7 @@ sortedcontainers==2.4.0
     # via hypothesis
 soupsieve==2.5
     # via beautifulsoup4
-sphinx==7.4.7
+sphinx==7.3.7
     # via
     #   myst-nb
     #   myst-parser
@@ -525,7 +525,7 @@ sphinx==7.4.7
     #   sphinx-autoapi
     #   sphinx-material
     #   sphinxcontrib-bibtex
-sphinx-autoapi==3.2.1
+sphinx-autoapi==3.1.2
     # via pymor (pyproject.toml)
 sphinx-material==0.0.36
     # via pymor (pyproject.toml)

--- a/src/pymor/analyticalproblems/domaindescriptions.py
+++ b/src/pymor/analyticalproblems/domaindescriptions.py
@@ -279,14 +279,14 @@ class PolygonalDomain(DomainDescription):
     Parameters
     ----------
     points
-        List of points [x_0, x_1] that describe the polygonal chain that bounds the domain.
+        2D |NumPy array| points [x_0, x_1] that describe the polygonal chain that bounds the domain.
     boundary_types
         Either a dictionary `{boundary_type: [i_0, ...], boundary_type: [j_0, ...], ...}`
         with `i_0, ...` being the ids of boundary segments for a given boundary type
         (`0` is the line connecting point `0` to `1`, `1` is the line connecting point `1` to `2`
         etc.), or a function that returns the boundary type for a given coordinate.
     holes
-        List of lists of points that describe the polygonal chains that bound the holes
+        List of 2D |NumPy arrays| of points that describe the polygonal chains that bound the holes
         inside the domain.
 
     Attributes
@@ -299,7 +299,14 @@ class PolygonalDomain(DomainDescription):
     dim = 2
 
     def __init__(self, points, boundary_types, holes=None):
+        points = np.asarray(points)
+        assert points.ndim == 2
+        assert points.shape[-1] == 2
+
         holes = holes or []
+        holes = [np.asarray(h) for h in holes]
+        assert all(h.ndim == 2 for h in holes)
+        assert all(h.shape[-1] == 2 for h in holes)
 
         if isinstance(boundary_types, dict):
             pass

--- a/src/pymor/analyticalproblems/expressions.py
+++ b/src/pymor/analyticalproblems/expressions.py
@@ -60,7 +60,7 @@ builtin_max = max
 
 if np.lib.NumpyVersion(np.__version__) >= '2.0.0':
     NUMPY_COPY_IF_NEEDED = None
-elif np.lib.NumpyVersion(np.__version__) < '1.28.0':
+else:
     NUMPY_COPY_IF_NEEDED = False
 
 

--- a/src/pymor/analyticalproblems/expressions.py
+++ b/src/pymor/analyticalproblems/expressions.py
@@ -58,6 +58,12 @@ from pymor.parameters.base import ParametricObject
 builtin_max = max
 
 
+if np.lib.NumpyVersion(np.__version__) >= '2.0.0':
+    NUMPY_COPY_IF_NEEDED = None
+elif np.lib.NumpyVersion(np.__version__) < '1.28.0':
+    NUMPY_COPY_IF_NEEDED = False
+
+
 def parse_expression(expression, parameters={}, values={}):
     if isinstance(expression, Expression):
         return expression
@@ -300,7 +306,7 @@ class BaseConstant(Expression):
     shape = ()
 
     def numpy_expr(self):
-        return f'array({self.numpy_symbol}, ndmin={len(self.shape)}, copy=False)'
+        return f'array({self.numpy_symbol}, ndmin={len(self.shape)}, copy={NUMPY_COPY_IF_NEEDED})'
 
     def fenics_expr(self, params):
         import ufl

--- a/src/pymor/analyticalproblems/functions.py
+++ b/src/pymor/analyticalproblems/functions.py
@@ -180,7 +180,10 @@ class ConstantFunction(Function):
         return f'{self.name}: x -> {self.value}'
 
     def evaluate(self, x, mu=None):
-        x = np.array(x, copy=False, ndmin=1)
+        x = np.asarray(x)
+        if x.ndim == 0:
+            x.shape = (1,)
+        assert x.ndim > 0
         assert x.shape[-1] == self.dim_domain
         if x.ndim == 1:
             return np.array(self.value)
@@ -234,7 +237,10 @@ class GenericFunction(Function):
 
     def evaluate(self, x, mu=None):
         assert self.parameters.assert_compatible(mu)
-        x = np.array(x, copy=False, ndmin=1)
+        x = np.asarray(x)
+        if x.ndim == 0:
+            x.shape = (1,)
+        assert x.ndim > 0
         assert x.shape[-1] == self.dim_domain
 
         if self.parametric:

--- a/src/pymor/discretizers/builtin/domaindiscretizers/gmsh.py
+++ b/src/pymor/discretizers/builtin/domaindiscretizers/gmsh.py
@@ -70,8 +70,8 @@ def discretize_gmsh(domain_description=None, geo_file=None, geo_file_path=None, 
 
     def discretize_PolygonalDomain():
         # combine points and holes, since holes are points, too, and have to be stored as such.
-        points = [domain_description.points]
-        points.extend(domain_description.holes)
+        points = [domain_description.points.tolist()]
+        points.extend([h.tolist() for h in domain_description.holes])
 
         return points, domain_description.boundary_types
 

--- a/src/pymor/parameters/base.py
+++ b/src/pymor/parameters/base.py
@@ -356,7 +356,9 @@ class Mu(FrozenDict):
                     t = np.zeros(1)
                 vv = v(t)
             else:
-                vv = np.array(v, copy=False, ndmin=1)
+                vv = np.asarray(v)
+                if vv.ndim == 0:
+                    vv.shape = (1,)
                 assert vv.ndim == 1
                 assert k != 't' or len(vv) == 1
             assert not vv.setflags(write=False)


### PR DESCRIPTION
Note that with NumPy 2,

```python
np.array(..., copy=False)
```

will raise an error when a copy cannot be avoided. The old 'avoid copy when possible' can be achieved by setting `copy=None`, which won't be accepted by older NumPys. NumPy recommends using `asarray`, which does not have the `ndmin` parameter.

Fixes #2205.