### PR TITLE
correct hamiltonian operator in linear wave equation demo

### DIFF
--- a/src/pymordemos/symplectic_wave_equation.py
+++ b/src/pymordemos/symplectic_wave_equation.py
@@ -11,7 +11,7 @@ from pymor.algorithms.pod import pod
 from pymor.algorithms.symplectic import psd_complex_svd, psd_cotangent_lift, psd_svd_like_decomp
 from pymor.models.symplectic import QuadraticHamiltonianModel
 from pymor.operators.block import BlockDiagonalOperator
-from pymor.operators.constructions import IdentityOperator, LincombOperator
+from pymor.operators.constructions import IdentityOperator
 from pymor.operators.numpy import NumpyMatrixOperator
 from pymor.reductors.basic import InstationaryRBReductor
 from pymor.reductors.symplectic import QuadraticHamiltonianRBReductor
@@ -112,8 +112,8 @@ def discretize_fom(T=50):
         format='csr',
     )
     H_op = BlockDiagonalOperator([
-        NumpyMatrixOperator(-wave_speed**2 / dx * Dxx),
-        LincombOperator([IdentityOperator(space)], [1/dx]),
+        NumpyMatrixOperator(-(wave_speed/dx)**2 * Dxx),
+        IdentityOperator(space),
     ])
 
     # construct initial_data


### PR DESCRIPTION
i found a small mistake in the definition of the Hamiltonian operator in the linear wave equation demo. 

I guess the mistake stem from description of the example in

L. Peng and K. Mohseni. Symplectic model reduction of Hamiltonian systems. SIAM Journal on Scientific Computing, 38(1):A1–A27, 2016. [doi:10.1137/140978922](https://doi.org/10.1137/140978922).

which is where the example is taken from. There the authors define in equation (6.5) $J_{2d} = \frac{J_{2n}}{\delta x}$, which might have created the confusion. A second reference that writes in a bit clearer is Section 4.1 of 

P. Buchfink, S. Glas, and B. Haasdonk. Symplectic model reduction of Hamiltonian systems on
nonlinear manifolds and approximation with weakly symplectic autoencoder. SIAM J. Sci. Comput.,
45(2):A289–A311, 2023.

where the discrete Hamiltonian $\mathcal{H}$ matches the renewed definition of the ``H_op`` in code.