### PR TITLE
fix small bug in `rand_la`

### DIFF
--- a/src/pymor/algorithms/rand_la.py
+++ b/src/pymor/algorithms/rand_la.py
@@ -108,7 +108,7 @@ class RandomizedRangeFinder(BasicObject):
         if self.qr_method == 'gram_schmidt':
             _, _R = gram_schmidt(Q, product=product, atol=0, rtol=0, offset=offset, copy=False, return_R=True)
         elif self.qr_method == 'shifted_chol_qr':
-            _, _R = shifted_chol_qr(Q, product=product, offset=offset, copy=False)
+            _, _R = shifted_chol_qr(Q, product=product, offset=offset, copy=False, return_R=True)
         if len(Q) == offset:
             raise ValueError('Basis extension broke down before convergence.')
         _R[:offset, :offset] = R


### PR DESCRIPTION
Adds the new `return_R` kwarg from #2383  to the `shifted_chol_qr` call in `rand_la` .