### PR TITLE
bugfix neural_network reductor returning only last epoch instead of best network

### DIFF
--- a/src/pymor/reductors/neural_network.py
+++ b/src/pymor/reductors/neural_network.py
@@ -1165,7 +1165,7 @@ def multiple_restarts_training(training_data, validation_data, neural_network,
         if target_loss and losses['full'] <= target_loss:
             logger.info(f'Finished training after {run - 1} restart{"s" if run - 1 != 1 else ""}, '
                         f'found neural network with loss of {losses["full"]:.3e} ...')
-            return neural_network, losses
+            return best_neural_network, losses
 
         with logger.block(f'Training neural network #{run} ...'):
             # reset parameters of layers to start training with a new and untrained network


### PR DESCRIPTION
This bug showed when I trained a neural network with very limited data. It ran fine in the first epochs, but then the loss exploded (1e+24), Early stopping was called and I got back the neural network architecture with a huge error on the data.

#### What does this implement/fix?
When a multiple_restarts_training is called it will first run the #0 training and check if the error is below the target loss before it then starts multiple other restarts to check if any of these reach below the target_loss.

Right now the neural_network of the last epoch is returned when the training stops after the #0 run. Instead it should be the best_neural network as in line 1204. 
