### PR TITLE
Add `use_umfpack` option to `ScipySpSolveSolver` class.

### DIFF
--- a/src/pymor/bindings/scipy.py
+++ b/src/pymor/bindings/scipy.py
@@ -27,11 +27,8 @@ from pymor.core.exceptions import InversionError
 from pymor.core.logger import getLogger
 from pymor.solvers.interface import Solver
 
-try:
+if config.HAVE_UMFPACK:
     import scikits.umfpack
-    HAS_UMFPACK = True
-except ImportError:
-    HAS_UMFPACK = False
 
 
 SCIPY_1_14_OR_NEWER = parse(config.SCIPY_VERSION) >= parse('1.14')
@@ -180,7 +177,7 @@ class ScipySpSolveSolver(ScipyLinearSolver):
                         raise KeyError
                 except KeyError:
                     matrix = matrix_astype_nocopy(matrix, promoted_type)
-                    if self.use_umfpack and HAS_UMFPACK:
+                    if self.use_umfpack and config.HAVE_UMFPACK:
                         fac = scikits.umfpack.splu(matrix)
                     else:
                         fac = splu(matrix, permc_spec=self.permc_spec)
@@ -194,7 +191,7 @@ class ScipySpSolveSolver(ScipyLinearSolver):
                 # the matrix is always converted to the promoted type.
                 # if matrix.dtype == promoted_type, this is a no_op
                 matrix = matrix_astype_nocopy(matrix, promoted_type)
-                if self.use_umfpack and HAS_UMFPACK:
+                if self.use_umfpack and config.HAVE_UMFPACK:
                     R = scikits.umfpack.spsolve(matrix, V)
                 else:
                     R = spsolve(matrix, V, permc_spec=self.permc_spec, use_umfpack=False)

--- a/src/pymor/core/config.py
+++ b/src/pymor/core/config.py
@@ -7,6 +7,7 @@ import platform
 import sys
 import warnings
 from importlib import import_module
+from importlib.metadata import PackageNotFoundError, version
 
 from packaging.version import parse
 
@@ -120,6 +121,14 @@ def _get_qt_version():
     return f'{qtpy.API_NAME} (Qt {qtpy.QT_VERSION})'
 
 
+def _get_umfpack_version():
+    try:
+        return version('scikit-umfpack')
+    except PackageNotFoundError:
+        pass
+    return False
+
+
 def is_jupyter():
     """Check if we believe to be running in a Jupyter Notebook or Lab.
 
@@ -160,6 +169,7 @@ _PACKAGES = {
     'TORCH': _get_version('torch', True),
     'THREADPOOLCTL': _get_version('threadpoolctl'),
     'TYPER': _get_version('typer'),
+    'UMFPACK': _get_umfpack_version,
     'VTKIO': lambda: _can_import(('meshio', 'pyevtk', 'lxml', 'xmljson')),
 }
 


### PR DESCRIPTION
`scipy.sparse.spsolve` offers a `use_umfpack` interface, in case suitesparse's umfpack is available. However, the `scipy.sparse.splu`, which returns a callable solver object, does not and `scikits.umfpack.splu` has to be called instead in order to make also the umfpack solver class cacheable.

