### PR TITLE
Improve default behavior of print_defaults

### DIFF
--- a/src/pymor/core/defaults.py
+++ b/src/pymor/core/defaults.py
@@ -264,7 +264,7 @@ def _import_all(package_name='pymor'):
                 logger.warning('Failed to import ' + p[1])
 
 
-def print_defaults(import_all=True, shorten_paths=2):
+def print_defaults(import_all=True, shorten_paths=0):
     """Print all |default| values set in pyMOR.
 
     Parameters

--- a/src/pymor/tools/table.py
+++ b/src/pymor/tools/table.py
@@ -8,6 +8,17 @@ from textwrap import wrap
 import numpy as np
 
 
+def _wrap_entry(entry, width):
+    # simple hack to make wrap break lines on '.' instead of '-'
+    # this is mainly for print_defaults
+    if '°' in entry:
+        raise ValueError
+    entry = entry.replace('-', '°').replace('.', '-')
+    lines = wrap(entry, width, subsequent_indent='  ', break_on_hyphens=True)
+    lines = [l.replace('-', '.').replace('°', '-') for l in lines]
+    return lines
+
+
 def format_table(rows, width='AUTO', title=None):
     rows = [[str(c) for c in r] for r in rows]
     if width == 'AUTO':
@@ -27,7 +38,7 @@ def format_table(rows, width='AUTO', title=None):
 
     wrapped_rows = []
     for row in rows:
-        cols = [wrap(c, width=cw) for c, cw in zip(row, column_widths)]
+        cols = [_wrap_entry(c, width=cw) for c, cw in zip(row, column_widths)]
         for r in zip_longest(*cols, fillvalue=''):
             wrapped_rows.append(r)
     rows = wrapped_rows


### PR DESCRIPTION
- Set the default for `shorten_paths` to zero. This ensures that, by default, users see the exact path that needs to be used in `set_defaults`.
- Hack `format_table` a bit to allow line breaks in long paths at dots.