### PR TITLE
Use for visualizer subprocess the parent Python executable

### DIFF
--- a/src/pymor/discretizers/builtin/gui/qt/__init__.py
+++ b/src/pymor/discretizers/builtin/gui/qt/__init__.py
@@ -324,10 +324,7 @@ def visualize_patch(grid, U, bounding_box=([0, 0], [1, 1]), codim=2, title=None,
             with NamedTemporaryFile(mode='wb', delete=False) as f:
                 dump(data, f)
                 filename = f.name
-            # Use python3 executable since python executable is not available
-            # on most system-wide installs.
-            # On windows, use python executable as there is no python3 executable on windows.
-            subprocess.Popen(['python' if is_windows_platform() else 'python3',
+            subprocess.Popen([sys.executable,
                               '-m', 'pymor.scripts.pymor_vis', '--delete', filename])
             return
 
@@ -485,10 +482,7 @@ def visualize_matplotlib_1d(grid, U, codim=1, title=None, legend=None, separate_
             with NamedTemporaryFile(mode='wb', delete=False) as f:
                 dump(data, f)
                 filename = f.name
-            # Use python3 executable since python executable is not available
-            # on most system-wide installs.
-            # On windows, use python executable as there is no python3 executable on windows.
-            subprocess.Popen(['python' if is_windows_platform() else 'python3',
+            subprocess.Popen([sys.executable,
                               '-m', 'pymor.scripts.pymor_vis', '--delete', filename])
             return
 


### PR DESCRIPTION
This PR replaces the logic for choosing the name of the Python executable for the visualization subprocess with simple call to `sys.executable`, which is the path to the running Python executable.

**Why?** Previously, choosing `python` on Windows and `python3` otherwise was a bit prone to the following (edge) case.
I start a script using the `python` command (which is a Conda Python on my Ubuntu machine). Then the visualization is started in a subprocess with the command `python3`. However, on my machine somehow, the Linuxbrew python3 was on the higher priority than the Conda one, which leads to the situation when the visualizer starts with a completely wrong Python executable.