### PR TITLE
Energy stable Petrov-Galerkin projection  in PHLTIPGReductor

### DIFF
--- a/docs/source/bibliography.bib
+++ b/docs/source/bibliography.bib
@@ -288,6 +288,17 @@
   issue         = 37,
 }
 
+@article{EHS20,
+  title = {On the Energy Stable Approximation of {H}amiltonian and Gradient Systems},
+  author = {Egger, H. and Habrich, O. and Shashkov, V.},
+  pages = {335--349},
+  volume = {21},
+  number = {2},
+  journal = {Computational Methods in Applied Mathematics},
+  doi = {doi:10.1515/cmam-2020-0025},
+  year = {2021},
+}
+
 @article{ET24,
   title         = {Efficient Error and Variance Estimation for Randomized Matrix Computations},
   author        = {Epperly, Ethan N. and Tropp, Joel A.},
@@ -699,6 +710,20 @@
   doi           = {10.1080/13873950701844170},
 }
 
+@article{RWBBZFB23,
+  author = {Rettberg, J. and Wittwar, D. and Buchfink, P. and Brauchler, A. and Ziegler, P. and Fehr, J{"o}rg and Haasdonk, B.},
+  title = {
+    Port-{Hamiltonian} fluid-structure interaction modelling and structure-preserving
+    model order reduction of a classical guitar
+  },
+  journal = {Mathematical and Computer Modelling of Dynamical Systems},
+  volume = {29},
+  number = {1},
+  pages = {116--148},
+  year = {2023},
+  doi = {10.1080/13873954.2023.2173238}
+}
+
 @article{S11,
   title         = {Symplectic {G}ram-{S}chmidt Algorithm with Re-Orthogonalization},
   author        = {Al-Aidarous, E. S.},
@@ -800,6 +825,21 @@
   volume        = 384,
   pages         = {289--307},
   doi           = {10.1016/j.jcp.2019.01.031},
+}
+
+@article{WLEK10,
+  title = {
+    Passivity and Structure Preserving Order Reduction of Linear
+    port-{H}amiltonian Systems Using {K}rylov Subspaces
+  },
+  journal = {European Journal of Control},
+  volume = {16},
+  number = {4},
+  pages = {401-406},
+  year = {2010},
+  issn = {0947-3580},
+  doi = {https://doi.org/10.3166/ejc.16.401-406},
+  author = {Wolf, T. and Lohmann, B. and Eid, R. and Kotyczka, P.},
 }
 
 @article{XZ11,

--- a/src/pymor/reductors/ph/basic.py
+++ b/src/pymor/reductors/ph/basic.py
@@ -3,7 +3,7 @@
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
 from pymor.algorithms.projection import project, project_to_subbasis
-from pymor.models.iosys import PHLTIModel
+from pymor.models.iosys import LTIModel, PHLTIModel
 from pymor.operators.constructions import IdentityOperator
 from pymor.reductors.basic import ProjectionBasedReductor
 
@@ -20,29 +20,56 @@ class PHLTIPGReductor(ProjectionBasedReductor):
     QTE_orthonormal
         If `True`, no `E` matrix will be assembled for the reduced |Model|.
         Set to `True` if `V` is orthonormal w.r.t. `fom.Q.H @ fom.E`.
+    pg_projection
+        Choice of test space:
+
+            - ``'ph_preserving'`` (default): :math:`W = Q V`. Yields a reduced
+            |PHLTIModel| with all pH structural properties preserved.
+            - ``'energy_stable'``: :math:`W = (J - R)^{-T} E V`.
+            Yields a reduced system that is no longer of pH structure, 
+            but preserves the Hamiltonian part of the structure and thus the energy. 
+            Requires :math:`J - R` to be invertible.
     """
 
-    def __init__(self, fom, V, QTE_orthonormal=False):
-        assert isinstance(fom, PHLTIModel)
+    _PG_PROJECTIONS = ('ph_preserving', 'energy_stable')
 
-        W = fom.Q.apply(V)
+    def __init__(self, fom, V, QTE_orthonormal=False, pg_projection="ph_preserving"):
+        assert isinstance(fom, PHLTIModel)
+        if pg_projection not in self._PG_PROJECTIONS:
+            raise ValueError(f"Unknown projection {pg_projection!r}. " 
+                             f"Expected one of {self._PG_PROJECTIONS}.")
+        
+        if pg_projection == 'ph_preserving':
+            W = fom.Q.apply(V)
+        else:
+            J_minus_R = fom.J - fom.R
+            W = J_minus_R.apply_inverse_adjoint(fom.E.apply(V))
 
         super().__init__(fom, {'W': W, 'V': V})
         self.QTE_orthonormal = QTE_orthonormal
+        self.pg_projection = pg_projection
 
     def project_operators(self):
         fom = self.fom
         W = self.bases['W']
         V = self.bases['V']
-        J = project(fom.J, W, W)
-        projected_operators = {'E': None if self.QTE_orthonormal else project(fom.E, W, V),
-                               'J': J,
-                               'R': project(fom.R, W, W),
-                               'Q': IdentityOperator(J.source),
-                               'G': project(fom.G, W, None),
-                               'P': project(fom.P, W, None),
-                               'S': fom.S,
-                               'N': fom.N}
+
+        if self.pg_projection is "ph_preserving":
+            J = project(fom.J, W, W)
+            projected_operators = {'E': None if self.QTE_orthonormal else project(fom.E, W, V),
+                                   'J': J,
+                                   'R': project(fom.R, W, W),
+                                   'Q': IdentityOperator(J.source),
+                                   'G': project(fom.G, W, None),
+                                   'P': project(fom.P, W, None),
+                                   'S': fom.S,
+                                   'N': fom.N}
+        else: 
+            projected_operators = {'E': project(fom.E, W, V), 
+                                   'A': None if self.QTE_orthonormal else project(fom.E.H @ fom.Q, V, V), 
+                                   'B': project(fom.G - fom.P, W, None),
+                                   'C': project((fom.G + fom.P).H @ fom.Q, None, V),
+                                   'D': fom.S - fom.N}
         return projected_operators
 
     def project_operators_to_subbasis(self, dims):
@@ -62,7 +89,10 @@ class PHLTIPGReductor(ProjectionBasedReductor):
         return projected_operators
 
     def build_rom(self, projected_operators, error_estimator):
-        return PHLTIModel(error_estimator=error_estimator, **projected_operators)
+        if self.pg_projection is "ph_preserving":
+            return PHLTIModel(error_estimator=error_estimator, **projected_operators)
+        else: 
+            return LTIModel(error_estimator=error_estimator, **projected_operators)
 
     def extend_basis(self, **kwargs):
         raise NotImplementedError

--- a/src/pymor/reductors/ph/basic.py
+++ b/src/pymor/reductors/ph/basic.py
@@ -24,21 +24,19 @@ class PHLTIPGReductor(ProjectionBasedReductor):
         Choice of test space:
 
         - `'ph_preserving'` (default): :math:`W = Q V`. Yields a reduced |PHLTIModel|
-          with all pH structural properties preserved.
+          with all pH structural properties preserved. First introduced in :cite:`WLEK10`.
         - `'energy_stable'`: :math:`W = (J - R)^{-T} E V`.
           The reduced system is not pH, but the quadratic Hamiltonian is
           consistently inherited as :math:`\tilde{H}(\tilde{x}) = H(V \tilde{x})`, so the
-          reduced state retains an energy interpretation.
-          Requires :math:`J - R` to be invertible.
+          reduced state retains an energy interpretation. Requires :math:`J - R` to be invertible.
+          First introduced in :cite:`RWBBZFB23` following the idea from :cite:`EHS20`.
     """
 
     _PG_PROJECTIONS = ('ph_preserving', 'energy_stable')
 
     def __init__(self, fom, V, QTE_orthonormal=False, pg_projection='ph_preserving'):
         assert isinstance(fom, PHLTIModel)
-        if pg_projection not in self._PG_PROJECTIONS:
-            raise ValueError(f'Unknown projection {pg_projection!r}. '
-                             f'Expected one of {self._PG_PROJECTIONS}.')
+        assert pg_projection in self._PG_PROJECTIONS
 
         if pg_projection == 'ph_preserving':
             W = fom.Q.apply(V)
@@ -65,13 +63,16 @@ class PHLTIPGReductor(ProjectionBasedReductor):
                                    'P': project(fom.P, W, None),
                                    'S': fom.S,
                                    'N': fom.N}
-        else:
+        elif self.pg_projection == 'energy_stable':
             projected_operators = {'E': project(fom.E, W, V),
                                    'A': IdentityOperator(fom.Q.source) if self.QTE_orthonormal
                                                                        else project(fom.E.H @ fom.Q, V, V),
                                    'B': project(fom.G - fom.P, W, None),
                                    'C': project((fom.G + fom.P).H @ fom.Q, None, V),
                                    'D': fom.S - fom.N}
+        else:
+            raise NotImplementedError
+
         return projected_operators
 
     def project_operators_to_subbasis(self, dims):
@@ -90,19 +91,24 @@ class PHLTIPGReductor(ProjectionBasedReductor):
                                    'P': project_to_subbasis(rom.P, dim, None),
                                    'S': rom.S,
                                    'N': rom.N}
-        else:
+        elif self.pg_projection == 'energy_stable':
             projected_operators = {'E': project_to_subbasis(rom.E, dim, dim),
                                    'A': project_to_subbasis(rom.A, dim, dim),
                                    'B': project_to_subbasis(rom.B, dim, None),
                                    'C': project_to_subbasis(rom.C, None, dim),
                                    'D': rom.D}
+        else:
+            raise NotImplementedError
+
         return projected_operators
 
     def build_rom(self, projected_operators, error_estimator):
         if self.pg_projection == 'ph_preserving':
             return PHLTIModel(error_estimator=error_estimator, **projected_operators)
-        else:
+        elif self.pg_projection == 'energy_stable':
             return LTIModel(error_estimator=error_estimator, **projected_operators)
+        else:
+            raise NotImplementedError
 
     def extend_basis(self, **kwargs):
         raise NotImplementedError

--- a/src/pymor/reductors/ph/basic.py
+++ b/src/pymor/reductors/ph/basic.py
@@ -9,7 +9,7 @@ from pymor.reductors.basic import ProjectionBasedReductor
 
 
 class PHLTIPGReductor(ProjectionBasedReductor):
-    """Petrov-Galerkin projection of an |PHLTIModel|.
+    r"""Petrov-Galerkin projection of an |PHLTIModel|.
 
     Parameters
     ----------
@@ -26,19 +26,20 @@ class PHLTIPGReductor(ProjectionBasedReductor):
             - ``'ph_preserving'`` (default): :math:`W = Q V`. Yields a reduced
             |PHLTIModel| with all pH structural properties preserved.
             - ``'energy_stable'``: :math:`W = (J - R)^{-T} E V`.
-            Yields a reduced system that is no longer of pH structure, 
-            but preserves the Hamiltonian part of the structure and thus the energy. 
+            The reduced system is not port-Hamiltonian, but the quadratic Hamiltonian is
+            consistently inherited as :math:\tilde{H}(\tilde{x}) = H(V\tilde{x}), so the
+            reduced state retains an energy interpretation.
             Requires :math:`J - R` to be invertible.
     """
 
     _PG_PROJECTIONS = ('ph_preserving', 'energy_stable')
 
-    def __init__(self, fom, V, QTE_orthonormal=False, pg_projection="ph_preserving"):
+    def __init__(self, fom, V, QTE_orthonormal=False, pg_projection='ph_preserving'):
         assert isinstance(fom, PHLTIModel)
         if pg_projection not in self._PG_PROJECTIONS:
-            raise ValueError(f"Unknown projection {pg_projection!r}. " 
-                             f"Expected one of {self._PG_PROJECTIONS}.")
-        
+            raise ValueError(f'Unknown projection {pg_projection!r}. '
+                             f'Expected one of {self._PG_PROJECTIONS}.')
+
         if pg_projection == 'ph_preserving':
             W = fom.Q.apply(V)
         else:
@@ -54,7 +55,7 @@ class PHLTIPGReductor(ProjectionBasedReductor):
         W = self.bases['W']
         V = self.bases['V']
 
-        if self.pg_projection is "ph_preserving":
+        if self.pg_projection == 'ph_preserving':
             J = project(fom.J, W, W)
             projected_operators = {'E': None if self.QTE_orthonormal else project(fom.E, W, V),
                                    'J': J,
@@ -64,9 +65,9 @@ class PHLTIPGReductor(ProjectionBasedReductor):
                                    'P': project(fom.P, W, None),
                                    'S': fom.S,
                                    'N': fom.N}
-        else: 
-            projected_operators = {'E': project(fom.E, W, V), 
-                                   'A': None if self.QTE_orthonormal else project(fom.E.H @ fom.Q, V, V), 
+        else:
+            projected_operators = {'E': project(fom.E, W, V),
+                                   'A': None if self.QTE_orthonormal else project(fom.E.H @ fom.Q, V, V),
                                    'B': project(fom.G - fom.P, W, None),
                                    'C': project((fom.G + fom.P).H @ fom.Q, None, V),
                                    'D': fom.S - fom.N}
@@ -89,9 +90,9 @@ class PHLTIPGReductor(ProjectionBasedReductor):
         return projected_operators
 
     def build_rom(self, projected_operators, error_estimator):
-        if self.pg_projection is "ph_preserving":
+        if self.pg_projection == 'ph_preserving':
             return PHLTIModel(error_estimator=error_estimator, **projected_operators)
-        else: 
+        else:
             return LTIModel(error_estimator=error_estimator, **projected_operators)
 
     def extend_basis(self, **kwargs):

--- a/src/pymor/reductors/ph/basic.py
+++ b/src/pymor/reductors/ph/basic.py
@@ -23,13 +23,13 @@ class PHLTIPGReductor(ProjectionBasedReductor):
     pg_projection
         Choice of test space:
 
-            - ``'ph_preserving'`` (default): :math:`W = Q V`. Yields a reduced
-            |PHLTIModel| with all pH structural properties preserved.
-            - ``'energy_stable'``: :math:`W = (J - R)^{-T} E V`.
-            The reduced system is not port-Hamiltonian, but the quadratic Hamiltonian is
-            consistently inherited as :math:\tilde{H}(\tilde{x}) = H(V\tilde{x}), so the
-            reduced state retains an energy interpretation.
-            Requires :math:`J - R` to be invertible.
+        - `'ph_preserving'` (default): :math:`W = Q V`. Yields a reduced |PHLTIModel|
+          with all pH structural properties preserved.
+        - `'energy_stable'`: :math:`W = (J - R)^{-T} E V`.
+          The reduced system is not pH, but the quadratic Hamiltonian is
+          consistently inherited as :math:`\tilde{H}(\tilde{x}) = H(V \tilde{x})`, so the
+          reduced state retains an energy interpretation.
+          Requires :math:`J - R` to be invertible.
     """
 
     _PG_PROJECTIONS = ('ph_preserving', 'energy_stable')
@@ -67,7 +67,8 @@ class PHLTIPGReductor(ProjectionBasedReductor):
                                    'N': fom.N}
         else:
             projected_operators = {'E': project(fom.E, W, V),
-                                   'A': None if self.QTE_orthonormal else project(fom.E.H @ fom.Q, V, V),
+                                   'A': IdentityOperator(fom.Q.source) if self.QTE_orthonormal
+                                                                       else project(fom.E.H @ fom.Q, V, V),
                                    'B': project(fom.G - fom.P, W, None),
                                    'C': project((fom.G + fom.P).H @ fom.Q, None, V),
                                    'D': fom.S - fom.N}
@@ -78,15 +79,23 @@ class PHLTIPGReductor(ProjectionBasedReductor):
             raise ValueError
         rom = self._last_rom
         dim = dims['V']
-        J = project_to_subbasis(rom.J, dim, dim)
-        projected_operators = {'E': None if self.QTE_orthonormal else project_to_subbasis(rom.E, dim, dim),
-                               'J': J,
-                               'R': project_to_subbasis(rom.R, dim, dim),
-                               'Q': IdentityOperator(J.source),
-                               'G': project_to_subbasis(rom.G, dim, None),
-                               'P': project_to_subbasis(rom.P, dim, None),
-                               'S': rom.S,
-                               'N': rom.N}
+
+        if self.pg_projection == 'ph_preserving':
+            J = project_to_subbasis(rom.J, dim, dim)
+            projected_operators = {'E': None if self.QTE_orthonormal else project_to_subbasis(rom.E, dim, dim),
+                                   'J': J,
+                                   'R': project_to_subbasis(rom.R, dim, dim),
+                                   'Q': IdentityOperator(J.source),
+                                   'G': project_to_subbasis(rom.G, dim, None),
+                                   'P': project_to_subbasis(rom.P, dim, None),
+                                   'S': rom.S,
+                                   'N': rom.N}
+        else:
+            projected_operators = {'E': project_to_subbasis(rom.E, dim, dim),
+                                   'A': project_to_subbasis(rom.A, dim, dim),
+                                   'B': project_to_subbasis(rom.B, dim, None),
+                                   'C': project_to_subbasis(rom.C, None, dim),
+                                   'D': rom.D}
         return projected_operators
 
     def build_rom(self, projected_operators, error_estimator):

--- a/src/pymor/reductors/ph/ph_irka.py
+++ b/src/pymor/reductors/ph/ph_irka.py
@@ -25,7 +25,7 @@ class PHIRKAReductor(GenericIRKAReductor):
         super().__init__(fom, mu=mu)
 
     def reduce(self, rom0_params, tol=1e-4, maxit=100, num_prev=1,
-               projection='orth', conv_crit='sigma',
+               projection='orth', pg_projection='ph_preserving', conv_crit='sigma',
                compute_errors=False):
         r"""Reduce using pH-IRKA.
 
@@ -62,6 +62,8 @@ class PHIRKAReductor(GenericIRKAReductor):
               respect to the Euclidean inner product.
             - `'QTEorth'`: projection matrix `V` is orthogonalized with
               respect to the `fom.Q.H @ fom.E` product.
+        pg_projection
+            See :class:`~pymor.reductors.ph.basic.PHLTIPGReductor`.
         conv_crit
             Convergence criterion:
 
@@ -95,7 +97,7 @@ class PHIRKAReductor(GenericIRKAReductor):
         if conv_crit == 'sigma':
             self._conv_data[0] = sigma
         for it in range(maxit):
-            self._set_V_reductor(sigma, b, projection)
+            self._set_V_reductor(sigma, b, projection, pg_projection)
             rom = self._pg_reductor.reduce()
             sigma, b, c = self._rom_to_sigma_b_c(rom, False)
             self._store_sigma_b_c(sigma, b, c)
@@ -117,11 +119,11 @@ class PHIRKAReductor(GenericIRKAReductor):
             else self.fom
         )
 
-    def _set_V_reductor(self, sigma, b, projection):
+    def _set_V_reductor(self, sigma, b, projection, pg_projection):
         fom = self._assemble_fom()
         self.V = tangential_rational_krylov(fom.A, fom.E, fom.B, fom.B.source.from_numpy(b.T), sigma, orth=False,
                                             shifted_system_solver=fom.shifted_system_solver)
         product = None if projection == 'orth' else fom.Q.H @ fom.E
         gram_schmidt(self.V, atol=0, rtol=0, product=product, copy=False)
-        self._pg_reductor = PHLTIPGReductor(fom, self.V, projection == 'QTEorth')
+        self._pg_reductor = PHLTIPGReductor(fom, self.V, projection == 'QTEorth', pg_projection)
         self.W = self._pg_reductor.bases['W']

--- a/src/pymordemos/phlti.py
+++ b/src/pymordemos/phlti.py
@@ -46,6 +46,7 @@ def main(n: int = 100, m: int = 2, max_reduced_order: int = 20):
     bt = BTReductor(fom).reduce
     prbt = PRBTReductor(fom).reduce
     irka = partial(IRKAReductor(fom).reduce, conv_crit='h2')
+    phirka_energy_stable = partial(PHIRKAReductor(fom).reduce, pg_projection='energy_stable')
     phirka = PHIRKAReductor(fom).reduce
     spectral_factor = SpectralFactorReductor(fom)
     def spectral_factor_reduce(r):
@@ -57,6 +58,7 @@ def main(n: int = 100, m: int = 2, max_reduced_order: int = 20):
         'PRBT': prbt,
         'IRKA': irka,
         'pH-IRKA': phirka,
+        'pH-IRKA_energy_stable': phirka_energy_stable,
         'spectral_factor': spectral_factor_reduce,
     }
     markers = {
@@ -64,6 +66,7 @@ def main(n: int = 100, m: int = 2, max_reduced_order: int = 20):
         'PRBT': 'x',
         'IRKA': 'o',
         'pH-IRKA': 's',
+        'pH-IRKA_energy_stable': 'p',
         'spectral_factor': 'v',
     }
     timings = {}


### PR DESCRIPTION
This PR includes an additional possible choice for the test space in the PGLTIPHReductor. Until now, the test space was always chosen as `W = QV`. This yields a reduced system that is pH again (and is the choice in most of the literature i reviewed so far) . The "energy stable" projection in this PR includes an alternative, namely `W = (J - R)^{-T} E V`, in which case the reduced system loses the pH structure, but the Hamiltonian part remains preserved, i.e., `\tilde{H}(\tilde{x}) = H(V\tilde{x})`. 

I extended ph-IRKA with this approach and tested it in the phlti.py demo, where it yields slightly better results that ph-IRKA with the previous PG projection using `W = QV`. (however ph-IRKA is in general quite bad compared to all the other methods tested in this demo) 

This follow the spirit of the work "On the Energy Stable Approximation of Hamiltonian and Gradient Systems" by  Egger, Habrich and Shashkov (which is formulated there for Hamiltonian systems only, but it is mentioned that it can be extended to pH as well, which has been done as one of the methods in "Port-Hamiltonian Fluid-Structure Interaction Modeling and Structure-Preserving Model Order Reduction of a Classical Guitar" by Rettberg et al. 