### PR TITLE
implement pH-DEIM and a nonlinear pHModel

### DIFF
--- a/docs/source/bibliography.bib
+++ b/docs/source/bibliography.bib
@@ -203,6 +203,17 @@
   doi           = {10.1016/j.automatica.2022.110368},
 }
 
+@article{CBG16,
+  title={Structure-preserving model reduction for nonlinear port-{H}amiltonian systems},
+  author={Chaturantabut, S. and Beattie, C. and Gugercin, S.},
+  journal={SIAM Journal on Scientific Computing},
+  volume={38},
+  number={5},
+  pages={B837--B865},
+  year={2016},
+  publisher={SIAM}
+}
+
 @article{CCA96,
   title         = {
     Bilinear transformation and generalized singular perturbation model

--- a/docs/source/substitutions.py
+++ b/docs/source/substitutions.py
@@ -131,6 +131,7 @@ common = """
 .. |LinearDelayModels| replace:: :class:`LinearDelayModels <pymor.models.iosys.LinearDelayModel>`
 .. |QuadraticHamiltonianModel| replace:: :class:`~pymor.models.symplectic.QuadraticHamiltonianModel`
 .. |SaddlePointModel| replace:: :class:`~pymor.models.saddle_point.SaddlePointModel`
+.. |NonlinearPHModel| replace:: :class:`~pymor.models.nonlinear_ph.NonlinearPHModel`
 
 .. |MoebiusTransformation| replace:: :class:`~pymor.models.transforms.MoebiusTransformation`
 .. |MoebiusTransformations| replace:: :class:`MoebiusTransformations <pymor.models.transforms.MoebiusTransformation>`

--- a/src/pymor/models/nonlinear_ph.py
+++ b/src/pymor/models/nonlinear_ph.py
@@ -7,122 +7,8 @@ import numpy as np
 from pymor.algorithms.timestepping import ImplicitEulerTimeStepper
 from pymor.models.interface import Model
 from pymor.operators.constructions import IdentityOperator, LinearInputOperator, VectorOperator, ZeroOperator
-from pymor.operators.interface import Operator
 from pymor.solvers.newton import NewtonSolver
 from pymor.vectorarrays.interface import VectorArray
-
-
-class NonlinearPHOperator(Operator):
-    r"""Nonlinear operator defining the state equation of a port-Hamiltonian system.
-
-    This operator represents the nonlinear mapping
-
-    .. math::
-        \mathcal{A}(x, \mu) = -\bigl(J(\mu) - R(\mu)\bigr) \bigl(Q(\mu)x + dh(x, \mu)\bigr).
-
-    It is used to write the nonlinear port-Hamiltonian state equation
-
-    .. math::
-        E(\mu)\dot{x}(t, \mu) + \mathcal{A}(x(t, \mu), \mu) = \bigl(G(\mu) - P(\mu)\bigr)u(t).
-
-    The co-energy vector is given by
-
-    .. math::
-        z(x, \mu) = Q(\mu)x + dh(x, \mu).
-
-    If there is a scalar-valued nonlinear function :math:`h` such that
-
-    .. math::
-        dh(x, \mu) = \nabla_x h(x, \mu),
-
-    and :math:`Q` is symmetric, then
-
-    .. math::
-        z(x, \mu) = \nabla_x \left(\frac{1}{2}x^TQ(\mu)x + h(x, \mu) \right).
-
-    The Jacobian of :math:`\mathcal{A}` at a state :math:`x` is
-
-    .. math::
-        D\mathcal{A}(x, \mu) = -\bigl(J(\mu) - R(\mu)\bigr) \left(Q(\mu) + Ddh(x, \mu) \right).
-
-
-    Parameters
-    ----------
-    J
-        The |Operator| J.
-    R
-        The |Operator| R.
-    Q
-        The |Operator| Q.
-    dh
-        The nonlinear |Operator| defining the nonlinear contribution
-        to the co-energy vector. It must have the same source and
-        range as J and provide a
-        :meth:`~pymor.operators.interface.Operator.jacobian`
-        implementation when Newton-type solvers are used.
-
-    Attributes
-    ----------
-    J
-        The |Operator| J.
-    R
-        The |Operator| R.
-    Q
-        The |Operator| Q.
-    dh
-        The nonlinear |Operator| ``dh``.
-    JmR
-        The linear |Operator| :math:`J-R`.
-    source
-        The state |VectorSpace|.
-    range
-        The state |VectorSpace|.
-    """
-
-    linear = False
-
-    def __init__(self, J, R, Q, dh):
-        assert J.linear
-        assert J.source == J.range
-
-        assert R.linear
-        assert R.source == J.source
-        assert R.range == J.source
-
-        assert Q.linear
-        assert Q.source == J.source
-        assert Q.range == J.source
-
-        assert dh.source == J.source
-        assert dh.range == J.source
-
-        self.J = J
-        self.R = R
-        self.Q = Q
-        self.dh = dh
-
-        self.JmR = J - R
-        self.source = J.source
-        self.range = J.range
-
-    def _grad_H(self, U, mu=None):
-        return self.Q.apply(U, mu=mu) + self.dh.apply(U, mu=mu)
-
-    def apply(self, U, mu=None):
-        assert U in self.source
-        grad_H = self._grad_H(U, mu=mu)
-        return (-1) * self.JmR.apply(grad_H, mu=mu)
-
-    def jacobian(self, U, mu=None):
-        assert U in self.source
-        assert len(U) == 1
-
-        if isinstance(self.dh, ZeroOperator):
-            dh_jac = ZeroOperator(self.source, self.source)
-        else:
-            dh_jac = self.dh.jacobian(U, mu=mu)
-
-        return (-1) * self.JmR @ (self.Q + dh_jac)
 
 
 class NonlinearPHModel(Model):
@@ -351,7 +237,9 @@ class NonlinearPHModel(Model):
         self.dim_input = G.source.dim
         self.dim_output = G.source.dim
 
-        self.ph_operator = NonlinearPHOperator(J, R, Q, dh)
+        # R-J instead of J-R as the ph_operator is applied on the LHS later
+        self.ph_operator = (R - J) @ (Q + dh)
+        #self.ph_operator = NonlinearPHOperator(J, R, Q, dh)
         self.rhs = LinearInputOperator(G - P)
         self.output_operator = G + P
         self.feedthrough = LinearInputOperator(S - N)

--- a/src/pymor/models/nonlinear_ph.py
+++ b/src/pymor/models/nonlinear_ph.py
@@ -1,0 +1,433 @@
+# This file is part of the pyMOR project (https://www.pymor.org).
+# Copyright pyMOR developers and contributors. All rights reserved.
+# License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
+
+import numpy as np
+
+from pymor.algorithms.timestepping import ImplicitEulerTimeStepper
+from pymor.models.interface import Model
+from pymor.operators.constructions import IdentityOperator, LinearInputOperator, VectorOperator, ZeroOperator
+from pymor.operators.interface import Operator
+from pymor.solvers.newton import NewtonSolver
+from pymor.vectorarrays.interface import VectorArray
+
+
+class NonlinearPHOperator(Operator):
+    r"""Nonlinear operator defining the state equation of a port-Hamiltonian system.
+
+    This operator represents the nonlinear mapping
+
+    .. math::
+        \mathcal{A}(x, \mu) = -\bigl(J(\mu) - R(\mu)\bigr) \bigl(Q(\mu)x + dh(x, \mu)\bigr).
+
+    It is used to write the nonlinear port-Hamiltonian state equation
+
+    .. math::
+        E(\mu)\dot{x}(t, \mu) + \mathcal{A}(x(t, \mu), \mu) = \bigl(G(\mu) - P(\mu)\bigr)u(t).
+
+    The co-energy vector is given by
+
+    .. math::
+        z(x, \mu) = Q(\mu)x + dh(x, \mu).
+
+    If there is a scalar-valued nonlinear function :math:`h` such that
+
+    .. math::
+        dh(x, \mu) = \nabla_x h(x, \mu),
+
+    and :math:`Q` is symmetric, then
+
+    .. math::
+        z(x, \mu) = \nabla_x \left(\frac{1}{2}x^TQ(\mu)x + h(x, \mu) \right).
+
+    The Jacobian of :math:`\mathcal{A}` at a state :math:`x` is
+
+    .. math::
+        D\mathcal{A}(x, \mu) = -\bigl(J(\mu) - R(\mu)\bigr) \left(Q(\mu) + Ddh(x, \mu) \right).
+
+
+    Parameters
+    ----------
+    J
+        The |Operator| J.
+    R
+        The |Operator| R.
+    Q
+        The |Operator| Q.
+    dh
+        The nonlinear |Operator| defining the nonlinear contribution
+        to the co-energy vector. It must have the same source and
+        range as J and provide a
+        :meth:`~pymor.operators.interface.Operator.jacobian`
+        implementation when Newton-type solvers are used.
+
+    Attributes
+    ----------
+    J
+        The |Operator| J.
+    R
+        The |Operator| R.
+    Q
+        The |Operator| Q.
+    dh
+        The nonlinear |Operator| ``dh``.
+    JmR
+        The linear |Operator| :math:`J-R`.
+    source
+        The state |VectorSpace|.
+    range
+        The state |VectorSpace|.
+    """
+
+    linear = False
+
+    def __init__(self, J, R, Q, dh):
+        assert J.linear
+        assert J.source == J.range
+
+        assert R.linear
+        assert R.source == J.source
+        assert R.range == J.source
+
+        assert Q.linear
+        assert Q.source == J.source
+        assert Q.range == J.source
+
+        assert dh.source == J.source
+        assert dh.range == J.source
+
+        self.J = J
+        self.R = R
+        self.Q = Q
+        self.dh = dh
+
+        self.JmR = J - R
+        self.source = J.source
+        self.range = J.range
+
+    def _grad_H(self, U, mu=None):
+        return self.Q.apply(U, mu=mu) + self.dh.apply(U, mu=mu)
+
+    def apply(self, U, mu=None):
+        assert U in self.source
+        grad_H = self._grad_H(U, mu=mu)
+        return (-1) * self.JmR.apply(grad_H, mu=mu)
+
+    def jacobian(self, U, mu=None):
+        assert U in self.source
+        assert len(U) == 1
+
+        if isinstance(self.dh, ZeroOperator):
+            dh_jac = ZeroOperator(self.source, self.source)
+        else:
+            dh_jac = self.dh.jacobian(U, mu=mu)
+
+        return (-1) * self.JmR @ (self.Q + dh_jac)
+
+
+class NonlinearPHModel(Model):
+    r"""Nonlinear port-Hamiltonian input-output model.
+
+    The model represents
+
+    .. math::
+        E(\mu) \dot{x}(t, \mu) & = (J(\mu) - R(\mu)) z(x, \mu) + (G(\mu) - P(\mu)) u(t), \\
+                     y(t, \mu) & = (G(\mu) + P(\mu))^T z(x, \mu) + (S(\mu) - N(\mu)) u(t),
+
+    where the co-energy vector is
+
+    .. math::
+        z(x, \mu) = Q(\mu)x + dh(x, \mu).
+
+    Here, ``dh`` is an |Operator| representing the nonlinear contribution
+    to the co-energy vector.
+
+    The system is port-Hamiltonian when there is a continuously
+    differentiable Hamiltonian :math:`\mathcal{H}` satisfying
+
+    .. math::
+        \nabla_x \mathcal{H}(x, \mu)
+        = E(\mu)^T z(x, \mu),
+
+    and
+
+    .. math::
+        \Gamma(\mu)
+        =
+        \begin{bmatrix}
+            J(\mu) & G(\mu) \\
+            -G(\mu)^T & N(\mu)
+        \end{bmatrix},
+        \qquad
+        \mathcal{W}(\mu)
+        =
+        \begin{bmatrix}
+            R(\mu) & P(\mu) \\
+            P(\mu)^T & S(\mu)
+        \end{bmatrix}
+
+    satisfy
+
+    .. math::
+        \Gamma(\mu)^T = -\Gamma(\mu),
+        \qquad
+        \mathcal{W}(\mu)
+        = \mathcal{W}(\mu)^T
+        \succcurlyeq 0.
+
+    In the special case :math:`E=I`, with symmetric :math:`Q`
+    the Hamiltonian is
+
+    .. math::
+        \mathcal{H}(x, \mu)
+        =
+        \frac{1}{2}x^TQ(\mu)x + h(x, \mu).
+
+    Parameters
+    ----------
+    J
+        The |Operator| J.
+    R
+        The |Operator| R.
+    G
+        The |Operator| G.
+    dh
+        The nonlinear |Operator| ``dh`` or `None` (then ``dh`` is assumed to be zero).
+    P
+        The |Operator| P or `None` (then P is assumed to be zero).
+    S
+        The |Operator| S or `None` (then S is assumed to be zero).
+    N
+        The |Operator| N or `None` (then N is assumed to be zero).
+    E
+        The |Operator| E or `None` (then E is assumed to be identity).
+    Q
+        The |Operator| Q or `None` (then Q is assumed to be identity).
+    T
+        The final time T. If `None`, no time-dependent solution can
+        be computed.
+    initial_data
+        The initial data :math:`x_0`. Either a |VectorArray| of length
+        1 or, for the |Parameter|-dependent case, a vector-like
+        |Operator|, i.e. a linear |Operator| with ``source.dim == 1``,
+        which yields the initial data for given |parameter values|.
+        If `None`, the initial data is assumed to be zero.
+    time_stepper
+        The :class:`time-stepper
+        <pymor.algorithms.timestepping.TimeStepper>` to be used by
+        :meth:`~pymor.models.interface.Model.solve`.
+
+        If `None` and `T` is specified, an
+        :class:`~pymor.algorithms.timestepping.ImplicitEulerTimeStepper`
+        with a Newton solver is used.
+    nt
+        The number of time steps used by the default implicit Euler
+        time-stepper. This argument is ignored when `time_stepper` is
+        specified.
+    num_values
+        The number of returned vectors of the solution trajectory. If
+        `None`, each intermediate vector that is calculated is
+        returned.
+    error_estimator
+        An error estimator for the problem. This can be any object
+        with an ``estimate_error(U, mu, model)`` method. If
+        `error_estimator` is not `None`, an ``estimate_error(U, mu)``
+        method is added to the model which calls
+        ``error_estimator.estimate_error(U, mu, self)``.
+    visualizer
+        A visualizer for the problem. This can be any object with a
+        ``visualize(U, model, ...)`` method. If `visualizer` is not
+        `None`, a ``visualize(U, *args, **kwargs)`` method is added to
+        the model which forwards its arguments to the visualizer's
+        ``visualize`` method.
+    name
+        Name of the system.
+
+    Attributes
+    ----------
+    order
+        The order of the system.
+    dim_input
+        The number of inputs.
+    dim_output
+        The number of outputs.
+    J
+        The |Operator| J.
+    R
+        The |Operator| R.
+    G
+        The |Operator| G.
+    dh
+        The nonlinear |Operator| ``dh``.
+    P
+        The |Operator| P.
+    S
+        The |Operator| S.
+    N
+        The |Operator| N.
+    E
+        The |Operator| E.
+    Q
+        The |Operator| Q.
+    T
+        The final time.
+    initial_data
+        The initial-data.
+    time_stepper
+        The time-stepper used for time integration.
+    solution_space
+        The |VectorSpace| in which the state trajectory lives.
+    """
+
+    linear = False
+    cache_region = 'memory'
+
+    def __init__(self, J, R, G, dh=None, P=None, S=None, N=None, E=None, Q=None,
+                 T=None, initial_data=None, time_stepper=None, nt=None, num_values=None,
+                 error_estimator=None, visualizer=None, name=None):
+        assert J.linear
+        assert J.source == J.range
+
+        assert R.linear
+        assert R.source == J.source
+        assert R.range == J.source
+
+        assert G.linear
+        assert G.range == J.source
+
+        P = P or ZeroOperator(G.range, G.source)
+        assert P.linear
+        assert P.source == G.source
+        assert P.range == J.source
+
+        S = S or ZeroOperator(G.source, G.source)
+        assert S.linear
+        assert S.source == G.source
+        assert S.range == G.source
+
+        N = N or ZeroOperator(G.source, G.source)
+        assert N.linear
+        assert N.source == G.source
+        assert N.range == G.source
+
+        E = E or IdentityOperator(J.source)
+        assert E.linear
+        assert E.source == J.source
+        assert E.range == J.source
+
+        Q = Q or IdentityOperator(J.source)
+        assert Q.linear
+        assert Q.source == J.source
+        assert Q.range == J.source
+
+        dh = dh or ZeroOperator(J.source, J.source)
+        assert dh.source == J.source
+        assert dh.range == J.source
+
+        assert T is None or T > 0
+
+        if T is not None:
+            if initial_data is None:
+                initial_data = J.source.zeros(1)
+            if isinstance(initial_data, VectorArray):
+                assert initial_data in J.source
+                assert len(initial_data) == 1
+                initial_data = VectorOperator(initial_data, name='initial_data')
+            assert initial_data.source.is_scalar
+            assert initial_data.range == J.source
+
+            if time_stepper is None:
+                newton_solver = NewtonSolver(relax='armijo', error_measure='residual')
+                time_stepper = ImplicitEulerTimeStepper(nt=nt, solver=newton_solver)
+        else:
+            if initial_data is not None:
+                raise ValueError('Initial data is given but T is not.')
+            if time_stepper is not None:
+                raise ValueError('Time-stepper is given but T is not.')
+
+        super().__init__(dim_input=G.source.dim, error_estimator=error_estimator, visualizer=visualizer, name=name)
+        self.__auto_init(locals())
+        self.solution_space = J.source
+        self.dim_input = G.source.dim
+        self.dim_output = G.source.dim
+
+        self.ph_operator = NonlinearPHOperator(J, R, Q, dh)
+        self.rhs = LinearInputOperator(G - P)
+        self.output_operator = G + P
+        self.feedthrough = LinearInputOperator(S - N)
+
+    def __str__(self):
+
+        string = (
+            f' {self.name}\n'
+            f'    nonlinear port-Hamiltonian system\n'
+            f'    class: {self.__class__.__name__}\n'
+            f'    number of equations: {self.order}\n'
+            f'    number of inputs:    {self.dim_input}\n'
+            f'    number of outputs:   {self.dim_output}\n'
+            f'    solution_space:      {self.solution_space}'
+        )
+        return string
+
+    def _grad_H(self, X, mu=None):
+        return self.Q.apply(X, mu=mu) + self.dh.apply(X, mu=mu)
+
+    def _compute(self, quantities, data, mu):
+        if 'solution' in quantities or 'output' in quantities:
+            assert self.T is not None
+
+            compute_solution = 'solution' in quantities
+            compute_output = 'output' in quantities
+
+            iterator = self.time_stepper.iterate(
+                0,
+                self.T,
+                self.initial_data.as_range_array(mu),
+                self.ph_operator,
+                rhs=self.rhs,
+                mass=None if isinstance(self.E, IdentityOperator) else self.E,
+                mu=mu,
+                num_values=self.num_values,
+            )
+
+            if self.num_values is None:
+                try:
+                    n = self.time_stepper.estimate_time_step_count(0, self.T) + 1
+                except NotImplementedError:
+                    n = 0
+            else:
+                n = self.num_values + 1
+
+            if compute_solution:
+                data['solution'] = self.solution_space.empty(reserve=n)
+
+            if compute_output:
+                data['output'] = np.empty((self.dim_output, n))
+                data_output_extra = []
+
+            for i, (x, t) in enumerate(iterator):
+                if compute_solution:
+                    data['solution'].append(x)
+                if compute_output:
+                    mu_t = mu.at_time(t)
+                    grad = self._grad_H(x, mu=mu_t)
+                    y = self.output_operator.apply_adjoint(grad, mu=mu_t).to_numpy()
+                    y += self.feedthrough.as_range_array(mu=mu_t).to_numpy()
+
+                    if i < n:
+                        data['output'][:, i] = y.ravel()
+                    else:
+                        data_output_extra.append(y)
+            if compute_output:
+                if data_output_extra:
+                    data['output'] = np.hstack([data['output'], data_output_extra])
+
+                if data['output'].shape[1] < i + 1:
+                    data['output'] = data['output'][:, :i + 1]
+
+            if compute_solution:
+                quantities.remove('solution')
+            if compute_output:
+                quantities.remove('output')
+
+        super()._compute(quantities, data, mu=mu)

--- a/src/pymor/reductors/ph/ph_deim.py
+++ b/src/pymor/reductors/ph/ph_deim.py
@@ -4,12 +4,12 @@
 
 import numpy as np
 
-from pymor.algorithms.ei import deim
 from pymor.algorithms.projection import project
 from pymor.models.nonlinear_ph import NonlinearPHModel
 from pymor.operators.constructions import IdentityOperator
-from pymor.operators.ei import EmpiricalInterpolatedOperator
+from pymor.operators.ei import EmpiricalInterpolatedOperator, ProjectedEmpiricalInterpolatedOperator
 from pymor.reductors.basic import ProjectionBasedReductor
+from pymor.vectorarrays.numpy import NumpyVectorSpace
 
 
 class PHdeimReductor(ProjectionBasedReductor):
@@ -19,6 +19,9 @@ class PHdeimReductor(ProjectionBasedReductor):
     structure-preserving Petrov--Galerkin projection combined with the port-Hamiltonian
     discrete empirical interpolation method (pH-DEIM), see Algorithm 5 in :cite:`CBG16`.
 
+    The interpolation DOFs and the collateral basis can be generated using
+    the algorithms provided in the :mod:`pymor.algorithms.ei` module.
+
 
     Parameters
     ----------
@@ -26,49 +29,66 @@ class PHdeimReductor(ProjectionBasedReductor):
         The full order |NonlinearPHModel| to reduce.
     V
         The basis of the trail space.
-    G
+    U
         The collateral basis as a |VectorArray| contained in
         ``fom.dh.range``. Its vectors are used to construct
-        the DEIM approximation of the nonlinear operator ``fom.dh``.
+        the |EmpiricalInterpolatedOperator| approximation of the
+        nonlinear operator ``fom.dh``.
+    Z
+        List or 1D |NumPy array| of the interpolation DOFs.
     QTE_orthonormal
         If `True`, no `E` matrix will be assembled for the reduced |Model|.
         Set to `True` if `V` is orthonormal w.r.t. `fom.Q.H @ fom.E`.
     """
 
-    def __init__(self, fom, V, G, QTE_orthonormal):
+    def __init__(self, fom, V, U, Z, QTE_orthonormal):
         assert isinstance(fom, NonlinearPHModel)
 
         W = fom.Q.apply(V)
 
-        super().__init__(fom, {'V': V, 'W': W, 'G': G})
+        super().__init__(fom, {'V': V, 'W': W, 'U': U})
 
         self.QTE_orthonormal = QTE_orthonormal
+        self.U = U
+        self.Z = Z
 
     def project_operators(self):
         fom = self.fom
         V = self.bases['V']
-        G = self.bases['G']
+        U = self.bases['U']
         W = self.bases['W']
-        J = project(fom.J, W, W)
+        Z = self.Z
 
-        interpolation_dofs, U, _ = deim(G, pod=False)
+        ei_dh = EmpiricalInterpolatedOperator(fom.dh, Z, U, triangular=False)
 
-        emp_grad_h = EmpiricalInterpolatedOperator(fom.dh, interpolation_dofs, U, triangular=False)
-
-        ET_U = U.dofs(interpolation_dofs)
+        ET_U = U.dofs(Z)
         UT_V = U.inner(V)
         C = np.linalg.solve(ET_U.T, UT_V)
 
-        PT_V_numpy = np.zeros((fom.solution_space.dim, len(V)))
-        PT_V_numpy[interpolation_dofs, :] = C
-        PT_V = fom.solution_space.from_numpy(PT_V_numpy)
+        # Calling project(ei_dh, ...) would require instantiating a high-dimensional array for
+        # the projected source basis P^T V, where P = E (E^T U)^{-1} E^T is the DEIM projector
+        # and E is the selection matrix for the interpolation DOFs Z. Instead, we construct
+        # ProjectedEmpiricalInterpolatedOperator directly: since P^T V = E C is row-sparse
+        # (nonzero only at the DEIM DOFs Z), its restriction to source_dofs reduces to selecting
+        # the rows of C whose DOF indices appear in source_dofs, via np.intersect1d, staying
+        # entirely in reduced dimensions.
+        source_dofs = ei_dh.source_dofs
+        source_basis_dofs = np.zeros((len(source_dofs), len(V)))
+        _, z_idx, s_idx = np.intersect1d(Z, source_dofs, return_indices=True)
+        source_basis_dofs[s_idx] = C[z_idx]
+
+        pei_dh = ProjectedEmpiricalInterpolatedOperator(ei_dh.restricted_operator,
+                                                        ei_dh.interpolation_matrix,
+                                                        NumpyVectorSpace.make_array(source_basis_dofs),
+                                                        NumpyVectorSpace.make_array(V.inner(U)),
+                                                        triangular=False)
 
         projected_operators = {'E': None if self.QTE_orthonormal else project(fom.E, W, V),
-                               'J': J,
+                               'J': project(fom.J, W, W),
                                'R': project(fom.R, W, W),
                                'G': project(fom.G, W, None),
-                               'dh': project(emp_grad_h, V, PT_V),
-                               'Q': IdentityOperator(J.source),
+                               'dh': pei_dh,
+                               'Q': IdentityOperator(pei_dh.source),
                                'P': project(fom.P, W, None),
                                'S': fom.S,
                                'N': fom.N}

--- a/src/pymor/reductors/ph/ph_deim.py
+++ b/src/pymor/reductors/ph/ph_deim.py
@@ -1,0 +1,143 @@
+# This file is part of the pyMOR project (https://www.pymor.org).
+# Copyright pyMOR developers and contributors. All rights reserved.
+# License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
+
+import numpy as np
+
+from pymor.algorithms.ei import deim
+from pymor.algorithms.projection import project
+from pymor.models.nonlinear_ph import NonlinearPHModel
+from pymor.operators.constructions import IdentityOperator
+from pymor.operators.ei import EmpiricalInterpolatedOperator
+from pymor.reductors.basic import ProjectionBasedReductor
+
+
+class PHdeimReductor(ProjectionBasedReductor):
+    """Structure-preserving DEIM reductor for nonlinear port-Hamiltonian systems.
+
+    This reductor constructs a reduced-order model for a |NonlinearPHModel| using a
+    structure-preserving Petrov--Galerkin projection combined with the port-Hamiltonian
+    discrete empirical interpolation method (pH-DEIM), see Algorithm 5 in :cite:`CBG16`.
+
+
+    Parameters
+    ----------
+    fom
+        The full order |NonlinearPHModel| to reduce.
+    V
+        The basis of the trail space.
+    G
+        The collateral basis as a |VectorArray| contained in
+        ``fom.dh.range``. Its vectors are used to construct
+        the DEIM approximation of the nonlinear operator ``fom.dh``.
+    QTE_orthonormal
+        If `True`, no `E` matrix will be assembled for the reduced |Model|.
+        Set to `True` if `V` is orthonormal w.r.t. `fom.Q.H @ fom.E`.
+    """
+
+    def __init__(self, fom, V, G, QTE_orthonormal):
+        assert isinstance(fom, NonlinearPHModel)
+
+        W = fom.Q.apply(V)
+
+        super().__init__(fom, {'V': V, 'W': W, 'G': G})
+
+        self.QTE_orthonormal = QTE_orthonormal
+
+    def project_operators(self):
+        fom = self.fom
+        V = self.bases['V']
+        G = self.bases['G']
+        W = self.bases['W']
+        J = project(fom.J, W, W)
+
+        interpolation_dofs, U, _ = deim(G, pod=False)
+
+        emp_grad_h = EmpiricalInterpolatedOperator(fom.dh, interpolation_dofs, U, triangular=False)
+
+        ET_U = U.dofs(interpolation_dofs)
+        UT_V = U.inner(V)
+        C = np.linalg.solve(ET_U.T, UT_V)
+
+        PT_V_numpy = np.zeros((fom.solution_space.dim, len(V)))
+        PT_V_numpy[interpolation_dofs, :] = C
+        PT_V = fom.solution_space.from_numpy(PT_V_numpy)
+
+        projected_operators = {'E': None if self.QTE_orthonormal else project(fom.E, W, V),
+                               'J': J,
+                               'R': project(fom.R, W, W),
+                               'G': project(fom.G, W, None),
+                               'dh': project(emp_grad_h, V, PT_V),
+                               'Q': IdentityOperator(J.source),
+                               'P': project(fom.P, W, None),
+                               'S': fom.S,
+                               'N': fom.N}
+        return projected_operators
+
+    def project_operators_to_subbasis(self, dims):
+        raise NotImplementedError
+
+    def build_rom(self, projected_operators, error_estimator):
+        fom = self.fom
+
+        if fom.initial_data is not None:
+            initial_data = project(fom.initial_data, self.bases['W'], None)
+        else:
+            initial_data = None
+
+        return NonlinearPHModel(T=fom.T, initial_data=initial_data, time_stepper=fom.time_stepper, nt=fom.nt,
+                                num_values=fom.num_values, error_estimator=error_estimator, **projected_operators)
+
+    def extend_basis(self, **kwargs):
+        raise NotImplementedError
+
+    def reconstruct(self, u, basis='V'):
+        return super().reconstruct(u, basis)
+
+
+
+class PGNonlinearPHReductor(ProjectionBasedReductor):
+    def __init__(self, fom, V, QTE_orthonormal):
+        assert isinstance(fom, NonlinearPHModel)
+        W = fom.Q.apply(V)
+
+        super().__init__(fom, {'V': V, 'W': W})
+
+        self.QTE_orthonormal = QTE_orthonormal
+
+    def project_operators(self):
+        fom = self.fom
+        V = self.bases['V']
+        W = self.bases['W']
+        J = project(fom.J, W, W)
+
+        projected_operators = {'E': None if self.QTE_orthonormal else project(fom.E, W, V),
+                               'J': J,
+                               'R': project(fom.R, W, W),
+                               'G': project(fom.G, W, None),
+                               'dh': project(fom.dh, V, V),
+                               'Q': IdentityOperator(J.source),
+                               'P': project(fom.P, W, None),
+                               'S': fom.S,
+                               'N': fom.N}
+        return projected_operators
+
+    def project_operators_to_subbasis(self, dims):
+        raise NotImplementedError
+
+    def build_rom(self, projected_operators, error_estimator):
+        fom = self.fom
+
+        if fom.initial_data is not None:
+            initial_data = project(fom.initial_data, self.bases['W'], None)
+        else:
+            initial_data = None
+
+        return NonlinearPHModel(T=fom.T, initial_data=initial_data, time_stepper=fom.time_stepper, nt=fom.nt,
+                                num_values=fom.num_values, error_estimator=error_estimator, **projected_operators)
+
+    def extend_basis(self, **kwargs):
+        raise NotImplementedError
+
+    def reconstruct(self, u, basis='V'):
+        return super().reconstruct(u, basis)

--- a/src/pymordemos/ph_nonlinear.py
+++ b/src/pymordemos/ph_nonlinear.py
@@ -1,0 +1,367 @@
+# This file is part of the pyMOR project (https://www.pymor.org).
+# Copyright pyMOR developers and contributors. All rights reserved.
+# License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
+
+from time import perf_counter
+
+import matplotlib.pyplot as plt
+import numpy as np
+from typer import run
+
+from pymor.algorithms.pod import pod
+from pymor.models.nonlinear_ph import NonlinearPHModel
+from pymor.operators.interface import Operator
+from pymor.operators.numpy import NumpyMatrixOperator
+from pymor.reductors.ph.ph_deim import PGNonlinearPHReductor, PHdeimReductor
+from pymor.vectorarrays.numpy import NumpyVectorSpace
+
+
+def main(
+    n: int = 500,
+    reduced_order: int = 100,
+    deim_order: int = 100,
+    final_time: float = 100.0,
+    time_steps: int = 1000,
+    damping: float = 0.1,
+    input_amplitude: float = 0.1,
+    plot: bool = True,
+):
+    """Compare projection-based MOR methods for a nonlinear port-Hamiltonian Toda lattice.
+
+    The Toda lattice is introduced as a benchmark example in Section 3.4 of :cite:`CBG16`.
+
+    The demo first simulates the full-order model and computes POD bases for the state trajectory
+    and the nonlinear part of the Hamiltonian gradient. It then compares a structure-preserving
+    Petrov--Galerkin ROM with a pH-DEIM ROM.
+
+    Parameters
+    ----------
+    n
+        Number of particles in the Toda lattice. The full-order state dimension is ``2 * n``.
+    reduced_order
+        Number of POD modes used for the state reduction basis.
+    deim_order
+        Number of POD modes used for the collateral basis of the pH-DEIM approximation.
+    final_time
+        Final simulation time.
+    time_steps
+        Number of implicit Euler time steps.
+    damping
+        Uniform damping coefficient in the momentum variables.
+    input_amplitude
+        Amplitude of the constant scalar input.
+    plot
+        Plot the outputs of the full-order and reduced-order models.
+    """
+    fom = create_toda_fom(n=n, damping=damping, final_time=final_time, time_steps=time_steps)
+    input_value = np.array([input_amplitude])
+
+    print('Solving the full-order model ...')
+    fom_result = solve_and_time(fom, input_value)
+    solution_fom = fom_result['solution']
+    output_fom = fom_result['output']
+
+    print('Computing the state POD basis ...')
+    state_basis, _ = pod(solution_fom, modes=reduced_order, product=fom.Q, rtol=0)
+
+    print('Evaluating the nonlinear force snapshots ...')
+    nonlinear_snapshots = fom.dh.apply(solution_fom)
+
+    print('Computing the collateral POD basis ...')
+    collateral_basis, _ = pod(nonlinear_snapshots, modes=deim_order, product=fom.Q, rtol=0)
+
+    reductors = {
+        'Petrov--Galerkin': PGNonlinearPHReductor(fom, V=state_basis, QTE_orthonormal=True),
+        'pH-DEIM': PHdeimReductor(fom, V=state_basis, G=collateral_basis, QTE_orthonormal=True),
+    }
+
+    results = {}
+
+    for name, reductor in reductors.items():
+        print(f'Reducing with {name} ...')
+        tic = perf_counter()
+        rom = reductor.reduce()
+        reduction_time = perf_counter() - tic
+
+        print(f'Solving the {name} ROM ...')
+        rom_result = solve_and_time(rom, input_value)
+        reconstructed_solution = reductor.reconstruct(rom_result['solution'])
+
+        results[name] = {
+            'rom': rom,
+            'reduction_time': reduction_time,
+            'simulation_time': rom_result['time'],
+            'solution': rom_result['solution'],
+            'reconstructed_solution': reconstructed_solution,
+            'output': rom_result['output'],
+            'state_error': relative_trajectory_error(solution_fom, reconstructed_solution, product=fom.Q),
+            'output_error': relative_output_error(output_fom, rom_result['output']),
+            'speedup': fom_result['time'] / rom_result['time'],
+        }
+
+    print_results(
+        fom=fom,
+        fom_time=fom_result['time'],
+        state_basis=state_basis,
+        collateral_basis=collateral_basis,
+        results=results,
+    )
+
+    if plot:
+        plot_outputs(final_time=fom.T, output_fom=output_fom, results=results)
+
+
+def create_toda_fom(n, damping, final_time, time_steps):
+    r"""Construct a tethered Toda lattice as a |NonlinearPHModel|.
+
+    The state is ordered as :math:`x=[q^T,p^T]^T`, and the Hamiltonian is
+
+    .. math::
+        H(q,p)
+        = \frac{1}{2}\sum_{i=1}^n p_i^2 + \sum_{i=1}^{n-1}\exp(q_i-q_{i+1}) + \exp(q_n)-q_1-n.
+
+    The Hamiltonian gradient is decomposed as
+
+    .. math::
+        \nabla H(x) = Qx + dh(x),
+
+    where :math:`Q` is the Hessian of :math:`H` at the equilibrium and ``dh`` contains
+    the nonlinear remainder.
+    """
+    identity = np.eye(n)
+    zero = np.zeros((n, n))
+
+    interconnection = NumpyMatrixOperator(np.block([[zero, identity], [-identity, zero]]))
+    dissipation = NumpyMatrixOperator(np.block([[zero, zero], [zero, damping * identity]]))
+
+    input_matrix = np.zeros((2*n, 1))
+    input_matrix[n, 0] = 1
+    port = NumpyMatrixOperator(input_matrix)
+
+    nonlinear_force = TodaNonlinearForceOperator(n)
+    energy_product = NumpyMatrixOperator(np.block([[nonlinear_force.position_hessian, zero], [zero, identity]]))
+
+    return NonlinearPHModel(
+        J=interconnection,
+        R=dissipation,
+        G=port,
+        dh=nonlinear_force,
+        Q=energy_product,
+        T=final_time,
+        nt=time_steps
+    )
+
+
+class TodaNonlinearForceOperator(Operator):
+    r"""Nonlinear remainder of the Hamiltonian gradient for the Toda lattice.
+
+    For :math:`x=[q^T,p^T]^T`, this operator evaluates
+
+    .. math::
+        dh(x) = \nabla H(x) - Qx.
+
+    Only the position block is nonlinear. The momentum block of the result is identically zero.
+    """
+
+    linear = False
+
+    def __init__(self, n):
+        self.n = n
+        self.source = NumpyVectorSpace(2*n)
+        self.range = NumpyVectorSpace(2*n)
+
+        diagonal = 2 * np.ones(n)
+        diagonal[0] = 1
+        self.position_hessian = np.diag(diagonal) - np.diag(np.ones(n - 1), k=1) - np.diag(np.ones(n - 1), k=-1)
+
+    def apply(self, U, mu=None):
+        states = U.to_numpy()
+        result = np.zeros_like(states)
+        result[:self.n] = self._position_force(states[:self.n])
+        return self.range.from_numpy(result)
+
+    def jacobian(self, U, mu=None):
+        assert len(U) == 1
+
+        positions = U.to_numpy()[:self.n, 0]
+        interaction_exponentials = np.exp(positions[:-1] - positions[1:])
+
+        diagonal = np.empty(self.n)
+        diagonal[0] = interaction_exponentials[0]
+        diagonal[1:-1] = interaction_exponentials[:-1] + interaction_exponentials[1:]
+        diagonal[-1] = interaction_exponentials[-1] + np.exp(positions[-1])
+
+        position_jacobian = np.diag(diagonal) - np.diag(interaction_exponentials, k=1) \
+                          - np.diag(interaction_exponentials, k=-1) - self.position_hessian
+
+        jacobian = np.zeros((2*self.n, 2*self.n))
+        jacobian[:self.n, :self.n] = position_jacobian
+
+        return NumpyMatrixOperator(jacobian)
+
+    def restricted(self, dofs):
+        output_dofs = np.asarray(dofs, dtype=int)
+        source_dofs = self._required_source_dofs(output_dofs)
+        restricted_operator = RestrictedTodaNonlinearForceOperator(self.n, output_dofs, source_dofs)
+        return restricted_operator, source_dofs
+
+    def _position_force(self, positions):
+        interaction_exponentials = np.exp(positions[:-1] - positions[1:])
+
+        hamiltonian_gradient = np.empty_like(positions)
+        hamiltonian_gradient[0] = interaction_exponentials[0] - 1
+        hamiltonian_gradient[1:-1] = interaction_exponentials[1:] - interaction_exponentials[:-1]
+        hamiltonian_gradient[-1] = np.exp(positions[-1]) - interaction_exponentials[-1]
+
+        return hamiltonian_gradient - self.position_hessian @ positions
+
+    def _required_source_dofs(self, output_dofs):
+        position_dofs = output_dofs[output_dofs < self.n]
+
+        if len(position_dofs) == 0:
+            return np.empty(0, dtype=int)
+
+        neighboring_dofs = np.concatenate((position_dofs - 1, position_dofs, position_dofs + 1))
+        valid_neighbors = neighboring_dofs[(0 <= neighboring_dofs) & (neighboring_dofs < self.n)]
+        return np.unique(valid_neighbors)
+
+
+class RestrictedTodaNonlinearForceOperator(Operator):
+    """Evaluate selected entries of the Toda nonlinear force from their local stencils."""
+
+    linear = False
+
+    def __init__(self, n, output_dofs, source_dofs):
+        self.n = n
+        self.output_dofs = np.asarray(output_dofs, dtype=int)
+        self.source_dofs = np.asarray(source_dofs, dtype=int)
+        self.source = NumpyVectorSpace(len(self.source_dofs))
+        self.range = NumpyVectorSpace(len(self.output_dofs))
+
+        input_index = {dof: local_index for local_index, dof in enumerate(self.source_dofs)}
+        self._position_stencils = []
+
+        for output_index, output_dof in enumerate(self.output_dofs):
+            if output_dof >= n:
+                continue
+
+            self._position_stencils.append((output_index, output_dof, input_index.get(output_dof - 1),
+                                            input_index[output_dof], input_index.get(output_dof + 1))
+            )
+
+    def apply(self, U, mu=None):
+        restricted_states = U.to_numpy()
+        result = np.zeros((len(self.output_dofs), restricted_states.shape[1]))
+
+        for output_index, position_dof, left_index, center_index, right_index in self._position_stencils:
+            center = restricted_states[center_index]
+
+            if position_dof == 0:
+                right = restricted_states[right_index]
+                result[output_index] = np.exp(center - right) - 1 - center + right
+            elif position_dof == self.n - 1:
+                left = restricted_states[left_index]
+                result[output_index] = np.exp(center) - np.exp(left - center) + left - 2 * center
+            else:
+                left = restricted_states[left_index]
+                right = restricted_states[right_index]
+                result[output_index] = np.exp(center - right) - np.exp(left - center) + left - 2 * center + right
+
+        return self.range.from_numpy(result)
+
+    def jacobian(self, U, mu=None):
+        assert len(U) == 1
+
+        restricted_state = U.to_numpy()[:, 0]
+        jacobian = np.zeros((len(self.output_dofs), len(self.source_dofs)))
+
+        for output_index, position_dof, left_index, center_index, right_index in self._position_stencils:
+            center = restricted_state[center_index]
+
+            if position_dof == 0:
+                right = restricted_state[right_index]
+                interaction_exponential = np.exp(center - right)
+                jacobian[output_index, center_index] = interaction_exponential - 1
+                jacobian[output_index, right_index] = 1 - interaction_exponential
+            elif position_dof == self.n - 1:
+                left = restricted_state[left_index]
+                terminal_exponential = np.exp(center)
+                left_exponential = np.exp(left - center)
+                jacobian[output_index, left_index] = 1 - left_exponential
+                jacobian[output_index, center_index] = terminal_exponential + left_exponential - 2
+            else:
+                left = restricted_state[left_index]
+                right = restricted_state[right_index]
+                right_exponential = np.exp(center - right)
+                left_exponential = np.exp(left - center)
+                jacobian[output_index, left_index] = 1 - left_exponential
+                jacobian[output_index, center_index] = right_exponential + left_exponential - 2
+                jacobian[output_index, right_index] = 1 - right_exponential
+
+        return NumpyMatrixOperator(jacobian)
+
+
+def solve_and_time(model, input_value):
+    tic = perf_counter()
+    data = model.compute(solution=True, output=True, input=input_value)
+    elapsed = perf_counter() - tic
+    return {'solution': data['solution'], 'output': data['output'], 'time': elapsed}
+
+
+def relative_trajectory_error(reference, approximation, product):
+    error_norms = (reference - approximation).norm(product=product)
+    reference_norms = reference.norm(product=product)
+    return np.linalg.norm(error_norms) / np.linalg.norm(reference_norms)
+
+
+def relative_output_error(reference, approximation):
+    return np.linalg.norm(reference - approximation) / np.linalg.norm(reference)
+
+
+def print_results(fom, fom_time, state_basis, collateral_basis, results):
+    print('\n======== Nonlinear pH ROM Evaluation ========\n')
+    print(f'FOM order:             {fom.order}')
+    print(f'State basis size:      {len(state_basis)}')
+    print(f'Collateral basis size: {len(collateral_basis)}')
+    print(f'FOM simulation time:   {fom_time:.3f}s\n')
+
+    print(
+        f"{'Method':<20} | {'ROM order':>9} | {'Offline [s]':>11} | {'Online [s]':>10} | "
+        f"{'Speedup':>9} | {'State error':>12} | {'Output error':>12}"
+    )
+    print('-' * 108)
+
+    for name, result in results.items():
+        print(
+            f"{name:<20} | {result['rom'].order:9d} | {result['reduction_time']:11.3f} | "
+            f"{result['simulation_time']:10.3f} | {result['speedup']:9.2f} | "
+            f"{result['state_error']:12.4e} | {result['output_error']:12.4e}"
+        )
+
+    print()
+
+
+def plot_outputs(final_time, output_fom, results):
+    times = np.linspace(0, final_time, output_fom.shape[1])
+
+    for output_index in range(output_fom.shape[0]):
+        fig, ax = plt.subplots()
+        ax.plot(times, output_fom[output_index], label='FOM')
+
+        for name, result in results.items():
+            output = result['output']
+            rom_times = np.linspace(0, final_time, output.shape[1])
+            ax.plot(rom_times, output[output_index], label=name)
+
+        ax.set_xlabel('$t$')
+        ax.set_ylabel(f'$y_{output_index + 1}(t)$')
+        ax.set_title(f'Output component {output_index + 1}')
+        ax.legend()
+        ax.grid()
+        fig.tight_layout()
+
+    plt.show()
+
+
+if __name__ == '__main__':
+    run(main)

--- a/src/pymordemos/ph_nonlinear.py
+++ b/src/pymordemos/ph_nonlinear.py
@@ -8,6 +8,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 from typer import run
 
+from pymor.algorithms.ei import deim
 from pymor.algorithms.pod import pod
 from pymor.models.nonlinear_ph import NonlinearPHModel
 from pymor.operators.interface import Operator
@@ -69,10 +70,11 @@ def main(
 
     print('Computing the collateral POD basis ...')
     collateral_basis, _ = pod(nonlinear_snapshots, modes=deim_order, product=fom.Q, rtol=0)
+    interpolation_dofs, U, _ = deim(collateral_basis, pod=False)
 
     reductors = {
         'Petrov--Galerkin': PGNonlinearPHReductor(fom, V=state_basis, QTE_orthonormal=True),
-        'pH-DEIM': PHdeimReductor(fom, V=state_basis, G=collateral_basis, QTE_orthonormal=True),
+        'pH-DEIM': PHdeimReductor(fom, V=state_basis, U=U, Z=interpolation_dofs, QTE_orthonormal=True),
     }
 
     results = {}


### PR DESCRIPTION
This PR implements a structure-preserving version of DEIM, see Algorithm 5 in [https://epubs.siam.org/doi/pdf/10.1137/15M1055085](). 

On top of the new PHdeimReductor i also implemented a PGNonlinearPHReductor, which i mainly use as a comparison in the demo, in order to show the achieved speedup by using DEIM. I am not sure if such a reductor should really be kept eventually, If yes, then maybe as part of the PHLTIReductor by adapting this reductor to also accept nonlinear PH models. 

To test the implementation, i implemented the Toda lattice from Section 3.4 in the paper. Maybe this example could become part of models.examples, but is is quite lengthy as i also had to implemented the restricted operator in order for DEIM to work. Especially here i am unsure i did this the most efficient way as this is my first time working with the restricted operators and DEIM, so feedback in terms of this would be nice. 

All seems to work nicely, and the DEIM ROM achieves speedup of factor 7.5 compared to the FOM, whereas the PGNonlinearPHReductor only has a speedup of 2, and both have very similar accurcy. 

I also checked the output plots and this looks like -- in the eyeball norm -- what the figures in the paper report, however, i am not able to match the accuracy they obtain (with neither of my methods), as the paper does not really report well how exactly the errors are measured and also do not state all details regarding the experimental setup, for example the amout of timesteps and the time-integrator used (and they do not provide any code to the best of my knowledge). 

**TODO** 
- document the demo better, especially the maths of the Toda lattice
- include the demo in tests
- docstring of the NonlinearPHModel is not done yet
- Think about where to put the PGNonlinearPHReductor 
- maybe simply the implementation of the example / include it in models.examples

**Future work (in some PR sometimes)** 
- currently i am using ImplicitEuler with a NewtonSolver for time-integration. I guess using a symplectic Integrator would be preferred, but currently the ImplicitMidpointTimestepper does not allow the operator to be nonlinear. I will include thus in the near future, but in a separate PR (maybe this already helps with the accuracy issues descriped above). 