### PR TITLE
Avoid data corruption in shifted_chol_qr

### DIFF
--- a/src/pymor/algorithms/chol_qr.py
+++ b/src/pymor/algorithms/chol_qr.py
@@ -141,7 +141,7 @@ def shifted_chol_qr(A, product=None, return_R=False, maxiter=3, offset=0, orth_t
             it = 0
             while True:
                 try:
-                    Rx = spla.cholesky(X, overwrite_a=True, check_finite=check_finite)
+                    Rx = spla.cholesky(X, overwrite_a=False, check_finite=check_finite)
                     break
                 except spla.LinAlgError:
                     it += 1


### PR DESCRIPTION
`scipy.linalg.cholesky` is called with `overwrite_a` in `shifted_chol_qr`. In the case of a breakdown in the Cholesky algorithm, this leaves `X` in an undefined stated. This has caused CI build failures in #2405 and also seems to be responsible for #2406. Actually, I'm quite surprised, that this usually worked before. (With the latest changes in #2405, `X` becomes Fortran ordered, which seems to select a different LAPACK code path. So maybe the code for C ordering made a copy even with `overwrite_a`. I haven't tested that.)

Fixes #2406.