### PR TITLE
Add feature to store visualizations as JPG images

### DIFF
--- a/src/pymor/discretizers/builtin/gui/jupyter/matplotlib.py
+++ b/src/pymor/discretizers/builtin/gui/jupyter/matplotlib.py
@@ -7,6 +7,7 @@ from pymor.core.config import config
 config.require('MATPLOTLIB')
 
 
+
 import matplotlib.pyplot as plt
 import numpy as np
 
@@ -79,7 +80,7 @@ class PatchVisualizer(BasicObject):
 
 def visualize_patch(grid, U, bounding_box=None, codim=2, title=None, legend=None,
                     separate_colorbars=False, rescale_colorbars=False, columns=2,
-                    return_widget=True):
+                    return_widget=True, filename=None):
     """Visualize scalar data associated to a two-dimensional |Grid| as a patch plot.
 
     The grid's |ReferenceElement| must be the triangle or square. The data can either
@@ -110,6 +111,10 @@ def visualize_patch(grid, U, bounding_box=None, codim=2, title=None, legend=None
     columns
         The number of columns in the visualizer GUI in case multiple plots are displayed
         at the same time.
+    filename
+        If specified, the visualized results will be saved as JPG files. For animations, a
+        folder named after this argument will be created, and the individual frames will be
+        stored as separate images within it.
     """
     assert isinstance(U, VectorArray) \
            or (isinstance(U, tuple)
@@ -128,6 +133,23 @@ def visualize_patch(grid, U, bounding_box=None, codim=2, title=None, legend=None
         separate_colorbars=separate_colorbars, rescale_colorbars=rescale_colorbars, columns=columns)
 
     do_animation = len(U[0]) > 1
+
+    if filename is not None:
+        assert isinstance(filename, str)
+
+        if do_animation:
+            import os
+            folder_path = filename
+            os.makedirs(folder_path)
+            filename = '{}.jpg'
+            for i in range(len(U[0])):
+                full_filename = os.path.join(folder_path, filename.format(i))
+                vis.set(idx=i)
+                vis.fig.savefig(full_filename)
+        else:
+            filename = filename+'.jpg'
+            vis.fig.savefig(filename)
+        return
 
     if return_widget:
         vis.fig.canvas.header_visible = False
@@ -171,7 +193,7 @@ def visualize_patch(grid, U, bounding_box=None, codim=2, title=None, legend=None
 
 
 def visualize_matplotlib_1d(grid, U, codim=1, title=None, legend=None, separate_plots=False,
-                            rescale_axes=False, columns=2, return_widget=True):
+                            rescale_axes=False, columns=2, return_widget=True, filename=None):
     """Visualize scalar data associated to a one-dimensional |Grid| as a plot.
 
     The grid's |ReferenceElement| must be the line. The data can either
@@ -199,6 +221,10 @@ def visualize_matplotlib_1d(grid, U, codim=1, title=None, legend=None, separate_
         If `True`, rescale axes to data in each frame.
     columns
         Number of columns the subplots are organized in.
+    filename
+        If specified, the visualized results will be saved as JPG files. For animations, a
+        folder named after this argument will be created, and the individual frames will be
+        stored as separate images within it.
     """
     assert isinstance(grid, OnedGrid)
     assert codim in (0, 1)
@@ -249,6 +275,23 @@ def visualize_matplotlib_1d(grid, U, codim=1, title=None, legend=None, separate_
                  [vmin[ind] for vmin in vmins],
                  [vmax[ind] for vmax in vmaxs])
         fig.canvas.draw_idle()
+
+    if filename is not None:
+        assert isinstance(filename, str)
+
+        if do_animation:
+            import os
+            folder_path = filename
+            os.makedirs(folder_path)
+            filename = '{}.jpg'
+            for i in range(len(U[0])):
+                full_filename = os.path.join(folder_path, filename.format(i))
+                set_data(ind=i)
+                fig.savefig(full_filename)
+        else:
+            filename = filename+'.jpg'
+            fig.savefig(filename)
+        return
 
     if return_widget:
         fig.canvas.header_visible = False

--- a/src/pymor/discretizers/builtin/gui/visualizers.py
+++ b/src/pymor/discretizers/builtin/gui/visualizers.py
@@ -45,7 +45,7 @@ class PatchVisualizer(ImmutableObject):
         self.__auto_init(locals())
 
     def visualize(self, U, title=None, legend=None, separate_colorbars=False,
-                  rescale_colorbars=False, block=None, filename=None, columns=2,
+                  rescale_colorbars=False, block=None, filename=None, img_filename=None, columns=2,
                   return_widget=False, **kwargs):
         """Visualize the provided data.
 
@@ -74,6 +74,10 @@ class PatchVisualizer(ImmutableObject):
         filename
             If specified, write the data to a VTK-file using
             :func:`~pymor.discretizers.builtin.grids.vtkio.write_vtk` instead of displaying it.
+        img_filename
+            If specified, write the visualized results to .jpg file using
+            :func:`~pymor.discretizers.builtin.gui.jupyter.matplotlib.visualize_patch` with
+            specified filename argument instead of displaying it.
         return_widget
             If `True`, create an interactive visualization that can be used as a jupyter widget.
         kwargs
@@ -90,6 +94,12 @@ class PatchVisualizer(ImmutableObject):
             else:
                 for i, u in enumerate(U):
                     write_vtk(self.grid, u, f'{filename}-{i}', codim=self.codim)
+        elif img_filename:
+            from pymor.discretizers.builtin.gui.jupyter.matplotlib import visualize_patch
+            return visualize_patch(self.grid, U, bounding_box=self.bounding_box, codim=self.codim, title=title,
+                                       legend=legend, separate_colorbars=separate_colorbars,
+                                       rescale_colorbars=rescale_colorbars, columns=columns,
+                                       return_widget=return_widget, filename=img_filename, **kwargs)
         else:
             if self.backend == 'jupyter':
                 from pymor.discretizers.builtin.gui.jupyter import get_visualizer
@@ -136,7 +146,7 @@ class OnedVisualizer(ImmutableObject):
         self.__auto_init(locals())
 
     def visualize(self, U, title=None, legend=None, separate_plots=False,
-                  rescale_axes=False, block=None, columns=2, return_widget=False):
+                  rescale_axes=False, block=None, columns=2, img_filename=None, return_widget=False):
         """Visualize the provided data.
 
         Parameters
@@ -160,9 +170,19 @@ class OnedVisualizer(ImmutableObject):
             default provided during instantiation.
         columns
             Number of columns the subplots are organized in.
+        img_filename
+            If specified, write the visualized results to .jpg file using
+            :func:`~pymor.discretizers.builtin.gui.jupyter.matplotlib.visualize_matplotlib_1d` with
+            specified filename argument instead of displaying it.
         return_widget
             If `True`, create an interactive visualization that can be used as a jupyter widget.
         """
+        if img_filename:
+            from pymor.discretizers.builtin.gui.jupyter.matplotlib import visualize_matplotlib_1d
+            return visualize_matplotlib_1d(self.grid, U, codim=self.codim, title=title, legend=legend,
+                                           separate_plots=separate_plots, rescale_axes=rescale_axes,
+                                           columns=columns, filename=img_filename, return_widget=return_widget)
+
         if self.backend == 'jupyter':
             from pymor.discretizers.builtin.gui.jupyter.matplotlib import visualize_matplotlib_1d
             return visualize_matplotlib_1d(self.grid, U, codim=self.codim, title=title, legend=legend,


### PR DESCRIPTION
This pull request is for issue #2146, which wants to have an option to store visualization results as image files.

**Features**

For both `PatchVisualizer` and `OnedVisualizer`, the visualization result could be saved as image files by specifying the `img_filename` argument as calling the function `visualize`, as shown below:

```
visualize(U, img_filename="IMG_NAME")
```

1. Single image output: a single JPG file named with the argument will be stored in the working directory.
2. Multiple image output: a folder named with the argument will be created in the working directory first. The frames will be stored as sequentially numbered JPG files inside the folder (e.g. `0.jpg`, `1.jpg`, etc.).


**Testing**

I have tested the code with :
1. The example provided in the issue for `PatchVisualizer`.
2. The following code for `OnedVisualizer`:

```
from pymor.models.examples import heat_equation_1d_example

fom_tb = heat_equation_1d_example()
mu = 0.1
U = fom_tb.solve(mu)
fom_tb.visualize(U, img_filename="1D_test")
```

If there is any problems or feedbacks, please let me know.