### PR TITLE
Automatically remove MPI object when ObjectId dies

### DIFF
--- a/src/pymor/models/mpi.py
+++ b/src/pymor/models/mpi.py
@@ -50,13 +50,10 @@ class MPIModel:
     def visualize(self, U, **kwargs):
         self.visualizer.visualize(U, **kwargs)
 
-    def __del__(self):
-        mpi.call(mpi.remove_object, self.obj_id)
-
 
 class MPIVisualizer(ImmutableObject):
 
-    def __init__(self, m_obj_id, remove_model=False):
+    def __init__(self, m_obj_id):
         self.__auto_init(locals())
 
     def visualize(self, U, **kwargs):
@@ -67,10 +64,6 @@ class MPIVisualizer(ImmutableObject):
             ind = U.ind
             U = U.impl.obj_id
         mpi.call(_MPIVisualizer_visualize, self.m_obj_id, U, ind, **kwargs)
-
-    def __del__(self):
-        if self.remove_model:
-            mpi.call(mpi.remove_object, self.m_obj_id)
 
 
 def _MPIVisualizer_visualize(m, U, ind, **kwargs):
@@ -153,9 +146,7 @@ def mpi_wrap_model(local_models, mpi_spaces=None, use_with=True, with_apply2=Fal
     if use_with:
         m = mpi.get_object(local_models)
         if m.visualizer:
-            wrapped_attributes['visualizer'] = MPIVisualizer(local_models, True)
-        else:
-            mpi.call(mpi.remove_object, local_models)
+            wrapped_attributes['visualizer'] = MPIVisualizer(local_models)
         m = m.with_(**wrapped_attributes)
         return m
     else:

--- a/src/pymor/operators/mpi.py
+++ b/src/pymor/operators/mpi.py
@@ -188,7 +188,6 @@ class MPIOperator(Operator):
         obj_id = mpi.call(_MPIOperator_assemble_lincomb, operators, coefficients, identity_shift, name=name)
         op = mpi.get_object(obj_id)
         if op is None:
-            mpi.call(mpi.remove_object, obj_id)
             return None
         else:
             return self.with_(obj_id=obj_id)
@@ -198,9 +197,6 @@ class MPIOperator(Operator):
         if retval is None:
             raise NotImplementedError
         return retval
-
-    def __del__(self):
-        mpi.call(mpi.remove_object, self.obj_id)
 
 
 def _MPIOperator_get_local_spaces(self, source, pickle_local_spaces):
@@ -303,7 +299,6 @@ def mpi_wrap_operator(obj_id, mpi_range, mpi_source, with_apply2=False, pickle_l
 def _mpi_wrap_operator_LincombOperator_manage_operators(obj_id):
     op = mpi.get_object(obj_id)
     obj_ids = [mpi.manage_object(o) for o in op.operators]
-    mpi.remove_object(obj_id)
     if mpi.rank0:
         return obj_ids
 
@@ -315,6 +310,5 @@ def _mpi_wrap_operator_VectorArrayOperator_manage_array(obj_id, pickle_local_spa
     if not pickle_local_spaces:
         local_space = _register_local_space(local_space)
     local_spaces = mpi.comm.gather(local_space, root=0)
-    mpi.remove_object(obj_id)
     if mpi.rank0:
         return array_obj_id, tuple(local_spaces)

--- a/src/pymor/parallel/mpi.py
+++ b/src/pymor/parallel/mpi.py
@@ -20,9 +20,6 @@ class MPIPool(WorkerPoolBase):
         self._apply(os.chdir, os.getcwd())
         self._map(_setup_rng, [[[s] for s in get_seed_seq().spawn(mpi.size)]])
 
-    def __del__(self):
-        mpi.call(mpi.remove_object, self._payload)
-
     def __len__(self):
         return mpi.size
 
@@ -51,7 +48,7 @@ class MPIPool(WorkerPoolBase):
         return result
 
     def _remove_object(self, remote_id):
-        mpi.call(mpi.remove_object, remote_id)
+        pass  # handled by obj_id going out of scope
 
 
 def _worker_call_function(function, *args, **kwargs):

--- a/src/pymor/vectorarrays/mpi.py
+++ b/src/pymor/vectorarrays/mpi.py
@@ -67,9 +67,6 @@ class MPIVectorArrayImpl(VectorArrayImpl):
     def amax(self, ind):
         return mpi.call(mpi.function_call, _MPIVectorArray_amax, self.obj_id, ind)
 
-    def __del__(self):
-        mpi.call(mpi.remove_object, self.obj_id)
-
     def real(self, ind):
         return type(self)(mpi.call(mpi.function_call_manage, _MPIVectorArray_real, self.obj_id, ind), self.space)
 


### PR DESCRIPTION
So far, objects stored using `pymor.tools.mpi.manage_object` had to be removed manually using `mpi.call(remove_object, obj_id)`. Obviously, this approach is error-prone. For instance

```python
op = MPIOperator(...)
op = op.with_(name='Foo')
```

would already yield an error: The first `MPIOperator` would delete the underlying MPI distributed `Operator` when going out of scope.

With this PR, `ObjectId` itself will remove the underlying object when it is deleted.