### PR TITLE
Add arbitrary (inequality) constraints to ParameterSpace

### DIFF
--- a/src/pymor/parameters/base.py
+++ b/src/pymor/parameters/base.py
@@ -600,6 +600,12 @@ class ParameterSpace(ParametricObject):
         - a list/tuple of two numbers specifying these bounds,
         - or a dict of those tuples, specifying upper and lower
           bounds individually for each parameter of the space.
+    constraints
+        If not `None`, a function `constraints(mu) -> bool`
+        defining additional (inequality) constraints on the space.
+        For each given |Mu| that lies within the given `ranges`,
+        `constraints` is called to check if the constraints
+        are satisfied.
     """
 
     def __init__(self, parameters, *ranges, constraints=None):
@@ -623,6 +629,11 @@ class ParameterSpace(ParametricObject):
     def sample_uniformly(self, counts):
         """Uniformly sample |parameter values| from the space.
 
+        In the case of additional :attr:`~ParameterSpace.constraints`, the samples
+        are generated w.r.t. the box constraints specified by
+        :attr:`~ParameterSpace.ranges`, but only those |Mus| are returned, which
+        satisfy the additional constraints.
+
         Parameters
         ----------
         counts
@@ -641,13 +652,13 @@ class ParameterSpace(ParametricObject):
                           for k in self.parameters)
         iters = tuple(product(linspace, repeat=size)
                       for linspace, size in zip(linspaces, self.parameters.values()))
-        unconstrainted_mus = (Mu((k, np.array(v)) for k, v in zip(self.parameters, i))
-                              for i in product(*iters))
+        unconstrained_mus = (Mu((k, np.array(v)) for k, v in zip(self.parameters, i))
+                             for i in product(*iters))
         if self.constraints:
             constraints = self.constraints
-            return [mu for mu in unconstrainted_mus if constraints(mu)]
+            return [mu for mu in unconstrained_mus if constraints(mu)]
         else:
-            return list(unconstrainted_mus)
+            return list(unconstrained_mus)
 
     def sample_randomly(self, count=None):
         """Randomly sample |parameter values| from the space.
@@ -684,6 +695,11 @@ class ParameterSpace(ParametricObject):
     def sample_logarithmic_uniformly(self, counts):
         """Logarithmically uniform sample |parameter values| from the space.
 
+        In the case of additional :attr:`~ParameterSpace.constraints`, the samples
+        are generated w.r.t. the box constraints specified by
+        :attr:`~ParameterSpace.ranges`, but only those |Mus| are returned, which
+        satisfy the additional constraints.
+
         Parameters
         ----------
         counts
@@ -702,13 +718,13 @@ class ParameterSpace(ParametricObject):
                           for k in self.parameters)
         iters = tuple(product(logspace, repeat=size)
                       for logspace, size in zip(logspaces, self.parameters.values()))
-        unconstrainted_mus = (Mu((k, np.array(v)) for k, v in zip(self.parameters, i))
-                              for i in product(*iters))
+        unconstrained_mus = (Mu((k, np.array(v)) for k, v in zip(self.parameters, i))
+                             for i in product(*iters))
         if self.constraints:
             constraints = self.constraints
-            return [mu for mu in unconstrainted_mus if constraints(mu)]
+            return [mu for mu in unconstrained_mus if constraints(mu)]
         else:
-            return list(unconstrainted_mus)
+            return list(unconstrained_mus)
 
     def sample_logarithmic_randomly(self, count=None):
         """Logarithmically scaled random sample |parameter values| from the space.

--- a/src/pymor/parameters/base.py
+++ b/src/pymor/parameters/base.py
@@ -235,16 +235,16 @@ class Parameters(SortedFrozenDict):
 
         return Mu({k: parse_value(k, v) for k, v in mu.items()})
 
-    def space(self, *ranges):
+    def space(self, *ranges, constraints=None):
         """Create a |ParameterSpace| with given ranges.
 
         This is a shorthand for ::
 
-            ParameterSpace(self, *range)
+            ParameterSpace(self, *range, constraints=constraints)
 
-        See |ParameterSpace| for allowed range arguments.
+        See |ParameterSpace| for allowed `range` and `constraints` arguments.
         """
-        return ParameterSpace(self, *ranges)
+        return ParameterSpace(self, *ranges, constraints=constraints)
 
     def assert_compatible(self, mu):
         """Assert that |parameter values| are compatible with the given |Parameters|.

--- a/src/pymor/parameters/base.py
+++ b/src/pymor/parameters/base.py
@@ -603,8 +603,8 @@ class ParameterSpace(ParametricObject):
     constraints
         If not `None`, a function `constraints(mu) -> bool`
         defining additional (inequality) constraints on the space.
-        For each given |Mu| that lies within the given `ranges`,
-        `constraints` is called to check if the constraints
+        For each given |parameter values| that lies within the given
+        `ranges`, `constraints` is called to check if the constraints
         are satisfied.
     """
 
@@ -631,8 +631,8 @@ class ParameterSpace(ParametricObject):
 
         In the case of additional :attr:`~ParameterSpace.constraints`, the samples
         are generated w.r.t. the box constraints specified by
-        :attr:`~ParameterSpace.ranges`, but only those |Mus| are returned, which
-        satisfy the additional constraints.
+        :attr:`~ParameterSpace.ranges`, but only those |parameter values| are returned,
+        which satisfy the additional constraints.
 
         Parameters
         ----------
@@ -697,8 +697,8 @@ class ParameterSpace(ParametricObject):
 
         In the case of additional :attr:`~ParameterSpace.constraints`, the samples
         are generated w.r.t. the box constraints specified by
-        :attr:`~ParameterSpace.ranges`, but only those |Mus| are returned, which
-        satisfy the additional constraints.
+        :attr:`~ParameterSpace.ranges`, but only those |parameter values| are returned,
+        which satisfy the additional constraints.
 
         Parameters
         ----------

--- a/src/pymor/parameters/base.py
+++ b/src/pymor/parameters/base.py
@@ -588,7 +588,7 @@ class ParameterSpace(ParametricObject):
     |parameter values| for given |Parameters| within a specified
     range.
 
-    Parameters
+    Attributes
     ----------
     parameters
         The |Parameters| which are part of the space.

--- a/src/pymortests/parameters/parameters.py
+++ b/src/pymortests/parameters/parameters.py
@@ -178,5 +178,25 @@ def test_mu_t_wrong_value():
         Mu(t=np.array([1, 2]))
 
 
+def test_constraints():
+    const = lambda mu: mu['a'][0] <= mu['b'][0]
+    space = Parameters({'a': 1, 'b': 1}).space(1, 2, constraints=const)
+
+    mus = space.sample_randomly(10)
+    assert len(mus) == 10
+    assert all(const(mu) for mu in mus)
+
+    mus = space.sample_uniformly(10)
+    assert len(mus) == 10*11//2
+
+    mus = space.sample_logarithmic_randomly(10)
+    assert len(mus) == 10
+    assert all(const(mu) for mu in mus)
+
+    mus = space.sample_logarithmic_uniformly(10)
+    assert len(mus) == 10*11//2
+    assert all(const(mu) for mu in mus)
+
+
 if __name__ == '__main__':
     runmodule(filename=__file__)


### PR DESCRIPTION
This adds a `constraints` parameter to `ParameterSpace.__init__` and `Parameters.space`, that allows defining arbitrary inequality constraints in addition to the box constraints specified by the `ranges` parameter. The sampling methods are adapted accordingly.

Fixes #2343.