### PR TITLE
Add type annotations for @defaults and @cached

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -134,6 +134,7 @@ nitpick_ignore = [
     ('py:obj', 'k3d.plot.Plot'),
     ('py:obj', 'qtpy.QtWidgets.QOpenGLWidget'),
     ('py:obj', 'qtpy.QtWidgets.QWidget'),
+    ('py:class', 'F'),
 ]
 nitpick_ignore_regex = [
     ('py:class', 'Choices(.+)'),  # pymor.tools.typer.Choices(...) cannot be referred to

--- a/src/pymor/core/cache.py
+++ b/src/pymor/core/cache.py
@@ -73,6 +73,7 @@ from copy import deepcopy
 from numbers import Number
 from textwrap import wrap
 from types import MethodType
+from typing import Any, Callable, TypeVar, cast
 
 import diskcache
 import numpy as np
@@ -436,8 +437,9 @@ class CacheableObject(ImmutableObject):
 
 _CACHED_METHODS = []
 
+F = TypeVar('F', bound=Callable[..., Any])
 
-def cached(function):
+def cached(function: F) -> F:
     """Decorator to make a method of `CacheableObject` actually cached."""
     params = inspect.signature(function).parameters
     if any(v.kind == v.VAR_POSITIONAL for v in params.values()):
@@ -453,7 +455,7 @@ def cached(function):
 
     _CACHED_METHODS.append(function.__qualname__)
 
-    return wrapper
+    return cast(F, wrapper)
 
 
 def print_cached_methods():


### PR DESCRIPTION
The type annotations should help type checkers / language servers to correctly understand the signatures of methods that have been decorated with `@defaults` or `@cached`.

In particular, `jedi-language-server` correctly completes the signature of `gram_schmidt` with this PR.