### PR TITLE
Catch all exceptions in config checks and make _init_mpi() more robust

### DIFF
--- a/src/pymor/__init__.py
+++ b/src/pymor/__init__.py
@@ -21,7 +21,10 @@ def _init_mpi():
 
     finalize = os.environ.get('PYMOR_MPI_FINALIZE', mpi4py.rc.finalize if mpi4py.rc.finalize is not None else True)
     mpi4py.rc(initialize=False, finalize=finalize)
-    from mpi4py import MPI
+    try:
+        from mpi4py import MPI
+    except RuntimeError:
+        return
     if not MPI.Is_initialized():
         required_level = int(os.environ.get('PYMOR_MPI_INIT_THREAD', MPI.THREAD_MULTIPLE))
         supported_lvl = MPI.Init_thread(required_level)


### PR DESCRIPTION
- mpi4py is available as a binary wheel on Windows. When no MPI library is installed `import mpi4py.MPI` will fail with a `RuntimeError`. We now catch this error in `pymor._init_mpi()`.

- `pymor.core.config` checks which fail with an exception different from `ImportError` will now longer cause pyMOR to crash. Instead, we set `HAVE_PACKAGE` to `False` and report 'import check failed' to the user.

Fixes #2344.