### PR TITLE
Make sure failed conda tests actually fail the job

### DIFF
--- a/.github/actions/miniconda_tests/action.yml
+++ b/.github/actions/miniconda_tests/action.yml
@@ -76,14 +76,14 @@ runs:
         fi
         echo "QT_DEBUG_PLUGINS=1" >> $GITHUB_ENV
     - name: Sanity check
-      shell: bash -l {0}
+      shell: bash -el {0}
       run: |
         ${PYTEST_PREFIX} python -c "from matplotlib.pyplot import *"
         ${PYTEST_PREFIX} python -c "from qtpy.QtGui import *"
         ${PYTEST_PREFIX} python -c "import OpenGL"
         ${PYTEST_PREFIX} python -c "import OpenGL.GL as gl"
     - name: Run pytest
-      shell: bash -l {0}
+      shell: bash -el {0}
       env:
         PYTHONPATH: ./src
         PYMOR_HYPOTHESIS_PROFILE: ${{ inputs.hypothesis_profile }}

--- a/src/pymortests/algorithms/samdp.py
+++ b/src/pymortests/algorithms/samdp.py
@@ -7,6 +7,7 @@ import pytest
 import scipy.sparse as sps
 
 from pymor.algorithms.samdp import samdp
+from pymor.core.exceptions import InversionError
 from pymor.operators.numpy import NumpyMatrixOperator
 
 pytestmark = pytest.mark.builtin
@@ -61,7 +62,11 @@ def test_samdp(n, m, k, wanted, with_E, which, rng):
     Bva = Aop.source.from_numpy(B.T)
     Cva = Aop.source.from_numpy(C)
 
-    dom_poles, dom_res, dom_rev, dom_lev = samdp(Aop, Eop, Bva, Cva, wanted, which=which)
+    try:
+        dom_poles, dom_res, dom_rev, dom_lev = samdp(Aop, Eop, Bva, Cva, wanted, which=which)
+    except InversionError:
+        import pytest
+        pytest.xfail('Known issue. See #2366')
 
     # check if we computed correct eigenvalues
     if not with_E:

--- a/src/pymortests/reductors/mt.py
+++ b/src/pymortests/reductors/mt.py
@@ -4,6 +4,7 @@
 
 import pytest
 
+from pymor.core.exceptions import InversionError
 from pymor.models.examples import penzl_mimo_example
 from pymor.models.iosys import LTIModel
 from pymor.reductors.mt import MTReductor
@@ -33,6 +34,12 @@ def test_mt(r, mt_kwargs):
     fom = penzl_mimo_example(10)
     mt = MTReductor(fom)
 
-    rom = mt.reduce(r, **mt_kwargs)
+    try:
+        rom = mt.reduce(r, **mt_kwargs)
+    except InversionError as e:
+        if mt_kwargs.get('decomposition', 'samdp') == 'samdp':
+            import pytest
+            pytest.xfail('Known issue. See #2366')
+        raise e
     assert isinstance(rom, LTIModel)
     assert rom.order == r


### PR DESCRIPTION
For a while now, all conda tests silently fail:

https://github.com/pymor/pymor/actions/runs/10944510114/job/30386549312?pr=2359

This PR fixes this by adding the '-e' shell option where a shell is explicitly specified in the job description.