### PR TITLE
Update installation command to be robust in ZSH

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,14 +70,14 @@ Note that most included demo scripts additionally require Qt bindings such as
 `pyside2` to function.
 Therefore we recommend install pyMOR with the `gui` extra:
 
-    pip install pymor[gui]  # 2023.1 and later
+    pip install 'pymor[gui]'  # 2023.1 and later
 
 ### Latest Release (with all Optional Dependencies)
 
 The following installs the latest release of pyMOR on your system with most
 optional dependencies:
 
-    pip install pymor[full]
+    pip install 'pymor[full]'
 
 There are some optional packages not included with `pymor[full]`
 because they need additional setup on your system:

--- a/docs/source/getting_started.md
+++ b/docs/source/getting_started.md
@@ -39,14 +39,14 @@ give pointers to further documentation.
 pyMOR can be installed via `pip`. To follow this guide, pyMOR should be installed with GUI support:
 
 ```bash
-pip install pymor[gui]
+pip install 'pymor[gui]'
 ```
 
 If you follow along in a [Jupyter](https://jupyter.org) notebook, you should install pyMOR using
 the `jupyter` extra:
 
 ```bash
-pip install pymor[jupyter]
+pip install 'pymor[jupyter]'
 ```
 
 We also provide [conda-forge](https://conda-forge.org) packages.


### PR DESCRIPTION
Installation instructions in the `README` and the "Getting started" are written for Bash and are not robust in ZSH (default shell in macOS and also popular with some people who use, say, Ubuntu while working at Uni Münster). For example, the command

```shell
pip install pymor[full]
```
leads to the error `zsh: no matches found: pymor[full]`.

This PR updates the installation instructions so that are compatible with ZSH by enclosing `pymor[full]` and similar with single quotes (for consistency with other instructions in these files).

Closes #2326
Similar to the old issue #1427 