### PR TITLE
Adaptive `RandomizedERAReductor`

### DIFF
--- a/docs/source/bibliography.bib
+++ b/docs/source/bibliography.bib
@@ -676,6 +676,16 @@
   doi           = {10.1137/140978922},
 }
 
+@article{PS26,
+  title         = {Adaptive reduced order modelling of acoustic {LTI} systems with input–output dead time},
+  author        = {Pelling, A.J.R. and Sarradj, E.},
+  year          = 2026,
+  journal       = {Mechanical Systems and Signal Processing},
+  volume        = 242,
+  pages         = {113613},
+  doi           = {10.1016/j.ymssp.2025.113613},
+}
+
 @phdthesis{RL95,
   title         = {Analysis and implementation of an implicitly restarted {A}rnoldi iteration},
   author        = {Lehoucq, R. B.},

--- a/docs/source/substitutions.py
+++ b/docs/source/substitutions.py
@@ -182,6 +182,7 @@ common = """
 .. |CanonicalSymplecticFormOperator| replace:: :class:`~pymor.operators.symplectic.CanonicalSymplecticFormOperator`
 
 .. |RNG| replace:: :class:`random number generator <pymor.tools.random.RNG>`
+.. |RandomizedRangeFinder| replace:: :class:`randmomized range finder <pymor.algorithms.rand_la.RandomizedRangeFinder>`
 """  # noqa: E501
 
 substitutions = interfaces + common

--- a/docs/source/substitutions.py
+++ b/docs/source/substitutions.py
@@ -199,6 +199,7 @@ common = """
 .. |SylvesterSolver| replace:: :class:`~pymor.solvers.matrix_equations.interface.SylvesterSolver`
 
 .. |RNG| replace:: :class:`random number generator <pymor.tools.random.RNG>`
+.. |RandomizedRangeFinder| replace:: :class:`randmomized range finder <pymor.algorithms.rand_la.RandomizedRangeFinder>`
 """  # noqa: E501
 
 substitutions = interfaces + common

--- a/src/pymor/algorithms/rand_la.py
+++ b/src/pymor/algorithms/rand_la.py
@@ -104,7 +104,7 @@ class RandomizedRangeFinder(BasicObject):
         r"""Update the QR decomposition.
 
         Q[:offset]R is assumed to be a QR decomposition.
-        Q[offset:] are contains new vectors that will be orthogonalized in place.
+        Q[offset:] contains new vectors that will be orthogonalized in place.
 
         Parameters
         ----------

--- a/src/pymor/reductors/era.py
+++ b/src/pymor/reductors/era.py
@@ -6,6 +6,7 @@ import numpy as np
 import scipy.linalg as spla
 
 from pymor.algorithms.projection import project
+from pymor.algorithms.rand_la import RandomizedRangeFinder
 from pymor.algorithms.to_matrix import to_matrix
 from pymor.core.cache import CacheableObject, cached
 from pymor.models.iosys import LTIModel
@@ -249,27 +250,73 @@ class ERAReductor(CacheableObject):
             r_tol = np.argmax(error_bounds <= tol) + 1
             r = r_tol if r is None else min(r, r_tol)
 
-        sv, U, V = sv[:r], U[:r].T, V[:r]
-
-        num_left = m * s if num_left is None and m * s < p else num_left
-        num_right = p * s if num_right is None and p * s < m else num_right
+        sv, U, V = sv[:r], U[:, :r], V[:, :r]
 
         self.logger.info(f'Constructing reduced realization of order {r} ...')
-        sqsv = np.sqrt(sv)
-        U *= sqsv.reshape(1, -1)
-        V *= sqsv.reshape(-1, 1)
-        A = NumpyMatrixOperator(spla.lstsq(U[: -(num_left or p)], U[(num_left or p):])[0])
-        B = NumpyMatrixOperator(V[:, :(num_right or m)])
-        C = NumpyMatrixOperator(U[:(num_left or p)])
+        return self._construct_realization(sv, U, V, m, p, num_left, num_right)
 
-        if num_left:
-            self.logger.info('Backprojecting tangential output directions ...')
-            W1 = self.output_projector(num_left)
-            C = project(C, source_basis=None, range_basis=C.range.from_numpy(W1.T))
-        if num_right:
-            self.logger.info('Backprojecting tangential input directions ...')
-            W2 = self.input_projector(num_right)
-            B = project(B, source_basis=B.source.from_numpy(W2.T), range_basis=None)
 
-        return LTIModel(A, B, C, D=self.feedthrough, sampling_time=self.sampling_time,
-                        presets={'o_dense': np.diag(sv), 'c_dense': np.diag(sv)})
+class RandomizedERAReductor(ERAReductor):
+    def __init__(self, data, sampling_time, force_stability=True, feedthrough=None, allow_transpose=True, rrf_opts={},
+                 num_left=None, num_right=None):
+        super().__init__(data, sampling_time, force_stability=force_stability, feedthrough=feedthrough)
+        self.__auto_init(locals())
+        #data = data.copy()
+        if num_left is not None or num_right is not None:
+            self.logger.info('Computing the projected Markov parameters ...')
+            data = self._project_markov_parameters(num_left, num_right)
+        if self.force_stability:
+            data = np.concatenate([data, np.zeros_like(data)[1:]], axis=0)
+        s = (data.shape[0] + 1) // 2
+        self._transpose = (data.shape[1] < data.shape[2]) if allow_transpose else False
+        self._H = NumpyHankelOperator(data[:s], r=data[s-1:])
+        if self._transpose:
+            self.logger.info('Using transposed formulation.')
+            self._H = self._H.H
+        self._last_sv_U_V = None
+        self._rrf = RandomizedRangeFinder(self._H, **rrf_opts)
+        self._rrf._draw_samples = self._draw_samples
+
+    @cached
+    def _weighted_h2_norm(self):
+        T = self.data.shape[0]
+        s = int((T+1)/2)
+        eta = np.ones(T)
+        eta[1:s+1] *= np.arange(s) + 1
+        eta[s+1:] *= np.arange(s-1)[::-1][:T-s-1] + 1
+        return spla.norm(self.data*np.sqrt(eta.reshape(-1, 1, 1)))
+
+    def _sv_U_V(self, num_left, num_right):
+        return self._last_sv_U_V
+
+    def _draw_samples(self, num):
+        # faster way of computing the random samples for Hankel matrices
+        self._rrf.logger.info(f'Taking {num} samples ...')
+        V = np.zeros((self._H._circulant.source.dim, num))
+        V[:self._H.source.dim] = self._H.source.random(num, distribution='normal').to_numpy()
+        return self._H.range.make_array(self._H._circulant._circular_matvec(V)[:, :self._H.range.dim].T)
+
+    def reduce(self, r=None, tol=None):
+        if tol is not None:
+            tol *= self._weighted_h2_norm()
+        last_basis_size = len(self._rrf.Q[-1])
+        Q = self._rrf.find_range(basis_size=r, tol=tol)
+        r = len(Q) if r is None else r
+        if r > last_basis_size:
+            self.logger.info('Projecting onto reduced space ...')
+            B = self._H.apply_adjoint(Q).to_numpy().T
+            self.logger.info(f'Computing reduced SVD of size {B.shape[0]}x{B.shape[1]} ...')
+            Ub, sv, Vh = np.linalg.svd(B, full_matrices=False)
+            self.logger.info('Lifting left singular vectors ...')
+            U = Q.lincomb(Ub)
+            self._last_sv_U_V = (sv, U.to_numpy(), Vh.T)
+        else:
+            self.logger.info('Smaller model order requested. Reusing last SVD.')
+        sv, U, V = self._last_sv_U_V
+        sv, U, V = sv[:r], U[:, :r], V[:, :r]
+        if self._transpose:  # switch back, if transposed formulation was used
+            U, V = V, U
+
+        self.logger.info(f'Constructing reduced realization of order {r} ...')
+        _, p, m = self.data.shape
+        return self._construct_realization(sv, U, V, m, p, self.num_left, self.num_right)

--- a/src/pymor/reductors/era.py
+++ b/src/pymor/reductors/era.py
@@ -113,19 +113,14 @@ class ERAReductor(CacheableObject):
     def _sv_U_V(self, num_left, num_right):
         n, p, m = self.data.shape
         s = n if self.force_stability else (n + 1) // 2
-        if num_left is None and m * s < p:
-            self.logger.info('Data has low rank! Accelerating computation with output tangential projections ...')
-            num_left = m * s
-        if num_right is None and p * s < m:
-            self.logger.info('Data has low rank! Accelerating computation with input tangential projections ...')
-            num_right = p * s
+
         h = self._project_markov_parameters(num_left, num_right) if num_left or num_right else self.data
         self.logger.info(f'Computing SVD of the {"projected " if num_left or num_right else ""}Hankel matrix ...')
         if self.force_stability:
             h = np.concatenate([h, np.zeros_like(h)[1:]], axis=0)
         H = NumpyHankelOperator(h[:s], r=h[s-1:])
-        U, sv, V = spla.svd(to_matrix(H), full_matrices=False)
-        return sv, U.T, V
+        U, sv, Vh = spla.svd(to_matrix(H), full_matrices=False)
+        return sv, U, Vh.T
 
     def output_projector(self, num_left):
         """Construct the left/output projector :math:`W_1`."""
@@ -183,7 +178,7 @@ class ERAReductor(CacheableObject):
 
         a = p * s if num_right is None and p * s < m else (num_right or m)
         b = m * s if num_left is None and m * s < p else (num_left or p)
-        err = (np.sqrt(np.arange(len(sv)) + a + b) * sv)[1:]
+        err = ((np.arange(len(sv)) + a + b) * sv**2)[1:]
 
         err = 2 * err if num_left or num_right else err
         if num_left:
@@ -194,6 +189,25 @@ class ERAReductor(CacheableObject):
             err += 4 * np.linalg.norm(s2[num_right:])**2
 
         return np.sqrt(err)
+
+    def _construct_realization(self, sv, U, V, m, p, num_left, num_right):
+        m, p = num_right or m, num_left or p
+        sqsv = np.sqrt(sv)
+        A, *_ = spla.lstsq(U[: -p], U[p:])
+        A = NumpyMatrixOperator((1/sqsv).reshape(-1,1)*A*sqsv.reshape(1,-1))
+        B = NumpyMatrixOperator((V[:m]*sqsv.reshape(1, -1)).T)
+        C = NumpyMatrixOperator(U[:p]*sqsv.reshape(1, -1))
+        if num_left:
+            self.logger.info('Backprojecting tangential output directions ...')
+            W1 = self.output_projector(num_left)
+            C = project(C, source_basis=None, range_basis=C.range.from_numpy(W1.T))
+        if num_right:
+            self.logger.info('Backprojecting tangential input directions ...')
+            W2 = self.input_projector(num_right)
+            B = project(B, source_basis=B.source.from_numpy(W2.T), range_basis=None)
+
+        return LTIModel(A, B, C, D=self.feedthrough, sampling_time=self.sampling_time,
+                        presets={'o_dense': np.diag(sv), 'c_dense': np.diag(sv), 'hsv': sv})
 
     def reduce(self, r=None, tol=None, num_left=None, num_right=None):
         """Construct a minimal realization.
@@ -220,6 +234,13 @@ class ERAReductor(CacheableObject):
         assert num_left is None or isinstance(num_left, int) and 0 < num_left < p
         assert num_right is None or isinstance(num_right, int) and 0 < num_right < m
         assert r is None or 0 < r <= min((num_left or p), (num_right or m)) * s
+
+        if num_left is None and m * s < p:
+            self.logger.info('Data has low rank! Accelerating computation with output tangential projections ...')
+            num_left = m * s
+        if num_right is None and p * s < m:
+            self.logger.info('Data has low rank! Accelerating computation with input tangential projections ...')
+            num_right = p * s
 
         sv, U, V = self._sv_U_V(num_left, num_right)
 

--- a/src/pymor/reductors/era.py
+++ b/src/pymor/reductors/era.py
@@ -271,7 +271,7 @@ class RandomizedERAReductor(ERAReductor):
     with many in- or outputs need to be performed beforehand, i.e. by setting `num_left` and
     `num_right` in the constructor.
 
-    The basic randomized ERA algorithm is based on :cite:`MKSC21`. Several computational
+    The basic randomized ERA algorithm is based on :cite:`MSKC21`. Several computational
     improvements, i.e., a memory-efficient Cholesky QR algorithm :cite:`BPS25` and a fast
     leave-one-out error estimator :cite:`ET24`, are implemented on top of that. Further, a heuristic
     error estimator is implemented which enables an adaptive refinement of the ROM that reuses

--- a/src/pymor/reductors/era.py
+++ b/src/pymor/reductors/era.py
@@ -355,7 +355,7 @@ class RandomizedERAReductor(ERAReductor):
         self._rrf.logger.info(f'Taking {num} samples ...')
         V = np.zeros((self._H._circulant.source.dim, num))
         V[:self._H.source.dim] = self._H.source.random(num, distribution='normal').to_numpy()
-        return self._H.range.make_array(self._H._circulant._circular_matvec(V)[:, :self._H.range.dim].T)
+        return self._H.range.make_array(self._H._circulant._circular_matvec(V)[:self._H.range.dim])
 
     def reduce(self, r=None, tol=None):
         """Construct a reduced realization with randomized methods.

--- a/src/pymor/reductors/era.py
+++ b/src/pymor/reductors/era.py
@@ -144,9 +144,9 @@ class ERAReductor(CacheableObject):
         of the Markov parameters :math:`\epsilon` is bounded by
 
         .. math::
-            \epsilon^2 =
-            \sum_{i = 1}^{2 s - 1}
-            \lVert C_r A_r^{i - 1} B_r - h_i \rVert_F^2
+            \epsilon = \lVert G-G_r\rVert_{\mathcal{H}_2}=
+            \left(\sum_{i = 1}^{2 s - 1}
+            \lVert C_r A_r^{i - 1} B_r - h_i \rVert_F^2\right)^{1/2}
             \leq
             \sigma_{r + 1}(\mathcal{H})
             \sqrt{r + p + m},
@@ -159,9 +159,9 @@ class ERAReductor(CacheableObject):
         With tangential projection, the bound is given by
 
         .. math::
-            \epsilon^2 =
-            \sum_{i = 1}^{2 s - 1}
-            \lVert C_r A_r^{i - 1} B_r - h_i \rVert_F^2
+            \epsilon = \lVert G-G_r\rVert_{\mathcal{H}_2}=
+            \left(\sum_{i = 1}^{2 s - 1}
+            \lVert C_r A_r^{i - 1} B_r - h_i \rVert_F^2\right)^{1/2}
             \leq
             4 \left(
                 \sum_{i = n_L + 1}^p \sigma_i^2(\Theta_L)
@@ -170,7 +170,9 @@ class ERAReductor(CacheableObject):
             + 2 \sigma_{r + 1}(\mathcal{H}) \sqrt{r + n_L + n_R},
 
         where :math:`\Theta_L,\,\Theta_R` is the matrix of horizontally or vertically stacked Markov
-        parameters, respectively. See :cite:`KG16` (Thm. 3.4) for details.
+        parameters, respectively. See :cite:`KG16` (Thm. 3.4) for details and note that there
+        present bound is squared due to a typographical error in :cite:`K78` that was reported in
+        :cite:`PS26`.
         """
         n, p, m = self.data.shape
         s = n if self.force_stability else (n + 1) // 2
@@ -257,11 +259,70 @@ class ERAReductor(CacheableObject):
 
 
 class RandomizedERAReductor(ERAReductor):
-    def __init__(self, data, sampling_time, force_stability=True, feedthrough=None, allow_transpose=True, rrf_opts={},
+    r"""Randomized Eigensystem Realization Algorithm reductor.
+
+    Constructs a (reduced) realization from a sequence of Markov parameters :math:`h_i`, for
+    :math:`i\in\{1,\,\dots,\,2s-1\}`, :math:`s\in\mathbb{N}`, by a (reduced) randomized orthogonal
+    factorization of the Hankel matrix of Markov parameters.
+
+    See :class:`ERAReductor` for details on the method and the error bounds. The main difference to
+    :class:`ERAReductor` is that the conventional SVD of the Hankel matrix is replaced by a
+    randomized SVD for greater efficiency. This implies that any tangential projections for systems
+    with many in- or outputs need to be performed beforehand, i.e. by setting `num_left` and
+    `num_right` in the constructor.
+
+    The basic randomized ERA algorithm is based on :cite:`MKSC21`. Several computational
+    improvements, i.e., a memory-efficient Cholesky QR algorithm :cite:`BPS25` and a fast
+    leave-one-out error estimator :cite:`ET24`, are implemented on top of that. Further, a heuristic
+    error estimator is implemented which enables an adaptive refinement of the ROM that reuses
+    previous computations. The heuristic error estimator, as well as the adaptive numerical
+    algorithm, are described in detail in :cite:`PS26`.
+
+    Attributes
+    ----------
+    data
+        |NumPy array| that contains the first :math:`n` Markov parameters of an LTI system.
+        Has to be one- or three-dimensional with either::
+
+            data.shape == (n,)
+
+        for scalar-valued Markov parameters or::
+
+            data.shape == (n, p, m)
+
+        for matrix-valued Markov parameters of dimension :math:`p\times m`, where
+        :math:`m` is the number of inputs and :math:`p` is the number of outputs of the system.
+    sampling_time
+        A number that denotes the sampling time of the system (in seconds).
+    force_stability
+        Whether the Markov parameters are zero-padded to double the length in order to enforce
+        Kung's stability assumption. See :cite:`K78`. Defaults to `True`.
+    feedthrough
+        (Optional) |Operator| or |Numpy array| of shape `(p, m)`. The zeroth Markov parameter that
+        defines the feedthrough of the realization. Defaults to `None`.
+    allow_transpose
+        Whether to allow the computation of the transposed problem, i.e., the randomized SVD of
+        :math:`\mathcal{H}^\top`. This can be computationally beneficial if the number of inputs is
+        larger than the number of outputs, as it reduces the second dimension of the Hankel matrix.
+        The transposition only happens internally and is resolved after randomized SVD such that the
+        in- and output dimensionality of the ROM is not affected. Defaults to `True`.
+    rrf_opts
+        Dictionary of options to pass to the constructor of |RandomizedRangeFinder| for the
+        randomized SVD of the Hankel matrix. See :class:`RandomizedRangeFinder` for details. It is
+        recommended to use a memory-efficient QR method, e.g., `shifted_chol_qr`, for better
+        performance, as well as two power iterations for a good balance of accuracy and speed.
+        Defaults to `{'qr_method': 'shifted_chol_qr', 'power_iterations': 2}`.
+    num_left
+        Number of left (output) directions for tangential projection.
+    num_right
+        Number of right (input) directions for tangential projection.
+    """
+
+    def __init__(self, data, sampling_time, force_stability=True, feedthrough=None, allow_transpose=True,
+                 rrf_opts={'qr_method': 'shifted_chol_qr', 'power_iterations': 2},
                  num_left=None, num_right=None):
         super().__init__(data, sampling_time, force_stability=force_stability, feedthrough=feedthrough)
         self.__auto_init(locals())
-        #data = data.copy()
         if num_left is not None or num_right is not None:
             self.logger.info('Computing the projected Markov parameters ...')
             data = self._project_markov_parameters(num_left, num_right)
@@ -274,7 +335,7 @@ class RandomizedERAReductor(ERAReductor):
             self.logger.info('Using transposed formulation.')
             self._H = self._H.H
         self._last_sv_U_V = None
-        self._rrf = RandomizedRangeFinder(self._H, **rrf_opts)
+        self._rrf = RandomizedRangeFinder(self._H, error_estimator='loo', **rrf_opts)
         self._rrf._draw_samples = self._draw_samples
 
     @cached
@@ -297,6 +358,21 @@ class RandomizedERAReductor(ERAReductor):
         return self._H.range.make_array(self._H._circulant._circular_matvec(V)[:, :self._H.range.dim].T)
 
     def reduce(self, r=None, tol=None):
+        """Construct a reduced realization with randomized methods.
+
+        Parameters
+        ----------
+        r
+            Order of the reduced model if `tol` is `None`, maximum order if `tol` is specified.
+        tol
+            Tolerance for the heuristic estimator of the relative error. For details, see Section
+            5.1 in :cite:`PS26`.
+
+        Returns
+        -------
+        rom
+            Reduced-order |LTIModel|.
+        """
         if tol is not None:
             tol *= self._weighted_h2_norm()
         last_basis_size = len(self._rrf.Q[-1])

--- a/src/pymor/reductors/era.py
+++ b/src/pymor/reductors/era.py
@@ -189,6 +189,17 @@ class ERAReductor(ERAReductorBase):
         U, sv, Vh = spla.svd(to_matrix(H), full_matrices=False)
         return sv, U, Vh.T
 
+    def _resolve_tangential_directions(self, num_left, num_right):
+        n, p, m = self.data.shape
+        s = n if self.force_stability else (n + 1) // 2
+        if num_left is None and m * s < p:
+            self.logger.info('Data has low rank! Accelerating computation with output tangential projections ...')
+            num_left = m * s
+        if num_right is None and p * s < m:
+            self.logger.info('Data has low rank! Accelerating computation with input tangential projections ...')
+            num_right = p * s
+        return num_left, num_right
+
     def error_bounds(self, num_left=None, num_right=None):
         r"""Compute the error bounds for all possible reduction orders.
 
@@ -226,13 +237,12 @@ class ERAReductor(ERAReductorBase):
         present bound is squared due to a typographical error in :cite:`K78` that was reported in
         :cite:`PS26`.
         """
-        n, p, m = self.data.shape
-        s = n if self.force_stability else (n + 1) // 2
-
+        _, p, m = self.data.shape
+        num_left, num_right = self._resolve_tangential_directions(num_left, num_right)
         sv = self._sv_U_V(num_left, num_right)[0]
 
-        a = p * s if num_right is None and p * s < m else (num_right or m)
-        b = m * s if num_left is None and m * s < p else (num_left or p)
+        a = num_right or m
+        b = num_left or p
         err = ((np.arange(len(sv)) + a + b) * sv**2)[1:]
 
         err = 2 * err if num_left or num_right else err
@@ -271,13 +281,7 @@ class ERAReductor(ERAReductorBase):
         assert num_right is None or isinstance(num_right, int) and 0 < num_right < m
         assert r is None or 0 < r <= min((num_left or p), (num_right or m)) * s
 
-        if num_left is None and m * s < p:
-            self.logger.info('Data has low rank! Accelerating computation with output tangential projections ...')
-            num_left = m * s
-        if num_right is None and p * s < m:
-            self.logger.info('Data has low rank! Accelerating computation with input tangential projections ...')
-            num_right = p * s
-
+        num_left, num_right = self._resolve_tangential_directions(num_left, num_right)
         sv, U, V = self._sv_U_V(num_left, num_right)
 
         if tol is not None:

--- a/src/pymor/reductors/era.py
+++ b/src/pymor/reductors/era.py
@@ -172,7 +172,7 @@ class ERAReductor(CacheableObject):
             + 2 \sigma_{r + 1}(\mathcal{H}) \sqrt{r + n_L + n_R},
 
         where :math:`\Theta_L,\,\Theta_R` is the matrix of horizontally or vertically stacked Markov
-        parameters, respectively. See :cite:`KG16` (Thm. 3.4) for details and note that there
+        parameters, respectively. See :cite:`KG16` (Thm. 3.4) for details and note that the
         present bound is squared due to a typographical error in :cite:`K78` that was reported in
         :cite:`PS26`.
         """
@@ -274,7 +274,7 @@ class RandomizedERAReductor(ERAReductor):
     `num_right` in the constructor.
 
     The basic randomized ERA algorithm is based on :cite:`MSKC21`. Several computational
-    improvements, i.e., a memory-efficient Cholesky QR algorithm :cite:`BPS25` and a fast
+    improvements, i.e., a memory-efficient Cholesky QR algorithm :cite:`BPS26` and a fast
     leave-one-out error estimator :cite:`ET24`, are implemented on top of that. Further, a heuristic
     error estimator is implemented which enables an adaptive refinement of the ROM that reuses
     previous computations. The heuristic error estimator, as well as the adaptive numerical

--- a/src/pymor/reductors/era.py
+++ b/src/pymor/reductors/era.py
@@ -7,6 +7,7 @@ import scipy.linalg as spla
 
 from pymor.algorithms.projection import project
 from pymor.algorithms.rand_la import RandomizedSVD
+from pymor.algorithms.svd_va import SVD_VA_METHODS
 from pymor.algorithms.to_matrix import to_matrix
 from pymor.core.cache import CacheableObject, cached
 from pymor.core.defaults import defaults
@@ -341,8 +342,8 @@ class RandomizedERAReductor(ERAReductor):
             **(rrf_args or {}),
             'error_estimator': 'loo',  # must use LOO
         }
-        self._rsvd = RandomizedSVD(self._H, power_iterations=power_iterations, rrf_args=rrf_args)
-        self._rsvd.range_finder._draw_samples = self._draw_samples
+        self.randomized_svd = RandomizedSVD(self._H, power_iterations=power_iterations, rrf_args=rrf_args)
+        self.randomized_svd.range_finder._draw_samples = self._draw_samples
 
     @cached
     def _weighted_h2_norm(self):
@@ -353,12 +354,33 @@ class RandomizedERAReductor(ERAReductor):
         eta[s+1:] *= np.arange(s-1)[::-1][:T-s-1] + 1
         return spla.norm(self.data*np.sqrt(eta.reshape(-1, 1, 1)))
 
+    def relative_error_estimate(self):
+        r"""Estimate the relative :math:`\mathcal{H}_2` error of the most recently reduced model.
+
+        The estimate is the LOO error estimate for the randomized Hankel approximation,
+        normalized by the weighted :math:`\mathcal{H}_2` norm. It is not a rigorous error bound.
+        See Section 3.5 in :cite:`PS26`.
+        """
+        range_finder = self.randomized_svd.range_finder
+        if len(range_finder.Q[-1]) == 0:
+            raise RuntimeError('Call reduce before estimating the relative error.')
+        return range_finder.estimate_error() / self._weighted_h2_norm()
+
     def _draw_samples(self, num):
         # faster way of computing the random samples for Hankel matrices
-        self._rsvd.range_finder.logger.info(f'Taking {num} samples ...')
+        self.randomized_svd.range_finder.logger.info(f'Taking {num} samples ...')
         V = np.zeros((self._H._circulant.source.dim, num))
         V[:self._H.source.dim] = self._H.source.random(num, distribution='normal').to_numpy()
         return self._H.range.make_array(self._H._circulant._circular_matvec(V)[:self._H.range.dim])
+
+    def _sv_U_V(self, num_left, num_right):
+        m, n = self._H.range.dim, self._H.source.dim
+        self.logger.warning(
+            f'Computing full SVD of the Hankel operator of size {m} x {n}! '
+            'Use `relative_error_estimate` for the randomized estimator.'
+        )
+        U, sv, Vh = SVD_VA_METHODS[self.randomized_svd.low_rank_svd_method](self._H.as_range_array(), modes=min(m, n))
+        return sv, U.to_numpy(), Vh.T
 
     def reduce(self, r=None, tol=None):
         r"""Construct a reduced realization with randomized methods.
@@ -379,7 +401,7 @@ class RandomizedERAReductor(ERAReductor):
         _, p, m = self.data.shape
         if tol is not None:
             tol *= self._weighted_h2_norm()
-        U, sv, V = self._rsvd.compute_svd(n=r, oversampling=0, rrf_tol=tol)
+        U, sv, V = self.randomized_svd.compute_svd(n=r, oversampling=0, rrf_tol=tol)
         if self._transpose:  # switch back, if transposed formulation was used
             U, V = V, U
 

--- a/src/pymor/reductors/era.py
+++ b/src/pymor/reductors/era.py
@@ -15,8 +15,8 @@ from pymor.operators.interface import Operator
 from pymor.operators.numpy import NumpyHankelOperator, NumpyMatrixOperator
 
 
-class GenericERAReductor(CacheableObject):
-    r"""Generic Eigensystem Realization Algorithm reductor.
+class ERAReductorBase(CacheableObject):
+    r"""Basic Eigensystem Realization Algorithm reductor.
 
     This class implements ROM construction from a orthogonal factorization of the Hankel matrix, as
     well as tangential projections of inputs and outputs. The actual factorization and error
@@ -116,7 +116,7 @@ class GenericERAReductor(CacheableObject):
                         presets={'o_dense': np.diag(sv), 'c_dense': np.diag(sv), 'hsv': sv})
 
 
-class ERAReductor(GenericERAReductor):
+class ERAReductor(ERAReductorBase):
     r"""Eigensystem Realization Algorithm reductor.
 
     Constructs a (reduced) realization from a sequence of Markov parameters :math:`h_i`,
@@ -291,7 +291,7 @@ class ERAReductor(GenericERAReductor):
         return self._construct_realization(sv, U, V, m, p, num_left, num_right)
 
 
-class RandomizedERAReductor(GenericERAReductor):
+class RandomizedERAReductor(ERAReductorBase):
     r"""Randomized Eigensystem Realization Algorithm reductor.
 
     Constructs a (reduced) realization from a sequence of Markov parameters :math:`h_i`, for

--- a/src/pymor/reductors/era.py
+++ b/src/pymor/reductors/era.py
@@ -7,7 +7,6 @@ import scipy.linalg as spla
 
 from pymor.algorithms.projection import project
 from pymor.algorithms.rand_la import RandomizedSVD
-from pymor.algorithms.svd_va import SVD_VA_METHODS
 from pymor.algorithms.to_matrix import to_matrix
 from pymor.core.cache import CacheableObject, cached
 from pymor.core.defaults import defaults
@@ -19,9 +18,9 @@ from pymor.operators.numpy import NumpyHankelOperator, NumpyMatrixOperator
 class GenericERAReductor(CacheableObject):
     r"""Generic Eigensystem Realization Algorithm reductor.
 
-    This class implements ROM construction from a orthogonal factorization of the Hankel matrix, as well as tangential
-    projections of inputs and outputs. The actual factorization and error bounds/estimators are implemented by the
-    subclasses.
+    This class implements ROM construction from a orthogonal factorization of the Hankel matrix, as
+    well as tangential projections of inputs and outputs. The actual factorization and error
+    bounds/estimators are implemented by the subclasses.
 
     Attributes
     ----------
@@ -352,7 +351,7 @@ class RandomizedERAReductor(GenericERAReductor):
         Number of right (input) directions for tangential projection.
     """
 
-    cache_region = "memory"
+    cache_region = 'memory'
 
     @defaults('power_iterations')
     def __init__(self, data, sampling_time, force_stability=True, feedthrough=None, allow_transpose=True,
@@ -389,12 +388,13 @@ class RandomizedERAReductor(GenericERAReductor):
         return spla.norm(self.data*np.sqrt(eta.reshape(-1, 1, 1)))
 
     def relative_error_estimate(self):
-        r"""Estimate the relative :math:`\mathcal{H}_2` error of the reduced model based on the current range space.
+        r"""Estimate the relative :math:`\mathcal{H}_2` error based on the current range space.
 
-        The estimate is the LOO error estimate for the randomized Hankel approximation, normalized by the weighted
-        :math:`\mathcal{H}_2` norm. It is not a rigorous error bound. The latest approximation of the range space will
-        be used for estimation. This means that the error corresponds to a ROM of order
-        `r=len(self.randomized_svd.range_finder.Q[-1])`. See Section 3.5 in :cite:`PS26` for details.
+        The estimate is the LOO error estimate for the randomized Hankel approximation, normalized
+        by the weighted :math:`\mathcal{H}_2` norm. It is not a rigorous error bound. The latest
+        approximation of the range space will be used for estimation. This means that the error
+        corresponds to a ROM of order `r=len(self.randomized_svd.range_finder.Q[-1])`. See Section
+        3.5 in :cite:`PS26` for details.
 
         .. note::
             To estimate the error of a ROM whose order is smaller than the latest range-space basis,

--- a/src/pymor/reductors/era.py
+++ b/src/pymor/reductors/era.py
@@ -381,10 +381,12 @@ class RandomizedERAReductor(ERAReductorBase):
     @cached
     def _weighted_h2_norm(self):
         T = self.data.shape[0]
-        s = int((T+1)/2)
-        eta = np.ones(T)
-        eta[1:s+1] *= np.arange(s) + 1
-        eta[s+1:] *= np.arange(s-1)[::-1][:T-s-1] + 1
+        if self.force_stability:
+            eta = np.arange(1, T + 1)
+        else:
+            s = (T + 1) // 2
+            t = np.arange(T)
+            eta = np.minimum(np.minimum(t + 1, s), T - t)
         return spla.norm(self.data*np.sqrt(eta.reshape(-1, 1, 1)))
 
     def relative_error_estimate(self):

--- a/src/pymor/reductors/era.py
+++ b/src/pymor/reductors/era.py
@@ -16,7 +16,108 @@ from pymor.operators.interface import Operator
 from pymor.operators.numpy import NumpyHankelOperator, NumpyMatrixOperator
 
 
-class ERAReductor(CacheableObject):
+class GenericERAReductor(CacheableObject):
+    r"""Generic Eigensystem Realization Algorithm reductor.
+
+    This class implements ROM construction from a orthogonal factorization of the Hankel matrix, as well as tangential
+    projections of inputs and outputs. The actual factorization and error bounds/estimators are implemented by the
+    subclasses.
+
+    Attributes
+    ----------
+    data
+        |NumPy array| that contains the first :math:`n` Markov parameters of an LTI system.
+        Has to be one- or three-dimensional with either::
+
+            data.shape == (n,)
+
+        for scalar-valued Markov parameters or::
+
+            data.shape == (n, p, m)
+
+        for matrix-valued Markov parameters of dimension :math:`p\times m`, where
+        :math:`m` is the number of inputs and :math:`p` is the number of outputs of the system.
+    sampling_time
+        A number that denotes the sampling time of the system (in seconds).
+    force_stability
+        Whether the Markov parameters are zero-padded to double the length in order to enforce
+        Kung's stability assumption. See :cite:`K78`. Defaults to `True`.
+    feedthrough
+        (Optional) |Operator| or |Numpy array| of shape `(p, m)`. The zeroth Markov parameter that
+        defines the feedthrough of the realization. Defaults to `None`.
+    """
+
+    def __init__(self, data, sampling_time, force_stability=True, feedthrough=None):
+        assert sampling_time >= 0
+        assert feedthrough is None or isinstance(feedthrough, np.ndarray | Operator)
+        assert np.isrealobj(data)
+        if data.ndim == 1:
+            data = data.reshape(-1, 1, 1)
+        assert data.ndim == 3
+        if isinstance(feedthrough, np.ndarray):
+            feedthrough = NumpyMatrixOperator(feedthrough)
+        if isinstance(feedthrough, Operator):
+            assert feedthrough.range.dim == data.shape[1]
+            assert feedthrough.source.dim == data.shape[2]
+        self.__auto_init(locals())
+
+    @cached
+    def _s1_W1(self):
+        self.logger.info('Computing output SVD ...')
+        W1, s1, _ = spla.svd(np.hstack(self.data), full_matrices=False)
+        return s1, W1
+
+    @cached
+    def _s2_W2(self):
+        self.logger.info('Computing input SVD ...')
+        _, s2, W2 = spla.svd(np.vstack(self.data), full_matrices=False)
+        return s2, W2.T
+
+    def output_projector(self, num_left):
+        """Construct the left/output projector :math:`W_1`."""
+        assert isinstance(num_left, int)
+        assert num_left <= self.data.shape[1]
+        self.logger.info(f'Constructing output projector ({num_left} tangential directions) ...')
+        return self._s1_W1()[1][:, :num_left]
+
+    def input_projector(self, num_right):
+        """Construct the right/input projector :math:`W_2`."""
+        assert isinstance(num_right, int)
+        assert num_right <= self.data.shape[2]
+        self.logger.info(f'Constructing input projector ({num_right} tangential directions) ...')
+        return self._s2_W2()[1][:, :num_right]
+
+    def _project_markov_parameters(self, num_left, num_right):
+        self.logger.info('Projecting Markov parameters ...')
+        mp = self.data
+        # computation strategy below is already improved but probably not optimal, see PR #1587.
+        if num_right:
+            mp = np.einsum('npm,mk->npk', mp, self.input_projector(num_right), optimize='optimal')
+        if num_left:
+            mp = self.output_projector(num_left).T @ mp
+        return mp
+
+    def _construct_realization(self, sv, U, V, m, p, num_left, num_right):
+        m, p = num_right or m, num_left or p
+        sqsv = np.sqrt(sv)
+        A, *_ = spla.lstsq(U[: -p], U[p:])
+        A = NumpyMatrixOperator((1/sqsv).reshape(-1,1)*A*sqsv.reshape(1,-1))
+        B = NumpyMatrixOperator((V[:m]*sqsv.reshape(1, -1)).T)
+        C = NumpyMatrixOperator(U[:p]*sqsv.reshape(1, -1))
+        if num_left:
+            self.logger.info('Backprojecting tangential output directions ...')
+            W1 = self.output_projector(num_left)
+            C = project(C, source_basis=None, range_basis=C.range.from_numpy(W1.T))
+        if num_right:
+            self.logger.info('Backprojecting tangential input directions ...')
+            W2 = self.input_projector(num_right)
+            B = project(B, source_basis=B.source.from_numpy(W2.T), range_basis=None)
+
+        return LTIModel(A, B, C, D=self.feedthrough, sampling_time=self.sampling_time,
+                        presets={'o_dense': np.diag(sv), 'c_dense': np.diag(sv), 'hsv': sv})
+
+
+class ERAReductor(GenericERAReductor):
     r"""Eigensystem Realization Algorithm reductor.
 
     Constructs a (reduced) realization from a sequence of Markov parameters :math:`h_i`,
@@ -76,42 +177,6 @@ class ERAReductor(CacheableObject):
 
     cache_region = 'memory'
 
-    def __init__(self, data, sampling_time, force_stability=True, feedthrough=None):
-        assert sampling_time >= 0
-        assert feedthrough is None or isinstance(feedthrough, np.ndarray | Operator)
-        assert np.isrealobj(data)
-        if data.ndim == 1:
-            data = data.reshape(-1, 1, 1)
-        assert data.ndim == 3
-        if isinstance(feedthrough, np.ndarray):
-            feedthrough = NumpyMatrixOperator(feedthrough)
-        if isinstance(feedthrough, Operator):
-            assert feedthrough.range.dim == data.shape[1]
-            assert feedthrough.source.dim == data.shape[2]
-        self.__auto_init(locals())
-
-    @cached
-    def _s1_W1(self):
-        self.logger.info('Computing output SVD ...')
-        W1, s1, _ = spla.svd(np.hstack(self.data), full_matrices=False)
-        return s1, W1
-
-    @cached
-    def _s2_W2(self):
-        self.logger.info('Computing input SVD ...')
-        _, s2, W2 = spla.svd(np.vstack(self.data), full_matrices=False)
-        return s2, W2.T
-
-    def _project_markov_parameters(self, num_left, num_right):
-        self.logger.info('Projecting Markov parameters ...')
-        mp = self.data
-        # computation strategy below is already improved but probably not optimal, see PR #1587.
-        if num_right:
-            mp = np.einsum('npm,mk->npk', mp, self.input_projector(num_right), optimize='optimal')
-        if num_left:
-            mp = self.output_projector(num_left).T @ mp
-        return mp
-
     @cached
     def _sv_U_V(self, num_left, num_right):
         n, p, m = self.data.shape
@@ -124,20 +189,6 @@ class ERAReductor(CacheableObject):
         H = NumpyHankelOperator(h[:s], r=h[s-1:])
         U, sv, Vh = spla.svd(to_matrix(H), full_matrices=False)
         return sv, U, Vh.T
-
-    def output_projector(self, num_left):
-        """Construct the left/output projector :math:`W_1`."""
-        assert isinstance(num_left, int)
-        assert num_left <= self.data.shape[1]
-        self.logger.info(f'Constructing output projector ({num_left} tangential directions) ...')
-        return self._s1_W1()[1][:, :num_left]
-
-    def input_projector(self, num_right):
-        """Construct the right/input projector :math:`W_2`."""
-        assert isinstance(num_right, int)
-        assert num_right <= self.data.shape[2]
-        self.logger.info(f'Constructing input projector ({num_right} tangential directions) ...')
-        return self._s2_W2()[1][:, :num_right]
 
     def error_bounds(self, num_left=None, num_right=None):
         r"""Compute the error bounds for all possible reduction orders.
@@ -195,25 +246,6 @@ class ERAReductor(CacheableObject):
 
         return np.sqrt(err)
 
-    def _construct_realization(self, sv, U, V, m, p, num_left, num_right):
-        m, p = num_right or m, num_left or p
-        sqsv = np.sqrt(sv)
-        A, *_ = spla.lstsq(U[: -p], U[p:])
-        A = NumpyMatrixOperator((1/sqsv).reshape(-1,1)*A*sqsv.reshape(1,-1))
-        B = NumpyMatrixOperator((V[:m]*sqsv.reshape(1, -1)).T)
-        C = NumpyMatrixOperator(U[:p]*sqsv.reshape(1, -1))
-        if num_left:
-            self.logger.info('Backprojecting tangential output directions ...')
-            W1 = self.output_projector(num_left)
-            C = project(C, source_basis=None, range_basis=C.range.from_numpy(W1.T))
-        if num_right:
-            self.logger.info('Backprojecting tangential input directions ...')
-            W2 = self.input_projector(num_right)
-            B = project(B, source_basis=B.source.from_numpy(W2.T), range_basis=None)
-
-        return LTIModel(A, B, C, D=self.feedthrough, sampling_time=self.sampling_time,
-                        presets={'o_dense': np.diag(sv), 'c_dense': np.diag(sv), 'hsv': sv})
-
     def reduce(self, r=None, tol=None, num_left=None, num_right=None):
         """Construct a minimal realization.
 
@@ -260,7 +292,7 @@ class ERAReductor(CacheableObject):
         return self._construct_realization(sv, U, V, m, p, num_left, num_right)
 
 
-class RandomizedERAReductor(ERAReductor):
+class RandomizedERAReductor(GenericERAReductor):
     r"""Randomized Eigensystem Realization Algorithm reductor.
 
     Constructs a (reduced) realization from a sequence of Markov parameters :math:`h_i`, for
@@ -320,6 +352,8 @@ class RandomizedERAReductor(ERAReductor):
         Number of right (input) directions for tangential projection.
     """
 
+    cache_region = "memory"
+
     @defaults('power_iterations')
     def __init__(self, data, sampling_time, force_stability=True, feedthrough=None, allow_transpose=True,
                  power_iterations=2, rrf_args=None, num_left=None, num_right=None):
@@ -372,15 +406,6 @@ class RandomizedERAReductor(ERAReductor):
         V = np.zeros((self._H._circulant.source.dim, num))
         V[:self._H.source.dim] = self._H.source.random(num, distribution='normal').to_numpy()
         return self._H.range.make_array(self._H._circulant._circular_matvec(V)[:self._H.range.dim])
-
-    def _sv_U_V(self, num_left, num_right):
-        m, n = self._H.range.dim, self._H.source.dim
-        self.logger.warning(
-            f'Computing full SVD of the Hankel operator of size {m} x {n}! '
-            'Use `relative_error_estimate` for the randomized estimator.'
-        )
-        U, sv, Vh = SVD_VA_METHODS[self.randomized_svd.low_rank_svd_method](self._H.as_range_array(), modes=min(m, n))
-        return sv, U.to_numpy(), Vh.T
 
     def reduce(self, r=None, tol=None):
         r"""Construct a reduced realization with randomized methods.

--- a/src/pymor/reductors/era.py
+++ b/src/pymor/reductors/era.py
@@ -46,7 +46,7 @@ class ERAReductorBase(CacheableObject):
         defines the feedthrough of the realization. Defaults to `None`.
     """
 
-    cache_region = "memory"
+    cache_region = 'memory'
 
     def __init__(self, data, sampling_time, force_stability=True, feedthrough=None):
         assert sampling_time >= 0

--- a/src/pymor/reductors/era.py
+++ b/src/pymor/reductors/era.py
@@ -6,9 +6,10 @@ import numpy as np
 import scipy.linalg as spla
 
 from pymor.algorithms.projection import project
-from pymor.algorithms.rand_la import RandomizedRangeFinder
+from pymor.algorithms.rand_la import RandomizedSVD
 from pymor.algorithms.to_matrix import to_matrix
 from pymor.core.cache import CacheableObject, cached
+from pymor.core.defaults import defaults
 from pymor.models.iosys import LTIModel
 from pymor.operators.interface import Operator
 from pymor.operators.numpy import NumpyHankelOperator, NumpyMatrixOperator
@@ -306,21 +307,21 @@ class RandomizedERAReductor(ERAReductor):
         larger than the number of outputs, as it reduces the second dimension of the Hankel matrix.
         The transposition only happens internally and is resolved after randomized SVD such that the
         in- and output dimensionality of the ROM is not affected. Defaults to `True`.
-    rrf_opts
-        Dictionary of options to pass to the constructor of |RandomizedRangeFinder| for the
-        randomized SVD of the Hankel matrix. See :class:`RandomizedRangeFinder` for details. It is
-        recommended to use a memory-efficient QR method, e.g., `shifted_chol_qr`, for better
-        performance, as well as two power iterations for a good balance of accuracy and speed.
-        Defaults to `{'qr_method': 'shifted_chol_qr', 'power_iterations': 2}`.
+    power_iterations
+        Number of power iterations used by the randomized SVD. Defaults to `2`.
+    rrf_args
+        Additional options passed to the underlying |RandomizedRangeFinder|. In particular,
+        `qr_method` defaults to `'shifted_chol_qr'` but can be overridden. The error estimator is
+        always `'loo'`, as required by the adaptive ERA algorithm, see :cite:`PS26`.
     num_left
         Number of left (output) directions for tangential projection.
     num_right
         Number of right (input) directions for tangential projection.
     """
 
+    @defaults('power_iterations')
     def __init__(self, data, sampling_time, force_stability=True, feedthrough=None, allow_transpose=True,
-                 rrf_opts={'qr_method': 'shifted_chol_qr', 'power_iterations': 2},
-                 num_left=None, num_right=None):
+                 power_iterations=2, rrf_args=None, num_left=None, num_right=None):
         super().__init__(data, sampling_time, force_stability=force_stability, feedthrough=feedthrough)
         self.__auto_init(locals())
         if num_left is not None or num_right is not None:
@@ -335,8 +336,13 @@ class RandomizedERAReductor(ERAReductor):
             self.logger.info('Using transposed formulation.')
             self._H = self._H.H
         self._last_sv_U_V = None
-        self._rrf = RandomizedRangeFinder(self._H, error_estimator='loo', **rrf_opts)
-        self._rrf._draw_samples = self._draw_samples
+        rrf_args = {
+            'qr_method': 'shifted_chol_qr',  # default, can override
+            **(rrf_args or {}),
+            'error_estimator': 'loo',  # must use LOO
+        }
+        self._rsvd = RandomizedSVD(self._H, power_iterations=power_iterations, rrf_args=rrf_args)
+        self._rsvd.range_finder._draw_samples = self._draw_samples
 
     @cached
     def _weighted_h2_norm(self):
@@ -347,52 +353,35 @@ class RandomizedERAReductor(ERAReductor):
         eta[s+1:] *= np.arange(s-1)[::-1][:T-s-1] + 1
         return spla.norm(self.data*np.sqrt(eta.reshape(-1, 1, 1)))
 
-    def _sv_U_V(self, num_left, num_right):
-        return self._last_sv_U_V
-
     def _draw_samples(self, num):
         # faster way of computing the random samples for Hankel matrices
-        self._rrf.logger.info(f'Taking {num} samples ...')
+        self._rsvd.range_finder.logger.info(f'Taking {num} samples ...')
         V = np.zeros((self._H._circulant.source.dim, num))
         V[:self._H.source.dim] = self._H.source.random(num, distribution='normal').to_numpy()
         return self._H.range.make_array(self._H._circulant._circular_matvec(V)[:self._H.range.dim])
 
     def reduce(self, r=None, tol=None):
-        """Construct a reduced realization with randomized methods.
+        r"""Construct a reduced realization with randomized methods.
 
         Parameters
         ----------
         r
             Order of the reduced model if `tol` is `None`, maximum order if `tol` is specified.
         tol
-            Tolerance for the heuristic estimator of the relative error. For details, see Section
-            5.1 in :cite:`PS26`.
+            Tolerance for the LOO range-approximation error estimator, scaled by the weighted
+            :math:`\mathcal{H}_2` norm. For details, see Section 5.1 in :cite:`PS26`.
 
         Returns
         -------
         rom
             Reduced-order |LTIModel|.
         """
+        _, p, m = self.data.shape
         if tol is not None:
             tol *= self._weighted_h2_norm()
-        last_basis_size = len(self._rrf.Q[-1])
-        Q = self._rrf.find_range(basis_size=r, tol=tol)
-        r = len(Q) if r is None else r
-        if r > last_basis_size:
-            self.logger.info('Projecting onto reduced space ...')
-            B = self._H.apply_adjoint(Q).to_numpy().T
-            self.logger.info(f'Computing reduced SVD of size {B.shape[0]}x{B.shape[1]} ...')
-            Ub, sv, Vh = np.linalg.svd(B, full_matrices=False)
-            self.logger.info('Lifting left singular vectors ...')
-            U = Q.lincomb(Ub)
-            self._last_sv_U_V = (sv, U.to_numpy(), Vh.T)
-        else:
-            self.logger.info('Smaller model order requested. Reusing last SVD.')
-        sv, U, V = self._last_sv_U_V
-        sv, U, V = sv[:r], U[:, :r], V[:, :r]
+        U, sv, V = self._rsvd.compute_svd(n=r, oversampling=0, rrf_tol=tol)
         if self._transpose:  # switch back, if transposed formulation was used
             U, V = V, U
 
         self.logger.info(f'Constructing reduced realization of order {r} ...')
-        _, p, m = self.data.shape
-        return self._construct_realization(sv, U, V, m, p, self.num_left, self.num_right)
+        return self._construct_realization(sv, U.to_numpy(), V.to_numpy(), m, p, self.num_left, self.num_right)

--- a/src/pymor/reductors/era.py
+++ b/src/pymor/reductors/era.py
@@ -389,11 +389,26 @@ class RandomizedERAReductor(GenericERAReductor):
         return spla.norm(self.data*np.sqrt(eta.reshape(-1, 1, 1)))
 
     def relative_error_estimate(self):
-        r"""Estimate the relative :math:`\mathcal{H}_2` error of the most recently reduced model.
+        r"""Estimate the relative :math:`\mathcal{H}_2` error of the reduced model based on the current range space.
 
-        The estimate is the LOO error estimate for the randomized Hankel approximation,
-        normalized by the weighted :math:`\mathcal{H}_2` norm. It is not a rigorous error bound.
-        See Section 3.5 in :cite:`PS26`.
+        The estimate is the LOO error estimate for the randomized Hankel approximation, normalized by the weighted
+        :math:`\mathcal{H}_2` norm. It is not a rigorous error bound. The latest approximation of the range space will
+        be used for estimation. This means that the error corresponds to a ROM of order
+        `r=len(self.randomized_svd.range_finder.Q[-1])`. See Section 3.5 in :cite:`PS26` for details.
+
+        .. note::
+            To estimate the error of a ROM whose order is smaller than the latest range-space basis,
+            add the SVD truncation error to this estimate.
+
+        Returns
+        -------
+        error
+            Estimated relative :math:`\mathcal{H}_2` error.
+
+        Raises
+        ------
+        RuntimeError
+            If :meth:`reduce` has not been called yet.
         """
         range_finder = self.randomized_svd.range_finder
         if len(range_finder.Q[-1]) == 0:

--- a/src/pymor/reductors/era.py
+++ b/src/pymor/reductors/era.py
@@ -356,6 +356,9 @@ class RandomizedERAReductor(ERAReductorBase):
                  power_iterations=2, rrf_args=None, num_left=None, num_right=None):
         super().__init__(data, sampling_time, force_stability=force_stability, feedthrough=feedthrough)
         self.__auto_init(locals())
+        if rrf_args is not None and 'error_estimator' in rrf_args:
+            assert rrf_args['error_estimator'] == 'loo', 'Only the leave-one-out error estimator is supported.'
+
         if num_left is not None or num_right is not None:
             self.logger.info('Computing the projected Markov parameters ...')
             data = self._project_markov_parameters(num_left, num_right)

--- a/src/pymor/reductors/era.py
+++ b/src/pymor/reductors/era.py
@@ -370,7 +370,6 @@ class RandomizedERAReductor(ERAReductorBase):
         if self._transpose:
             self.logger.info('Using transposed formulation.')
             self._H = self._H.H
-        self._last_sv_U_V = None
         rrf_args = {
             'qr_method': 'shifted_chol_qr',  # default, can override
             **(rrf_args or {}),

--- a/src/pymor/reductors/era.py
+++ b/src/pymor/reductors/era.py
@@ -183,9 +183,7 @@ class ERAReductor(ERAReductorBase):
 
         h = self._project_markov_parameters(num_left, num_right) if num_left or num_right else self.data
         self.logger.info(f'Computing SVD of the {"projected " if num_left or num_right else ""}Hankel matrix ...')
-        if self.force_stability:
-            h = np.concatenate([h, np.zeros_like(h)[1:]], axis=0)
-        H = NumpyHankelOperator(h[:s], r=h[s-1:])
+        H = NumpyHankelOperator(h) if self.force_stability else NumpyHankelOperator(h[:s], r=h[s-1:])
         U, sv, Vh = spla.svd(to_matrix(H), full_matrices=False)
         return sv, U, Vh.T
 
@@ -366,11 +364,9 @@ class RandomizedERAReductor(ERAReductorBase):
         if num_left is not None or num_right is not None:
             self.logger.info('Computing the projected Markov parameters ...')
             data = self._project_markov_parameters(num_left, num_right)
-        if self.force_stability:
-            data = np.concatenate([data, np.zeros_like(data)[1:]], axis=0)
-        s = (data.shape[0] + 1) // 2
+        s = data.shape[0] if self.force_stability else (data.shape[0] + 1) // 2
         self._transpose = (data.shape[1] < data.shape[2]) if allow_transpose else False
-        self._H = NumpyHankelOperator(data[:s], r=data[s-1:])
+        self._H = NumpyHankelOperator(data) if self.force_stability else NumpyHankelOperator(data[:s], r=data[s-1:])
         if self._transpose:
             self.logger.info('Using transposed formulation.')
             self._H = self._H.H

--- a/src/pymor/reductors/era.py
+++ b/src/pymor/reductors/era.py
@@ -46,6 +46,8 @@ class ERAReductorBase(CacheableObject):
         defines the feedthrough of the realization. Defaults to `None`.
     """
 
+    cache_region = "memory"
+
     def __init__(self, data, sampling_time, force_stability=True, feedthrough=None):
         assert sampling_time >= 0
         assert feedthrough is None or isinstance(feedthrough, np.ndarray | Operator)
@@ -173,8 +175,6 @@ class ERAReductor(ERAReductorBase):
         (Optional) |Operator| or |Numpy array| of shape `(p, m)`. The zeroth Markov parameter that
         defines the feedthrough of the realization. Defaults to `None`.
     """
-
-    cache_region = 'memory'
 
     @cached
     def _sv_U_V(self, num_left, num_right):
@@ -350,8 +350,6 @@ class RandomizedERAReductor(ERAReductorBase):
     num_right
         Number of right (input) directions for tangential projection.
     """
-
-    cache_region = 'memory'
 
     @defaults('power_iterations')
     def __init__(self, data, sampling_time, force_stability=True, feedthrough=None, allow_transpose=True,

--- a/src/pymordemos/era.py
+++ b/src/pymordemos/era.py
@@ -9,7 +9,7 @@ from cyclopts import App
 from pymor.core.logger import set_log_levels
 from pymor.models.iosys import LTIModel
 from pymor.reductors.bt import BTReductor
-from pymor.reductors.era import ERAReductor
+from pymor.reductors.era import ERAReductor, RandomizedERAReductor
 from pymor.tools.random import get_rng, new_rng
 
 
@@ -87,22 +87,26 @@ def main(n: int = 10):
     mp = compute_markov_parameters(fom, n=100)
 
     era = ERAReductor(mp, sampling_time=sampling_time, feedthrough=fom.D)
+    randera = RandomizedERAReductor(mp, sampling_time=sampling_time, feedthrough=fom.D)
     bt = BTReductor(fom)
 
     era_rom = era.reduce(4)
+    randera_rom = randera.reduce(4)
     bt_rom = bt.reduce(4)
 
     fig, axs = plt.subplots(1, 2, figsize=(12, 5), constrained_layout=True)
     ax = axs[0]
-    fom.transfer_function.mag_plot(w, ax=ax, label='FOM', dB=True)
+    fom.transfer_function.mag_plot(w, ax=ax, label='FOM', dB=True, c='k')
     era_rom.transfer_function.mag_plot(w, ax=ax, label='ERA ROM', dB=True, linestyle='dashed')
+    randera_rom.transfer_function.mag_plot(w, ax=ax, label='RandERA ROM', dB=True, linestyle='dashdot')
     bt_rom.transfer_function.mag_plot(w, ax=ax, label='BT ROM', dB=True, linestyle='dotted')
     ax.set_title(r'Transfer function magnitude ($r=4$)')
     ax.legend()
 
     ax = axs[1]
     (fom-era_rom).transfer_function.mag_plot(w, ax=ax, label='ERA', dB=True)
-    (fom-bt_rom).transfer_function.mag_plot(w, ax=ax, label='BT', dB=True, linestyle='dashed')
+    (fom-randera_rom).transfer_function.mag_plot(w, ax=ax, label='RandERA', dB=True, linestyle='dashdot')
+    (fom-bt_rom).transfer_function.mag_plot(w, ax=ax, label='BT', dB=True, linestyle='dotted')
     ax.set_title(r'Error magnitude ($r=4$)')
     ax.legend()
 


### PR DESCRIPTION
This PR adds a new `RandomizedERAReductor` based on (https://doi.org/10.1137/20M1327616).

I've also corrected a mistake in the error bound of the original `ERAReductor` that originated from a typo in the original paper.

The `RandomizedERAReductor` can also be used in an adaptive way by using a leave-one-out error estimator that I will introduce in an upcoming paper. The estimator is not a true upper bound for the error but very fast to evaluate and performs much better than all other available estimators in practice (the established error bounds are grossly conservative).