### PR TITLE
Progress bars

### DIFF
--- a/docs/source/environment.md
+++ b/docs/source/environment.md
@@ -54,3 +54,7 @@ is unset the value of `mpi4py.rc.finalize` remains unchanged, unless
 ```{envvar} PYMOR_MPI_INIT_THREAD
 Required threading level to require when pyMOR calls `mpi4py.MPI.Init_thread`.
 ```
+
+```{envvar} PYMOR_PROGRESS
+If set, display progress bars for long running operations. (EXPERIMENTAL)
+```

--- a/src/pymor/algorithms/ei.py
+++ b/src/pymor/algorithms/ei.py
@@ -13,6 +13,8 @@ the empirical interpolation of the |Operators| of a given model with
 a single function call.
 """
 
+from itertools import count
+
 import numpy as np
 import scipy.linalg as spla
 
@@ -23,6 +25,7 @@ from pymor.operators.ei import EmpiricalInterpolatedOperator
 from pymor.parallel.dummy import dummy_pool
 from pymor.parallel.interface import RemoteObject
 from pymor.parallel.manager import RemoteObjectManager
+from pymor.tools.progress import track
 from pymor.vectorarrays.interface import VectorArray
 from pymor.vectorarrays.numpy import NumpyVectorSpace
 
@@ -116,7 +119,7 @@ def ei_greedy(U, error_norm=None, atol=None, rtol=None, max_interpolation_dofs=N
     initial_max_err = max_err = errs[max_err_ind]
 
     # main loop
-    while True:
+    for _ in track(count(), 'ei_greedy', min(max_interpolation_dofs, len(U)) if max_interpolation_dofs else len(U)):
         if max_interpolation_dofs is not None and len(interpolation_dofs) >= max_interpolation_dofs:
             logger.info('Maximum number of interpolation DOFs reached. Stopping extension loop.')
             logger.info(f'Final maximum interpolation error with '
@@ -235,7 +238,7 @@ def deim(U, modes=None, pod=True, atol=None, rtol=None, product=None, pod_option
     interpolation_dofs = np.zeros((0,), dtype=np.int32)
     interpolation_matrix = np.zeros((0, 0))
 
-    for i in range(len(collateral_basis)):
+    for i in track(range(len(collateral_basis)), 'deim'):
         logger.info(f'Choosing interpolation point for basis vector {i}.')
 
         if len(interpolation_dofs) > 0:
@@ -401,10 +404,11 @@ def interpolate_operators(fom, operator_names, parameter_sample, error_norm=None
                 logger.info(f'Using pool of {len(pool)} workers for parallel evaluation')
                 evaluations = rom.manage(pool.push(fom.solution_space.empty()))
                 pool.map(_interpolate_operators_build_evaluations, parameter_sample,
-                         fom=fom, operators=operators, evaluations=evaluations)
+                         fom=fom, operators=operators, evaluations=evaluations,
+                         task_label='eval operator')
             else:
                 evaluations = operators[0].range.empty()
-                for mu in parameter_sample:
+                for mu in track(parameter_sample, 'eval operator'):
                     U = fom.solve(mu)
                     for op in operators:
                         evaluations.append(op.apply(U, mu=mu))
@@ -534,7 +538,7 @@ def _parallel_ei_greedy(U, pool, error_norm=None, atol=None, rtol=None, max_inte
         initial_max_err = max_err = errs[max_err_ind]
 
         # main loop
-        while True:
+        for _ in track(count(), 'ei_greedy', max_interpolation_dofs):
 
             if max_interpolation_dofs is not None and len(interpolation_dofs) >= max_interpolation_dofs:
                 logger.info('Maximum number of interpolation DOFs reached. Stopping extension loop.')

--- a/src/pymor/algorithms/error.py
+++ b/src/pymor/algorithms/error.py
@@ -189,7 +189,7 @@ def reduction_error_analysis(rom, fom, reductor, test_mus,
     norms, error_estimates, errors, conditions, custom_values = \
         list(zip(*pool.map(_compute_errors, test_mus, fom=fom, reductor=reductor, error_estimator=error_estimator,
                            error_norms=error_norms, condition=condition, custom=custom, basis_sizes=basis_sizes,
-                           task_title='compute errors'),
+                           task_label='compute errors'),
                  strict=True))
     print()
 

--- a/src/pymor/algorithms/error.py
+++ b/src/pymor/algorithms/error.py
@@ -188,7 +188,8 @@ def reduction_error_analysis(rom, fom, reductor, test_mus,
 
     norms, error_estimates, errors, conditions, custom_values = \
         list(zip(*pool.map(_compute_errors, test_mus, fom=fom, reductor=reductor, error_estimator=error_estimator,
-                           error_norms=error_norms, condition=condition, custom=custom, basis_sizes=basis_sizes),
+                           error_norms=error_norms, condition=condition, custom=custom, basis_sizes=basis_sizes,
+                           task_title='compute errors'),
                  strict=True))
     print()
 
@@ -395,11 +396,6 @@ def plot_reduction_error_analysis(result, max_basis_size=None, plot_effectivitie
 
 
 def _compute_errors(mu, fom, reductor, error_estimator, error_norms, condition, custom, basis_sizes):
-    import sys
-
-    print('.', end='')
-    sys.stdout.flush()
-
     error_estimates = np.empty(len(basis_sizes)) if error_estimator else None
     norms = np.empty(len(error_norms))
     errors = np.empty((len(error_norms), len(basis_sizes)))

--- a/src/pymor/algorithms/gram_schmidt.py
+++ b/src/pymor/algorithms/gram_schmidt.py
@@ -7,7 +7,7 @@ import numpy as np
 from pymor.core.defaults import defaults
 from pymor.core.exceptions import AccuracyError
 from pymor.core.logger import getLogger
-from pymor.tools.progress import get_progress_display
+from pymor.tools.progress import track
 
 
 @defaults('atol', 'rtol', 'reiterate', 'reiteration_threshold', 'check', 'check_tol')
@@ -61,7 +61,7 @@ def gram_schmidt(A, product=None, return_R=False, atol=1e-13, rtol=1e-13, offset
     # main loop
     R = np.eye(len(A))
     remove = []  # indices of to be removed vectors
-    for i in get_progress_display().track(range(offset, len(A)), 'Gram-Schmidt'):
+    for i in track(range(offset, len(A)), 'Gram-Schmidt'):
         # first calculate norm
         initial_norm = A[i].norm(product)[0]
 

--- a/src/pymor/algorithms/gram_schmidt.py
+++ b/src/pymor/algorithms/gram_schmidt.py
@@ -7,6 +7,7 @@ import numpy as np
 from pymor.core.defaults import defaults
 from pymor.core.exceptions import AccuracyError
 from pymor.core.logger import getLogger
+from pymor.tools.progress import get_progress_display
 
 
 @defaults('atol', 'rtol', 'reiterate', 'reiteration_threshold', 'check', 'check_tol')
@@ -60,7 +61,7 @@ def gram_schmidt(A, product=None, return_R=False, atol=1e-13, rtol=1e-13, offset
     # main loop
     R = np.eye(len(A))
     remove = []  # indices of to be removed vectors
-    for i in range(offset, len(A)):
+    for i in get_progress_display().track(range(offset, len(A)), 'Gram-Schmidt'):
         # first calculate norm
         initial_norm = A[i].norm(product)[0]
 

--- a/src/pymor/algorithms/gram_schmidt.py
+++ b/src/pymor/algorithms/gram_schmidt.py
@@ -7,7 +7,7 @@ import numpy as np
 from pymor.core.defaults import defaults
 from pymor.core.exceptions import AccuracyError
 from pymor.core.logger import getLogger
-from pymor.tools.progress import track
+from pymor.tools.progress import add_task
 
 
 @defaults('atol', 'rtol', 'reiterate', 'reiteration_threshold', 'check', 'check_tol')
@@ -61,49 +61,51 @@ def gram_schmidt(A, product=None, return_R=False, atol=1e-13, rtol=1e-13, offset
     # main loop
     R = np.eye(len(A))
     remove = []  # indices of to be removed vectors
-    for i in track(range(offset, len(A)), 'Gram-Schmidt'):
-        # first calculate norm
-        initial_norm = A[i].norm(product)[0]
+    with add_task('Gram-Schmidt', (len(A)-offset)*(len(A)-offset+1)//2) as task:
+        for i in range(offset, len(A)):
+            # first calculate norm
+            initial_norm = A[i].norm(product)[0]
 
-        if initial_norm <= atol:
-            logger.info(f'Removing vector {i} of norm {initial_norm}')
-            remove.append(i)
-            continue
+            if initial_norm <= atol:
+                logger.info(f'Removing vector {i} of norm {initial_norm}')
+                remove.append(i)
+                continue
 
-        if i == 0:
-            A[0].scal(1 / initial_norm)
-            R[i, i] = initial_norm
-        else:
-            norm = initial_norm
-            # If reiterate is True, reiterate as long as the norm of the vector changes
-            # strongly during orthogonalization (due to Andreas Buhr).
-            while True:
-                # orthogonalize to all vectors left
-                for j in range(i):
-                    if j in remove:
-                        continue
-                    p = A[j].pairwise_inner(A[i], product)[0]
-                    A[i].axpy(-p, A[j])
-                    common_dtype = np.promote_types(R.dtype, type(p))
-                    R = R.astype(common_dtype, copy=False)
-                    R[j, i] += p
+            if i == 0:
+                A[0].scal(1 / initial_norm)
+                R[i, i] = initial_norm
+            else:
+                norm = initial_norm
+                # If reiterate is True, reiterate as long as the norm of the vector changes
+                # strongly during orthogonalization (due to Andreas Buhr).
+                while True:
+                    # orthogonalize to all vectors left
+                    for j in range(i):
+                        if j in remove:
+                            continue
+                        p = A[j].pairwise_inner(A[i], product)[0]
+                        A[i].axpy(-p, A[j])
+                        common_dtype = np.promote_types(R.dtype, type(p))
+                        R = R.astype(common_dtype, copy=False)
+                        R[j, i] += p
 
-                # calculate new norm
-                old_norm, norm = norm, A[i].norm(product)[0]
+                    # calculate new norm
+                    old_norm, norm = norm, A[i].norm(product)[0]
 
-                # remove vector if it got too small
-                if norm <= rtol * initial_norm:
-                    logger.info(f'Removing linearly dependent vector {i}')
-                    remove.append(i)
-                    break
+                    # remove vector if it got too small
+                    if norm <= rtol * initial_norm:
+                        logger.info(f'Removing linearly dependent vector {i}')
+                        remove.append(i)
+                        break
 
-                # check if reorthogonalization should be done
-                if reiterate and norm < reiteration_threshold * old_norm:
-                    logger.info(f'Orthonormalizing vector {i} again')
-                else:
-                    A[i].scal(1 / norm)
-                    R[i, i] = norm
-                    break
+                    # check if reorthogonalization should be done
+                    if reiterate and norm < reiteration_threshold * old_norm:
+                        logger.info(f'Orthonormalizing vector {i} again')
+                    else:
+                        A[i].scal(1 / norm)
+                        R[i, i] = norm
+                        break
+            task.update((i+1-offset)*(i+1-offset+1)//2)
 
     if remove:
         del A[remove]

--- a/src/pymor/algorithms/greedy.py
+++ b/src/pymor/algorithms/greedy.py
@@ -12,7 +12,7 @@ from pymor.core.exceptions import ExtensionError
 from pymor.core.logger import getLogger
 from pymor.parallel.dummy import dummy_pool
 from pymor.parallel.interface import RemoteObject
-from pymor.tools.progress import get_progress_display
+from pymor.tools.progress import track
 
 
 def weak_greedy(surrogate, training_set, atol=None, rtol=None, max_extensions=None, pool=None):
@@ -96,7 +96,7 @@ def weak_greedy(surrogate, training_set, atol=None, rtol=None, max_extensions=No
     max_errs = []
     max_err_mus = []
 
-    for extensions in get_progress_display().track(count(), 'Greedy', max_extensions):
+    for extensions in track(count(), 'Greedy', max_extensions):
         with logger.block('Estimating errors ...'):
             max_err, max_err_mu = surrogate.evaluate(training_set)
             max_errs.append(max_err)

--- a/src/pymor/algorithms/greedy.py
+++ b/src/pymor/algorithms/greedy.py
@@ -3,6 +3,7 @@
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
 import time
+from itertools import count
 
 import numpy as np
 
@@ -11,6 +12,7 @@ from pymor.core.exceptions import ExtensionError
 from pymor.core.logger import getLogger
 from pymor.parallel.dummy import dummy_pool
 from pymor.parallel.interface import RemoteObject
+from pymor.tools.progress import get_progress_display
 
 
 def weak_greedy(surrogate, training_set, atol=None, rtol=None, max_extensions=None, pool=None):
@@ -91,11 +93,10 @@ def weak_greedy(surrogate, training_set, atol=None, rtol=None, max_extensions=No
     if pool:
         training_set = pool.scatter_list(training_set)
 
-    extensions = 0
     max_errs = []
     max_err_mus = []
 
-    while True:
+    for extensions in get_progress_display().track(count(), 'Greedy', max_extensions):
         with logger.block('Estimating errors ...'):
             max_err, max_err_mu = surrogate.evaluate(training_set)
             max_errs.append(max_err)

--- a/src/pymor/core/logger.py
+++ b/src/pymor/core/logger.py
@@ -17,6 +17,9 @@ from contextlib import contextmanager
 from functools import lru_cache
 from types import MethodType
 
+import rich
+from rich.text import Text
+
 from pymor.core.defaults import defaults
 from pymor.tools import mpi
 
@@ -172,15 +175,7 @@ class ColoredFormatter(logging.Formatter):
         return f'{timestamp} {indent}{levelname}{path}: {msg}'
 
 
-from logging import Handler
-
-import rich
-from rich.text import Text
-
-
-class RichAwareHandler(Handler):
-    def __init__(self):
-        super().__init__()
+class RichAwareHandler(logging.Handler):
 
     def emit(self, record):
         msg = self.format(record)
@@ -189,8 +184,7 @@ class RichAwareHandler(Handler):
 
 @defaults('filename')
 def default_handler(filename=None):
-    streamhandler = RichAwareHandler()
-    # streamhandler = logging.StreamHandler()
+    streamhandler = RichAwareHandler() if int(os.environ.get('PYMOR_PROGRESS', 0)) == 1 else logging.StreamHandler()
     streamformatter = ColoredFormatter()
     streamhandler.setFormatter(streamformatter)
     handlers = [streamhandler]

--- a/src/pymor/core/logger.py
+++ b/src/pymor/core/logger.py
@@ -172,9 +172,25 @@ class ColoredFormatter(logging.Formatter):
         return f'{timestamp} {indent}{levelname}{path}: {msg}'
 
 
+from logging import Handler
+
+import rich
+from rich.text import Text
+
+
+class RichAwareHandler(Handler):
+    def __init__(self):
+        super().__init__()
+
+    def emit(self, record):
+        msg = self.format(record)
+        rich.print(Text.from_ansi(msg))
+
+
 @defaults('filename')
 def default_handler(filename=None):
-    streamhandler = logging.StreamHandler()
+    streamhandler = RichAwareHandler()
+    # streamhandler = logging.StreamHandler()
     streamformatter = ColoredFormatter()
     streamhandler.setFormatter(streamformatter)
     handlers = [streamhandler]

--- a/src/pymor/parallel/basic.py
+++ b/src/pymor/parallel/basic.py
@@ -73,7 +73,7 @@ class WorkerPoolBase(WorkerPoolDefaultImplementations, WorkerPool):
         kwargs = self._map_kwargs(kwargs)
         return self._apply_only(function, worker, *args, **kwargs)
 
-    def map(self, function, *args, **kwargs):
+    def map(self, function, *args, task_title=None, **kwargs):
         kwargs = self._map_kwargs(kwargs)
         chunks = self._split_into_chunks(len(self), *args)
         return self._map(function, chunks, **kwargs)

--- a/src/pymor/parallel/basic.py
+++ b/src/pymor/parallel/basic.py
@@ -73,7 +73,7 @@ class WorkerPoolBase(WorkerPoolDefaultImplementations, WorkerPool):
         kwargs = self._map_kwargs(kwargs)
         return self._apply_only(function, worker, *args, **kwargs)
 
-    def map(self, function, *args, task_title=None, **kwargs):
+    def map(self, function, *args, task_label=None, **kwargs):
         kwargs = self._map_kwargs(kwargs)
         chunks = self._split_into_chunks(len(self), *args)
         return self._map(function, chunks, **kwargs)

--- a/src/pymor/parallel/dummy.py
+++ b/src/pymor/parallel/dummy.py
@@ -43,9 +43,9 @@ class DummyPool(WorkerPool):
     def map(self, function, *args, task_label=None, **kwargs):
         kwargs = self._map_kwargs(kwargs)
         if task_label:
-            from pymor.tools.progress import get_progress_display
+            from pymor.tools.progress import track
             result = [function(*a, **kwargs)
-                      for a in get_progress_display().track(
+                      for a in track(
                           zip(*args, strict=True), label=task_label, total=len(args[0]))]
         else:
             result = [function(*a, **kwargs) for a in zip(*args, strict=True)]

--- a/src/pymor/parallel/dummy.py
+++ b/src/pymor/parallel/dummy.py
@@ -40,13 +40,13 @@ class DummyPool(WorkerPool):
         kwargs = self._map_kwargs(kwargs)
         return function(*args, **kwargs)
 
-    def map(self, function, *args, task_title=None, **kwargs):
+    def map(self, function, *args, task_label=None, **kwargs):
         kwargs = self._map_kwargs(kwargs)
-        if task_title:
+        if task_label:
             from pymor.tools.progress import get_progress_display
             result = [function(*a, **kwargs)
                       for a in get_progress_display().track(
-                          zip(*args, strict=True), title=task_title, total=len(args[0]))]
+                          zip(*args, strict=True), label=task_label, total=len(args[0]))]
         else:
             result = [function(*a, **kwargs) for a in zip(*args, strict=True)]
         return result

--- a/src/pymor/parallel/dummy.py
+++ b/src/pymor/parallel/dummy.py
@@ -40,9 +40,15 @@ class DummyPool(WorkerPool):
         kwargs = self._map_kwargs(kwargs)
         return function(*args, **kwargs)
 
-    def map(self, function, *args, **kwargs):
+    def map(self, function, *args, task_title=None, **kwargs):
         kwargs = self._map_kwargs(kwargs)
-        result = [function(*a, **kwargs) for a in zip(*args, strict=True)]
+        if task_title:
+            from pymor.tools.progress import get_progress_display
+            result = [function(*a, **kwargs)
+                      for a in get_progress_display().track(
+                          zip(*args, strict=True), title=task_title, total=len(args[0]))]
+        else:
+            result = [function(*a, **kwargs) for a in zip(*args, strict=True)]
         return result
 
     def __bool__(self):

--- a/src/pymor/parallel/interface.py
+++ b/src/pymor/parallel/interface.py
@@ -156,7 +156,7 @@ class WorkerPool(BasicObject):
         pass
 
     @abstractmethod
-    def map(self, function, *args, task_title=None, **kwargs):
+    def map(self, function, *args, task_label=None, **kwargs):
         """Parallel version of the builtin :func:`map` function.
 
         Each positional argument (after `function`) must be a sequence

--- a/src/pymor/parallel/interface.py
+++ b/src/pymor/parallel/interface.py
@@ -177,6 +177,10 @@ class WorkerPool(BasicObject):
             The sequences of positional arguments for `function`.
         kwargs
             The keyword arguments for `function`.
+        task_label
+            If not `None`, a progress bar with this label will be created
+            in the active :cls:`~pymor.tools.progress.ProgressDisplay` to
+            track the progress of the operator.
 
         Returns
         -------

--- a/src/pymor/parallel/interface.py
+++ b/src/pymor/parallel/interface.py
@@ -179,7 +179,7 @@ class WorkerPool(BasicObject):
             The keyword arguments for `function`.
         task_label
             If not `None`, a progress bar with this label will be created
-            in the active :cls:`~pymor.tools.progress.ProgressDisplay` to
+            in the active :class:`~pymor.tools.progress.ProgressDisplay` to
             track the progress of the operator.
 
         Returns

--- a/src/pymor/parallel/interface.py
+++ b/src/pymor/parallel/interface.py
@@ -156,7 +156,7 @@ class WorkerPool(BasicObject):
         pass
 
     @abstractmethod
-    def map(self, function, *args, **kwargs):
+    def map(self, function, *args, task_title=None, **kwargs):
         """Parallel version of the builtin :func:`map` function.
 
         Each positional argument (after `function`) must be a sequence

--- a/src/pymor/tools/progress.py
+++ b/src/pymor/tools/progress.py
@@ -29,7 +29,7 @@ class ProgressDisplay(ABC):
         Returns
         -------
         task
-            The :cls:`Task` object representing the progress bar.
+            The :class:`Task` object representing the progress bar.
         """
         pass
 
@@ -70,7 +70,7 @@ class ProgressDisplay(ABC):
 class Task:
     """A task corresponding to a progress bar.
 
-    Created by a :cls:`ProgressDisplay`.
+    Created by a :class:`ProgressDisplay`.
 
     Can be used as a context manager. In that case, the task is
     automatically :meth:`finished <Task.finish>` when the context
@@ -198,12 +198,12 @@ progress_display = RichProgressDisplay() if int(os.environ.get('PYMOR_PROGRESS',
 
 
 def get_progress_display():
-    """Returns the currently active :cls:`ProgressDisplay`."""
+    """Returns the currently active :class:`ProgressDisplay`."""
     return progress_display
 
 
 def add_task(label=None, total=None):
-    """Add new progress bar for given task to active :cls:`ProgressDisplay`.
+    """Add new progress bar for given task to active :class:`ProgressDisplay`.
 
     Parameters
     ----------
@@ -215,13 +215,13 @@ def add_task(label=None, total=None):
     Returns
     -------
     task
-        The :cls:`Task` object representing the progress bar.
+        The :class:`Task` object representing the progress bar.
     """
     return get_progress_display().add_task(label=label, total=total)
 
 
 def track(iterable, label=None, total=None):
-    """Track iteration over an iterable in the active :cls:`ProgressDisplay`.
+    """Track iteration over an iterable in the active :class:`ProgressDisplay`.
 
     Consecutively yields the items of the iterable and updates the
     corresponding progress bar.

--- a/src/pymor/tools/progress.py
+++ b/src/pymor/tools/progress.py
@@ -2,6 +2,7 @@
 # Copyright pyMOR developers and contributors. All rights reserved.
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
+import os
 from abc import ABC, abstractmethod
 from time import perf_counter
 
@@ -193,7 +194,7 @@ class RichProgressDisplay(ProgressDisplay):
                 pass
 
 
-progress_display = RichProgressDisplay()
+progress_display = RichProgressDisplay() if int(os.environ.get('PYMOR_PROGRESS', 0)) == 1 else DummyProgressDisplay()
 
 
 def get_progress_display():

--- a/src/pymor/tools/progress.py
+++ b/src/pymor/tools/progress.py
@@ -2,6 +2,7 @@
 # Copyright pyMOR developers and contributors. All rights reserved.
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
+from abc import ABC, abstractmethod
 from time import perf_counter
 
 from rich.console import Group
@@ -10,8 +11,10 @@ from rich.progress import Progress
 from rich.text import Text
 
 
-class ProgressDisplay:
+class ProgressDisplay(ABC):
+    """Displays multiple progress bars."""
 
+    @abstractmethod
     def add_task(self, label=None, total=None):
         """Add new progress bar for given task.
 
@@ -27,7 +30,7 @@ class ProgressDisplay:
         task
             The :cls:`Task` object representing the progress bar.
         """
-        return Task(self, 0)
+        pass
 
     def track(self, iterable, label=None, total=None):
         """Track iteration over an iterable.
@@ -54,9 +57,11 @@ class ProgressDisplay:
                 yield v
                 task.update(i+1)
 
+    @abstractmethod
     def _update_task(self, task_id, value, total=None):
         pass
 
+    @abstractmethod
     def _task_finished(self, task_id):
         pass
 
@@ -102,6 +107,18 @@ class Task:
         if not self.finished:
             self.progress_display._task_finished(self.id)
             self.finished = True
+
+
+class DummyProgressDisplay(ProgressDisplay):
+
+    def add_task(self, label=None, total=None):
+        return Task(self, 0)
+
+    def _update_task(self, task_id, value, total=None):
+        pass
+
+    def _task_finished(self, task_id):
+        pass
 
 
 class RichProgressDisplay(ProgressDisplay):

--- a/src/pymor/tools/progress.py
+++ b/src/pymor/tools/progress.py
@@ -13,9 +13,37 @@ from rich.text import Text
 class ProgressDisplay:
 
     def add_task(self, label=None, total=None):
+        """Add new progress bar for given task.
+
+        Parameters
+        ----------
+        label
+            If not `None`, the label to use for the progress bar for this task.
+        total
+            If not `None`, the total units of work to be performed by this task.
+
+        Returns
+        -------
+        task
+            The :cls:`Task` object representing the progress bar.
+        """
         return Task(self, 0)
 
     def track(self, iterable, label=None, total=None):
+        """Track iteration over an iterable.
+
+        Consecutively yields the items of the iterable and updates the
+        corresponding progress bar.
+
+        Parameters
+        ----------
+        iterable
+            The iterable to track.
+        label
+            If not `None`, the label for the corresponding progress bar.
+        total
+            If not `None`, the the length of the iterable.
+        """
         if total is None:
             try:
                 total = len(iterable)
@@ -34,6 +62,15 @@ class ProgressDisplay:
 
 
 class Task:
+    """A task corresponding to a progress bar.
+
+    Created by a :cls:`ProgressDisplay`.
+
+    Can be used as a context manager. In that case, the task is
+    automatically :meth:`finished <Task.finish>` when the context
+    is left.
+    """
+
     def __init__(self, progress_display, id):
         self.progress_display, self.id = progress_display, id
         self.finished = False
@@ -48,9 +85,20 @@ class Task:
         self.finish()
 
     def update(self, value, total=None):
+        """Update progress of the task.
+
+        Parameters
+        ----------
+        value
+            The units of work that have been finished.
+        total
+            If not `None` a (new) value for the total number of unit of
+            work to be performed.
+        """
         self.progress_display._update_task(self.id, value, total=total)
 
     def finish(self):
+        """Mark task as finished."""
         if not self.finished:
             self.progress_display._task_finished(self.id)
             self.finished = True
@@ -132,4 +180,5 @@ progress_display = RichProgressDisplay()
 
 
 def get_progress_display():
+    """Returns the currently active :cls:`ProgressDisplay`."""
     return progress_display

--- a/src/pymor/tools/progress.py
+++ b/src/pymor/tools/progress.py
@@ -12,16 +12,16 @@ from rich.text import Text
 
 class ProgressDisplay:
 
-    def add_task(self, title=None, total=None):
+    def add_task(self, label=None, total=None):
         return Task(self, 0)
 
-    def track(self, iterable, title=None, total=None):
+    def track(self, iterable, label=None, total=None):
         if total is None:
             try:
                 total = len(iterable)
             except TypeError:
                 pass
-        with self.add_task(title=title, total=total) as task:
+        with self.add_task(label=label, total=total) as task:
             for i, v in enumerate(iterable):
                 yield v
                 task.update(i+1)
@@ -67,20 +67,20 @@ class RichProgressDisplay(ProgressDisplay):
         self.tasks = []
         self.finished_tasks = {}
         self.last_update_max_tasks = perf_counter()
-        self.longest_title = 0
+        self.longest_label = 0
         self.live = Live(get_renderable=self._get_rederable, transient=True)
         self.started = False
 
-    def add_task(self, title=None, total=None):
+    def add_task(self, label=None, total=None):
         for task_id in self.finished_tasks:
             self.progress.remove_task(task_id)
             self.tasks.remove(task_id)
         self.finished_tasks.clear()
-        if title is not None:
-            self.longest_title = max(self.longest_title, len(title))
+        if label is not None:
+            self.longest_label = max(self.longest_label, len(label))
         for task_id, task in zip(self.progress.task_ids, self.progress.tasks, strict=True):
-            self.progress.update(task_id, description=f'{task.description:{self.longest_title}}')
-        task_id = self.progress.add_task(f'{title:{self.longest_title}}', total=total)
+            self.progress.update(task_id, description=f'{task.description:{self.longest_label}}')
+        task_id = self.progress.add_task(f'{label:{self.longest_label}}', total=total)
         self.tasks.append(task_id)
         self.max_tasks = max(self.max_tasks, len(self.tasks))
         if not self.started:

--- a/src/pymor/tools/progress.py
+++ b/src/pymor/tools/progress.py
@@ -58,6 +58,9 @@ class Task:
 
 class RichProgressDisplay(ProgressDisplay):
 
+    TASK_LINGER_TIME = 2
+    TASK_PANE_UPDATE_TIME = 2
+
     def __init__(self):
         self.max_tasks = 0
         self.progress = Progress(auto_refresh=False)
@@ -91,13 +94,13 @@ class RichProgressDisplay(ProgressDisplay):
         tic = perf_counter()
         to_remove = []
         for tid, t_finished in self.finished_tasks.items():
-            if tic - t_finished > 2:
+            if tic - t_finished > self.TASK_LINGER_TIME:
                 to_remove.append(tid)
         for tid in to_remove:
             self.progress.remove_task(tid)
             self.tasks.remove(tid)
             del self.finished_tasks[tid]
-        if tic - self.last_update_max_tasks > 2:
+        if tic - self.last_update_max_tasks > self.TASK_PANE_UPDATE_TIME:
             self.max_tasks = len(self.tasks)
             self.last_update_max_tasks = tic
         if self.max_tasks > len(self.tasks):

--- a/src/pymor/tools/progress.py
+++ b/src/pymor/tools/progress.py
@@ -200,3 +200,39 @@ progress_display = RichProgressDisplay() if int(os.environ.get('PYMOR_PROGRESS',
 def get_progress_display():
     """Returns the currently active :cls:`ProgressDisplay`."""
     return progress_display
+
+
+def add_task(label=None, total=None):
+    """Add new progress bar for given task to active :cls:`ProgressDisplay`.
+
+    Parameters
+    ----------
+    label
+        If not `None`, the label to use for the progress bar for this task.
+    total
+        If not `None`, the total units of work to be performed by this task.
+
+    Returns
+    -------
+    task
+        The :cls:`Task` object representing the progress bar.
+    """
+    return get_progress_display().add_task(label=label, total=total)
+
+
+def track(iterable, label=None, total=None):
+    """Track iteration over an iterable in the active :cls:`ProgressDisplay`.
+
+    Consecutively yields the items of the iterable and updates the
+    corresponding progress bar.
+
+    Parameters
+    ----------
+    iterable
+        The iterable to track.
+    label
+        If not `None`, the label for the corresponding progress bar.
+    total
+        If not `None`, the the length of the iterable.
+    """
+    return get_progress_display().track(iterable, label=label, total=total)

--- a/src/pymor/tools/progress.py
+++ b/src/pymor/tools/progress.py
@@ -1,0 +1,132 @@
+# This file is part of the pyMOR project (https://www.pymor.org).
+# Copyright pyMOR developers and contributors. All rights reserved.
+# License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
+
+from time import perf_counter
+
+from rich.console import Group
+from rich.live import Live
+from rich.progress import Progress
+from rich.text import Text
+
+
+class ProgressDisplay:
+
+    def add_task(self, title=None, total=None):
+        return Task(self, 0)
+
+    def track(self, iterable, title=None, total=None):
+        if total is None:
+            try:
+                total = len(iterable)
+            except TypeError:
+                pass
+        with self.add_task(title=title, total=total) as task:
+            for i, v in enumerate(iterable):
+                yield v
+                task.update(i+1)
+
+    def _update_task(self, task_id, value, total=None):
+        pass
+
+    def _task_finished(self, task_id):
+        pass
+
+
+class Task:
+    def __init__(self, progress_display, id):
+        self.progress_display, self.id = progress_display, id
+        self.finished = False
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.finish()
+
+    def __del__(self):
+        self.finish()
+
+    def update(self, value, total=None):
+        self.progress_display._update_task(self.id, value, total=total)
+
+    def finish(self):
+        if not self.finished:
+            self.progress_display._task_finished(self.id)
+            self.finished = True
+
+
+class RichProgressDisplay(ProgressDisplay):
+
+    def __init__(self):
+        self.max_tasks = 0
+        self.progress = Progress(auto_refresh=False)
+        self.tasks = []
+        self.finished_tasks = {}
+        self.last_update_max_tasks = perf_counter()
+        self.longest_title = 0
+        self.live = Live(get_renderable=self._get_rederable, transient=True)
+        self.started = False
+
+    def add_task(self, title=None, total=None):
+        for task_id in self.finished_tasks:
+            self.progress.remove_task(task_id)
+            self.tasks.remove(task_id)
+        self.finished_tasks.clear()
+        if title is not None:
+            self.longest_title = max(self.longest_title, len(title))
+        for task_id, task in zip(self.progress.task_ids, self.progress.tasks, strict=True):
+            self.progress.update(task_id, description=f'{task.description:{self.longest_title}}')
+        task_id = self.progress.add_task(f'{title:{self.longest_title}}', total=total)
+        self.tasks.append(task_id)
+        self.max_tasks = max(self.max_tasks, len(self.tasks))
+        if not self.started:
+            self.live.start()
+        return Task(self, task_id)
+
+    def _update_task(self, task_id, value, total=None):
+        self.progress.update(task_id, completed=value, total=total)
+
+    def _get_rederable(self):
+        tic = perf_counter()
+        to_remove = []
+        for tid, t_finished in self.finished_tasks.items():
+            if tic - t_finished > 2:
+                to_remove.append(tid)
+        for tid in to_remove:
+            self.progress.remove_task(tid)
+            self.tasks.remove(tid)
+            del self.finished_tasks[tid]
+        if tic - self.last_update_max_tasks > 2:
+            self.max_tasks = len(self.tasks)
+            self.last_update_max_tasks = tic
+        if self.max_tasks > len(self.tasks):
+            return Group(self.progress.get_renderable(), Text('\n' * (self.max_tasks - len(self.tasks) - 1)))
+        else:
+            return self.progress.get_renderable()
+
+    def _task_finished(self, task_id):
+        for tid, task in zip(self.progress.task_ids, self.progress.tasks, strict=True):
+            if tid == task_id:
+                if task.completed == 0:
+                    if not task.total:
+                        self.progress.update(task_id, completed=1, total=1)
+                    else:
+                        self.progress.update(task_id, completed=task.total)
+                else:
+                    self.progress.update(task_id, total=task.completed)
+                break
+        self.finished_tasks[task_id] = perf_counter()
+        if len(self.tasks) == len(self.finished_tasks):
+            try:
+                self.live.stop()
+                self.started = False
+            except AttributeError:
+                pass
+
+
+progress_display = RichProgressDisplay()
+
+
+def get_progress_display():
+    return progress_display

--- a/src/pymordemos/burgers_ei.py
+++ b/src/pymordemos/burgers_ei.py
@@ -16,6 +16,7 @@ from pymor.analyticalproblems.burgers import burgers_problem_2d
 from pymor.discretizers.builtin import RectGrid, TriaGrid, discretize_instationary_fv
 from pymor.parallel.default import new_parallel_pool
 from pymor.reductors.basic import InstationaryRBReductor
+from pymor.tools.progress import track
 
 app = App(help_on_error=True)
 
@@ -193,14 +194,12 @@ def main(
     mus = problem.parameter_space.sample_randomly(test)
 
     def error_analysis(N, M):
-        print(f'N = {N}, M = {M}: ', end='')
+        print(f'N = {N}, M = {M}')
         rom = reductor.reduce(N)
         rom = rom.with_(operator=rom.operator.with_cb_dim(M))
         l2_err_max = -1
         mumax = None
-        for mu in mus:
-            print('.', end='')
-            sys.stdout.flush()
+        for mu in track(mus, 'error_analysis'):
             u = rom.solve(mu)
             URB = reductor.reconstruct(u)
             U = fom.solve(mu)
@@ -209,7 +208,6 @@ def main(
             if l2_err > l2_err_max:
                 l2_err_max = l2_err
                 mumax = mu
-        print()
         return l2_err_max, mumax
     error_analysis = np.frompyfunc(error_analysis, 2, 2)
 


### PR DESCRIPTION
This PR adds experimental support for progress bars throughout pyMOR. Since there might still be issues with the generated output on different platforms, progress bars are disabled by default. To enable, set the `PYMOR_PROGRESS` environment variable to `1`.

Multiple tasks can be tracked at the same time using individual progress bars. Finished bars are removed after some time or when a new task is started.

- Adds `ProgressDisplay` abstract base class and `Task` objects.
- The `track` and `add_task` allow adding progress bars to the current active `ProgressDisplay`.
- Implements `ProgressDisplay` using `rich`.
- Use progress bars for various algorithms (`gram_schmidt`, `ei_greedy`, `deim`, `interpolate_operators`, `reduction_error_analysis`, `DummyPool.map`).
