### PR TITLE
No longer support time-dependent parameter values

### DIFF
--- a/src/pymor/algorithms/error.py
+++ b/src/pymor/algorithms/error.py
@@ -163,6 +163,8 @@ def reduction_error_analysis(rom, fom, reductor, test_mus,
     assert custom_names is None or (custom and len(custom_names) == len(custom))
     assert not condition \
         or isinstance(rom, StationaryModel) and rom.operator.linear
+    if rom.dim_input > 0:
+        raise NotImplementedError
 
     logger = getLogger('pymor.algorithms.error')
     if pool is None or pool is dummy_pool:

--- a/src/pymor/analyticalproblems/functions.py
+++ b/src/pymor/analyticalproblems/functions.py
@@ -195,6 +195,9 @@ class ConstantFunction(Function):
         from dolfin import Constant
         return np.vectorize(Constant)(self.value), {}
 
+    def _cache_key_reduce(self):
+        return (self.value, self.dim_domain)
+
 
 class GenericFunction(Function):
     """Wrapper making an arbitrary Python function between |NumPy arrays| a proper |Function|.

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -667,7 +667,7 @@ class LTIModel(Model):
         if E is not None:
             _mmwrite(Path(files_basename + '.E'), E)
 
-    def _compute(self, quantities, data, mu):
+    def _compute(self, quantities, data, mu, input):
         if 'solution' in quantities or 'output' in quantities:
             assert self.T is not None
 
@@ -680,9 +680,9 @@ class LTIModel(Model):
                 self.T,  # end_time
                 self.initial_data.as_range_array(mu),  # initial_data
                 -self.A,  # operator
-                rhs=LinearInputOperator(self.B),
+                rhs=LinearInputOperator(self.B, input),
                 mass=None if isinstance(self.E, IdentityOperator) else self.E,
-                mu=mu.with_(t=0),
+                mu=mu,
                 num_values=self.num_values
             )
             if self.num_values is None:
@@ -696,7 +696,7 @@ class LTIModel(Model):
             if compute_solution:
                 data['solution'] = self.solution_space.empty(reserve=n)
             if compute_output:
-                D = LinearInputOperator(self.D)
+                D = LinearInputOperator(self.D, input)
                 data['output'] = np.empty((n, self.dim_output))
                 data_output_extra = []
             for i, (x, t) in enumerate(iterator):
@@ -719,7 +719,7 @@ class LTIModel(Model):
             if compute_output:
                 quantities.remove('output')
 
-        super()._compute(quantities, data, mu=mu)
+        super()._compute(quantities, data, mu=mu, input=input)
 
     def __add__(self, other):
         """Add an |LTIModel|."""

--- a/src/pymor/models/neural_network.py
+++ b/src/pymor/models/neural_network.py
@@ -99,7 +99,7 @@ class NeuralNetworkModel(BaseNeuralNetworkModel):
         assert self.output_functional.source == self.solution_space
         self.dim_output = self.output_functional.range.dim
 
-    def _compute(self, quantities, data, mu):
+    def _compute(self, quantities, data, mu, input):
         if 'solution' in quantities:
             # convert the parameter `mu` into a form that is usable in PyTorch
             converted_input = torch.DoubleTensor(mu.to_numpy())
@@ -113,7 +113,7 @@ class NeuralNetworkModel(BaseNeuralNetworkModel):
             data['solution'] = U
             quantities.remove('solution')
 
-        super()._compute(quantities, data, mu=mu)
+        super()._compute(quantities, data, mu, input)
 
 
 class NeuralNetworkStatefreeOutputModel(BaseNeuralNetworkModel):
@@ -155,7 +155,7 @@ class NeuralNetworkStatefreeOutputModel(BaseNeuralNetworkModel):
 
         self.__auto_init(locals())
 
-    def _compute(self, quantities, data, mu):
+    def _compute(self, quantities, data, mu, input):
         if 'output' in quantities:
             converted_input = torch.from_numpy(mu.to_numpy()).double()
             converted_input = self._scale_input(converted_input)
@@ -166,7 +166,7 @@ class NeuralNetworkStatefreeOutputModel(BaseNeuralNetworkModel):
             data['output'] = output
             quantities.remove('output')
 
-        super()._compute(quantities, data, mu=mu)
+        super()._compute(quantities, data, mu, input)
 
 
 class NeuralNetworkInstationaryModel(BaseNeuralNetworkModel):
@@ -232,7 +232,7 @@ class NeuralNetworkInstationaryModel(BaseNeuralNetworkModel):
         assert output_functional.source == self.solution_space
         self.dim_output = output_functional.range.dim
 
-    def _compute(self, quantities, data, mu):
+    def _compute(self, quantities, data, mu, input):
         if 'solution' in quantities:
             # collect all inputs in a single tensor
             inputs = self._scale_input(torch.DoubleTensor(np.array([mu.with_(t=t).to_numpy()
@@ -244,7 +244,7 @@ class NeuralNetworkInstationaryModel(BaseNeuralNetworkModel):
             data['solution'] = self.solution_space.make_array(result)
             quantities.remove('solution')
 
-        super()._compute(quantities, data, mu=mu)
+        super()._compute(quantities, data, mu, input)
 
 
 class NeuralNetworkInstationaryStatefreeOutputModel(BaseNeuralNetworkModel):
@@ -290,7 +290,7 @@ class NeuralNetworkInstationaryStatefreeOutputModel(BaseNeuralNetworkModel):
 
         self.__auto_init(locals())
 
-    def _compute(self, quantities, data, mu):
+    def _compute(self, quantities, data, mu, input):
         if 'output' in quantities:
             inputs = self._scale_input(torch.DoubleTensor(np.array([mu.with_(t=t).to_numpy()
                                                                     for t in np.linspace(0., self.T, self.nt)])))
@@ -301,7 +301,7 @@ class NeuralNetworkInstationaryStatefreeOutputModel(BaseNeuralNetworkModel):
             data['output'] = outputs
             quantities.remove('output')
 
-        super()._compute(quantities, data, mu=mu)
+        super()._compute(quantities, data, mu, input)
 
 
 class FullyConnectedNN(nn.Module, BasicObject):

--- a/src/pymor/operators/constructions.py
+++ b/src/pymor/operators/constructions.py
@@ -1437,21 +1437,28 @@ class LinearInputOperator(Operator):
     ----------
     B
         The input |Operator|.
+    input
+        The input |Function|.
     """
 
     linear = True
 
-    def __init__(self, B):
-        self.B = B
+    def __init__(self, B, input):
+        assert (B.source.dim,) == input.shape_range
+        self.__auto_init(locals())
         self.source = NumpyVectorSpace(1)
         self.range = B.range
-        self.parameters_own = {'input': B.source.dim}
+        self.parameters_own = {'t': 1}
 
     def apply(self, U, mu=None):
-        return self.B.as_range_array(mu).lincomb(U.to_numpy() * mu['input'])
+        assert U in self.source
+        B_ut = self.as_range_array(mu)
+        return B_ut.lincomb(U.to_numpy())
 
     def as_range_array(self, mu=None):
-        return self.B.as_range_array(mu).lincomb(mu['input'])
+        assert self.parameters.assert_compatible(mu)
+        inp = self.B.source.from_numpy(self.input(mu['t']))
+        return self.B.apply(inp, mu=mu)
 
 
 class QuadraticFunctional(Operator):

--- a/src/pymor/parameters/base.py
+++ b/src/pymor/parameters/base.py
@@ -269,7 +269,8 @@ class Mu(FrozenDict):
 
     def __new__(cls, *args, **kwargs):
         values = dict(*args, **kwargs)
-        for k, v in sorted(values.items()):
+
+        def process_value(k, v):
             assert isinstance(k, str)
             vv = np.asarray(v)
             if vv.ndim == 0:
@@ -277,8 +278,11 @@ class Mu(FrozenDict):
             assert vv.ndim == 1
             assert k != 't' or len(vv) == 1
             assert not vv.setflags(write=False)
+            return vv
 
-        mu = super().__new__(cls, values)
+        processed_values = {k: process_value(k, v) for k, v in sorted(values.items())}
+
+        mu = super().__new__(cls, processed_values)
         return mu
 
     def with_(self, **kwargs):

--- a/src/pymor/parameters/base.py
+++ b/src/pymor/parameters/base.py
@@ -133,10 +133,10 @@ class Parameters(SortedFrozenDict):
             set(mu) == set(self) or fail(f'additional parameters {set(mu) - set(self)}')
             return mu
 
-        # convert mu to dict
         if isinstance(mu, Number):
             mu = [mu]
-        elif isinstance(mu, (tuple, list, np.ndarray)):
+
+        if isinstance(mu, (tuple, list, np.ndarray)):
             if isinstance(mu, np.ndarray):
                 mu = mu.ravel()
             all(isinstance(v, Number) for v in mu) or fail('not every element a number')

--- a/src/pymor/parameters/base.py
+++ b/src/pymor/parameters/base.py
@@ -442,6 +442,10 @@ class ParametricObject(ImmutableObject):
     def parametric(self):
         return bool(self.parameters)
 
+    @property
+    def is_time_dependent(self):
+        return 't' in self.parameters
+
     def __check_parameter_consistency(self):
         if self._parameters_internal is not None:
             if self._parameters is not None:

--- a/src/pymor/reductors/coercive.py
+++ b/src/pymor/reductors/coercive.py
@@ -77,16 +77,16 @@ class CoerciveRBEstimator(ImmutableObject):
     def __init__(self, residual, residual_range_dims, coercivity_estimator, projected_output_adjoint=None):
         self.__auto_init(locals())
 
-    def estimate_error(self, U, mu, m):
+    def estimate_error(self, U, mu, input, m):
         est = self.residual.apply(U, mu=mu).norm()
         if self.coercivity_estimator:
             est /= self.coercivity_estimator(mu)
         return est
 
-    def estimate_output_error(self, U, mu, m):
+    def estimate_output_error(self, U, mu, input, m):
         if self.projected_output_adjoint is None:
             raise NotImplementedError
-        estimate = self.estimate_error(U, mu, m)
+        estimate = self.estimate_error(U, mu, input, m)
         # scale with dual norm of the output functional
         output_functional_norms = self.projected_output_adjoint.as_range_array(mu).norm()
         errs = estimate * output_functional_norms
@@ -262,7 +262,7 @@ class SimpleCoerciveRBEstimator(ImmutableObject):
         self.__auto_init(locals())
         self.norm = induced_norm(estimator_matrix)
 
-    def estimate_error(self, U, mu, m):
+    def estimate_error(self, U, mu, input, m):
         if len(U) > 1:
             raise NotImplementedError
         if not m.rhs.parametric:
@@ -283,10 +283,10 @@ class SimpleCoerciveRBEstimator(ImmutableObject):
 
         return est
 
-    def estimate_output_error(self, U, mu, m):
+    def estimate_output_error(self, U, mu, input, m):
         if not self.output_estimator_matrices or not self.output_functional_coeffs:
             raise NotImplementedError
-        estimate = self.estimate_error(U, mu, m)
+        estimate = self.estimate_error(U, mu, input, m)
         # scale with dual norm of the output functional
         coeff_vals = np.array([c.evaluate(mu) for c in self.output_functional_coeffs])
         dual_norms = []

--- a/src/pymor/reductors/dwr.py
+++ b/src/pymor/reductors/dwr.py
@@ -220,15 +220,15 @@ class DWRCoerciveRBEstimator(ImmutableObject):
     def __init__(self, primal_estimator, dual_estimators, dual_models):
         self.__auto_init(locals())
 
-    def estimate_error(self, U, mu, m):
-        return self.primal_estimator.estimate_error(U, mu, m)
+    def estimate_error(self, U, mu, input, m):
+        return self.primal_estimator.estimate_error(U, mu, input, m)
 
-    def estimate_output_error(self, U, mu, m):
-        est_pr = self.estimate_error(U, mu, m).item()
+    def estimate_output_error(self, U, mu, input, m):
+        est_pr = self.estimate_error(U, mu, input, m).item()
         est_dus = []
         for d in range(m.dim_output):
             dual_solution = self.dual_models[d].solve(mu)
-            est_dus.append(self.dual_estimators[d].estimate_error(dual_solution, mu, m).item())
+            est_dus.append(self.dual_estimators[d].estimate_error(dual_solution, mu, input, m).item())
         ret = est_pr * np.array(est_dus).reshape((1, -1))
         return ret
 

--- a/src/pymor/reductors/parabolic.py
+++ b/src/pymor/reductors/parabolic.py
@@ -111,7 +111,7 @@ class ParabolicRBEstimator(ImmutableObject):
                  coercivity_estimator, projected_output_adjoint=None):
         self.__auto_init(locals())
 
-    def estimate_error(self, U, mu, m):
+    def estimate_error(self, U, mu, input, m):
         dt = m.T / m.time_stepper.nt
         C = self.coercivity_estimator(mu) if self.coercivity_estimator else 1.
 
@@ -130,10 +130,10 @@ class ParabolicRBEstimator(ImmutableObject):
 
         return est
 
-    def estimate_output_error(self, U, mu, m):
+    def estimate_output_error(self, U, mu, input, m):
         if self.projected_output_adjoint is None:
             raise NotImplementedError
-        estimate = self.estimate_error(U, mu, m)
+        estimate = self.estimate_error(U, mu, input, m)
         # scale with dual norm of the output functional
         output_functional_norms = self.projected_output_adjoint.as_range_array(mu).norm()
         errs = estimate[:, np.newaxis] * output_functional_norms[np.newaxis, :]

--- a/src/pymortests/parameters/parameters.py
+++ b/src/pymortests/parameters/parameters.py
@@ -7,7 +7,6 @@ import pytest
 from hypothesis import given
 
 import pymortests.strategies as pyst
-from pymor.analyticalproblems.functions import ConstantFunction
 from pymor.parameters.base import Mu, Parameters
 from pymortests.base import runmodule
 
@@ -90,18 +89,6 @@ def test_parse_parameter():
     assert mu_as_list == mu_as_parameter_and_back
 
 
-def test_parse_parameter_time_dep():
-    parameters = Parameters(b=2, a=1)
-    mu = parameters.parse([7, 't**2', 't[0]'])
-    assert list(mu.with_(t=3)['a']) == [7]
-    assert list(mu.with_(t=3)['b']) == [9, 3]
-
-
-def test_parse_parameter_scalar_time_dep():
-    parameters = Parameters(a=1)
-    parameters.parse(ConstantFunction(np.ones(1)))
-
-
 @given(pyst.mus)
 def test_parse_mu(mu):
     parameters = mu.parameters
@@ -147,8 +134,6 @@ def test_mu_algebra(mu):
 
 
 def test_mu_t_wrong_value():
-    with pytest.raises(Exception):
-        Mu(t=ConstantFunction(np.array([3])))
     with pytest.raises(Exception):
         Mu(t=np.array([1, 2]))
 

--- a/src/pymortests/parameters/parameters.py
+++ b/src/pymortests/parameters/parameters.py
@@ -124,31 +124,6 @@ def test_mu_values(mu):
 
 
 @given(pyst.mus)
-def test_mu_time_dependent(mu):
-    for param in mu:
-        func = mu.get_time_dependent_value(param)
-        if mu.is_time_dependent(param):
-            assert np.all(mu[param] == func(mu.get('t', 0)))
-        else:
-            assert isinstance(func, ConstantFunction)
-            assert np.all(mu[param] == func.value)
-
-
-@given(pyst.mus)
-def test_mu_with_changed_time(mu):
-    mu2 = mu.with_(t=42)
-    for param in mu:
-        if param == 't':
-            assert mu2['t'].item() == 42
-            continue
-        func = mu.get_time_dependent_value(param)
-        if mu.is_time_dependent(param):
-            assert np.all(mu2[param] == func(42))
-        else:
-            assert np.all(mu[param] == mu2[param])
-
-
-@given(pyst.mus)
 def test_mu_to_numpy(mu):
     mu_array = mu.to_numpy()
     mu2 = mu.parameters.parse(mu_array)

--- a/src/pymortests/strategies.py
+++ b/src/pymortests/strategies.py
@@ -9,7 +9,6 @@ from hypothesis import strategies as hyst
 from hypothesis.extra import numpy as hynp
 from scipy.stats import random_correlation
 
-from pymor.analyticalproblems.functions import ConstantFunction, ExpressionFunction, Function
 from pymor.core.config import config
 from pymor.parameters.base import Mu, Parameters
 from pymor.vectorarrays.block import BlockVectorSpace
@@ -524,8 +523,5 @@ mus = hyst.dictionaries(
     values=hyst.sampled_from([
         np.array([1.]),
         np.array([1., 32., 3]),
-        ExpressionFunction('x+1', 1),
-        ExpressionFunction('[1., 0] * x + [0, 1.] * x**2', 1),
-        ConstantFunction(np.array([1., 2, 3]))
     ])
-).filter(lambda mu: 't' not in mu or (not isinstance(mu['t'], Function) and len(mu['t']) == 1)).map(Mu)
+).filter(lambda mu: 't' not in mu or len(mu['t']) == 1).map(Mu)


### PR DESCRIPTION
This PR removes support for time-dependent parameter values (`mus`) from pyMOR. 

As a consequence, inputs are no longer treated internally as time-dependent parameter values but simply as `Functions`, mapping time to some vector. It is up to `Model.compute` to do something reasonable with it.

Reasons for the removal:
- I want to simplify the concept of parameter values to make it simple enough for inclusion into NiAS.
- The current implementation with `Mu.get_time_depenent_values` and friends is complicated and error prone. It is undesirable surprising behavior that `mu.with_(t=new_value)` magically changes other values as well.
- Even though I argued in a different direction before, I think it is conceptually clearer to say that parameter values are fixed numbers and only inputs can be functions of time, than saying that everything is a parameter value.

Changes:
- `Mus` can no longer depend on time.
- add `ParametricObject.is_time_dependent` as an alias for `'t' in obj.parameters`.
- `_compute` and related methods, as well as `estimate` methods of error estimators gain `input` as a parameter.
- `Models.interact` has been updated accordingly.

Notes:
- I am still unsure how to proceed with `StationaryModel`. With the new distinction between parameters and inputs, some clarification is needed what an input is. Is it always a function of time? Can `StationaryModel` have an input?
Should there be a separate `Model` interface for the stationary case that does not accept any inputs?  Should every time-dependent `Model` like `InstationaryModel` accept an input or do we want an `IOModel` base class?
- To bring back 'time-dependent parameters', I am planning to have a `TimeParameterizedOperator`, which accepts  parameter-dependent functions of time, which maps a `mu` with values for these parameters and `t` to the values of these functions for `t`. The result is passed to a wrapped operator. This would be a generic way to transform arbitrary `Models` to time-parameterized `Models`.