### PR TITLE
upcast numpy arrays for portable caching

### DIFF
--- a/src/pymor/core/cache.py
+++ b/src/pymor/core/cache.py
@@ -517,6 +517,12 @@ def build_cache_key(obj):
         elif t is np.ndarray:
             if obj.dtype == object:
                 raise CacheKeyGenerationError('Cannot generate cache key for provided arguments')
+            # we need to upcast into the largest possible dtype, to ensure portable hashing
+            # e.g., numpy < 2 uses int32 per default on Windows, but int64 everywhere else
+            if np.issubdtype(obj.dtype, np.integer) or np.issubdtype(obj.dtype, np.floating):
+                return obj.astype(np.float64)
+            elif np.issubdtype(obj.dtype, np.complexfloating):
+                return obj.astype(np.complex128)
             return obj
         elif t in (list, tuple):
             return tuple(transform_obj(o) for o in obj)


### PR DESCRIPTION
This upcasts all numpy arrays used in Mus to the largest appropriate dtype before hashing. Among other things, this ensures that `12` and `12.` have the same hash. It also ensures that the keys passed on to cache backends are portable across OSes.