### PR TITLE
Add `return_R` flag and respective logic to the `shifted_chol_qr`

### DIFF
--- a/src/pymor/algorithms/chol_qr.py
+++ b/src/pymor/algorithms/chol_qr.py
@@ -10,7 +10,7 @@ from pymor.core.exceptions import AccuracyError
 from pymor.core.logger import getLogger
 
 
-def shifted_chol_qr(A, product=None, maxiter=3, offset=0, orth_tol=None,
+def shifted_chol_qr(A, product=None, return_R=False, maxiter=3, offset=0, orth_tol=None,
                     check_finite=True, copy=True, product_norm=None):
     r"""Orthonormalize a |VectorArray| using the shifted CholeskyQR algorithm.
 
@@ -165,4 +165,4 @@ def shifted_chol_qr(A, product=None, maxiter=3, offset=0, orth_tol=None,
     R[:offset, offset:] = Bi
     R[offset:, offset:] = Ri
 
-    return A, R
+    return (A, R) if return_R else A

--- a/src/pymor/algorithms/chol_qr.py
+++ b/src/pymor/algorithms/chol_qr.py
@@ -42,6 +42,8 @@ def shifted_chol_qr(A, product=None, return_R=False, maxiter=3, offset=0, orth_t
     product
         The inner product |Operator| w.r.t. which to orthonormalize.
         If `None`, the Euclidean product is used.
+    return_R
+        If `True`, the R matrix from QR decomposition is returned.
     maxiter
         Maximum number of iterations. Defaults to 3.
     offset

--- a/src/pymortests/algorithms/chol_qr.py
+++ b/src/pymortests/algorithms/chol_qr.py
@@ -29,7 +29,7 @@ def test_shifted_chol_qr(vector_array):
         warnings.warn('Linearly dependent vectors detected! Skipping ...')
         return
 
-    onb, R = shifted_chol_qr(U, copy=True)
+    onb, R = shifted_chol_qr(U, return_R=True, copy=True)
     assert np.all(almost_equal(U, V))
     assert np.allclose(onb.inner(onb), np.eye(len(onb)))
     lc = onb.lincomb(onb.inner(U).T)
@@ -41,7 +41,7 @@ def test_shifted_chol_qr(vector_array):
     except AssertionError:
         assert 0
 
-    onb2, R2 = shifted_chol_qr(U, copy=False)
+    onb2, R2 = shifted_chol_qr(U, return_R=True, copy=False)
     assert np.all(almost_equal(onb, onb2))
     assert np.all(R == R2)
     assert np.all(almost_equal(onb, U))
@@ -57,13 +57,13 @@ def test_shifted_chol_qr_with_product(operator_with_arrays_and_products):
 
     V = U.copy()
 
-    onb, R = shifted_chol_qr(U, product=p, copy=True)
+    onb, R = shifted_chol_qr(U, product=p, return_R=True, copy=True)
     assert np.all(almost_equal(U, V))
     assert np.allclose(p.apply2(onb, onb), np.eye(len(onb)))
     assert np.all(almost_equal(U, onb.lincomb(p.apply2(onb, U).T), rtol=1e-11))
     assert np.all(almost_equal(U, onb.lincomb(R.T)))
 
-    onb2, R2 = shifted_chol_qr(U, product=p, copy=False)
+    onb2, R2 = shifted_chol_qr(U, product=p, return_R=True, copy=False)
     assert np.all(almost_equal(onb, onb2))
     assert np.all(R == R2)
     assert np.all(almost_equal(onb, U))


### PR DESCRIPTION
The documentation of the algorithm stated, that it returns the `R` matrix, if `return_R` is set to True. However, there was no option to specify `return_R` and both `Q` and `R` were always returned.