### PR TITLE
Time stepping backwards in time

### DIFF
--- a/src/pymor/algorithms/timestepping.py
+++ b/src/pymor/algorithms/timestepping.py
@@ -60,8 +60,10 @@ class TimeStepper(ImmutableObject):
             The time at which to begin time-stepping.
         end_time
             The time until which to perform time-stepping.
-            The end time is also allowed to be smaller than the
-            initial time which results in backwards time stepping.
+            The end time is also allowed to be smaller than the initial time
+            which results in solving the corresponding terminal value problem,
+            i.e. `initial_data` serves as terminal data in this case and is
+            also stored first in the resulting |VectorArray|.
         initial_data
             The solution vector at `initial_time`.
         operator
@@ -108,8 +110,10 @@ class TimeStepper(ImmutableObject):
             The time at which to begin time-stepping.
         end_time
             The time until which to perform time-stepping.
-            The end time is also allowed to be smaller than the
-            initial time which results in backwards time stepping.
+            The end time is also allowed to be smaller than the initial time
+            which results in solving the corresponding terminal value problem,
+            i.e. `initial_data` serves as terminal data in this case and is
+            also stored first in the resulting |VectorArray|.
         initial_data
             The solution vector at `initial_time`.
         operator

--- a/src/pymor/algorithms/timestepping.py
+++ b/src/pymor/algorithms/timestepping.py
@@ -204,9 +204,7 @@ class ImplicitEulerTimeStepper(TimeStepper):
         if mu is None:
             mu = Mu()
 
-        sign = 1
-        if initial_time > end_time:
-            sign = -1
+        sign = np.sign(end_time - initial_time)
 
         for n in range(nt):
             t += dt
@@ -282,9 +280,7 @@ class ExplicitEulerTimeStepper(TimeStepper):
         if mu is None:
             mu = Mu()
 
-        sign = 1
-        if initial_time > end_time:
-            sign = -1
+        sign = np.sign(end_time - initial_time)
 
         if F is None:
             for n in range(nt):
@@ -390,9 +386,7 @@ class ImplicitMidpointTimeStepper(TimeStepper):
         if mu is None:
             mu = Mu()
 
-        sign = 1
-        if initial_time > end_time:
-            sign = -1
+        sign = np.sign(end_time - initial_time)
 
         for n in range(nt):
             mu = mu.with_(t=t + dt/2)

--- a/src/pymor/algorithms/timestepping.py
+++ b/src/pymor/algorithms/timestepping.py
@@ -60,6 +60,8 @@ class TimeStepper(ImmutableObject):
             The time at which to begin time-stepping.
         end_time
             The time until which to perform time-stepping.
+            The end time is also allowed to be smaller than the
+            initial time which results in backwards time stepping.
         initial_data
             The solution vector at `initial_time`.
         operator
@@ -106,6 +108,8 @@ class TimeStepper(ImmutableObject):
             The time at which to begin time-stepping.
         end_time
             The time until which to perform time-stepping.
+            The end time is also allowed to be smaller than the
+            initial time which results in backwards time stepping.
         initial_data
             The solution vector at `initial_time`.
         operator

--- a/src/pymortests/algorithms/timestepping.py
+++ b/src/pymortests/algorithms/timestepping.py
@@ -12,32 +12,36 @@ operator = fom.operator
 rhs = fom.rhs
 mass = fom.mass
 
-time_stepper = ImplicitEulerTimeStepper(nt)
 
-U = time_stepper.solve(initial_time, end_time, initial_data, operator, rhs=rhs, mass=mass)
+def test_implicit_euler():
+    time_stepper = ImplicitEulerTimeStepper(nt)
 
-U_backwards = time_stepper.solve(end_time, initial_time, initial_data, operator, rhs=rhs, mass=-mass)
+    U = time_stepper.solve(initial_time, end_time, initial_data, operator, rhs=rhs, mass=mass)
 
-assert np.all((U - U_backwards).norm() <= 1e-12)
+    U_backwards = time_stepper.solve(end_time, initial_time, initial_data, operator, rhs=rhs, mass=-mass)
 
-
-time_stepper = ImplicitMidpointTimeStepper(nt)
-
-U = time_stepper.solve(initial_time, end_time, initial_data, operator, rhs=rhs, mass=mass)
-
-U_backwards = time_stepper.solve(end_time, initial_time, initial_data, operator, rhs=rhs, mass=-mass)
-
-assert np.all((U - U_backwards).norm() <= 1e-12)
+    assert np.all((U - U_backwards).norm() <= 1e-12)
 
 
-time_stepper = DiscreteTimeStepper()
+def test_implicit_midpoint():
+    time_stepper = ImplicitMidpointTimeStepper(nt)
 
-initial_time = 0
-end_time = 10
-dt = 1. / (end_time - initial_time)
+    U = time_stepper.solve(initial_time, end_time, initial_data, operator, rhs=rhs, mass=mass)
 
-U = time_stepper.solve(initial_time, end_time, initial_data, dt * operator, rhs=dt * rhs, mass=mass)
+    U_backwards = time_stepper.solve(end_time, initial_time, initial_data, operator, rhs=rhs, mass=-mass)
 
-U_backwards = time_stepper.solve(end_time, initial_time, initial_data, dt * operator, rhs=dt * rhs, mass=-mass)
+    assert np.all((U - U_backwards).norm() <= 1e-12)
 
-assert np.all((U - U_backwards).norm() <= 1e-12)
+
+def test_discrete():
+    time_stepper = DiscreteTimeStepper()
+
+    initial_time = 0
+    end_time = 10
+    dt = 1. / (end_time - initial_time)
+
+    U = time_stepper.solve(initial_time, end_time, initial_data, dt * operator, rhs=dt * rhs, mass=mass)
+
+    U_backwards = time_stepper.solve(end_time, initial_time, initial_data, dt * operator, rhs=dt * rhs, mass=-mass)
+
+    assert np.all((U - U_backwards).norm() <= 1e-12)

--- a/src/pymortests/algorithms/timestepping.py
+++ b/src/pymortests/algorithms/timestepping.py
@@ -34,9 +34,10 @@ time_stepper = DiscreteTimeStepper()
 
 initial_time = 0
 end_time = 10
-U = time_stepper.solve(initial_time, end_time, initial_data, operator, rhs=rhs, mass=mass)
+dt = 1. / (end_time - initial_time)
 
-U_backwards = time_stepper.solve(initial_time, end_time, initial_data, operator, rhs=rhs, mass=mass,
-                                 backwards_in_time=True)
+U = time_stepper.solve(initial_time, end_time, initial_data, dt * operator, rhs=dt * rhs, mass=mass)
+
+U_backwards = time_stepper.solve(end_time, initial_time, initial_data, dt * operator, rhs=dt * rhs, mass=-mass)
 
 assert np.all((U - U_backwards).norm() <= 1e-12)

--- a/src/pymortests/algorithms/timestepping.py
+++ b/src/pymortests/algorithms/timestepping.py
@@ -1,0 +1,44 @@
+import numpy as np
+
+from pymor.algorithms.timestepping import DiscreteTimeStepper, ImplicitEulerTimeStepper, ImplicitMidpointTimeStepper
+from pymor.models.examples import heat_equation_non_parametric_example
+
+nt = 10
+initial_time = 0.
+end_time = 1.
+fom = heat_equation_non_parametric_example(diameter=1., nt=nt)
+initial_data = fom.initial_data.as_range_array()
+operator = fom.operator
+rhs = fom.rhs
+mass = fom.mass
+
+time_stepper = ImplicitEulerTimeStepper(nt)
+
+U = time_stepper.solve(initial_time, end_time, initial_data, operator, rhs=rhs, mass=mass)
+
+U_backwards = time_stepper.solve(initial_time, end_time, initial_data, operator, rhs=rhs, mass=-mass,
+                                 backwards_in_time=True)
+
+assert np.all((U - U_backwards).norm() <= 1e-12)
+
+
+time_stepper = ImplicitMidpointTimeStepper(nt)
+
+U = time_stepper.solve(initial_time, end_time, initial_data, operator, rhs=rhs, mass=mass)
+
+U_backwards = time_stepper.solve(initial_time, end_time, initial_data, operator, rhs=rhs, mass=-mass,
+                                 backwards_in_time=True)
+
+assert np.all((U - U_backwards).norm() <= 1e-12)
+
+
+time_stepper = DiscreteTimeStepper()
+
+initial_time = 0
+end_time = 10
+U = time_stepper.solve(initial_time, end_time, initial_data, operator, rhs=rhs, mass=mass)
+
+U_backwards = time_stepper.solve(initial_time, end_time, initial_data, operator, rhs=rhs, mass=mass,
+                                 backwards_in_time=True)
+
+assert np.all((U - U_backwards).norm() <= 1e-12)

--- a/src/pymortests/algorithms/timestepping.py
+++ b/src/pymortests/algorithms/timestepping.py
@@ -12,25 +12,34 @@ operator = fom.operator
 rhs = fom.rhs
 mass = fom.mass
 
+tol = 1e-12
+num_values = 19
+
 
 def test_implicit_euler():
     time_stepper = ImplicitEulerTimeStepper(nt)
 
     U = time_stepper.solve(initial_time, end_time, initial_data, operator, rhs=rhs, mass=mass)
-
     U_backwards = time_stepper.solve(end_time, initial_time, initial_data, operator, rhs=rhs, mass=-mass)
+    assert np.all((U - U_backwards).norm() <= tol)
 
-    assert np.all((U - U_backwards).norm() <= 1e-12)
+    U = time_stepper.solve(initial_time, end_time, initial_data, operator, rhs=rhs, mass=mass, num_values=num_values)
+    U_backwards = time_stepper.solve(end_time, initial_time, initial_data, operator, rhs=rhs, mass=-mass,
+                                     num_values=num_values)
+    assert np.all((U - U_backwards).norm() <= tol)
 
 
 def test_implicit_midpoint():
     time_stepper = ImplicitMidpointTimeStepper(nt)
 
     U = time_stepper.solve(initial_time, end_time, initial_data, operator, rhs=rhs, mass=mass)
-
     U_backwards = time_stepper.solve(end_time, initial_time, initial_data, operator, rhs=rhs, mass=-mass)
+    assert np.all((U - U_backwards).norm() <= tol)
 
-    assert np.all((U - U_backwards).norm() <= 1e-12)
+    U = time_stepper.solve(initial_time, end_time, initial_data, operator, rhs=rhs, mass=mass, num_values=num_values)
+    U_backwards = time_stepper.solve(end_time, initial_time, initial_data, operator, rhs=rhs, mass=-mass,
+                                     num_values=num_values)
+    assert np.all((U - U_backwards).norm() <= tol)
 
 
 def test_discrete():
@@ -41,7 +50,11 @@ def test_discrete():
     dt = 1. / (end_time - initial_time)
 
     U = time_stepper.solve(initial_time, end_time, initial_data, dt * operator, rhs=dt * rhs, mass=mass)
-
     U_backwards = time_stepper.solve(end_time, initial_time, initial_data, dt * operator, rhs=dt * rhs, mass=-mass)
+    assert np.all((U - U_backwards).norm() <= tol)
 
-    assert np.all((U - U_backwards).norm() <= 1e-12)
+    U = time_stepper.solve(initial_time, end_time, initial_data, dt * operator, rhs=dt * rhs, mass=mass,
+                           num_values=num_values)
+    U_backwards = time_stepper.solve(end_time, initial_time, initial_data, dt * operator, rhs=dt * rhs, mass=-mass,
+                                     num_values=num_values)
+    assert np.all((U - U_backwards).norm() <= tol)

--- a/src/pymortests/algorithms/timestepping.py
+++ b/src/pymortests/algorithms/timestepping.py
@@ -16,8 +16,7 @@ time_stepper = ImplicitEulerTimeStepper(nt)
 
 U = time_stepper.solve(initial_time, end_time, initial_data, operator, rhs=rhs, mass=mass)
 
-U_backwards = time_stepper.solve(initial_time, end_time, initial_data, operator, rhs=rhs, mass=-mass,
-                                 backwards_in_time=True)
+U_backwards = time_stepper.solve(end_time, initial_time, initial_data, operator, rhs=rhs, mass=-mass)
 
 assert np.all((U - U_backwards).norm() <= 1e-12)
 
@@ -26,8 +25,7 @@ time_stepper = ImplicitMidpointTimeStepper(nt)
 
 U = time_stepper.solve(initial_time, end_time, initial_data, operator, rhs=rhs, mass=mass)
 
-U_backwards = time_stepper.solve(initial_time, end_time, initial_data, operator, rhs=rhs, mass=-mass,
-                                 backwards_in_time=True)
+U_backwards = time_stepper.solve(end_time, initial_time, initial_data, operator, rhs=rhs, mass=-mass)
 
 assert np.all((U - U_backwards).norm() <= 1e-12)
 


### PR DESCRIPTION
Resolves #2310.

Time stepping backwards is now possible by choosing a larger `initial_time` compared to the `end_time`.