### PR TITLE
Fix test_adaptive_rrf with LOO estimator and shifted_chol_qr

### DIFF
--- a/src/pymortests/algorithms/rand_la.py
+++ b/src/pymortests/algorithms/rand_la.py
@@ -20,6 +20,7 @@ def test_adaptive_rrf(rng, qr_method, error_estimator):
     op = NumpyMatrixOperator(A)
 
     B = A + 1j*rng.uniform(low=-1.0, high=1.0, size=(100, 10))
+    B *= (10**(np.linspace(-1, -10, 10)))[np.newaxis, :]
     op_complex = NumpyMatrixOperator(B)
 
     Q1 = RandomizedRangeFinder(


### PR DESCRIPTION
The test used a random matrix B with very slow singular value decay, so RandomizedRangeFinder had to return rank B many vectors. Since the LOO estimator is based on the range approximation with one vector removed, the estimated error remained in the order of one until the very end, forcing the RRF to include a rank B+1-th vector. This caused shifted_chol_qr to break down occasionally.