### PR TITLE
New approach to time-dependent parameter values

### DIFF
--- a/docs/source/substitutions.py
+++ b/docs/source/substitutions.py
@@ -129,6 +129,7 @@ common = """
 
 .. |Parameter| replace:: :class:`Parameter <pymor.parameters.base.Parameters>`
 .. |Parameters| replace:: :class:`~pymor.parameters.base.Parameters`
+.. |Mu| replace:: :class:`~pymor.parameters.base.Mu`
 .. |Parameter values| replace:: :class:`Parameter values <pymor.parameters.base.Mu>`
 .. |parameter values| replace:: :class:`parameter values <pymor.parameters.base.Mu>`
 .. |Parameter value| replace:: :class:`Parameter value <pymor.parameters.base.Mu>`

--- a/src/pymor/algorithms/error.py
+++ b/src/pymor/algorithms/error.py
@@ -192,7 +192,12 @@ def reduction_error_analysis(rom, fom, reductor, test_mus,
     print()
 
     result = {}
-    result['mus'] = test_mus = np.array(test_mus)
+
+    # convert test_mus to object array. np.array(test_mus) will try to iterate over the mus
+    result['mus'] =  np.empty(len(test_mus), dtype=object)
+    result['mus'][:] = test_mus
+    test_mus = result['mus']
+
     result['basis_sizes'] = basis_sizes
 
     summary = [('number of samples', str(len(test_mus)))]

--- a/src/pymor/algorithms/error.py
+++ b/src/pymor/algorithms/error.py
@@ -194,7 +194,7 @@ def reduction_error_analysis(rom, fom, reductor, test_mus,
     result = {}
 
     # convert test_mus to object array. np.array(test_mus) will try to iterate over the mus
-    result['mus'] =  np.empty(len(test_mus), dtype=object)
+    result['mus'] = np.empty(len(test_mus), dtype=object)
     result['mus'][:] = test_mus
     test_mus = result['mus']
 

--- a/src/pymor/algorithms/timestepping.py
+++ b/src/pymor/algorithms/timestepping.py
@@ -351,6 +351,11 @@ class ImplicitMidpointTimeStepper(TimeStepper):
         assert isinstance(F, (type(None), Operator, VectorArray))
         assert isinstance(M, (type(None), Operator))
         assert A.source == A.range
+
+        if mu is None:
+            mu = Mu()
+        assert 't' not in mu
+
         num_values = num_values or nt + 1
         dt = (t1 - t0) / nt
         DT = (t1 - t0) / (num_values - 1)
@@ -377,10 +382,6 @@ class ImplicitMidpointTimeStepper(TimeStepper):
         assert not M.parametric
         assert U0 in A.source
         assert len(U0) == 1
-
-        if mu is None:
-            mu = Mu()
-        assert 't' not in mu
 
         num_ret_values = 1
         yield U0, t0

--- a/src/pymor/algorithms/tr.py
+++ b/src/pymor/algorithms/tr.py
@@ -238,8 +238,10 @@ def trust_region(fom, surrogate, parameter_space=None, initial_guess=None, beta=
 
                 with logger.block('Computing first order criticality...'):
                     # fom.output_d_mu is potentially for free after enrichment, e.g. using caching
-                    gradient = fom.parameters.parse(fom.output_d_mu(mu).to_numpy())
-                    first_order_criticality = np.linalg.norm(mu - parameter_space.clip(mu - gradient).to_numpy())
+                    gradient = fom.output_d_mu(mu).to_numpy().ravel()
+                    first_order_criticality = np.linalg.norm(
+                        mu - parameter_space.clip(fom.parameters.parse(mu - gradient)).to_numpy()
+                    )
                     foc_norms.append(first_order_criticality)
 
                 surrogate.accept()

--- a/src/pymor/core/cache.py
+++ b/src/pymor/core/cache.py
@@ -83,6 +83,7 @@ from pymor.core.exceptions import CacheKeyGenerationError, UnpicklableError
 from pymor.core.logger import getLogger
 from pymor.core.pickle import dumps
 from pymor.parameters.base import Mu
+from pymor.tools.frozendict import FrozenDict
 
 
 @atexit.register
@@ -521,7 +522,7 @@ def build_cache_key(obj):
             return tuple(transform_obj(o) for o in obj)
         elif t in (set, frozenset):
             return tuple(transform_obj(o) for o in sorted(obj))
-        elif t is dict:
+        elif t in (dict, FrozenDict):
             return tuple((transform_obj(k), transform_obj(v)) for k, v in sorted(obj.items()))
         elif isinstance(obj, Number):
             # handle numpy number objects

--- a/src/pymor/models/basic.py
+++ b/src/pymor/models/basic.py
@@ -314,7 +314,6 @@ class InstationaryModel(Model):
 
     def _compute(self, quantities, data, mu=None):
         if 'solution' in quantities:
-            mu = mu.with_(t=0.)
             U0 = self.initial_data.as_range_array(mu)
             U = self.time_stepper.solve(operator=self.operator,
                                         rhs=None if isinstance(self.rhs, ZeroOperator) else self.rhs,

--- a/src/pymor/models/interact.py
+++ b/src/pymor/models/interact.py
@@ -16,7 +16,7 @@ from ipywidgets import Accordion, Button, Checkbox, FloatSlider, HBox, Label, La
 
 from pymor.core.base import BasicObject
 from pymor.models.basic import StationaryModel
-from pymor.parameters.base import Mu, Parameters, ParameterSpace
+from pymor.parameters.base import Parameters, ParameterSpace
 
 
 class ParameterSelector(BasicObject):
@@ -181,10 +181,7 @@ def interact(model, parameter_space, show_solution=True, visualizer=None, transf
     has_output = model.dim_output > 0
     tic = perf_counter()
     mu = parameter_selector.mu
-    input = parameter_selector.mu.get('input', None)
-    mu = Mu({k: mu.get_time_dependent_value(k) if mu.is_time_dependent(k) else mu[k]
-            for k in mu if k != 'input'})
-    data = model.compute(solution=show_solution, output=has_output, input=input, mu=mu)
+    data = model.compute(solution=show_solution, output=has_output, mu=mu)
     sim_time = perf_counter() - tic
 
     if has_output:
@@ -225,14 +222,8 @@ def interact(model, parameter_space, show_solution=True, visualizer=None, transf
         widget = right_pane
 
     def do_update(mu):
-        if 'input' in mu:
-            input = mu.get_time_dependent_value('input') if mu.is_time_dependent('input') else mu['input']
-        else:
-            input = None
-        mu = Mu({k: mu.get_time_dependent_value(k) if mu.is_time_dependent(k) else mu[k]
-                for k in mu if k != 'input'})
         tic = perf_counter()
-        data = model.compute(solution=show_solution, output=has_output, input=input, mu=mu)
+        data = model.compute(solution=show_solution, output=has_output, mu=mu)
         sim_time = perf_counter() - tic
         if show_solution:
             U = data['solution']

--- a/src/pymor/models/interface.py
+++ b/src/pymor/models/interface.py
@@ -114,17 +114,18 @@ class Model(CacheableObject, ParametricObject):
         -------
         A dict with the computed values.
         """
-        assert input is not None or self.dim_input == 0
-
         # parse parameter values
         if not isinstance(mu, Mu):
             mu = self.parameters.parse(mu)
-        assert self.parameters.assert_compatible(mu)
+        assert self.parameters.assert_compatible(mu, allow_time_dependent=True)
 
         # parse input and add it to the parameter values
-        mu_input = Parameters(input=self.dim_input).parse(input)
-        input = mu_input.get_time_dependent_value('input') if mu_input.is_time_dependent('input') else mu_input['input']
-        mu = mu.with_(input=input)
+        if input is not None:
+            mu_input = Parameters(input=self.dim_input).parse(input)
+            input = mu_input.time_dependent_values.get('input') or mu_input['input']
+            mu = mu.with_(input=input)
+        assert self.dim_input == 0 or 'input' in mu or 'input' in mu.time_dependent_values
+
 
         # collect all quantities to be computed
         wanted_quantities = {quantity for quantity, wanted in kwargs.items() if wanted}

--- a/src/pymor/models/interface.py
+++ b/src/pymor/models/interface.py
@@ -121,6 +121,8 @@ class Model(CacheableObject, ParametricObject):
 
         # parse input and add it to the parameter values
         if input is not None:
+            assert 'input' not in mu
+            assert 'input' not in mu.time_dependent_values
             mu_input = Parameters(input=self.dim_input).parse(input)
             input = mu_input.time_dependent_values.get('input') or mu_input['input']
             mu = mu.with_(input=input)

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -682,7 +682,7 @@ class LTIModel(Model):
                 -self.A,  # operator
                 rhs=LinearInputOperator(self.B),
                 mass=None if isinstance(self.E, IdentityOperator) else self.E,
-                mu=mu.with_(t=0),
+                mu=mu,
                 num_values=self.num_values
             )
             if self.num_values is None:
@@ -703,7 +703,7 @@ class LTIModel(Model):
                 if compute_solution:
                     data['solution'].append(x)
                 if compute_output:
-                    y = self.C.apply(x, mu=mu).to_numpy() + D.as_range_array(mu=mu.with_(t=t)).to_numpy()
+                    y = self.C.apply(x, mu=mu).to_numpy() + D.as_range_array(mu=mu.at_time(t)).to_numpy()
                     if i < n:
                         data['output'][i] = y
                     else:

--- a/src/pymor/models/neural_network.py
+++ b/src/pymor/models/neural_network.py
@@ -235,7 +235,7 @@ class NeuralNetworkInstationaryModel(BaseNeuralNetworkModel):
     def _compute(self, quantities, data, mu):
         if 'solution' in quantities:
             # collect all inputs in a single tensor
-            inputs = self._scale_input(torch.DoubleTensor(np.array([mu.with_(t=t).to_numpy()
+            inputs = self._scale_input(torch.DoubleTensor(np.array([mu.at_time(t).to_numpy()
                                                                     for t in np.linspace(0., self.T, self.nt)])))
             # pass batch of inputs to neural network
             result = self.neural_network(inputs).detach().numpy()
@@ -292,7 +292,7 @@ class NeuralNetworkInstationaryStatefreeOutputModel(BaseNeuralNetworkModel):
 
     def _compute(self, quantities, data, mu):
         if 'output' in quantities:
-            inputs = self._scale_input(torch.DoubleTensor(np.array([mu.with_(t=t).to_numpy()
+            inputs = self._scale_input(torch.DoubleTensor(np.array([mu.at_time(t).to_numpy()
                                                                     for t in np.linspace(0., self.T, self.nt)])))
             outputs = self.neural_network(inputs).detach().numpy()
             outputs = self._scale_target(outputs)

--- a/src/pymor/operators/constructions.py
+++ b/src/pymor/operators/constructions.py
@@ -1005,7 +1005,7 @@ class FixedParameterOperator(ProxyOperator):
         assert operator.parameters.assert_compatible(mu)
         self.mu = mu
         if mu:
-            self.parameters_internal = mu.parameters
+            self.parameters_internal = operator.parameters
 
     def apply(self, U, mu=None):
         return self.operator.apply(U, mu=self.mu)

--- a/src/pymor/parameters/base.py
+++ b/src/pymor/parameters/base.py
@@ -396,7 +396,7 @@ class Mu(ImmutableObject):
     def parameters(self, include_time_dependent=False):
         params = {k: v.size for k, v in self.items()}
         if include_time_dependent:
-            params.update({k: v.shape_range[0] for k, v in self.items()})
+            params.update({k: v.shape_range[0] for k, v in self.time_dependent_values.items()})
         return Parameters(params)
 
     def with_(self, new_type=None, **kwargs):
@@ -415,7 +415,7 @@ class Mu(ImmutableObject):
         if len(self) == 0:
             return np.array([])
         else:
-            return np.hstack([v for k, v in self._values.items()])
+            return np.hstack([v for k, v in self.items()])
 
     def __eq__(self, other):
         if not isinstance(other, Mu):

--- a/src/pymor/parameters/base.py
+++ b/src/pymor/parameters/base.py
@@ -455,7 +455,7 @@ class Mu(ImmutableObject):
     def at_time(self, t):
         """Return a new |Mu| instance with values for given time.
 
-        This methods evaluates all :attr:`time_dependent_values` for
+        This method evaluates all :attr:`time_dependent_values` for
         the given evaluation time `t` and returns a new |Mu| containing
         these values along with the other non-time-dependent values.
 

--- a/src/pymor/reductors/neural_network.py
+++ b/src/pymor/reductors/neural_network.py
@@ -100,7 +100,7 @@ class NeuralNetworkReductor(BasicObject):
         if not fom:
             assert training_set is not None
             assert len(training_set) > 0
-            self.parameters_dim = training_set[0][0].parameters.dim
+            self.parameters_dim = training_set[0][0].parameters().dim
         else:
             self.parameters_dim = fom.parameters.dim
 
@@ -394,7 +394,7 @@ class NeuralNetworkReductor(BasicObject):
             name = self.fom.name
         else:
             projected_output_functional = None
-            parameters = self.training_set[0][0].parameters
+            parameters = self.training_set[0][0].parameters()
             name = 'data_driven'
 
         with self.logger.block('Building ROM ...'):
@@ -451,7 +451,7 @@ class NeuralNetworkStatefreeOutputReductor(NeuralNetworkReductor):
         if not fom:
             assert training_set is not None
             assert len(training_set) > 0
-            self.parameters_dim = training_set[0][0].parameters.dim
+            self.parameters_dim = training_set[0][0].parameters().dim
             self.dim_output = len(training_set[0][1].flatten())
         else:
             self.parameters_dim = fom.parameters.dim
@@ -503,7 +503,7 @@ class NeuralNetworkStatefreeOutputReductor(NeuralNetworkReductor):
             parameters = self.fom.parameters
             name = self.fom.name
         else:
-            parameters = self.training_set[0][0].parameters
+            parameters = self.training_set[0][0].parameters()
             name = 'data_driven'
 
         with self.logger.block('Building ROM ...'):
@@ -565,7 +565,7 @@ class NeuralNetworkInstationaryReductor(NeuralNetworkReductor):
             assert training_set is not None
             assert len(training_set) > 0
             assert T is not None
-            self.parameters_dim = training_set[0][0].parameters.dim
+            self.parameters_dim = training_set[0][0].parameters(include_time_dependent=True).dim
             self.T = T
         else:
             self.parameters_dim = fom.parameters.dim
@@ -629,7 +629,7 @@ class NeuralNetworkInstationaryReductor(NeuralNetworkReductor):
         if u is None:
             u = self.fom.solve(mu)
 
-        parameters_with_time = [mu.with_(t=t) for t in np.linspace(0, self.T, self.nt)]
+        parameters_with_time = [mu.at_time(t) for t in np.linspace(0, self.T, self.nt)]
 
         product = self.pod_params.get('product')
 
@@ -659,7 +659,7 @@ class NeuralNetworkInstationaryReductor(NeuralNetworkReductor):
             name = self.fom.name
         else:
             projected_output_functional = None
-            parameters = self.training_set[0][0].parameters
+            parameters = self.training_set[0][0].parameters(include_time_dependent=True)
             name = 'data_driven'
 
         with self.logger.block('Building ROM ...'):
@@ -749,7 +749,7 @@ class NeuralNetworkLSTMInstationaryReductor(NeuralNetworkInstationaryReductor):
         if u is None:
             u = self.fom.solve(mu)
 
-        parameters = torch.DoubleTensor(np.array([mu.with_(t=t).to_numpy()
+        parameters = torch.DoubleTensor(np.array([mu.at_time(t).to_numpy()
                                                   for t in np.linspace(0., self.fom.T, self.nt)]))
 
         product = self.pod_params.get('product')
@@ -809,7 +809,7 @@ class NeuralNetworkInstationaryStatefreeOutputReductor(NeuralNetworkStatefreeOut
             assert training_set is not None
             assert len(training_set) > 0
             assert T is not None
-            self.parameters_dim = training_set[0][0].parameters.dim
+            self.parameters_dim = training_set[0][0].parameters(include_time_dependent=True).dim
             self.dim_output = len(training_set[0][1].flatten())
             self.T = T
         else:
@@ -845,7 +845,7 @@ class NeuralNetworkInstationaryStatefreeOutputReductor(NeuralNetworkStatefreeOut
             output_trajectory = self.fom.output(mu)
 
         output_size = output_trajectory.shape[0]
-        samples = [(mu.with_(t=t), output.flatten())
+        samples = [(mu.at_time(t), output.flatten())
                    for t, output in zip(np.linspace(0, self.T, output_size), output_trajectory)]
 
         return samples
@@ -866,7 +866,7 @@ class NeuralNetworkInstationaryStatefreeOutputReductor(NeuralNetworkStatefreeOut
             parameters = self.fom.parameters
             name = self.fom.name
         else:
-            parameters = self.training_set[0][0].parameters
+            parameters = self.training_set[0][0].parameters(include_time_dependent=True)
             name = 'data_driven'
 
         with self.logger.block('Building ROM ...'):
@@ -898,7 +898,7 @@ class NeuralNetworkLSTMInstationaryStatefreeOutputReductor(NeuralNetworkInstatio
         output_trajectory = self.fom.output(mu)
         output_size = output_trajectory.shape[0]
 
-        parameters = torch.DoubleTensor(np.array([mu.with_(t=t).to_numpy()
+        parameters = torch.DoubleTensor(np.array([mu.at_time(t).to_numpy()
                                                   for t in np.linspace(0., self.fom.T, output_size)]))
 
         sample = [(parameters, output_trajectory)]

--- a/src/pymor/reductors/parabolic.py
+++ b/src/pymor/reductors/parabolic.py
@@ -117,12 +117,12 @@ class ParabolicRBEstimator(ImmutableObject):
 
         est = np.empty(len(U))
         est[0] = (1./C) * self.initial_residual.apply(U[0], mu=mu).norm2()[0]
-        if 't' in self.residual.parameters:
+        if 't' in self.residual.parameters or mu.has_time_dependent_values:
             t = 0
             for n in range(1, m.time_stepper.nt + 1):
                 t += dt
-                mu = mu.with_(t=t)
-                est[n] = self.residual.apply(U[n], U[n-1], mu=mu).norm2()[0]
+                mu_t = mu.at_time(t)
+                est[n] = self.residual.apply(U[n], U[n-1], mu=mu_t).norm2()[0]
         else:
             est[1:] = self.residual.apply(U[1:], U[:-1], mu=mu).norm2()
         est[1:] *= (dt/C**2)

--- a/src/pymortests/parameters/parameters.py
+++ b/src/pymortests/parameters/parameters.py
@@ -7,7 +7,7 @@ import pytest
 from hypothesis import given
 
 import pymortests.strategies as pyst
-from pymor.analyticalproblems.functions import ConstantFunction
+from pymor.analyticalproblems.functions import ConstantFunction, Function
 from pymor.parameters.base import Mu, Parameters
 from pymortests.base import runmodule
 
@@ -93,27 +93,13 @@ def test_parse_parameter():
 def test_parse_parameter_time_dep():
     parameters = Parameters(b=2, a=1)
     mu = parameters.parse([7, 't**2', 't[0]'])
-    assert list(mu.with_(t=3)['a']) == [7]
-    assert list(mu.with_(t=3)['b']) == [9, 3]
+    assert list(mu.at_time(3)['a']) == [7]
+    assert list(mu.at_time(3)['b']) == [9, 3]
 
 
 def test_parse_parameter_scalar_time_dep():
     parameters = Parameters(a=1)
     parameters.parse(ConstantFunction(np.ones(1)))
-
-
-@given(pyst.mus)
-def test_parse_mu(mu):
-    parameters = mu.parameters
-    assert parameters.parse(mu) == mu
-
-
-@given(pyst.mus)
-def test_mu_parameters(mu):
-    params = mu.parameters
-    assert isinstance(params, Parameters)
-    assert mu.keys() == params.keys()
-    assert params.is_compatible(mu)
 
 
 @given(pyst.mus)
@@ -125,50 +111,30 @@ def test_mu_values(mu):
 
 @given(pyst.mus)
 def test_mu_time_dependent(mu):
-    for param in mu:
-        func = mu.get_time_dependent_value(param)
-        if mu.is_time_dependent(param):
-            assert np.all(mu[param] == func(mu.get('t', 0)))
-        else:
-            assert isinstance(func, ConstantFunction)
-            assert np.all(mu[param] == func.value)
+    for v in mu.time_dependent_values.values():
+        assert isinstance(v, Function)
+        assert len(v.shape_range) == 1
+    assert 't' not in mu.time_dependent_values
+    assert 't' not in mu or not mu.has_time_dependent_values
 
 
 @given(pyst.mus)
 def test_mu_with_changed_time(mu):
-    mu2 = mu.with_(t=42)
-    for param in mu:
-        if param == 't':
-            assert mu2['t'].item() == 42
-            continue
-        func = mu.get_time_dependent_value(param)
-        if mu.is_time_dependent(param):
-            assert np.all(mu2[param] == func(42))
-        else:
-            assert np.all(mu[param] == mu2[param])
+    mu2 = mu.at_time(t=42)
+    assert mu2['t'].item() == 42
+    for k, v  in mu.time_dependent_values.items():
+        assert np.all(mu2[k] == v(42))
 
 
 @given(pyst.mus)
 def test_mu_to_numpy(mu):
-    mu_array = mu.to_numpy()
-    mu2 = mu.parameters.parse(mu_array)
-    assert mu == mu2
-
-@given(pyst.mus)
-def test_mu_algebra(mu):
-    mu_np = mu.to_numpy()
-    other_np = np.ones(len(mu_np))
-    other = mu.parameters.parse(other_np)
-
-    assert mu + other == other + mu
-    assert other_np + mu == other + mu_np
-    assert all((mu + other).to_numpy() == (mu_np + other_np))
-    assert all((mu - other).to_numpy() == (mu_np - other_np))
-    assert all((other + mu).to_numpy() == (other_np + mu_np))
-    assert all((other - mu).to_numpy() == (other_np - mu_np))
-    assert all((-mu).to_numpy() == -mu_np)
-    assert all((2. * mu).to_numpy() == 2. * mu_np)
-    assert 2. * mu == mu * 2.
+    if mu.has_time_dependent_values:
+        with pytest.raises(ValueError):
+            mu_array = mu.to_numpy()
+    else:
+        mu_array = mu.to_numpy()
+        mu2 = Parameters({k: len(v) for k,v in mu.items()}).parse(mu_array)
+        assert mu == mu2
 
 
 def test_mu_t_wrong_value():

--- a/src/pymortests/strategies.py
+++ b/src/pymortests/strategies.py
@@ -9,7 +9,7 @@ from hypothesis import strategies as hyst
 from hypothesis.extra import numpy as hynp
 from scipy.stats import random_correlation
 
-from pymor.analyticalproblems.functions import ConstantFunction, ExpressionFunction, Function
+from pymor.analyticalproblems.functions import ConstantFunction, ExpressionFunction
 from pymor.core.config import config
 from pymor.parameters.base import Mu, Parameters
 from pymor.vectorarrays.block import BlockVectorSpace
@@ -520,7 +520,7 @@ def active_mu_data(draw, min_num=1, max_num=3, min_dim=1, max_dim=5, num_mus=10)
 # stick to a few representative examples to avoid only seeing degenerate cases
 # in the selected examples
 mus = hyst.dictionaries(
-    keys=hyst.sampled_from(['t', 'foo', 'bar']),
+    keys=hyst.sampled_from(['foo', 'bar']),
     values=hyst.sampled_from([
         np.array([1.]),
         np.array([1., 32., 3]),
@@ -528,4 +528,4 @@ mus = hyst.dictionaries(
         ExpressionFunction('[1., 0] * x + [0, 1.] * x**2', 1),
         ConstantFunction(np.array([1., 2, 3]))
     ])
-).filter(lambda mu: 't' not in mu or (not isinstance(mu['t'], Function) and len(mu['t']) == 1)).map(Mu)
+).map(Mu)


### PR DESCRIPTION
In #2375 I proposed removing time-dependent parameter values from pyMOR. The main reasons were: 1. to simplify the concept of parameter values to make it suitable for more basic libraries like NiAS. 2. the current implementation, where time-dependent values appear as normal parameter values which magically change when `'t'` changes, is surprising and error prone.

After thinking some more about it and also about how inputs would fit into the picture, I came to the conclusion that it might make more sense to keep the feature but improve the implementation by a clearer concept. What I propose with this PR is the following:

- A `Mu` is essentially a pair of a dict of constant values and a dict of time-dependent values. The former is accessible via the usual dict protocol methods. The latter is accessible via an `time_dependent_values` attribute. 
- By default, `Parameters.is_compatible` does not take the time-dependent values into account. Only if I opt-in by specifying `allow_time_depenent=True`, `Mus` with needed values which are time-dependent are deemed acceptable.
- To get values for given time `'t'`, one uses the new `Mu.at_time(t)` method to obtain a new `Mu` with fixed values for that time.
- It is not allowed to have time-dependent values *and* a value for `'t'`.
- `Mu.to_numpy` will fail when time-dependent values are present.
- The `Mu.parameters` property has been replaced by a method, which by default only returns the parameters corresponding to the time-independent values. If `include_time_dependent=True` is specified, the parameters for the time-dependent values are included as well.
- To make the code easier to comprehend, I have based the new `Mu` implementation on `ImmutableObject` and simply store the values in `Mu._values` and `Mu.time_dependent_values`.
- I have removed the arithmetic operations on `Mu`s for now. They are used nowhere in the pyMOR code base, and I am not sure how helpful they are. In the optimization code, everything is converted to a NuPy array first.

The entire design is based on the idea that code that is not aware of time-dependent parameter values should not fail silently if such values are provided (as is currently the case for the parabolic error estimator). If a `mu` is passed with time-dependent values for a parameter that is not required, everything will just work. If `mu` has a time-dependent value for a required parameter value, one will get a failure in `Parameters.assert_compatible`, unless the code is aware of time-dependent values. In particular, the time-independent part of `Mu` could be implemented by a base class (in NiAS), which can be used everywhere, where time-dependent values are not needed. 

As a further minor change, it is now allowed to pass the input to `Model.compute` and friends as part of the `mu` argument instead of having to pass it as a separate `input` parameter.

Todo:
- [x] update documentation