### PR TITLE
created a new hash function to make Mu values hashable.

### DIFF
--- a/src/pymor/parameters/base.py
+++ b/src/pymor/parameters/base.py
@@ -437,6 +437,21 @@ class Mu(FrozenDict):
                 return False
         return self.keys() == mu.keys() and all(np.array_equal(v, mu[k]) for k, v in self.items())
 
+    def __hash__(self):
+        # Convert each value (which is a numpy array by design) into a tuple so it becomes hashable
+        key_value_tuples = []
+        for key, value in self.items():
+            # Ensure each value is converted to a tuple (numpy arrays are not hashable)
+            value_tuple = tuple(value)
+            key_value_tuples.append((key, value_tuple))
+
+        # Sort the list of (key, value_tuple) to ensure consistent ordering
+        # ensures that the hash is the same regardless of the order of keys
+        sorted_items = sorted(key_value_tuples)
+
+        # Create a hash from the sorted list of items
+        return hash(tuple(sorted_items))
+
     def __neg__(self):
         return Mu({key: -value for key, value in self.items()})
 


### PR DESCRIPTION
The new hash function in the Mu class enables to set these as dict keys in a newly created dictionary.
The function does the following:

- value of a key is by design choice a NumPy array, which is mutable and unhashable. tuple(value) turns it into a hashable tuple.
- Then we make a list of (key, value_tuple) pairs.
- We sort the key_value_tuple list for consistency, because dictionaries do not guarantee order. Sorting ensures that the hash is always the same regardless of the order of a dictionary.
- Finally we convert the sorted list to a tuple (which is hashable) and compute the hash.


MWE:
Sorry for this big hardcoded chunk of data, I do not know how to get this into the right form so I just post it here. I tested this in the neural_network demo, that is where I copied the data from. I hope someone knows how to make this MWE work, in my debug mode it works.

training_data = [(Mu({'exponent': array([1.]), 't': 0.0}), [-2.46374145e+00 -1.11307991e+00  3.25267368e-01  5.92128252e-02,  1.86589144e-02 -1.83649347e-03 -5.08727691e-03  1.23445262e-04, -1.34023726e-05  0.00000000e+00]), (Mu({'exponent': array([1.]), 't': 0.03}), [-2.52532631e+00 -9.06649113e-01  1.49524555e-01  2.31398840e-02, -4.86414448e-02 -5.27539009e-03 -8.47323134e-03  3.01620809e-04,  7.58226477e-05  6.66133815e-16])]

param_to_keys = {}
for key in training_data:
    mu, t = key
    param_to_keys.setdefault(mu, []).append(key)