### PR TITLE
scikit-fem: Fix boundary handling for 1.13 <= scipy < 1.15

### DIFF
--- a/src/pymor/discretizers/skfem/cg.py
+++ b/src/pymor/discretizers/skfem/cg.py
@@ -45,11 +45,14 @@ class SKFemBilinearFormOperator(NumpyMatrixBasedOperator):
                 from scipy.sparse import SparseEfficiencyWarning
                 warnings.filterwarnings('ignore', category=SparseEfficiencyWarning)
 
-                # see https://github.com/scipy/scipy/issues/21791
                 if parse('1.15.0') > parse(config.SCIPY_VERSION) >= parse('1.13.0'):
+                    # see https://github.com/scipy/scipy/issues/21791
                     A = A.tocoo()
                     A.setdiag(A.diagonal())
                     A = A.tocsr()
+                else:
+                    # avoid index errors in enforce
+                    A.setdiag(A.diagonal())
 
                 enforce(A, D=self.dirichlet_dofs, diag=0. if self.dirichlet_clear_diag else 1., overwrite=True)
         return A

--- a/src/pymortests/bindings/skfem.py
+++ b/src/pymortests/bindings/skfem.py
@@ -34,13 +34,7 @@ def test_skfem1d():
 
 @skip_if_missing('SCIKIT_FEM')
 def test_skfem2d():
-    from packaging.version import parse
-
-    from pymor.core.config import config
     from pymor.discretizers.skfem.cg import discretize_stationary_cg
-    if parse(config.SCIPY_VERSION) >= parse('1.13.0'):
-        import pytest
-        pytest.xfail('Broken for newer scipy versions.')
 
     p = StationaryProblem(
         domain=RectDomain([[-1, -1], [1, 1]], bottom='neumann', right='neumann'),


### PR DESCRIPTION
Fixes #2299.