### PR TITLE
add set method around dict in skfem discretizer boundary treatment

### DIFF
--- a/src/pymor/analyticalproblems/domaindescriptions.py
+++ b/src/pymor/analyticalproblems/domaindescriptions.py
@@ -280,7 +280,7 @@ class PolygonalDomain(DomainDescription):
     ----------
     points
         2D |NumPy array| points [x_0, x_1] that describe the polygonal chain that bounds the domain.
-    boundary_types
+    boundary_description
         Either a dictionary `{boundary_type: [i_0, ...], boundary_type: [j_0, ...], ...}`
         with `i_0, ...` being the ids of boundary segments for a given boundary type
         (`0` is the line connecting point `0` to `1`, `1` is the line connecting point `1` to `2`
@@ -298,7 +298,7 @@ class PolygonalDomain(DomainDescription):
 
     dim = 2
 
-    def __init__(self, points, boundary_types, holes=None):
+    def __init__(self, points, boundary_description, holes=None):
         points = np.asarray(points)
         assert points.ndim == 2
         assert points.shape[-1] == 2
@@ -308,7 +308,7 @@ class PolygonalDomain(DomainDescription):
         assert all(h.ndim == 2 for h in holes)
         assert all(h.shape[-1] == 2 for h in holes)
 
-        if isinstance(boundary_types, dict):
+        if isinstance(boundary_description, dict):
             pass
         # if the boundary types are not given as a dict, try to evaluate at
         # the edge centers to get a dict.
@@ -319,15 +319,16 @@ class PolygonalDomain(DomainDescription):
                 for index in range(len(curve)):
                     p0, p1 = curve[index], curve[index % len(curve)]
                     center = [(p0[0]+p1[0])/2, (p0[1]+p1[1])/2]
-                    boundary_types_dict[boundary_types(center)].append(segment_id)
+                    boundary_types_dict[boundary_description(center)].append(segment_id)
                     segment_id += 1
 
-            boundary_types = dict(boundary_types_dict)
+            boundary_description = dict(boundary_types_dict)
 
-        for bt in boundary_types:
+        for bt in boundary_description:
             if bt is not None and bt not in KNOWN_BOUNDARY_TYPES:
                 self.logger.warning(f'Unknown boundary type: {bt}')
 
+        self.boundary_types = frozenset(boundary_description.keys())
         self.__auto_init(locals())
 
 

--- a/src/pymor/analyticalproblems/domaindescriptions.py
+++ b/src/pymor/analyticalproblems/domaindescriptions.py
@@ -371,13 +371,13 @@ class CircularSectorDomain(PolygonalDomain):
         if arc == radii:
             boundary_description = {arc: list(range(1, len(points)+1))}
         else:
-            boundary_description  = {arc: list(range(2, len(points)))}
-            boundary_description .update({radii: [1, len(points)]})
+            boundary_description = {arc: list(range(2, len(points)))}
+            boundary_description.update({radii: [1, len(points)]})
 
         if None in boundary_description :
-            del boundary_description [None]
+            del boundary_description[None]
 
-        super().__init__(points, boundary_description )
+        super().__init__(points, boundary_description)
         self.__auto_init(locals())
 
 
@@ -406,7 +406,7 @@ class DiscDomain(PolygonalDomain):
 
         points = [[radius*np.cos(t), radius*np.sin(t)] for t in
                   np.linspace(start=0, stop=2*np.pi, num=num_points, endpoint=False)]
-        boundary_description  = {} if boundary is None else {boundary: list(range(1, len(points)+1))}
+        boundary_description = {} if boundary is None else {boundary: list(range(1, len(points)+1))}
 
-        super().__init__(points, boundary_description )
+        super().__init__(points, boundary_description)
         self.__auto_init(locals())

--- a/src/pymor/analyticalproblems/domaindescriptions.py
+++ b/src/pymor/analyticalproblems/domaindescriptions.py
@@ -369,15 +369,15 @@ class CircularSectorDomain(PolygonalDomain):
                        np.linspace(start=0, stop=angle, num=num_points, endpoint=True)])
 
         if arc == radii:
-            boundary_types = {arc: list(range(1, len(points)+1))}
+            boundary_description = {arc: list(range(1, len(points)+1))}
         else:
-            boundary_types = {arc: list(range(2, len(points)))}
-            boundary_types.update({radii: [1, len(points)]})
+            boundary_description  = {arc: list(range(2, len(points)))}
+            boundary_description .update({radii: [1, len(points)]})
 
-        if None in boundary_types:
-            del boundary_types[None]
+        if None in boundary_description :
+            del boundary_description [None]
 
-        super().__init__(points, boundary_types)
+        super().__init__(points, boundary_description )
         self.__auto_init(locals())
 
 
@@ -406,7 +406,7 @@ class DiscDomain(PolygonalDomain):
 
         points = [[radius*np.cos(t), radius*np.sin(t)] for t in
                   np.linspace(start=0, stop=2*np.pi, num=num_points, endpoint=False)]
-        boundary_types = {} if boundary is None else {boundary: list(range(1, len(points)+1))}
+        boundary_description  = {} if boundary is None else {boundary: list(range(1, len(points)+1))}
 
-        super().__init__(points, boundary_types)
+        super().__init__(points, boundary_description )
         self.__auto_init(locals())

--- a/src/pymor/discretizers/builtin/domaindiscretizers/gmsh.py
+++ b/src/pymor/discretizers/builtin/domaindiscretizers/gmsh.py
@@ -73,7 +73,7 @@ def discretize_gmsh(domain_description=None, geo_file=None, geo_file_path=None, 
         points = [domain_description.points.tolist()]
         points.extend([h.tolist() for h in domain_description.holes])
 
-        return points, domain_description.boundary_types
+        return points, domain_description.boundary_description
 
     def discretize_RectDomain():
         points = [[domain_description.domain[0].tolist(),

--- a/src/pymor/discretizers/skfem/cg.py
+++ b/src/pymor/discretizers/skfem/cg.py
@@ -232,7 +232,7 @@ def discretize_stationary_cg(analytical_problem, diameter=None, mesh_type=None, 
         raise NotImplementedError
     if p.nonlinear_reaction_derivative is not None:
         raise NotImplementedError
-    if not p.domain.boundary_types <= {'dirichlet', 'neumann'}:
+    if not set(p.domain.boundary_types) <= {'dirichlet', 'neumann'}:
         raise NotImplementedError
 
     mesh, boundary_facets = discretize_domain(p.domain, mesh_type=mesh_type, diameter=diameter)

--- a/src/pymor/discretizers/skfem/cg.py
+++ b/src/pymor/discretizers/skfem/cg.py
@@ -232,7 +232,7 @@ def discretize_stationary_cg(analytical_problem, diameter=None, mesh_type=None, 
         raise NotImplementedError
     if p.nonlinear_reaction_derivative is not None:
         raise NotImplementedError
-    if not set(p.domain.boundary_types) <= {'dirichlet', 'neumann'}:
+    if not p.domain.boundary_types <= {'dirichlet', 'neumann'}:
         raise NotImplementedError
 
     mesh, boundary_facets = discretize_domain(p.domain, mesh_type=mesh_type, diameter=diameter)

--- a/src/pymortests/analyticalproblems/polygonal_chain.py
+++ b/src/pymortests/analyticalproblems/polygonal_chain.py
@@ -31,7 +31,7 @@ def test_polygonal_chain_boundary_function():
             [2]
     }
 
-    domain = PolygonalDomain(points=chain, boundary_types=_determine_boundary_type)
+    domain = PolygonalDomain(points=chain, boundary_description=_determine_boundary_type)
 
     print(domain.boundary_types)
 

--- a/src/pymortests/analyticalproblems/polygonal_chain.py
+++ b/src/pymortests/analyticalproblems/polygonal_chain.py
@@ -35,7 +35,8 @@ def test_polygonal_chain_boundary_function():
 
     print(domain.boundary_types)
 
-    assert domain.boundary_types == reference_boundary_types
+    assert domain.boundary_description == reference_boundary_types
+    assert domain.boundary_types == frozenset(reference_boundary_types.keys())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR fixes the following bug: In `discretize_stationary_cg` one assert checks `p.domain.boundary_types <= {'dirichlet', 'neumann'}`. This works fine for most domain, but not for `DiscDomain` and `Polygonal` domain, as there `p.domain.boundary_types` is a dictionary and the comparison `<=` only works to compare two sets. By calling set(dict) the dict gets turned into a set with the keys as entries in the set. For a set, calling set(set) does not do anything, so this is also fine. 


