### PR TITLE
Flip range_product and source_product args of RandomizedRangeFinder

### DIFF
--- a/src/pymor/algorithms/rand_la.py
+++ b/src/pymor/algorithms/rand_la.py
@@ -60,7 +60,7 @@ class RandomizedRangeFinder(BasicObject):
     """
 
     @defaults('num_testvecs', 'failure_tolerance')
-    def __init__(self, A, source_product=None, range_product=None, A_adj=None,
+    def __init__(self, A, range_product=None, source_product=None, A_adj=None,
                  power_iterations=0, failure_tolerance=1e-15, num_testvecs=20,
                  lambda_min=None, block_size=None, iscomplex=False):
         assert source_product is None or isinstance(source_product, Operator)


### PR DESCRIPTION
The general convention in pyMOR is that the 'left' product should come before the 'right' product in the argument list.