### PR TITLE
Fix version regex for selecting release directories on docs.pymor.org

### DIFF
--- a/.ci/gitlab/docs_update_versions.py
+++ b/.ci/gitlab/docs_update_versions.py
@@ -11,7 +11,7 @@ from pathlib import Path
 base_path = Path('/var/www/docs.pymor.org/')
 
 def versions():
-    pattern = re.compile(r'20\d\d-\d-\d')
+    pattern = re.compile(r'^20\d\d-\d-\d$')
 
     for d in base_path.iterdir():
         if not d.is_dir():


### PR DESCRIPTION
This makes sure that the regex does not match branches containing the version string in their name.