### PR TITLE
Add print_cached_methods()

### DIFF
--- a/docs/source/technical_overview.rst
+++ b/docs/source/technical_overview.rst
@@ -124,7 +124,8 @@ operating on objects of the following types:
     algorithms for |solving| the given problem, returning |VectorArrays|
     from the |solution_space|. The solution can be |cached|, s.t.
     subsequent solving of the problem for the same |parameter values| reduces
-    to looking up the solution in pyMOR's cache.
+    to looking up the solution in pyMOR's cache. To get an overview, which
+    methods can be cached in pyMOR, use :func:`~pymor.core.cache.print_cached_methods`.
 
     While special model classes may be implemented which make use of
     the specific types of operators they contain (e.g. using some external

--- a/src/pymor/basic.py
+++ b/src/pymor/basic.py
@@ -44,7 +44,7 @@ from pymor.analyticalproblems.helmholtz import helmholtz_problem
 from pymor.analyticalproblems.instationary import InstationaryProblem
 from pymor.analyticalproblems.text import text_problem
 from pymor.analyticalproblems.thermalblock import thermal_block_problem
-from pymor.core.cache import clear_caches, disable_caching, enable_caching
+from pymor.core.cache import clear_caches, disable_caching, enable_caching, print_cached_methods
 from pymor.core.defaults import load_defaults_from_file, print_defaults, set_defaults, write_defaults_to_file
 from pymor.core.exceptions import DependencyMissingError
 from pymor.core.logger import getLogger, set_log_levels

--- a/src/pymortests/core/cache.py
+++ b/src/pymortests/core/cache.py
@@ -125,5 +125,9 @@ def test_memory_region_safety():
     assert len(U) == 1
 
 
+def test_print_cached_methods():
+    cache.print_cached_methods()
+
+
 if __name__ == '__main__':
     runmodule(filename=__file__)


### PR DESCRIPTION
This add a `print_cached_methods()` function which will list all methods in pyMOR that have been decorated with `@cached`. In addition, all subclasses of `CacheableObjects` are listed, for which caching is enabled by default.

Fixes #2337.