### PR TITLE
Add overview of available Models

### DIFF
--- a/docs/source/mor_methods.md
+++ b/docs/source/mor_methods.md
@@ -221,6 +221,60 @@ rom = greedy_data['rom']
 
 ## LTI System MOR
 
+### Available models
+
+<details>
+<summary>{{LTIModels}}</summary>
+
+**Description** 
+This class describes input-state-output systems given by:
+
+$$
+E(\mu) \dot{x}(t, \mu) = A(\mu) x(t, \mu) + B(\mu) u(t), \\
+y(t, \mu) = C(\mu) x(t, \mu) + D(\mu) u(t)
+$$
+
+if continuous-time, or
+
+$$
+E(\mu) x(k + 1, \mu) = A(\mu) x(k, \mu) + B(\mu) u(k), \\
+y(k, \mu) = C(\mu) x(k, \mu) + D(\mu) u(k)
+$$
+
+if discrete-time, where $A$, $B$, $C$, $D$, and $E$ are linear operators.
+
+**Initializing the LTIModel Class**
+
+```{code-cell} ipython3
+:tags: [remove-output]
+import numpy as np
+from pymor.models.iosys import LTIModel
+from pymor.operators.numpy import NumpyMatrixOperator
+
+# Define mandatory operators A, B, and C
+A = NumpyMatrixOperator(np.array([[1, 2], [3, 4]]))  # The Operator A
+B = NumpyMatrixOperator(np.array([[1], [0]]))        # The Operator B
+C = NumpyMatrixOperator(np.array([[0, 1]]))          # The Operator C
+
+# Other parameters
+D = NumpyMatrixOperator(np.array([[0]]))             # The Operator D
+E = NumpyMatrixOperator(np.array([[1, 0], [0, 1]]))  # The Operator E
+sampling_time = 0.01  # Discrete-time system with sampling time of 0.01s
+T = 10                # Final time
+initial_data = A.source.zeros(1) # Initial 1D data
+
+# Initialize with only mandatory parameters
+fom_basic = LTIModel(A=A, B=B, C=C)
+
+# Initialize with initial data and time configuration
+fom_discrete = LTIModel(A=A, B=B, C=C, D=D, E=E, sampling_time=sampling_time, T=T, initial_data=initial_data)
+
+print('LTI Model with only mandatory parameters: \n{}\n'.format(fom_basic))
+print('LTI Model with input data and time configuration: \n{}\n'.format(fom_discrete))
+```
+
+</details>
+
 Here we consider some of the methods for {{LTIModels}}.
 
 ### Balancing-based MOR

--- a/docs/source/mor_methods.md
+++ b/docs/source/mor_methods.md
@@ -275,6 +275,68 @@ print('LTI Model with input data and time configuration: \n{}\n'.format(fom_disc
 
 </details>
 
+<details>
+<summary>{{PHLTIModel}}</summary>
+
+**Description**
+This class describes input-state-output systems given by:
+
+$$
+E(\mu) \dot{x}(t, \mu) = (J(\mu) - R(\mu)) Q(\mu)   x(t, \mu) + (G(\mu) - P(\mu)) u(t), \\
+y(t, \mu) = (G(\mu) + P(\mu))^T Q(\mu) x(t, \mu) + (S(\mu) - N(\mu)) u(t),
+$$
+
+where $H(\mu) = Q(\mu)^T E(\mu)$
+
+$$
+\Gamma(\mu) =
+        \begin{bmatrix}
+            J(\mu) & G(\mu) \\
+            -G(\mu)^T & N(\mu)
+        \end{bmatrix},
+        \text{ and }
+        \mathcal{W}(\mu) =
+        \begin{bmatrix}
+            R(\mu) & P(\mu) \\
+            P(\mu)^T & S(\mu)
+        \end{bmatrix}
+$$
+
+satisfy $H(\mu) = H(\mu)^T \succ 0$, $\Gamma(\mu)^T = -\Gamma(\mu)$, $\mathcal{W}(\mu) = \mathcal{W}(\mu)^T \succcurlyeq 0$
+
+**Initializing the PHLTIModel Class**
+
+```{code-cell} ipython3
+:tags: [remove-output]
+from pymor.models.iosys import PHLTIModel
+from pymor.operators.numpy import NumpyMatrixOperator
+import numpy as np
+
+# Define mandatory operators
+J = NumpyMatrixOperator(np.array([[0, 1], [-1, 0]]))  # Parameter J
+R = NumpyMatrixOperator(np.array([[1, 0], [0, 1]]))   # Parameter R
+G = NumpyMatrixOperator(np.array([[1, 1], [1, 1]]))   # Parameter G
+
+# Define optional parameters
+P = NumpyMatrixOperator(np.array([[0, 0], [0, 0]]))   # Parameter P
+S = NumpyMatrixOperator(np.array([[1, 0], [1, 0]]))   # Parameter S
+N = NumpyMatrixOperator(np.array([[0, 1], [2, 0]]))   # Parameter N
+E = NumpyMatrixOperator(np.array([[1, 0], [0, 1]]))   # Parameter E
+Q = NumpyMatrixOperator(np.array([[1, 0], [0, 1]]))   # Parameter Q
+solver_options = {'lyap_lrcf': 'scipy'}               # Option to solve Lyapunov equations
+
+# Initialize with only mandatory parameters
+fom_basic = PHLTIModel(J=J, R=R, G=G)
+
+# Initialize with addtional parameters
+fom_detailed = PHLTIModel(J=J, R=R, G=G, P=P, S=S, N=N, E=E, Q=Q, solver_options=solver_options)
+
+print('PHLTI Model with only mandatory parameters: \n{}\n'.format(fom_basic))
+print('PHLTI Model with additional parameters: \n{}\n'.format(fom_detailed))
+```
+
+</details>
+
 Here we consider some of the methods for {{LTIModels}}.
 
 ### Balancing-based MOR


### PR DESCRIPTION
This pull request has efforts taken towards resolving issue [#2339 ](https://github.com/pymor/pymor/issues/2339), wherein an overview of all available models would be added to the `docs/source/mor_methods.md` document. 

The current approach for writing an overview involves:

1. Using the existing grouping in the document and adding available models' overview under the relevant subsection.
2. Each overview subsection consists of: 
             - The theoretical equation of the system represented by the model.
             - A short Python code snippet demonstrating how the model can be initialized.
3. Each section is encapsulated in `details` and `summary` tags to allow expansion and collapse of the information as the reader pleases. This is done to avoid cluttering of the page and allow the user to look at one or more overview sections at a time.