### PR TITLE
Adaptive RandomizedSVD class

### DIFF
--- a/src/pymor/algorithms/dmd.py
+++ b/src/pymor/algorithms/dmd.py
@@ -1,7 +1,7 @@
 import numpy as np
 import scipy.linalg as spla
 
-from pymor.algorithms.svd_va import method_of_snapshots, qr_svd
+from pymor.algorithms.svd_va import SVD_VA_METHODS
 from pymor.core.defaults import defaults
 from pymor.core.logger import getLogger
 from pymor.operators.constructions import LowRankOperator
@@ -38,8 +38,7 @@ def dmd(X, Y=None, modes=None, atol=None, rtol=None, cont_time_dt=None, type='ex
     order
         Sort DMD eigenvalues either by `'magnitude'` or `'phase'`.
     svd_method
-        Which SVD method from :mod:`~pymor.algorithms.svd_va` to use
-        (`'method_of_snapshots'` or `'qr_svd'`).
+        Which SVD method from :mod:`~pymor.algorithms.svd_va` to use.
     return_A_approx
         If `True`, the approximation of the operator `A` with `AX=Y` is returned as
         a :class:`~pymor.operators.constructions.LowRankOperator`.
@@ -65,7 +64,7 @@ def dmd(X, Y=None, modes=None, atol=None, rtol=None, cont_time_dt=None, type='ex
     assert Y is None or len(X) == len(Y)
     assert type in ('exact', 'standard')
     assert order in ('magnitude', 'phase')
-    assert svd_method in ('qr_svd', 'method_of_snapshots')
+    assert svd_method in SVD_VA_METHODS
 
     logger = getLogger('pymor.algorithms.dmd.dmd')
 
@@ -73,7 +72,7 @@ def dmd(X, Y=None, modes=None, atol=None, rtol=None, cont_time_dt=None, type='ex
         Y = X[1:]
         X = X[:-1]
 
-    svd = qr_svd if svd_method == 'qr_svd' else method_of_snapshots
+    svd = SVD_VA_METHODS[svd_method]
 
     logger.info('SVD of X ...')
     U, s, Vh = svd(X, modes=modes, atol=atol, rtol=rtol)

--- a/src/pymor/algorithms/pod.py
+++ b/src/pymor/algorithms/pod.py
@@ -5,7 +5,7 @@
 import numpy as np
 
 from pymor.algorithms.gram_schmidt import gram_schmidt
-from pymor.algorithms.svd_va import method_of_snapshots, qr_svd
+from pymor.algorithms.svd_va import SVD_VA_METHODS
 from pymor.core.defaults import defaults
 from pymor.core.logger import getLogger
 from pymor.operators.interface import Operator
@@ -14,7 +14,7 @@ from pymor.vectorarrays.interface import VectorArray
 
 @defaults('rtol', 'atol', 'l2_err', 'method', 'orth_tol')
 def pod(A, product=None, modes=None, rtol=1e-7, atol=0., l2_err=0.,
-        method='method_of_snapshots', orth_tol=1e-10,
+        method='qr_svd', orth_tol=1e-10,
         return_reduced_coefficients=False):
     """Proper orthogonal decomposition of `A`.
 
@@ -50,8 +50,7 @@ def pod(A, product=None, modes=None, rtol=1e-7, atol=0., l2_err=0.,
 
         where `s_n` denotes the n-th singular value.
     method
-        Which SVD method from :mod:`~pymor.algorithms.svd_va` to use
-        (`'method_of_snapshots'` or `'qr_svd'`).
+        Which SVD method from :mod:`~pymor.algorithms.svd_va` to use.
     orth_tol
         POD modes are reorthogonalized if the orthogonality error is
         above this value.
@@ -71,11 +70,11 @@ def pod(A, product=None, modes=None, rtol=1e-7, atol=0., l2_err=0.,
     """
     assert isinstance(A, VectorArray)
     assert product is None or isinstance(product, Operator)
-    assert method in ('method_of_snapshots', 'qr_svd')
+    assert method in SVD_VA_METHODS
 
     logger = getLogger('pymor.algorithms.pod.pod')
 
-    svd_va = method_of_snapshots if method == 'method_of_snapshots' else qr_svd
+    svd_va = SVD_VA_METHODS[method]
     with logger.block('Computing SVD ...'):
         POD, SVALS, COEFFS = svd_va(A, product=product, modes=modes, rtol=rtol, atol=atol, l2_err=l2_err)
 

--- a/src/pymor/algorithms/rand_la.py
+++ b/src/pymor/algorithms/rand_la.py
@@ -9,7 +9,7 @@ from scipy.special import erfinv
 from pymor.algorithms.chol_qr import shifted_chol_qr
 from pymor.algorithms.eigs import eigs
 from pymor.algorithms.gram_schmidt import gram_schmidt
-from pymor.algorithms.svd_va import qr_svd
+from pymor.algorithms.svd_va import SVD_VA_METHODS
 from pymor.core.base import BasicObject
 from pymor.core.defaults import defaults
 from pymor.core.logger import getLogger
@@ -253,7 +253,10 @@ class RandomizedRangeFinder(BasicObject):
 
 class RandomizedSVD(BasicObject):
 
-    def __init__(self, A, range_product=None, source_product=None, power_iterations=0, rrf_args=None):
+    @defaults('low_rank_svd_method')
+    def __init__(self, A, range_product=None, source_product=None, power_iterations=0,
+                 low_rank_svd_method='qr_svd', rrf_args=None):
+        assert low_rank_svd_method in SVD_VA_METHODS
         self.__auto_init(locals())
         self.range_finder = RandomizedRangeFinder(A, range_product=range_product, source_product=source_product,
                                                   power_iterations=power_iterations, **(rrf_args or {}))
@@ -280,7 +283,8 @@ class RandomizedSVD(BasicObject):
 
         with self.logger.block(f'Computing transposed SVD in the reduced space ({len(Q)}x{Q.dim})...'):
             B = source_product.apply_inverse(A.apply_adjoint(range_product.apply(Q)))
-            V, s, Uh_b = qr_svd(B, product=source_product, modes=n, rtol=0)
+            svd = SVD_VA_METHODS[self.low_rank_svd_method]
+            V, s, Uh_b = svd(B, product=source_product, modes=n, rtol=0)
 
         with self.logger.block('Backprojecting the left'
                           f'{" " if isinstance(range_product, IdentityOperator) else " generalized "}'

--- a/src/pymor/algorithms/rand_la.py
+++ b/src/pymor/algorithms/rand_la.py
@@ -299,7 +299,7 @@ class RandomizedSVD(BasicObject):
         One-dimensional |NumPy array| of the approximated singular values.
     V
         |VectorArray| containing the approximated right singular vectors.
-        Available methods are defined in `pymor.algortihms.svd_va.SVD_VA_METHODS`.
+        Available methods are defined in `pymor.algorithms.svd_va.SVD_VA_METHODS`.
     rrf_args
         Dict of additional arguments that are passed to :class:`RandomizedRangeFinder`.
     """
@@ -323,13 +323,13 @@ class RandomizedSVD(BasicObject):
             The number of eigenvalues and eigenvectors which are to be computed.
         rtol
             Relative truncation error tolerance for the low-rank SVD.
-            See :func:`~pymor.algortihms.svd_va.method_of_snapshots` for a detailed description.
+            See :func:`~pymor.algorithms.svd_va.method_of_snapshots` for a detailed description.
         atol
             Absolute truncation error tolerance for the low-rank SVD.
-            See :func:`~pymor.algortihms.svd_va.method_of_snapshots` for a detailed description.
+            See :func:`~pymor.algorithms.svd_va.method_of_snapshots` for a detailed description.
         l2_err
             :math:`\ell^2` error bound for the low-rank SVD:
-            See :func:`~pymor.algortihms.svd_va.method_of_snapshots` for a detailed description.
+            See :func:`~pymor.algorithms.svd_va.method_of_snapshots` for a detailed description.
         power_iterations
             The number of power iterations to increase the relative weight of the larger singular
             values.

--- a/src/pymor/algorithms/rand_la.py
+++ b/src/pymor/algorithms/rand_la.py
@@ -261,11 +261,13 @@ class RandomizedSVD(BasicObject):
         self.range_finder = RandomizedRangeFinder(A, range_product=range_product, source_product=source_product,
                                                   power_iterations=power_iterations, **(rrf_args or {}))
 
-    def compute_svd(self, n, oversampling=20, rrf_tol=None):
+    @defaults('rtol', 'atol', 'l2_err', 'oversampling')
+    def compute_svd(self, n=None, rtol=4e-8, atol=0., l2_err=0., oversampling=20, rrf_tol=None):
         A, range_product, source_product = self.A, self.range_product, self.source_product
-        assert 0 <= n <= max(A.source.dim, A.range.dim)
+        assert n is None or (0 <= n <= max(A.source.dim, A.range.dim))
         assert 0 <= oversampling
-        if oversampling > max(A.source.dim, A.range.dim) - n:
+        assert n is not None or rrf_tol is not None
+        if n is not None and oversampling > max(A.source.dim, A.range.dim) - n:
             self.logger.warning('Oversampling parameter is too large!')
             oversampling = max(A.source.dim, A.range.dim) - n
             self.logger.info(f'Setting oversampling to {oversampling} and proceeding ...')
@@ -279,17 +281,17 @@ class RandomizedSVD(BasicObject):
             return A.source.empty(), np.array([]), A.range.empty()
 
         with self.logger.block('Approximating basis for the operator range ...'):
-            Q = self.range_finder.find_range(basis_size=n+oversampling, tol=rrf_tol)
+            Q = self.range_finder.find_range(basis_size=(n+oversampling if n is not None else None), tol=rrf_tol)
 
         with self.logger.block(f'Computing transposed SVD in the reduced space ({len(Q)}x{Q.dim})...'):
             B = source_product.apply_inverse(A.apply_adjoint(range_product.apply(Q)))
             svd = SVD_VA_METHODS[self.low_rank_svd_method]
-            V, s, Uh_b = svd(B, product=source_product, modes=n, rtol=0)
+            V, s, Uh_b = svd(B, product=source_product, modes=n, rtol=rtol, atol=atol, l2_err=l2_err)
 
         with self.logger.block('Backprojecting the left'
                           f'{" " if isinstance(range_product, IdentityOperator) else " generalized "}'
-                          f'singular vector{"s" if n > 1 else ""} ...'):
-            U = Q.lincomb(Uh_b[:n].T)
+                          f'singular vector{"s" if len(s) > 1 else ""} ...'):
+            U = Q.lincomb(Uh_b.T)
 
         return U, s, V
 

--- a/src/pymor/algorithms/rand_la.py
+++ b/src/pymor/algorithms/rand_la.py
@@ -281,30 +281,20 @@ class RandomizedSVD(BasicObject):
     ----------
     A
         The |Operator| for which the randomized SVD is to be computed.
-    source_product
-        Source product |Operator| :math:`S` w.r.t. which the randomized SVD is computed.
     range_product
         Range product |Operator| :math:`R` w.r.t. which the randomized SVD is computed.
+    source_product
+        Source product |Operator| :math:`S` w.r.t. which the randomized SVD is computed.
     power_iterations
         The number of power iterations to increase the relative weight of the larger singular
         values.
     low_rank_svd_method
         SVD algorithm to use on the computed low-rank approximation of :math:`A`.
-
-    Returns
-    -------
-    U
-        |VectorArray| containing the approximated left singular vectors.
-    s
-        One-dimensional |NumPy array| of the approximated singular values.
-    V
-        |VectorArray| containing the approximated right singular vectors.
-        Available methods are defined in `pymor.algorithms.svd_va.SVD_VA_METHODS`.
     rrf_args
         Dict of additional arguments that are passed to :class:`RandomizedRangeFinder`.
     """
 
-    @defaults('low_rank_svd_method')
+    @defaults('power_iterations', 'low_rank_svd_method')
     def __init__(self, A, range_product=None, source_product=None, power_iterations=0,
                  low_rank_svd_method='qr_svd', rrf_args=None):
         assert low_rank_svd_method in SVD_VA_METHODS
@@ -320,7 +310,7 @@ class RandomizedSVD(BasicObject):
         Parameters
         ----------
         n
-            The number of eigenvalues and eigenvectors which are to be computed.
+            The number of singular values and signular vectors which are to be computed.
         rtol
             Relative truncation error tolerance for the low-rank SVD.
             See :func:`~pymor.algorithms.svd_va.method_of_snapshots` for a detailed description.
@@ -343,11 +333,11 @@ class RandomizedSVD(BasicObject):
         Returns
         -------
         U
-            |VectorArray| containing the approximated left singular vectors.
+            |VectorArray| containing the computed left singular vectors.
         s
-            One-dimensional |NumPy array| of the approximated singular values.
+            One-dimensional |NumPy array| of the computed singular values.
         V
-            |VectorArray| containing the approximated right singular vectors.
+            |VectorArray| containing the computed right singular vectors.
         """
         A, range_product, source_product = self.A, self.range_product, self.source_product
         assert n is None or (0 <= n <= max(A.source.dim, A.range.dim))

--- a/src/pymor/algorithms/rand_la.py
+++ b/src/pymor/algorithms/rand_la.py
@@ -311,6 +311,7 @@ class RandomizedSVD(BasicObject):
         self.__auto_init(locals())
         self.range_finder = RandomizedRangeFinder(A, range_product=range_product, source_product=source_product,
                                                   power_iterations=power_iterations, **(rrf_args or {}))
+        self.B = A.source.empty()
 
     @defaults('rtol', 'atol', 'l2_err', 'oversampling')
     def compute_svd(self, n=None, rtol=4e-8, atol=0., l2_err=0., oversampling=20, rrf_tol=None):
@@ -369,7 +370,10 @@ class RandomizedSVD(BasicObject):
             Q = self.range_finder.find_range(basis_size=(n+oversampling if n is not None else None), tol=rrf_tol)
 
         with self.logger.block(f'Computing transposed SVD in the reduced space ({len(Q)}x{Q.dim})...'):
-            B = source_product.apply_inverse(A.apply_adjoint(range_product.apply(Q)))
+            if len(self.B) < len(Q):
+                self.B.append(source_product.apply_inverse(A.apply_adjoint(range_product.apply(Q[len(self.B):]))),
+                              remove_from_other=True)
+            B = self.B[:len(Q)]
             svd = SVD_VA_METHODS[self.low_rank_svd_method]
             V, s, Uh_b = svd(B, product=source_product, modes=n, rtol=rtol, atol=atol, l2_err=l2_err)
 

--- a/src/pymor/algorithms/rand_la.py
+++ b/src/pymor/algorithms/rand_la.py
@@ -251,6 +251,45 @@ class RandomizedRangeFinder(BasicObject):
             return Q[-1].copy()
 
 
+class RandomizedSVD(BasicObject):
+
+    def __init__(self, A, range_product=None, source_product=None, power_iterations=0, rrf_args=None):
+        self.__auto_init(locals())
+        self.range_finder = RandomizedRangeFinder(A, range_product=range_product, source_product=source_product,
+                                                  power_iterations=power_iterations, **(rrf_args or {}))
+
+    def compute_svd(self, n, oversampling=20):
+        A, range_product, source_product = self.A, self.range_product, self.source_product
+        assert 0 <= n <= max(A.source.dim, A.range.dim)
+        assert 0 <= oversampling
+        if oversampling > max(A.source.dim, A.range.dim) - n:
+            self.logger.warning('Oversampling parameter is too large!')
+            oversampling = max(A.source.dim, A.range.dim) - n
+            self.logger.info(f'Setting oversampling to {oversampling} and proceeding ...')
+
+        if range_product is None:
+            range_product = IdentityOperator(A.range)
+        if source_product is None:
+            source_product = IdentityOperator(A.source)
+
+        if A.source.dim == 0 or A.range.dim == 0:
+            return A.source.empty(), np.array([]), A.range.empty()
+
+        with self.logger.block('Approximating basis for the operator range ...'):
+            Q = self.range_finder.find_range(basis_size=n+oversampling)
+
+        with self.logger.block(f'Computing transposed SVD in the reduced space ({len(Q)}x{Q.dim})...'):
+            B = source_product.apply_inverse(A.apply_adjoint(range_product.apply(Q)))
+            V, s, Uh_b = qr_svd(B, product=source_product, modes=n, rtol=0)
+
+        with self.logger.block('Backprojecting the left'
+                          f'{" " if isinstance(range_product, IdentityOperator) else " generalized "}'
+                          f'singular vector{"s" if n > 1 else ""} ...'):
+            U = Q.lincomb(Uh_b[:n].T)
+
+        return U, s, V
+
+
 @defaults('oversampling', 'power_iterations')
 def randomized_svd(A, n, source_product=None, range_product=None, power_iterations=0, oversampling=20):
     r"""Randomized SVD of an |Operator| based on :cite:`SHB21`.
@@ -304,44 +343,9 @@ def randomized_svd(A, n, source_product=None, range_product=None, power_iteratio
     V
         |VectorArray| containing the approximated right singular vectors.
     """
-    logger = getLogger('pymor.algorithms.rand_la.randomized_svd')
-
-    RRF = RandomizedRangeFinder(A, power_iterations=power_iterations, range_product=range_product,
-                                source_product=source_product)
-
-    assert 0 <= n <= max(A.source.dim, A.range.dim)
-    assert 0 <= oversampling
-    if oversampling > max(A.source.dim, A.range.dim) - n:
-        logger.warning('Oversampling parameter is too large!')
-        oversampling = max(A.source.dim, A.range.dim) - n
-        logger.info(f'Setting oversampling to {oversampling} and proceeding ...')
-
-    if range_product is None:
-        range_product = IdentityOperator(A.range)
-    if source_product is None:
-        source_product = IdentityOperator(A.source)
-
-    assert isinstance(range_product, Operator)
-    assert range_product.source == range_product.range == A.range
-    assert isinstance(source_product, Operator)
-    assert source_product.source == source_product.range == A.source
-
-    if A.source.dim == 0 or A.range.dim == 0:
-        return A.source.empty(), np.array([]), A.range.empty()
-
-    with logger.block('Approximating basis for the operator range ...'):
-        Q = RRF.find_range(basis_size=n+oversampling)
-
-    with logger.block(f'Computing transposed SVD in the reduced space ({len(Q)}x{Q.dim})...'):
-        B = source_product.apply_inverse(A.apply_adjoint(range_product.apply(Q)))
-        V, s, Uh_b = qr_svd(B, product=source_product, modes=n, rtol=0)
-
-    with logger.block('Backprojecting the left'
-                      f'{" " if isinstance(range_product, IdentityOperator) else " generalized "}'
-                      f'singular vector{"s" if n > 1 else ""} ...'):
-        U = Q.lincomb(Uh_b[:n].T)
-
-    return U, s, V
+    svd_alg = RandomizedSVD(A, range_product=range_product, source_product=source_product,
+                            power_iterations=power_iterations)
+    return svd_alg.compute_svd(n, oversampling=oversampling)
 
 
 @defaults('n', 'oversampling', 'power_iterations')

--- a/src/pymor/algorithms/rand_la.py
+++ b/src/pymor/algorithms/rand_la.py
@@ -381,15 +381,17 @@ class RandomizedSVD(BasicObject):
         return U, s, V
 
 
-@defaults('oversampling', 'power_iterations')
-def randomized_svd(A, n, *, range_product=None, source_product=None, power_iterations=0, oversampling=20):
+def randomized_svd(A, n=None, *, rtol=None, atol=None, l2_err=None, rrf_tol=None,
+                   range_product=None, source_product=None, power_iterations=None, oversampling=None,
+                   low_rank_svd_method=None, rrf_args=None):
     r"""Randomized SVD of an |Operator|.
 
     This is a just a wrapper for :class:`RandomizedSVD`.
     """
     svd_alg = RandomizedSVD(A, range_product=range_product, source_product=source_product,
-                            power_iterations=power_iterations)
-    return svd_alg.compute_svd(n, oversampling=oversampling)
+                            power_iterations=power_iterations, low_rank_svd_method=low_rank_svd_method,
+                            rrf_args=rrf_args)
+    return svd_alg.compute_svd(n, rtol=rtol, atol=atol, l2_err=l2_err, oversampling=oversampling, rrf_tol=rrf_tol)
 
 
 @defaults('n', 'oversampling', 'power_iterations')

--- a/src/pymor/algorithms/rand_la.py
+++ b/src/pymor/algorithms/rand_la.py
@@ -258,7 +258,7 @@ class RandomizedSVD(BasicObject):
         self.range_finder = RandomizedRangeFinder(A, range_product=range_product, source_product=source_product,
                                                   power_iterations=power_iterations, **(rrf_args or {}))
 
-    def compute_svd(self, n, oversampling=20):
+    def compute_svd(self, n, oversampling=20, rrf_tol=None):
         A, range_product, source_product = self.A, self.range_product, self.source_product
         assert 0 <= n <= max(A.source.dim, A.range.dim)
         assert 0 <= oversampling
@@ -276,7 +276,7 @@ class RandomizedSVD(BasicObject):
             return A.source.empty(), np.array([]), A.range.empty()
 
         with self.logger.block('Approximating basis for the operator range ...'):
-            Q = self.range_finder.find_range(basis_size=n+oversampling)
+            Q = self.range_finder.find_range(basis_size=n+oversampling, tol=rrf_tol)
 
         with self.logger.block(f'Computing transposed SVD in the reduced space ({len(Q)}x{Q.dim})...'):
             B = source_product.apply_inverse(A.apply_adjoint(range_product.apply(Q)))

--- a/src/pymor/algorithms/rand_la.py
+++ b/src/pymor/algorithms/rand_la.py
@@ -252,6 +252,57 @@ class RandomizedRangeFinder(BasicObject):
 
 
 class RandomizedSVD(BasicObject):
+    r"""Randomized SVD of an |Operator| based on :cite:`SHB21`.
+
+    Viewing the |Operator| :math:`A` as an :math:`m` by :math:`n` matrix, this methods computes and
+    returns the randomized generalized singular value decomposition of `A` according :cite:`SHB21`:
+
+    .. math::
+
+        A = U \Sigma V^{-1},
+
+    where the inner product on the range :math:`\mathbb{R}^m` is given by
+
+    .. math::
+
+        (x, y)_R = x^TRy
+
+    and the inner product on the source :math:`\mathbb{R}^n` is given by
+
+    .. math::
+
+        (x, y)_S = x^TSy.
+
+    Note that :math:`U` is :math:`R`-orthogonal, i.e. :math:`U^TRU=I`
+    and :math:`V` is :math:`S`-orthogonal, i.e. :math:`V^TSV=I`.
+    In particular, `V^{-1}=V^TS`.
+
+    Parameters
+    ----------
+    A
+        The |Operator| for which the randomized SVD is to be computed.
+    source_product
+        Source product |Operator| :math:`S` w.r.t. which the randomized SVD is computed.
+    range_product
+        Range product |Operator| :math:`R` w.r.t. which the randomized SVD is computed.
+    power_iterations
+        The number of power iterations to increase the relative weight of the larger singular
+        values.
+    low_rank_svd_method
+        SVD algorithm to use on the computed low-rank approximation of :math:`A`.
+
+    Returns
+    -------
+    U
+        |VectorArray| containing the approximated left singular vectors.
+    s
+        One-dimensional |NumPy array| of the approximated singular values.
+    V
+        |VectorArray| containing the approximated right singular vectors.
+        Available methods are defined in `pymor.algortihms.svd_va.SVD_VA_METHODS`.
+    rrf_args
+        Dict of additional arguments that are passed to :class:`RandomizedRangeFinder`.
+    """
 
     @defaults('low_rank_svd_method')
     def __init__(self, A, range_product=None, source_product=None, power_iterations=0,
@@ -263,6 +314,40 @@ class RandomizedSVD(BasicObject):
 
     @defaults('rtol', 'atol', 'l2_err', 'oversampling')
     def compute_svd(self, n=None, rtol=4e-8, atol=0., l2_err=0., oversampling=20, rrf_tol=None):
+        r"""Compute the SVD.
+
+        Parameters
+        ----------
+        n
+            The number of eigenvalues and eigenvectors which are to be computed.
+        rtol
+            Relative truncation error tolerance for the low-rank SVD.
+            See :func:`~pymor.algortihms.svd_va.method_of_snapshots` for a detailed description.
+        atol
+            Absolute truncation error tolerance for the low-rank SVD.
+            See :func:`~pymor.algortihms.svd_va.method_of_snapshots` for a detailed description.
+        l2_err
+            :math:`\ell^2` error bound for the low-rank SVD:
+            See :func:`~pymor.algortihms.svd_va.method_of_snapshots` for a detailed description.
+        power_iterations
+            The number of power iterations to increase the relative weight of the larger singular
+            values.
+        oversampling
+            The number of samples that are drawn in addition to the desired basis size in the
+            randomized range approximation process. Only used when `n` is specified.
+        rrf_tol
+            Error tolerance for computing a low-rank approximation of :math:`A` using
+            :class:`RandomizedRangeFinder`.
+
+        Returns
+        -------
+        U
+            |VectorArray| containing the approximated left singular vectors.
+        s
+            One-dimensional |NumPy array| of the approximated singular values.
+        V
+            |VectorArray| containing the approximated right singular vectors.
+        """
         A, range_product, source_product = self.A, self.range_product, self.source_product
         assert n is None or (0 <= n <= max(A.source.dim, A.range.dim))
         assert 0 <= oversampling
@@ -298,56 +383,9 @@ class RandomizedSVD(BasicObject):
 
 @defaults('oversampling', 'power_iterations')
 def randomized_svd(A, n, *, range_product=None, source_product=None, power_iterations=0, oversampling=20):
-    r"""Randomized SVD of an |Operator| based on :cite:`SHB21`.
+    r"""Randomized SVD of an |Operator|.
 
-    Viewing the |Operator| :math:`A` as an :math:`m` by :math:`n` matrix, this methods computes and
-    returns the randomized generalized singular value decomposition of `A` according :cite:`SHB21`:
-
-    .. math::
-
-        A = U \Sigma V^{-1},
-
-    where the inner product on the range :math:`\mathbb{R}^m` is given by
-
-    .. math::
-
-        (x, y)_R = x^TRy
-
-    and the inner product on the source :math:`\mathbb{R}^n` is given by
-
-    .. math::
-
-        (x, y)_S = x^TSy.
-
-    Note that :math:`U` is :math:`R`-orthogonal, i.e. :math:`U^TRU=I`
-    and :math:`V` is :math:`S`-orthogonal, i.e. :math:`V^TSV=I`.
-    In particular, `V^{-1}=V^TS`.
-
-    Parameters
-    ----------
-    A
-        The |Operator| for which the randomized SVD is to be computed.
-    n
-        The number of eigenvalues and eigenvectors which are to be computed.
-    source_product
-        Source product |Operator| :math:`S` w.r.t. which the randomized SVD is computed.
-    range_product
-        Range product |Operator| :math:`R` w.r.t. which the randomized SVD is computed.
-    power_iterations
-        The number of power iterations to increase the relative weight of the larger singular
-        values.
-    oversampling
-        The number of samples that are drawn in addition to the desired basis size in the
-        randomized range approximation process.
-
-    Returns
-    -------
-    U
-        |VectorArray| containing the approximated left singular vectors.
-    s
-        One-dimensional |NumPy array| of the approximated singular values.
-    V
-        |VectorArray| containing the approximated right singular vectors.
+    This is a just a wrapper for :class:`RandomizedSVD`.
     """
     svd_alg = RandomizedSVD(A, range_product=range_product, source_product=source_product,
                             power_iterations=power_iterations)

--- a/src/pymor/algorithms/rand_la.py
+++ b/src/pymor/algorithms/rand_la.py
@@ -291,7 +291,7 @@ class RandomizedSVD(BasicObject):
 
 
 @defaults('oversampling', 'power_iterations')
-def randomized_svd(A, n, source_product=None, range_product=None, power_iterations=0, oversampling=20):
+def randomized_svd(A, n, *, range_product=None, source_product=None, power_iterations=0, oversampling=20):
     r"""Randomized SVD of an |Operator| based on :cite:`SHB21`.
 
     Viewing the |Operator| :math:`A` as an :math:`m` by :math:`n` matrix, this methods computes and

--- a/src/pymor/algorithms/svd_va.py
+++ b/src/pymor/algorithms/svd_va.py
@@ -234,6 +234,13 @@ def scipy_svd(A, product=None, modes=None, rtol=4e-8, atol=0., l2_err=0.):
     return U, s, Vh
 
 
+SVD_VA_METHODS = {
+    'method_of_snapshots': method_of_snapshots,
+    'qr_svd': qr_svd,
+    'scipy_svd': scipy_svd
+}
+
+
 def _select_modes(s, modes, rtol, atol, l2_err):
     tol = max(rtol * s[0], atol)
     above_tol = np.where(s >= tol)[0]

--- a/src/pymor/algorithms/svd_va.py
+++ b/src/pymor/algorithms/svd_va.py
@@ -11,6 +11,7 @@ from pymor.algorithms.gram_schmidt import gram_schmidt
 from pymor.bindings.scipy import svd_lapack_driver
 from pymor.core.defaults import defaults
 from pymor.core.logger import getLogger
+from pymor.operators.constructions import IdentityOperator
 from pymor.operators.interface import Operator
 from pymor.vectorarrays.interface import VectorArray
 
@@ -216,7 +217,7 @@ def scipy_svd(A, product=None, modes=None, rtol=4e-8, atol=0., l2_err=0.):
         |NumPy array| of right singular vectors.
     """
     assert isinstance(A, VectorArray)
-    if product is not None:
+    if product is not None and not isinstance(product, IdentityOperator):
         raise NotImplementedError
 
     if A.dim == 0 or len(A) == 0:

--- a/src/pymor/algorithms/svd_va.py
+++ b/src/pymor/algorithms/svd_va.py
@@ -81,26 +81,14 @@ def method_of_snapshots(A, product=None, modes=None, rtol=1e-7, atol=0., l2_err=
         evals, V = spla.eigh(B, overwrite_a=True, subset_by_index=eigvals)
         evals = evals[::-1]
         V = V[:, ::-1]
+        s = np.sqrt(np.clip(evals, a_min=0., a_max=None))
 
-        tol = max(rtol ** 2 * evals[0], atol ** 2)
-        above_tol = np.where(evals >= tol)[0]
-        if len(above_tol) == 0:
-            return A.space.empty(), np.array([]), np.zeros((0, len(A)))
-        last_above_tol = above_tol[-1]
-
-        errs = np.concatenate((np.cumsum(evals[::-1])[::-1], [0.]))
-        below_err = np.where(errs <= l2_err**2)[0]
-        first_below_err = below_err[0]
-
-        selected_modes = min(first_below_err, last_above_tol + 1)
-        if modes is not None:
-            selected_modes = min(selected_modes, modes)
-
+        selected_modes = _select_modes(s, modes, rtol, atol, l2_err)
         if selected_modes > A.dim:
             logger.warning('Number of computed singular vectors larger than array dimension! Truncating ...')
             selected_modes = A.dim
 
-        s = np.sqrt(evals[:selected_modes])
+        s = s[:selected_modes]
         V = V[:, :selected_modes]
         Vh = V.conj().T
 
@@ -168,20 +156,7 @@ def qr_svd(A, product=None, modes=None, rtol=4e-8, atol=0., l2_err=0.):
         U2, s, Vh = spla.svd(R, lapack_driver=svd_lapack_driver())
 
     with logger.block('Choosing the number of modes ...'):
-        tol = max(rtol * s[0], atol)
-        above_tol = np.where(s >= tol)[0]
-        if len(above_tol) == 0:
-            return A.space.empty(), np.array([]), np.zeros((0, len(A)))
-        last_above_tol = above_tol[-1]
-
-        errs = np.concatenate((np.cumsum(s[::-1] ** 2)[::-1], [0.]))
-        below_err = np.where(errs <= l2_err**2)[0]
-        first_below_err = below_err[0]
-
-        selected_modes = min(first_below_err, last_above_tol + 1)
-        if modes is not None:
-            selected_modes = min(selected_modes, modes)
-
+        selected_modes = _select_modes(s, modes, rtol, atol, l2_err)
         U2 = U2[:, :selected_modes]
         s = s[:selected_modes]
         Vh = Vh[:selected_modes]
@@ -190,3 +165,87 @@ def qr_svd(A, product=None, modes=None, rtol=4e-8, atol=0., l2_err=0.):
         U = Q.lincomb(U2)
 
     return U, s, Vh
+
+
+@defaults('rtol', 'atol', 'l2_err')
+def scipy_svd(A, product=None, modes=None, rtol=4e-8, atol=0., l2_err=0.):
+    """SVD of a |VectorArray| using :func:`scipy.linalg.svd`.
+
+    Viewing the |VectorArray| `A` as a `A.dim` x `len(A)` matrix, the
+    return value of this method is the singular value decomposition of
+    `A`, where the inner product on R^(`dim(A)`) is given by `product`
+    and the inner product on R^(`len(A)`) is the Euclidean inner
+    product.
+
+    This functions uses :func:`scipy_linalg.svd` by converting the input
+    |VectorArray| `A` to a |NumPy arry| by calling
+    :meth:`~pymor.vectorarrays.interface.VectorArray.to_numpy`.
+
+    Parameters
+    ----------
+    A
+        The |VectorArray| for which the SVD is to be computed.
+    product
+        Not supported. Must be `None`.
+        (Inner product |Operator| w.r.t. which the left singular vectors
+        are computed.)
+    modes
+        If not `None`, at most the first `modes` singular values and
+        vectors are returned.
+    rtol
+        Singular values smaller than this value multiplied by the
+        largest singular value are ignored.
+    atol
+        Singular values smaller than this value are ignored.
+    l2_err
+        Do not return more modes than needed to bound the
+        l2-approximation error by this value. I.e. the number of
+        returned modes is at most ::
+
+            argmin_N { sum_{n=N+1}^{infty} s_n^2 <= l2_err^2 }
+
+        where `s_n` denotes the n-th singular value.
+
+    Returns
+    -------
+    U
+        |VectorArray| of left singular vectors.
+    s
+        One-dimensional |NumPy array| of singular values.
+    Vh
+        |NumPy array| of right singular vectors.
+    """
+    assert isinstance(A, VectorArray)
+    if product is not None:
+        raise NotImplementedError
+
+    if A.dim == 0 or len(A) == 0:
+        return A.space.empty(), np.array([]), np.zeros((0, len(A)))
+
+    a = A.to_numpy(ensure_copy=True)
+    U, s, Vh = spla.svd(a, full_matrices=False, compute_uv=True, overwrite_a=True, lapack_driver=svd_lapack_driver())
+
+    selected_modes = _select_modes(s, modes, rtol, atol, l2_err)
+    U = U[:, :selected_modes]
+    s = s[:selected_modes]
+    Vh = Vh[:selected_modes]
+
+    U = A.space.from_numpy(U)
+    return U, s, Vh
+
+
+def _select_modes(s, modes, rtol, atol, l2_err):
+    tol = max(rtol * s[0], atol)
+    above_tol = np.where(s >= tol)[0]
+    if len(above_tol) == 0:
+        return 0
+    last_above_tol = above_tol[-1]
+
+    errs = np.concatenate((np.cumsum(s[::-1] ** 2)[::-1], [0.]))
+    below_err = np.where(errs <= l2_err**2)[0]
+    first_below_err = below_err[0]
+
+    selected_modes = min(first_below_err, last_above_tol + 1)
+    if modes is not None:
+        selected_modes = min(selected_modes, modes)
+    return selected_modes

--- a/src/pymor/algorithms/svd_va.py
+++ b/src/pymor/algorithms/svd_va.py
@@ -178,8 +178,8 @@ def scipy_svd(A, product=None, modes=None, rtol=4e-8, atol=0., l2_err=0.):
     and the inner product on R^(`len(A)`) is the Euclidean inner
     product.
 
-    This functions uses :func:`scipy_linalg.svd` by converting the input
-    |VectorArray| `A` to a |NumPy arry| by calling
+    This functions uses :func:`scipy.linalg.svd` by converting the input
+    |VectorArray| `A` to a |NumPy array| by calling
     :meth:`~pymor.vectorarrays.interface.VectorArray.to_numpy`.
 
     Parameters

--- a/src/pymortests/algorithms/rand_la.py
+++ b/src/pymortests/algorithms/rand_la.py
@@ -99,8 +99,8 @@ def test_RandomizedSVD_repeated_calls(low_rank_svd_method, power_iterations, ove
         U2, s2, V2 = svd.compute_svd(4, oversampling=oversampling)
 
     assert np.allclose(s1, s2)
-    assert np.all(almost_equal(U1, U2))
-    assert np.all(almost_equal(V1, V2))
+    assert np.all(almost_equal(U1, U2, atol=1e-13)), (U1-U2).norm()
+    assert np.all(almost_equal(V1, V2, atol=1e-13)), (V1-V2).norm()
 
 
 def test_random_generalized_svd(rng):

--- a/src/pymortests/algorithms/rand_la.py
+++ b/src/pymortests/algorithms/rand_la.py
@@ -6,9 +6,12 @@ import numpy as np
 import pytest
 import scipy.linalg as spla
 
-from pymor.algorithms.rand_la import RandomizedRangeFinder, randomized_ghep, randomized_svd
+from pymor.algorithms.basic import almost_equal
+from pymor.algorithms.rand_la import RandomizedRangeFinder, RandomizedSVD, randomized_ghep, randomized_svd
+from pymor.algorithms.svd_va import SVD_VA_METHODS
 from pymor.operators.constructions import VectorArrayOperator
 from pymor.operators.numpy import NumpyMatrixOperator
+from pymor.tools.random import new_rng
 
 pytestmark = pytest.mark.builtin
 
@@ -69,6 +72,35 @@ def test_adaptive_rrf_with_product(rng, qr_method):
     ).find_range(tol=1e-5)
     assert np.iscomplexobj(Q2.to_numpy())
     assert Q2 in op.range
+
+
+@pytest.mark.parametrize('low_rank_svd_method', SVD_VA_METHODS)
+@pytest.mark.parametrize('power_iterations', [0, 1, 2])
+@pytest.mark.parametrize('oversampling', [1, 10])
+@pytest.mark.parametrize('range_product', [True, None])
+@pytest.mark.parametrize('source_product', [True, None])
+def test_RandomizedSVD_repeated_calls(low_rank_svd_method, power_iterations, oversampling,
+                                      range_product, source_product):
+    if source_product and low_rank_svd_method == 'scipy_svd':
+        pytest.skip('scipy_svd does not support products.')
+    A = NumpyMatrixOperator(np.diag(np.linspace(1, 10, 100)))
+    if range_product:
+        range_product = NumpyMatrixOperator(np.diag(np.linspace(2, 1, 100)))
+    if source_product:
+        source_product = NumpyMatrixOperator(np.diag(np.linspace(3, 1, 100)))
+    with new_rng():
+        svd = RandomizedSVD(A, range_product=range_product, source_product=source_product,
+                            low_rank_svd_method=low_rank_svd_method, power_iterations=power_iterations)
+        svd.compute_svd(3)
+        U1, s1, V1 = svd.compute_svd(4, oversampling=oversampling)
+    with new_rng():
+        svd = RandomizedSVD(A, range_product=range_product, source_product=source_product,
+                            low_rank_svd_method=low_rank_svd_method, power_iterations=power_iterations)
+        U2, s2, V2 = svd.compute_svd(4, oversampling=oversampling)
+
+    assert np.allclose(s1, s2)
+    assert np.all(almost_equal(U1, U2))
+    assert np.all(almost_equal(V1, V2))
 
 
 def test_random_generalized_svd(rng):

--- a/src/pymortests/algorithms/svd_va.py
+++ b/src/pymortests/algorithms/svd_va.py
@@ -8,13 +8,14 @@ from hypothesis import HealthCheck, assume, settings
 from hypothesis.strategies import sampled_from
 
 from pymor.algorithms.basic import almost_equal, contains_zero_vector
-from pymor.algorithms.svd_va import method_of_snapshots, qr_svd
+from pymor.algorithms.svd_va import method_of_snapshots, qr_svd, scipy_svd
 from pymor.core.logger import log_levels
 from pymor.vectorarrays.numpy import NumpyVectorSpace
 from pymortests.base import runmodule
 from pymortests.strategies import given_vector_arrays
 
-methods = [method_of_snapshots, qr_svd]
+methods = [method_of_snapshots, qr_svd, scipy_svd]
+methods_with_product = [method_of_snapshots, qr_svd]
 
 
 @given_vector_arrays(method=sampled_from(methods))
@@ -40,7 +41,7 @@ def test_method_of_snapshots(vector_array, method):
         assert np.all(almost_equal(A, UsVh, atol=s[0]*4e-8*2))
 
 
-@pytest.mark.parametrize('method', methods)
+@pytest.mark.parametrize('method', methods_with_product)
 def test_method_of_snapshots_with_product(operator_with_arrays_and_products, method):
     _, _, A, _, p, _ = operator_with_arrays_and_products
 


### PR DESCRIPTION
This PR adds a `RadomizedSVD` class that can be used to efficiently compute multiple SVDs of the same operator $A$ for different truncation ranks.

- Add `RandomizedSVD` class.
- Add `RandomizedRangeFinder` as instance attribute to efficiently update the approximate range space $Q$ when more vectors are requested. Also keep the low-rank approximation $Q^T \cdot A$ for further updates.
- Refactor `randomized_svd` to use `RandomizedSVD`.
- Add `rtol`, `atol`, `l2_err` parameters to select truncation rank. These should be used in conjuction with the added `rrf_tol` parameter to control the low-rank approximation error $\|A - Q^T \cdot A\|$.
- Add `low_rank_svd_method` parameter to select the SVD algorithm used to compute the SVD of $Q^T \cdot A$.
- Add `scipy_svd` to `pymor.algortihms.svd_va` as an additional option for computing the SVD of a `VectorArray` by converting it to NumPy data.