### PR TITLE
docstring fix for `gram_schmidt`

### DIFF
--- a/src/pymor/algorithms/gram_schmidt.py
+++ b/src/pymor/algorithms/gram_schmidt.py
@@ -50,7 +50,7 @@ def gram_schmidt(A, product=None, return_R=False, atol=1e-13, rtol=1e-13, offset
     Q
         The orthonormalized |VectorArray|.
     R
-        The upper-triangular/trapezoidal matrix (if `compute_R` is `True`).
+        The upper-triangular/trapezoidal matrix (if `return_R` is `True`).
     """
     logger = getLogger('pymor.algorithms.gram_schmidt.gram_schmidt')
 


### PR DESCRIPTION
When renaming the `compute_R` argument to `return_R` one instance was missed in the docstring. This is fixed here. 