### PR TITLE
Various shifted_chol_qr improvements

### DIFF
--- a/src/pymor/algorithms/chol_qr.py
+++ b/src/pymor/algorithms/chol_qr.py
@@ -216,7 +216,8 @@ def _solve_chol_qr(params: _CholQRParameters):
 
     trmm, trtri = spla.get_blas_funcs('trmm', dtype=params.dtype), spla.get_lapack_funcs('trtri', dtype=params.dtype)
 
-    for iter in range(1,params.maxiter+1):
+    iter = 1
+    while iter <= params.maxiter:
         with params.logger.block(f'Iteration {iter}'):
             X -= B.conj().T@B
             Rx = params.chol_kernel(params, X)
@@ -250,6 +251,8 @@ def _solve_chol_qr(params: _CholQRParameters):
                 elif iter == params.maxiter:
                     raise AccuracyError('Orthonormality could not be achieved within the given tolerance. \
                     Consider increasing maxiter or enabling recompute_shift.')
+
+            iter += 1
 
     if not params.return_R:
         return A

--- a/src/pymor/algorithms/chol_qr.py
+++ b/src/pymor/algorithms/chol_qr.py
@@ -166,6 +166,7 @@ def _compute_gramian_and_offset_matrix(A, offset, product):
 
 
 class ShiftedCholQRKernel(BasicObject):
+    """Abstract base class for shifted_chol_qr kernels."""
 
     def __init__(self, dim, product=None, product_norm=None, check_finite=True):
         self.__auto_init(locals())

--- a/src/pymor/algorithms/chol_qr.py
+++ b/src/pymor/algorithms/chol_qr.py
@@ -194,6 +194,7 @@ class ShiftedCholQRKernel(BasicObject):
 
         # eigsh outputs warnings, if n <= 2; it also throws an exception,
         # if X is a zero matrix (or is close to) or contains subnormal numbers
+        # see https://github.com/pymor/pymor/pull/2570#issuecomment-5045868061
         use_eigh = n <= 2 or X.max() - X.min() < eps or np.any((X != 0) & (np.abs(X) < np.finfo(dtype).tiny))
         if not use_eigh:
             try:

--- a/src/pymor/algorithms/chol_qr.py
+++ b/src/pymor/algorithms/chol_qr.py
@@ -176,8 +176,7 @@ def _solve_chol_qr(params: _CholQRParameters):
     # compute shift
     shift = None
 
-    iter = 1
-    while iter <= params.maxiter:
+    for iter in range(1,params.maxiter+1):
         with params.logger.block(f'Iteration {iter}'):
             # This will compute the Cholesky factor of the lower right block
             # and keep applying shifts if it breaks down.
@@ -226,8 +225,6 @@ def _solve_chol_qr(params: _CholQRParameters):
                 elif iter == params.maxiter:
                     raise AccuracyError('Orthonormality could not be achieved within the given tolerance. \
                     Consider increasing maxiter or enabling recompute_shift.')
-
-            iter += 1
 
     # construct R from blocks
     R = np.eye(len(A), dtype=params.dtype)

--- a/src/pymor/algorithms/chol_qr.py
+++ b/src/pymor/algorithms/chol_qr.py
@@ -105,6 +105,8 @@ class _CholQRParameters:
         self.check_finite = check_finite
         self.product_norm = product_norm
 
+        self.dtype = None
+        self.eps = None
         self.logger = getLogger('pymor.algorithms.chol_qr.shifted_chol_qr')
 
 
@@ -123,6 +125,31 @@ def _compute_gramian_and_offset_matrix(params):
     return B, X
 
 
+def _compute_shift(params: _CholQRParameters, X: np.ndarray):
+    m = params.A.dim
+    n = len(X)
+    product_norm = params.product_norm
+
+    shift = 11*params.eps
+    if params.product is None:
+        shift *= m*n+n*(n+1)
+        XX = X
+    else:
+        if product_norm is None:
+            from pymor.algorithms.eigs import eigs
+            product_norm = np.sqrt(np.abs(eigs(params.product, k=1)[0][0]))
+        shift *= (2*m*np.sqrt(m*n)+n*(n+1))*product_norm
+        XX = params.A[params.offset:].gramian()
+    try:
+        shift *= spsla.eigsh(XX, k=1, tol=1e-2, return_eigenvectors=False, v0=np.ones([n]))[0]
+    except spsla.ArpackNoConvergence as e:
+        params.logger.warning(f'ARPACK failed with: {e}')
+        params.logger.info('Proceeding with dense solver.')
+        shift *= spla.eigh(XX, eigvals_only=True, subset_by_index=[n-1, n-1], driver='evr')[0]
+    shift = max(shift, params.eps)  # ensure that shift is non-zero
+    return shift
+
+
 def _solve_chol_qr(params: _CholQRParameters):
     # unpack often used arguments
     A = params.A
@@ -136,35 +163,13 @@ def _solve_chol_qr(params: _CholQRParameters):
 
     B, X = _compute_gramian_and_offset_matrix(params)
 
-    dtype = np.promote_types(X.dtype, np.float32)
+    params.dtype = dtype = np.promote_types(X.dtype, np.float32)
+    params.eps = np.finfo(dtype).eps
     B = B.astype(dtype=dtype, copy=False)
     trmm, trtri = spla.get_blas_funcs('trmm', dtype=dtype), spla.get_lapack_funcs('trtri', dtype=dtype)
 
     # compute shift
-    m, n = A.dim, len(A[offset:])
     shift = None
-    def _compute_shift():
-        product = params.product
-        product_norm = params.product_norm
-
-        shift = 11*np.finfo(params.dtype).eps
-        if product is None:
-            shift *= m*n+n*(n+1)
-            XX = X
-        else:
-            if product_norm is None:
-                from pymor.algorithms.eigs import eigs
-                product_norm = np.sqrt(np.abs(eigs(product, k=1)[0][0]))
-            shift *= (2*m*np.sqrt(m*n)+n*(n+1))*product_norm
-            XX = A[offset:].gramian()
-        try:
-            shift *= spsla.eigsh(XX, k=1, tol=1e-2, return_eigenvectors=False, v0=np.ones([n]))[0]
-        except spsla.ArpackNoConvergence as e:
-            params.logger.warning(f'ARPACK failed with: {e}')
-            params.logger.info('Proceeding with dense solver.')
-            shift *= spla.eigh(XX, eigvals_only=True, subset_by_index=[n-1, n-1], driver='evr')[0]
-        shift = max(shift, np.finfo(dtype).eps)  # ensure that shift is non-zero
-        return shift
 
     iter = 1
     while iter <= params.maxiter:
@@ -182,7 +187,7 @@ def _solve_chol_qr(params: _CholQRParameters):
                     if it > 100:
                         assert False
                     if not shift or params.recompute_shift and it == 1:
-                        shift = _compute_shift()
+                        shift = _compute_shift(params, X)
                     params.logger.warning('Cholesky factorization broke down! Matrix is ill-conditioned.')
                     params.logger.info(f'Applying shift: {shift}')
                     X[np.diag_indices_from(X)] += shift

--- a/src/pymor/algorithms/chol_qr.py
+++ b/src/pymor/algorithms/chol_qr.py
@@ -138,25 +138,31 @@ def _compute_gramian_and_offset_matrix(params):
 def _compute_shift(params: _CholQRParameters, X: np.ndarray):
     m = params.A.dim
     n = len(X)
-    product_norm = params.product_norm
 
     shift = 11*params.eps
     if params.product is None:
         shift *= m*n+n*(n+1)
-        XX = X
     else:
-        if product_norm is None:
+        if params.product_norm is None:
             from pymor.algorithms.eigs import eigs
-            product_norm = np.sqrt(np.abs(eigs(params.product, k=1)[0][0]))
-        shift *= (2*m*np.sqrt(m*n)+n*(n+1))*product_norm
-        XX = params.A[params.offset:].gramian()
-    try:
-        shift *= spsla.eigsh(XX, k=1, tol=1e-2, return_eigenvectors=False, v0=np.ones([n]))[0]
-    except spsla.ArpackNoConvergence as e:
-        params.logger.warning(f'ARPACK failed with: {e}')
-        params.logger.info('Proceeding with dense solver.')
-        shift *= spla.eigh(XX, eigvals_only=True, subset_by_index=[n-1, n-1], driver='evr')[0]
-    shift = max(shift, params.eps)  # ensure that shift is non-zero
+            params.product_norm = np.sqrt(np.abs(eigs(params.product, k=1)[0][0]))
+        shift *= (2*m*np.sqrt(m*n)+n*(n+1))*params.product_norm
+
+    # eigsh outputs warnings, if n <= 2; it also throws an exception,
+    # if X is a zero matrix (or is close to) or contains subnormal numbers
+    use_eigh = n <= 2 or X.max() - X.min() < params.eps or np.any((X != 0) & (np.abs(X) < np.finfo(params.dtype).tiny))
+    if not use_eigh:
+        try:
+            ew = spsla.eigsh(X, k=1, tol=1e-2, return_eigenvectors=False, v0=np.ones([n]))[0]
+        except spsla.ArpackNoConvergence as e:
+            params.logger.warning(f'ARPACK failed with: {e}')
+            params.logger.info('Proceeding with dense solver.')
+            use_eigh = True
+
+    if use_eigh:
+        ew = spla.eigh(X, eigvals_only=True, subset_by_index=[n-1, n-1], driver='evr')[0]
+
+    shift = max(shift*ew, params.eps) # ensure that shift is non-zero
     return shift
 
 

--- a/src/pymor/algorithms/chol_qr.py
+++ b/src/pymor/algorithms/chol_qr.py
@@ -195,8 +195,8 @@ def _solve_chol_qr(params: _CholQRParameters):
                 Bi = B.T
                 Ri = Rx
             else:
-                Bi += B.T @ Rx
-                trmm(1, Rx, Ri, overwrite_b=True)
+                Bi += B.T @ Ri
+                Ri = trmm(1, Rx, Ri, overwrite_b=True)
 
             # computation not needed in the last iteration
             if iter < params.maxiter:

--- a/src/pymor/algorithms/chol_qr.py
+++ b/src/pymor/algorithms/chol_qr.py
@@ -207,7 +207,7 @@ def _solve_chol_qr(params: _CholQRParameters):
     offset = params.offset
 
     if offset == len(A):
-        return A, np.eye(len(A))
+        return (A, np.eye(len(A))) if params.return_R else A
 
     if params.maxiter == 1:
         params.logger.warning('Single iteration shifted CholeskyQR can lead to poor orthogonality!')

--- a/src/pymor/algorithms/chol_qr.py
+++ b/src/pymor/algorithms/chol_qr.py
@@ -117,11 +117,19 @@ def _compute_gramian_and_offset_matrix(params):
 
     if isinstance(A, ListVectorArray):
         # for a |ListVectorArray| it is slightly faster to compute `B` and `X` separately
-        B = A[offset:].inner(A[:offset], product=product)
+        B = A[:offset].inner(A[offset:], product=product)
         X = A[offset:].gramian(product)
     else:
-        B, X = np.split(A[offset:].inner(A, product=product), [offset], axis=1)
-    B = B.conj()
+        B, X = np.split(A.inner(A[offset:], product=product), [offset], axis=0)
+
+    if params.dtype is None:
+        params.dtype = np.promote_types(X.dtype, np.promote_types(B.dtype, np.float32))
+        params.eps = np.finfo(params.dtype).eps
+
+    dtype = params.dtype
+    B = B.astype(dtype=dtype, copy=False)
+    X = X.astype(dtype=dtype, copy=False)
+
     return B, X
 
 
@@ -163,10 +171,7 @@ def _solve_chol_qr(params: _CholQRParameters):
 
     B, X = _compute_gramian_and_offset_matrix(params)
 
-    params.dtype = dtype = np.promote_types(X.dtype, np.float32)
-    params.eps = np.finfo(dtype).eps
-    B = B.astype(dtype=dtype, copy=False)
-    trmm, trtri = spla.get_blas_funcs('trmm', dtype=dtype), spla.get_lapack_funcs('trtri', dtype=dtype)
+    trmm, trtri = spla.get_blas_funcs('trmm', dtype=params.dtype), spla.get_lapack_funcs('trtri', dtype=params.dtype)
 
     # compute shift
     shift = None
@@ -176,7 +181,7 @@ def _solve_chol_qr(params: _CholQRParameters):
         with params.logger.block(f'Iteration {iter}'):
             # This will compute the Cholesky factor of the lower right block
             # and keep applying shifts if it breaks down.
-            X -= B@B.T
+            X -= B.conj().T@B
             it = 0
             while True:
                 try:
@@ -194,16 +199,16 @@ def _solve_chol_qr(params: _CholQRParameters):
 
             # orthogonalize
             Rinv = trtri(Rx)[0]
-            A_todo = A[:offset].lincomb(-B.T@Rinv) + A[offset:].lincomb(Rinv)
+            A_todo = A[:offset].lincomb(-B@Rinv) + A[offset:].lincomb(Rinv)
             del A[offset:]
             A.append(A_todo)
 
             # update blocks of R
             if iter == 1:
-                Bi = B.T
+                Bi = B
                 Ri = Rx
             else:
-                Bi += B.T @ Ri
+                Bi += B @ Ri
                 Ri = trmm(1, Rx, Ri, overwrite_b=True)
 
             # computation not needed in the last iteration
@@ -225,7 +230,7 @@ def _solve_chol_qr(params: _CholQRParameters):
             iter += 1
 
     # construct R from blocks
-    R = np.eye(len(A), dtype=dtype)
+    R = np.eye(len(A), dtype=params.dtype)
     R[:offset, offset:] = Bi
     R[offset:, offset:] = Ri
 

--- a/src/pymor/algorithms/chol_qr.py
+++ b/src/pymor/algorithms/chol_qr.py
@@ -11,6 +11,7 @@ from pymor.core.logger import getLogger
 from pymor.vectorarrays.interface import VectorArray
 from pymor.vectorarrays.list import ListVectorArray
 
+_INNER_ITERS = 10
 
 def shifted_chol_qr(A, product=None, return_R=False, maxiter=3, offset=0, orth_tol=None,
                     recompute_shift=False, check_finite=True, copy=True, product_norm=None):
@@ -101,10 +102,11 @@ class _CholQRParameters:
         self.maxiter = maxiter
         self.offset = offset
         self.orth_tol = orth_tol
-        self.recompute_shift = recompute_shift
         self.check_finite = check_finite
         self.product_norm = product_norm
 
+        self.chol_kernel = _recomputed_shifted_chol_kernel if recompute_shift else _basic_shifted_chol_kernel
+        self.shift = None # used by `_basic_shifted_chol_kernel``
         self.dtype = None
         self.eps = None
         self.logger = getLogger('pymor.algorithms.chol_qr.shifted_chol_qr')
@@ -158,6 +160,41 @@ def _compute_shift(params: _CholQRParameters, X: np.ndarray):
     return shift
 
 
+def _basic_shifted_chol_kernel(params, X):
+    """Kernel computes `R` and shift according to Algorithm 4.1 in :cite:`FKNYY20`."""
+    global _INNER_ITERS
+    for _ in range(_INNER_ITERS):
+        try:
+            R = spla.cholesky(X, overwrite_a=False, check_finite=params.check_finite)
+            return R
+        except spla.LinAlgError:
+            params.logger.warning('Cholesky factorization broke down! Matrix is ill-conditioned.')
+
+            if not params.shift:
+                params.shift = _compute_shift(params, X)
+            params.logger.info(f'Applying shift: {params.shift}')
+            X[np.diag_indices_from(X)] += params.shift
+    raise AccuracyError('Failed to compute a Cholesky factorization of X.')
+
+
+def _recomputed_shifted_chol_kernel(params, X):
+    """Kernel computes `R` and shift according to :cite:`BPS26`."""
+    global _INNER_ITERS
+    shift = 0 # does not use self.shift; recomputes it in every CholQR iteration
+    for i in range(_INNER_ITERS):
+        try:
+            R = spla.cholesky(X + np.eye(len(X))*shift, overwrite_a=False, check_finite=params.check_finite)
+            return R
+        except spla.LinAlgError:
+            params.logger.warning('Cholesky factorization broke down! Matrix is ill-conditioned.')
+
+            # for really ill-conditioned matrices increasing the shift exponentially,
+            # by multiplying it by 10 in each iteration
+            shift = _compute_shift(params, X) if i == 0 else shift*10
+            params.logger.info(f'Applying shift: {shift}')
+    raise AccuracyError('Failed to compute a Cholesky factorization of X.')
+
+
 def _solve_chol_qr(params: _CholQRParameters):
     # unpack often used arguments
     A = params.A
@@ -173,28 +210,10 @@ def _solve_chol_qr(params: _CholQRParameters):
 
     trmm, trtri = spla.get_blas_funcs('trmm', dtype=params.dtype), spla.get_lapack_funcs('trtri', dtype=params.dtype)
 
-    # compute shift
-    shift = None
-
     for iter in range(1,params.maxiter+1):
         with params.logger.block(f'Iteration {iter}'):
-            # This will compute the Cholesky factor of the lower right block
-            # and keep applying shifts if it breaks down.
             X -= B.conj().T@B
-            it = 0
-            while True:
-                try:
-                    Rx = spla.cholesky(X, overwrite_a=False, check_finite=params.check_finite)
-                    break
-                except spla.LinAlgError:
-                    it += 1
-                    if it > 100:
-                        assert False
-                    if not shift or params.recompute_shift and it == 1:
-                        shift = _compute_shift(params, X)
-                    params.logger.warning('Cholesky factorization broke down! Matrix is ill-conditioned.')
-                    params.logger.info(f'Applying shift: {shift}')
-                    X[np.diag_indices_from(X)] += shift
+            Rx = params.chol_kernel(params, X)
 
             # orthogonalize
             Rinv = trtri(Rx)[0]

--- a/src/pymor/algorithms/chol_qr.py
+++ b/src/pymor/algorithms/chol_qr.py
@@ -8,6 +8,7 @@ import scipy.sparse.linalg as spsla
 
 from pymor.core.exceptions import AccuracyError
 from pymor.core.logger import getLogger
+from pymor.vectorarrays.interface import VectorArray
 from pymor.vectorarrays.list import ListVectorArray
 
 
@@ -78,22 +79,49 @@ def shifted_chol_qr(A, product=None, return_R=False, maxiter=3, offset=0, orth_t
     R
         The upper-triangular/trapezoidal matrix (if `compute_R` is `True`).
     """
-    assert 0 <= offset <= len(A)
-    assert 0 < maxiter
-    assert orth_tol is None or 0 < orth_tol
+    params = _CholQRParameters(**locals())
+    return _solve_chol_qr(params)
 
-    if copy:
-        A = A.copy()
+
+class _CholQRParameters:
+    r"""Helper class for managing the parameters and options."""
+
+    def __init__(self, A, product, return_R, maxiter, offset, orth_tol,
+                 recompute_shift, check_finite, copy, product_norm):
+        assert isinstance(A, VectorArray)
+        assert 0 <= offset <= len(A)
+        assert A.dim >= len(A)
+        assert 0 < maxiter
+        assert orth_tol is None or 0 < orth_tol
+
+        # set input parameters
+        self.A = A.copy() if copy else A
+        self.product = product
+        self.return_R = return_R
+        self.maxiter = maxiter
+        self.offset = offset
+        self.orth_tol = orth_tol
+        self.recompute_shift = recompute_shift
+        self.check_finite = check_finite
+        self.product_norm = product_norm
+
+        self.logger = getLogger('pymor.algorithms.chol_qr.shifted_chol_qr')
+
+
+def _solve_chol_qr(params: _CholQRParameters):
+    # unpack often used arguments
+    A = params.A
+    offset = params.offset
 
     if offset == len(A):
         return A, np.eye(len(A))
 
-    logger = getLogger('pymor.algorithms.chol_qr.shifted_chol_qr')
-
-    if maxiter == 1:
-        logger.warning('Single iteration shifted CholeskyQR can lead to poor orthogonality!')
+    if params.maxiter == 1:
+        params.logger.warning('Single iteration shifted CholeskyQR can lead to poor orthogonality!')
 
     def _compute_gramian_and_offset_matrix():
+        product = params.product
+
         if isinstance(A, ListVectorArray):
             # for a |ListVectorArray| it is slightly faster to compute `B` and `X` separately
             B = A[offset:].inner(A[:offset], product=product)
@@ -113,8 +141,10 @@ def shifted_chol_qr(A, product=None, return_R=False, maxiter=3, offset=0, orth_t
     m, n = A.dim, len(A[offset:])
     shift = None
     def _compute_shift():
-        nonlocal product_norm
-        shift = 11*np.finfo(dtype).eps
+        product = params.product
+        product_norm = params.product_norm
+
+        shift = 11*np.finfo(params.dtype).eps
         if product is None:
             shift *= m*n+n*(n+1)
             XX = X
@@ -127,31 +157,31 @@ def shifted_chol_qr(A, product=None, return_R=False, maxiter=3, offset=0, orth_t
         try:
             shift *= spsla.eigsh(XX, k=1, tol=1e-2, return_eigenvectors=False, v0=np.ones([n]))[0]
         except spsla.ArpackNoConvergence as e:
-            logger.warning(f'ARPACK failed with: {e}')
-            logger.info('Proceeding with dense solver.')
+            params.logger.warning(f'ARPACK failed with: {e}')
+            params.logger.info('Proceeding with dense solver.')
             shift *= spla.eigh(XX, eigvals_only=True, subset_by_index=[n-1, n-1], driver='evr')[0]
         shift = max(shift, np.finfo(dtype).eps)  # ensure that shift is non-zero
         return shift
 
     iter = 1
-    while iter <= maxiter:
-        with logger.block(f'Iteration {iter}'):
+    while iter <= params.maxiter:
+        with params.logger.block(f'Iteration {iter}'):
             # This will compute the Cholesky factor of the lower right block
             # and keep applying shifts if it breaks down.
             X -= B@B.T
             it = 0
             while True:
                 try:
-                    Rx = spla.cholesky(X, overwrite_a=False, check_finite=check_finite)
+                    Rx = spla.cholesky(X, overwrite_a=False, check_finite=params.check_finite)
                     break
                 except spla.LinAlgError:
                     it += 1
                     if it > 100:
                         assert False
-                    if not shift or recompute_shift and it == 1:
+                    if not shift or params.recompute_shift and it == 1:
                         shift = _compute_shift()
-                    logger.warning('Cholesky factorization broke down! Matrix is ill-conditioned.')
-                    logger.info(f'Applying shift: {shift}')
+                    params.logger.warning('Cholesky factorization broke down! Matrix is ill-conditioned.')
+                    params.logger.info(f'Applying shift: {shift}')
                     X[np.diag_indices_from(X)] += shift
 
             # orthogonalize
@@ -169,18 +199,18 @@ def shifted_chol_qr(A, product=None, return_R=False, maxiter=3, offset=0, orth_t
                 trmm(1, Rx, Ri, overwrite_b=True)
 
             # computation not needed in the last iteration
-            if iter < maxiter:
+            if iter < params.maxiter:
                 B, X = _compute_gramian_and_offset_matrix()
-            elif orth_tol is not None:
-                X = A[offset:].gramian(product=product)
+            elif params.orth_tol is not None:
+                X = A[offset:].gramian(product=params.product)
 
             # check orthonormality (for an iterative algorithm)
-            if orth_tol is not None:
-                res = spla.norm(X - np.eye(len(A) - offset), ord='fro', check_finite=check_finite)
-                logger.info(f'Residual = {res}')
-                if res <= orth_tol*np.sqrt(len(A)):
+            if params.orth_tol is not None:
+                res = spla.norm(X - np.eye(len(A) - offset), ord='fro', check_finite=params.check_finite)
+                params.logger.info(f'Residual = {res}')
+                if res <= params.orth_tol*np.sqrt(len(A)):
                     break
-                elif iter == maxiter:
+                elif iter == params.maxiter:
                     raise AccuracyError('Orthonormality could not be achieved within the given tolerance. \
                     Consider increasing maxiter or enabling recompute_shift.')
 
@@ -191,4 +221,4 @@ def shifted_chol_qr(A, product=None, return_R=False, maxiter=3, offset=0, orth_t
     R[:offset, offset:] = Bi
     R[offset:, offset:] = Ri
 
-    return (A, R) if return_R else A
+    return (A, R) if params.return_R else A

--- a/src/pymor/algorithms/chol_qr.py
+++ b/src/pymor/algorithms/chol_qr.py
@@ -6,12 +6,12 @@ import numpy as np
 import scipy.linalg as spla
 import scipy.sparse.linalg as spsla
 
+from pymor.core.base import BasicObject, abstractmethod
 from pymor.core.exceptions import AccuracyError
 from pymor.core.logger import getLogger
 from pymor.vectorarrays.interface import VectorArray
 from pymor.vectorarrays.list import ListVectorArray
 
-_INNER_ITERS = 10
 
 def shifted_chol_qr(A, product=None, return_R=False, maxiter=3, offset=0, orth_tol=None,
                     recompute_shift=False, check_finite=True, copy=True, product_norm=None):
@@ -80,146 +80,31 @@ def shifted_chol_qr(A, product=None, return_R=False, maxiter=3, offset=0, orth_t
     R
         The upper-triangular/trapezoidal matrix (if `compute_R` is `True`).
     """
-    params = _CholQRParameters(**locals())
-    return _solve_chol_qr(params)
+    assert isinstance(A, VectorArray)
+    assert 0 <= offset <= len(A)
+    assert A.dim >= len(A)
+    assert 0 < maxiter
+    assert orth_tol is None or 0 < orth_tol
+    logger = getLogger('pymor.algorithms.chol_qr.shifted_chol_qr')
 
-
-class _CholQRParameters:
-    r"""Helper class for managing the parameters and options."""
-
-    def __init__(self, A, product, return_R, maxiter, offset, orth_tol,
-                 recompute_shift, check_finite, copy, product_norm):
-        assert isinstance(A, VectorArray)
-        assert 0 <= offset <= len(A)
-        assert A.dim >= len(A)
-        assert 0 < maxiter
-        assert orth_tol is None or 0 < orth_tol
-
-        # set input parameters
-        self.A = A.copy() if copy else A
-        self.product = product
-        self.return_R = return_R
-        self.maxiter = maxiter
-        self.offset = offset
-        self.orth_tol = orth_tol
-        self.check_finite = check_finite
-        self.product_norm = product_norm
-
-        self.chol_kernel = _recomputed_shifted_chol_kernel if recompute_shift else _basic_shifted_chol_kernel
-        self.shift = None # used by `_basic_shifted_chol_kernel``
-        self.dtype = None
-        self.eps = None
-        self.logger = getLogger('pymor.algorithms.chol_qr.shifted_chol_qr')
-
-
-def _compute_gramian_and_offset_matrix(params):
-    A = params.A
-    offset = params.offset
-    product = params.product
-
-    if isinstance(A, ListVectorArray):
-        # for a |ListVectorArray| it is slightly faster to compute `B` and `X` separately
-        B = A[:offset].inner(A[offset:], product=product)
-        X = A[offset:].gramian(product)
-    else:
-        B, X = np.split(A.inner(A[offset:], product=product), [offset], axis=0)
-
-    if params.dtype is None:
-        params.dtype = np.promote_types(X.dtype, np.promote_types(B.dtype, np.float32))
-        params.eps = np.finfo(params.dtype).eps
-
-    dtype = params.dtype
-    B = B.astype(dtype=dtype, copy=False)
-    X = X.astype(dtype=dtype, copy=False)
-
-    return B, X
-
-
-def _compute_shift(params: _CholQRParameters, X: np.ndarray):
-    m = params.A.dim
-    n = len(X)
-
-    shift = 11*params.eps
-    if params.product is None:
-        shift *= m*n+n*(n+1)
-    else:
-        if params.product_norm is None:
-            from pymor.algorithms.eigs import eigs
-            params.product_norm = np.sqrt(np.abs(eigs(params.product, k=1)[0][0]))
-        shift *= (2*m*np.sqrt(m*n)+n*(n+1))*params.product_norm
-
-    # eigsh outputs warnings, if n <= 2; it also throws an exception,
-    # if X is a zero matrix (or is close to) or contains subnormal numbers
-    use_eigh = n <= 2 or X.max() - X.min() < params.eps or np.any((X != 0) & (np.abs(X) < np.finfo(params.dtype).tiny))
-    if not use_eigh:
-        try:
-            ew = spsla.eigsh(X, k=1, tol=1e-2, return_eigenvectors=False, v0=np.ones([n]))[0]
-        except spsla.ArpackNoConvergence as e:
-            params.logger.warning(f'ARPACK failed with: {e}')
-            params.logger.info('Proceeding with dense solver.')
-            use_eigh = True
-
-    if use_eigh:
-        ew = spla.eigh(X, eigvals_only=True, subset_by_index=[n-1, n-1], driver='evr')[0]
-
-    shift = max(shift*ew, params.eps) # ensure that shift is non-zero
-    return shift
-
-
-def _basic_shifted_chol_kernel(params, X):
-    """Kernel computes `R` and shift according to Algorithm 4.1 in :cite:`FKNYY20`."""
-    global _INNER_ITERS
-    for _ in range(_INNER_ITERS):
-        try:
-            R = spla.cholesky(X, overwrite_a=False, check_finite=params.check_finite)
-            return R
-        except spla.LinAlgError:
-            params.logger.warning('Cholesky factorization broke down! Matrix is ill-conditioned.')
-
-            if not params.shift:
-                params.shift = _compute_shift(params, X)
-            params.logger.info(f'Applying shift: {params.shift}')
-            X[np.diag_indices_from(X)] += params.shift
-    raise AccuracyError('Failed to compute a Cholesky factorization of X.')
-
-
-def _recomputed_shifted_chol_kernel(params, X):
-    """Kernel computes `R` and shift according to :cite:`BPS26`."""
-    global _INNER_ITERS
-    shift = 0 # does not use self.shift; recomputes it in every CholQR iteration
-    for i in range(_INNER_ITERS):
-        try:
-            R = spla.cholesky(X + np.eye(len(X))*shift, overwrite_a=False, check_finite=params.check_finite)
-            return R
-        except spla.LinAlgError:
-            params.logger.warning('Cholesky factorization broke down! Matrix is ill-conditioned.')
-
-            # for really ill-conditioned matrices increasing the shift exponentially,
-            # by multiplying it by 10 in each iteration
-            shift = _compute_shift(params, X) if i == 0 else shift*10
-            params.logger.info(f'Applying shift: {shift}')
-    raise AccuracyError('Failed to compute a Cholesky factorization of X.')
-
-
-def _solve_chol_qr(params: _CholQRParameters):
-    # unpack often used arguments
-    A = params.A
-    offset = params.offset
+    chol_kernel = (RecomputedShiftedCholQRKernel if recompute_shift else BasicShiftedCholQRKernel)(
+        A.dim, product=product, product_norm=product_norm, check_finite=check_finite
+    )
 
     if offset == len(A):
-        return (A, np.eye(len(A))) if params.return_R else A
+        return (A, np.eye(len(A))) if return_R else A
 
-    if params.maxiter == 1:
-        params.logger.warning('Single iteration shifted CholeskyQR can lead to poor orthogonality!')
+    if maxiter == 1:
+        logger.warning('Single iteration shifted CholeskyQR can lead to poor orthogonality!')
 
-    B, X = _compute_gramian_and_offset_matrix(params)
+    B, X = _compute_gramian_and_offset_matrix(A, offset, product)
 
-    trmm, trtri = spla.get_blas_funcs('trmm', dtype=params.dtype), spla.get_lapack_funcs('trtri', dtype=params.dtype)
+    trmm, trtri = spla.get_blas_funcs('trmm', dtype=X.dtype), spla.get_lapack_funcs('trtri', dtype=X.dtype)
 
-    for iter in range(1,params.maxiter+1):
-        with params.logger.block(f'Iteration {iter}'):
+    for iter in range(1, maxiter+1):
+        with logger.block(f'Iteration {iter}'):
             X -= B.conj().T@B
-            Rx = params.chol_kernel(params, X)
+            Rx = chol_kernel.apply(X)
 
             # orthogonalize
             Rinv = trtri(Rx)[0]
@@ -236,27 +121,124 @@ def _solve_chol_qr(params: _CholQRParameters):
                 Ri = trmm(1, Rx, Ri, overwrite_b=True)
 
             # computation not needed in the last iteration
-            if iter < params.maxiter:
-                B, X = _compute_gramian_and_offset_matrix(params)
-            elif params.orth_tol is not None:
-                X = A[offset:].gramian(product=params.product)
+            if iter < maxiter:
+                B, X = _compute_gramian_and_offset_matrix(A, offset, product)
+            elif orth_tol is not None:
+                X = A[offset:].gramian(product=product)
 
             # check orthonormality (for an iterative algorithm)
-            if params.orth_tol is not None:
-                res = spla.norm(X - np.eye(len(A) - offset), ord='fro', check_finite=params.check_finite)
-                params.logger.info(f'Residual = {res}')
-                if res <= params.orth_tol*np.sqrt(len(A)):
+            if orth_tol is not None:
+                res = spla.norm(X - np.eye(len(A) - offset), ord='fro', check_finite=check_finite)
+                logger.info(f'Residual = {res}')
+                if res <= orth_tol*np.sqrt(len(A)):
                     break
-                elif iter == params.maxiter:
+                elif iter == maxiter:
                     raise AccuracyError('Orthonormality could not be achieved within the given tolerance. \
                     Consider increasing maxiter or enabling recompute_shift.')
 
-    if not params.return_R:
+    if not return_R:
         return A
 
     # construct R from blocks
-    R = np.eye(len(A), dtype=params.dtype)
+    R = np.eye(len(A), dtype=X.dtype)
     R[:offset, offset:] = Bi
     R[offset:, offset:] = Ri
 
     return (A, R)
+
+
+def _compute_gramian_and_offset_matrix(A, offset, product):
+    if isinstance(A, ListVectorArray):
+        # for a |ListVectorArray| it is slightly faster to compute `B` and `X` separately
+        B = A[:offset].inner(A[offset:], product=product)
+        X = A[offset:].gramian(product)
+    else:
+        B, X = np.split(A.inner(A[offset:], product=product), [offset], axis=0)
+
+    dtype = np.promote_types(X.dtype, np.promote_types(B.dtype, np.float32))
+    B = B.astype(dtype=dtype, copy=False)
+    X = X.astype(dtype=dtype, copy=False)
+
+    return B, X
+
+
+class ShiftedCholQRKernel(BasicObject):
+
+    def __init__(self, dim, product=None, product_norm=None, check_finite=True):
+        self.__auto_init(locals())
+
+    @abstractmethod
+    def apply(self, X): ...
+
+    def _compute_shift(self, X):
+        m = self.dim
+        n = len(X)
+        dtype = X.dtype
+        eps = np.finfo(dtype).eps
+
+        shift = 11*eps
+        if self.product is None:
+            shift *= m*n+n*(n+1)
+        else:
+            if self.product_norm is None:
+                from pymor.algorithms.eigs import eigs
+                self.product_norm = np.sqrt(np.abs(eigs(self.product, k=1)[0][0]))
+            shift *= (2*m*np.sqrt(m*n)+n*(n+1))*self.product_norm
+
+        # eigsh outputs warnings, if n <= 2; it also throws an exception,
+        # if X is a zero matrix (or is close to) or contains subnormal numbers
+        use_eigh = n <= 2 or X.max() - X.min() < eps or np.any((X != 0) & (np.abs(X) < np.finfo(dtype).tiny))
+        if not use_eigh:
+            try:
+                ew = spsla.eigsh(X, k=1, tol=1e-2, return_eigenvectors=False, v0=np.ones([n]))[0]
+            except spsla.ArpackNoConvergence as e:
+                self.logger.warning(f'ARPACK failed with: {e}')
+                self.logger.info('Proceeding with dense solver.')
+                use_eigh = True
+
+        if use_eigh:
+            ew = spla.eigh(X, eigvals_only=True, subset_by_index=[n-1, n-1], driver='evr')[0]
+
+        shift = max(shift*ew, eps) # ensure that shift is non-zero
+        return shift
+
+
+class BasicShiftedCholQRKernel(ShiftedCholQRKernel):
+    """Kernel computes `R` and shift according to Algorithm 4.1 in :cite:`FKNYY20`."""
+
+    INNER_ITERS = 10
+
+    def apply(self, X):
+        for _ in range(self.INNER_ITERS):
+            try:
+                R = spla.cholesky(X, overwrite_a=False, check_finite=self.check_finite)
+                return R
+            except spla.LinAlgError:
+                self.logger.warning('Cholesky factorization broke down! Matrix is ill-conditioned.')
+
+                if not self.shift:
+                    self.shift = self._compute_shift(X)
+                self.logger.info(f'Applying shift: {self.shift}')
+                X[np.diag_indices_from(X)] += self.shift
+        raise AccuracyError('Failed to compute a Cholesky factorization of X.')
+
+
+class RecomputedShiftedCholQRKernel(ShiftedCholQRKernel):
+    """Kernel computes `R` and shift according to :cite:`BPS26`."""
+
+    INNER_ITERS = 10
+
+    def apply(self, X):
+        shift = 0 # does not use self.shift; recomputes it in every CholQR iteration
+        for i in range(self.INNER_ITERS):
+            try:
+                R = spla.cholesky(X + np.eye(len(X))*shift, overwrite_a=False, check_finite=self.check_finite)
+                return R
+            except spla.LinAlgError:
+                self.logger.warning('Cholesky factorization broke down! Matrix is ill-conditioned.')
+
+                # for really ill-conditioned matrices increasing the shift exponentially,
+                # by multiplying it by 10 in each iteration
+                shift = self._compute_shift(X) if i == 0 else shift*10
+                self.logger.info(f'Applying shift: {shift}')
+        raise AccuracyError('Failed to compute a Cholesky factorization of X.')

--- a/src/pymor/algorithms/chol_qr.py
+++ b/src/pymor/algorithms/chol_qr.py
@@ -245,9 +245,12 @@ def _solve_chol_qr(params: _CholQRParameters):
                     raise AccuracyError('Orthonormality could not be achieved within the given tolerance. \
                     Consider increasing maxiter or enabling recompute_shift.')
 
+    if not params.return_R:
+        return A
+
     # construct R from blocks
     R = np.eye(len(A), dtype=params.dtype)
     R[:offset, offset:] = Bi
     R[offset:, offset:] = Ri
 
-    return (A, R) if params.return_R else A
+    return (A, R)

--- a/src/pymor/algorithms/chol_qr.py
+++ b/src/pymor/algorithms/chol_qr.py
@@ -108,6 +108,21 @@ class _CholQRParameters:
         self.logger = getLogger('pymor.algorithms.chol_qr.shifted_chol_qr')
 
 
+def _compute_gramian_and_offset_matrix(params):
+    A = params.A
+    offset = params.offset
+    product = params.product
+
+    if isinstance(A, ListVectorArray):
+        # for a |ListVectorArray| it is slightly faster to compute `B` and `X` separately
+        B = A[offset:].inner(A[:offset], product=product)
+        X = A[offset:].gramian(product)
+    else:
+        B, X = np.split(A[offset:].inner(A, product=product), [offset], axis=1)
+    B = B.conj()
+    return B, X
+
+
 def _solve_chol_qr(params: _CholQRParameters):
     # unpack often used arguments
     A = params.A
@@ -119,19 +134,7 @@ def _solve_chol_qr(params: _CholQRParameters):
     if params.maxiter == 1:
         params.logger.warning('Single iteration shifted CholeskyQR can lead to poor orthogonality!')
 
-    def _compute_gramian_and_offset_matrix():
-        product = params.product
-
-        if isinstance(A, ListVectorArray):
-            # for a |ListVectorArray| it is slightly faster to compute `B` and `X` separately
-            B = A[offset:].inner(A[:offset], product=product)
-            X = A[offset:].gramian(product)
-        else:
-            B, X = np.split(A[offset:].inner(A, product=product), [offset], axis=1)
-        B = B.conj()
-        return B, X
-
-    B, X = _compute_gramian_and_offset_matrix()
+    B, X = _compute_gramian_and_offset_matrix(params)
 
     dtype = np.promote_types(X.dtype, np.float32)
     B = B.astype(dtype=dtype, copy=False)
@@ -200,7 +203,7 @@ def _solve_chol_qr(params: _CholQRParameters):
 
             # computation not needed in the last iteration
             if iter < params.maxiter:
-                B, X = _compute_gramian_and_offset_matrix()
+                B, X = _compute_gramian_and_offset_matrix(params)
             elif params.orth_tol is not None:
                 X = A[offset:].gramian(product=params.product)
 

--- a/src/pymor/algorithms/chol_qr.py
+++ b/src/pymor/algorithms/chol_qr.py
@@ -87,6 +87,9 @@ def shifted_chol_qr(A, product=None, return_R=False, maxiter=3, offset=0, orth_t
     assert orth_tol is None or 0 < orth_tol
     logger = getLogger('pymor.algorithms.chol_qr.shifted_chol_qr')
 
+    if copy:
+        A = A.copy()
+
     chol_kernel = (RecomputedShiftedCholQRKernel if recompute_shift else BasicShiftedCholQRKernel)(
         A.dim, product=product, product_norm=product_norm, check_finite=check_finite
     )


### PR DESCRIPTION
Various improvements to `shifted_chol_qr`:

- Fix #2569
- Fix a previous problem with `scipy.sparse.linalg.eigsh` printing warnings, if `n<=2` (`n` being the size of the Gramian `X`), and throwing exceptions, if `X` is a zero matrix (or close to one) or if it contains subnormal numbers. I cannot seem to reproduce it with newer scipy versions, so this fix might not be necessary.
- Adjust code to compute the shift based on the article `BPS26`, if `recompute_shift` is set.
- Refactor code by adding `ShiftedCholQRKernel` classes for better maintainability.