### PR TITLE
Chol QR `rtol`

### DIFF
--- a/src/pymor/algorithms/chol_qr.py
+++ b/src/pymor/algorithms/chol_qr.py
@@ -14,7 +14,7 @@ from pymor.vectorarrays.list import ListVectorArray
 
 
 def shifted_chol_qr(A, product=None, return_R=False, maxiter=3, offset=0, orth_tol=None,
-                    recompute_shift=False, check_finite=True, copy=True, product_norm=None):
+                    recompute_shift=False, rtol=1e-13, check_finite=True, copy=True, product_norm=None):
     r"""Orthonormalize a |VectorArray| using the shifted CholeskyQR algorithm.
 
     This method computes a QR decomposition of a |VectorArray| via Cholesky factorizations of its
@@ -63,6 +63,12 @@ def shifted_chol_qr(A, product=None, return_R=False, maxiter=3, offset=0, orth_t
         If `True`, the shift is recomputed in iterations in which the Cholesky decomposition fails.
         Even for an ill-conditioned `A` (at least for matrix condition numbers up to 10^20)
         is it able to compute an orthonormal basis at the cost of higher runtimes.
+    rtol
+        If zero, it only removes zero vectors. Otherwise, if greater than zero, it removes too
+        small vectors (relative to the longest vector). Furthermore, if offset is used,
+        it might remove linearly dependent vectors. Decision is based on the diagonal of
+        the initial Gramian. Additionally, if `return_R` is set, a potentially
+        upper-trapezoidal factor `R` is returned. It holds `A \approx Q@R`.
     check_finite
         This argument is passed down to |SciPy linalg| functions. Disabling may give a
         performance gain, but may result in problems (crashes, non-termination) if the
@@ -85,6 +91,7 @@ def shifted_chol_qr(A, product=None, return_R=False, maxiter=3, offset=0, orth_t
     assert A.dim >= len(A)
     assert 0 < maxiter
     assert orth_tol is None or 0 < orth_tol
+    assert rtol >= 0
     logger = getLogger('pymor.algorithms.chol_qr.shifted_chol_qr')
 
     if copy:
@@ -103,6 +110,30 @@ def shifted_chol_qr(A, product=None, return_R=False, maxiter=3, offset=0, orth_t
     B, X = _compute_gramian_and_offset_matrix(A, offset, product)
 
     trmm, trtri = spla.get_blas_funcs('trmm', dtype=X.dtype), spla.get_lapack_funcs('trtri', dtype=X.dtype)
+
+    # diagonal of X contains the pairwise result of inner-products of the vectors A[offset:]
+    diag = np.abs(np.diag(X))
+    M = np.max(diag)
+    if offset > 0:
+        M = max(M, 1) # length of orthonormal vectors is 1
+
+    # find vectors that are to short relative to the longest vector in A
+    # used squared relative tolerance, since diagonal contains squared norms of vectors
+    A_rem = B_rem = None
+    remove = np.where(M*rtol**2 >= diag)[0]
+    if len(remove) > 0:
+        logger.info(f'Removing linearly dependent vector {remove}')
+
+    if len(remove) == len(A[offset:]):
+        del A[offset:]
+        return (A, np.hstack([np.eye(offset), B])) if return_R else A
+    elif len(remove) > 0:
+        B_rem = B[:,remove]
+        B = np.delete(B, remove, axis=1)
+        X = np.delete(np.delete(X, remove, axis=0), remove, axis=1)
+        remove += offset
+        A_rem = A[remove].copy()
+        del A[remove]
 
     iter = 1
     while iter <= maxiter:
@@ -146,9 +177,16 @@ def shifted_chol_qr(A, product=None, return_R=False, maxiter=3, offset=0, orth_t
         return A
 
     # construct R from blocks
-    R = np.eye(len(A), dtype=X.dtype)
-    R[:offset, offset:] = Bi
-    R[offset:, offset:] = Ri
+    R = np.zeros([offset+Ri.shape[0], offset+Ri.shape[1]], dtype=X.dtype)
+    R[:offset,:offset] = np.eye(offset)
+    R[:offset, offset:] = Bi.astype(X.dtype, copy=False)
+    R[offset:, offset:] = Ri.astype(X.dtype, copy=False)
+
+    if B_rem is not None:
+        # compute linear dependence of removed vectors to the orthonormal basis
+        # and insert them back into R
+        T = A[offset:].inner(A_rem, product=product)
+        R = np.insert(R, [r-i for i,r in enumerate(remove)], values=np.vstack([B_rem, T]), axis=1)
 
     return (A, R)
 

--- a/src/pymor/algorithms/chol_qr.py
+++ b/src/pymor/algorithms/chol_qr.py
@@ -7,12 +7,14 @@ import scipy.linalg as spla
 import scipy.sparse.linalg as spsla
 
 from pymor.core.base import BasicObject, abstractmethod
+from pymor.core.defaults import defaults
 from pymor.core.exceptions import AccuracyError
 from pymor.core.logger import getLogger
 from pymor.vectorarrays.interface import VectorArray
 from pymor.vectorarrays.list import ListVectorArray
 
 
+@defaults('maxiter', 'orth_tol', 'recompute_shift', 'rtol', 'check_finite')
 def shifted_chol_qr(A, product=None, return_R=False, maxiter=3, offset=0, orth_tol=None,
                     recompute_shift=False, rtol=1e-13, check_finite=True, copy=True, product_norm=None):
     r"""Orthonormalize a |VectorArray| using the shifted CholeskyQR algorithm.

--- a/src/pymor/algorithms/chol_qr.py
+++ b/src/pymor/algorithms/chol_qr.py
@@ -256,6 +256,10 @@ class BasicShiftedCholQRKernel(ShiftedCholQRKernel):
 
     INNER_ITERS = 10
 
+    def __init__(self, dim, product=None, product_norm=None, check_finite=True):
+        super().__init__(dim, product, product_norm, check_finite)
+        self.shift = None
+
     def apply(self, X):
         for _ in range(self.INNER_ITERS):
             try:
@@ -277,7 +281,7 @@ class RecomputedShiftedCholQRKernel(ShiftedCholQRKernel):
     INNER_ITERS = 10
 
     def apply(self, X):
-        shift = 0 # does not use self.shift; recomputes it in every CholQR iteration
+        shift = 0 # recomputes shift in every CholQR iteration
         for i in range(self.INNER_ITERS):
             try:
                 R = spla.cholesky(X + np.eye(len(X))*shift, overwrite_a=False, check_finite=self.check_finite)

--- a/src/pymor/algorithms/chol_qr.py
+++ b/src/pymor/algorithms/chol_qr.py
@@ -194,12 +194,15 @@ def shifted_chol_qr(A, product=None, return_R=False, maxiter=3, offset=0, orth_t
 
 def _compute_gramian_and_offset_matrix(A, offset, product):
     if isinstance(A, ListVectorArray):
-        # for a |ListVectorArray| it is slightly faster to compute `B` and `X` separately
+        # due to `ListVectorArray.gramian` exploiting symmetry it is slightly faster
+        # for a |ListVectorArray| to compute `B` and `X` separately
         B = A[:offset].inner(A[offset:], product=product)
         X = A[offset:].gramian(product)
     else:
         B, X = np.split(A.inner(A[offset:], product=product), [offset], axis=0)
 
+    # dtypes of X and B might be different if `A` is a |ListVectorArray|
+    # due to the split up computation
     dtype = np.promote_types(X.dtype, np.promote_types(B.dtype, np.float32))
     B = B.astype(dtype=dtype, copy=False)
     X = X.astype(dtype=dtype, copy=False)

--- a/src/pymor/algorithms/chol_qr.py
+++ b/src/pymor/algorithms/chol_qr.py
@@ -119,12 +119,12 @@ def shifted_chol_qr(A, product=None, return_R=False, maxiter=3, offset=0, orth_t
     if offset > 0:
         M = max(M, 1) # length of orthonormal vectors is 1
 
-    # find vectors that are to short relative to the longest vector in A
+    # find vectors that are to short relative to the longest vector in A[offset:]
     # used squared relative tolerance, since diagonal contains squared norms of vectors
     A_rem = B_rem = None
     remove = np.where(M*rtol**2 >= diag)[0]
     if len(remove) > 0:
-        logger.info(f'Removing linearly dependent vector {remove}')
+        logger.info(f'Removing linearly dependent vectors {remove}')
 
     if len(remove) == len(A[offset:]):
         del A[offset:]

--- a/src/pymor/algorithms/chol_qr.py
+++ b/src/pymor/algorithms/chol_qr.py
@@ -140,7 +140,6 @@ def shifted_chol_qr(A, product=None, return_R=False, maxiter=3, offset=0, orth_t
     iter = 1
     while iter <= maxiter:
         with logger.block(f'Iteration {iter}'):
-            X -= B.conj().T@B
             Rx = chol_kernel.apply(X)
 
             # orthogonalize
@@ -204,6 +203,8 @@ def _compute_gramian_and_offset_matrix(A, offset, product):
     dtype = np.promote_types(X.dtype, np.promote_types(B.dtype, np.float32))
     B = B.astype(dtype=dtype, copy=False)
     X = X.astype(dtype=dtype, copy=False)
+
+    X -= B.conj().T@B
 
     return B, X
 

--- a/src/pymortests/algorithms/chol_qr.py
+++ b/src/pymortests/algorithms/chol_qr.py
@@ -6,83 +6,51 @@ import warnings
 
 import numpy as np
 import pytest
-from hypothesis import assume, settings
+from hypothesis import assume
+from hypothesis.errors import UnsatisfiedAssumption
 
 import pymortests.strategies as pyst
 from pymor.algorithms.basic import almost_equal, contains_zero_vector
 from pymor.algorithms.chol_qr import shifted_chol_qr
 from pymor.algorithms.gram_schmidt import gram_schmidt
 from pymor.core.config import is_scipy_mkl
+from pymor.vectorarrays.list import NumpyListVectorSpace
 from pymor.vectorarrays.numpy import NumpyVectorSpace
+from pymortests.algorithms.qr_test_util import evaluate_qr, generate_hilbert_va
 from pymortests.base import runmodule
 
-
-@pytest.mark.xfail
-@pyst.given_vector_arrays()
-@settings(deadline=None)
-def test_shifted_chol_qr(vector_array):
-    U = vector_array
-
-    assume(len(U) >= 1 and not contains_zero_vector(U))
-
-    V = U.copy()
-
-    onbgs, Rgs = gram_schmidt(U, copy=True, return_R=True)
-    if len(onbgs) < len(V):
-        warnings.warn('Linearly dependent vectors detected! Skipping ...')
-        return
-
-    onb, R = shifted_chol_qr(U, return_R=True, copy=True)
-    assert np.all(almost_equal(U, V))
-    assert np.allclose(onb.inner(onb), np.eye(len(onb)))
-    lc = onb.lincomb(onb.inner(U))
-    rtol = atol = 1e-10
-
-    assert np.all(almost_equal(U, lc, rtol=rtol, atol=atol))
-    try:
-        assert np.all(almost_equal(V, onb.lincomb(R), rtol=rtol, atol=atol))
-    except AssertionError:
-        assert 0
-
-    onb2, R2 = shifted_chol_qr(U, return_R=True, copy=False)
-    assert np.all(almost_equal(onb, onb2))
-    assert np.all(R == R2)
-    assert np.all(almost_equal(onb, U))
+# use lower tolerance for MKL
+ORTH_TOL = 1e-13 if is_scipy_mkl() else 5e-15
 
 
-@pytest.mark.xfail
-def test_shifted_chol_qr_with_product(operator_with_arrays_and_products):
-    if is_scipy_mkl():
-        pytest.xfail('fails with mkl')
-    _, _, U, _, p, _ = operator_with_arrays_and_products
-
-    assume(len(U) >= 1 and not contains_zero_vector(U))
-
-    if U.dim < len(U):
-        return
-
-    V = U.copy()
-
-    onb, R = shifted_chol_qr(U, product=p, return_R=True, copy=True)
-    assert np.all(almost_equal(U, V))
-    # atol increased from 1e-7 to 1e-3 due to failing macos 15 build
-    assert np.allclose(p.apply2(onb, onb), np.eye(len(onb)), atol=1e-3)
-    assert np.all(almost_equal(U, onb.lincomb(p.apply2(onb, U)), rtol=1e-11))
-    assert np.all(almost_equal(U, onb.lincomb(R)))
-
-    onb2, R2 = shifted_chol_qr(U, product=p, return_R=True, copy=False)
-    assert np.all(almost_equal(onb, onb2))
-    assert np.all(R == R2)
-    assert np.all(almost_equal(onb, U))
-
-
-@pytest.mark.builtin
+@pytest.mark.parametrize('va_space', [NumpyVectorSpace, NumpyListVectorSpace])
+@pytest.mark.parametrize('n', [1, 5, 25])
+@pytest.mark.parametrize('return_R', [False, True])
 @pytest.mark.parametrize('copy', [False, True])
-def test_chol_qr_empty(copy):
-    n = 5
-    V = NumpyVectorSpace(n).empty(0)
-    Q, R = shifted_chol_qr(V, return_R=True, copy=copy)
-    assert len(V) == len(Q) == 0
+@pytest.mark.parametrize('recompute_shift', [False, True])
+@pytest.mark.parametrize('orth_tol', [None, ORTH_TOL])
+@pytest.mark.parametrize('rtol', [0, 1e-13, 1e-8])
+def test_chol_qr_parameters(va_space, n, return_R, copy, recompute_shift, orth_tol, rtol):
+    A = generate_hilbert_va(va_space, n)
+    evaluate_qr(shifted_chol_qr, A, None, return_R, copy,
+        {'recompute_shift': recompute_shift, 'maxiter': 10, 'orth_tol': orth_tol, 'rtol': rtol}
+    )
+
+
+@pytest.mark.parametrize('recompute_shift', [False, True])
+def test_chol_qr_with_product(operator_with_arrays_and_products, recompute_shift):
+    _, _, A, _, product, _ = operator_with_arrays_and_products
+
+    # keeps failing due to restriction; requires more hypothesis examples
+    try:
+        assume(A.dim >= len(A))
+    except UnsatisfiedAssumption:
+        pytest.xfail(f'{UnsatisfiedAssumption.__qualname__} was raised')
+
+    evaluate_qr(shifted_chol_qr, A, product, True, True,
+        {'recompute_shift': recompute_shift, 'maxiter': 10, 'orth_tol': ORTH_TOL}
+    )
+
 
 @pytest.mark.xfail
 @pyst.given_vector_arrays()
@@ -116,59 +84,6 @@ def test_shifted_chol_qr_with_offset(vector_array):
     assert np.all(almost_equal(onb, onbgs, rtol=rtol, atol=atol))
     assert np.allclose(Rgs, R)
 
-
-@pytest.mark.xfail
-@pyst.given_vector_arrays()
-@settings(deadline=None)
-def test_recalculated_shifted_chol_qr(vector_array):
-    U = vector_array
-
-    assume(len(U) >= 1 and not contains_zero_vector(U))
-
-    V = U.copy()
-
-    onbgs, Rgs = gram_schmidt(U, copy=True, return_R=True, atol=0, rtol=0)
-    if len(onbgs) < len(V):
-        warnings.warn('Linearly dependent vectors detected! Skipping ...')
-        return
-
-    onb, R = shifted_chol_qr(U, return_R=True, copy=True, recompute_shift=True, maxiter=10, orth_tol=1e-13)
-    assert np.all(almost_equal(U, V))
-    assert np.allclose(onb.inner(onb), np.eye(len(onb)))
-    lc = onb.lincomb(onb.inner(U))
-    rtol = atol = 1e-9
-
-    assert np.all(almost_equal(U, lc, rtol=rtol, atol=atol))
-    assert np.all(almost_equal(V, onb.lincomb(R), rtol=rtol, atol=atol))
-
-    onb2, R2 = shifted_chol_qr(U, return_R=True, copy=False, recompute_shift=True, maxiter=10, orth_tol=1e-13)
-    assert np.all(almost_equal(onb, onb2))
-    assert np.all(R == R2)
-    assert np.all(almost_equal(onb, U))
-
-
-@pytest.mark.xfail
-def test_recalculated_shifted_chol_qr_with_product(operator_with_arrays_and_products):
-    _, _, U, _, p, _ = operator_with_arrays_and_products
-
-    assume(len(U) >= 1 and not contains_zero_vector(U))
-
-    if U.dim < len(U):
-        return
-
-    V = U.copy()
-
-    onb, R = shifted_chol_qr(U, return_R=True, product=p, copy=True, recompute_shift=True, maxiter=10, orth_tol=1e-13)
-    assert np.all(almost_equal(U, V))
-    assert np.allclose(p.apply2(onb, onb), np.eye(len(onb)))
-    assert np.all(almost_equal(U, onb.lincomb(p.apply2(onb, U)), rtol=1e-11))
-    assert np.all(almost_equal(U, onb.lincomb(R)))
-
-    onb2, R2 = shifted_chol_qr(U, return_R=True, product=p, copy=False,
-                               recompute_shift=True, maxiter=10, orth_tol=1e-13)
-    assert np.all(almost_equal(onb, onb2))
-    assert np.all(R == R2)
-    assert np.all(almost_equal(onb, U))
 
 if __name__ == '__main__':
     runmodule(filename=__file__)

--- a/src/pymortests/algorithms/chol_qr.py
+++ b/src/pymortests/algorithms/chol_qr.py
@@ -16,11 +16,15 @@ from pymor.algorithms.gram_schmidt import gram_schmidt
 from pymor.core.config import is_scipy_mkl
 from pymor.vectorarrays.list import NumpyListVectorSpace
 from pymor.vectorarrays.numpy import NumpyVectorSpace
-from pymortests.algorithms.qr_test_util import evaluate_qr, generate_hilbert_va
+from pymortests.algorithms.qr_test_util import evaluate_qr, evaluate_qr_empty, generate_hilbert_va
 from pymortests.base import runmodule
 
 # use lower tolerance for MKL
 ORTH_TOL = 1e-13 if is_scipy_mkl() else 5e-15
+
+
+def test_chol_qr_empty():
+    evaluate_qr_empty(shifted_chol_qr)
 
 
 @pytest.mark.parametrize('va_space', [NumpyVectorSpace, NumpyListVectorSpace])

--- a/src/pymortests/algorithms/chol_qr.py
+++ b/src/pymortests/algorithms/chol_qr.py
@@ -16,7 +16,12 @@ from pymor.algorithms.gram_schmidt import gram_schmidt
 from pymor.core.config import is_scipy_mkl
 from pymor.vectorarrays.list import NumpyListVectorSpace
 from pymor.vectorarrays.numpy import NumpyVectorSpace
-from pymortests.algorithms.qr_test_util import evaluate_qr, evaluate_qr_empty, generate_hilbert_va
+from pymortests.algorithms.qr_test_util import (
+    evaluate_qr,
+    evaluate_qr_empty,
+    evaluate_qr_full_offset,
+    generate_hilbert_va,
+)
 from pymortests.base import runmodule
 
 # use lower tolerance for MKL
@@ -25,6 +30,10 @@ ORTH_TOL = 1e-13 if is_scipy_mkl() else 5e-15
 
 def test_chol_qr_empty():
     evaluate_qr_empty(shifted_chol_qr)
+
+
+def test_chol_qr_full_offset():
+    evaluate_qr_full_offset(shifted_chol_qr)
 
 
 @pytest.mark.parametrize('va_space', [NumpyVectorSpace, NumpyListVectorSpace])

--- a/src/pymortests/algorithms/chol_qr.py
+++ b/src/pymortests/algorithms/chol_qr.py
@@ -2,7 +2,6 @@
 # Copyright pyMOR developers and contributors. All rights reserved.
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
-
 import pytest
 from hypothesis import assume
 from hypothesis.errors import UnsatisfiedAssumption

--- a/src/pymortests/algorithms/chol_qr.py
+++ b/src/pymortests/algorithms/chol_qr.py
@@ -2,17 +2,12 @@
 # Copyright pyMOR developers and contributors. All rights reserved.
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
-import warnings
 
-import numpy as np
 import pytest
 from hypothesis import assume
 from hypothesis.errors import UnsatisfiedAssumption
 
-import pymortests.strategies as pyst
-from pymor.algorithms.basic import almost_equal, contains_zero_vector
 from pymor.algorithms.chol_qr import shifted_chol_qr
-from pymor.algorithms.gram_schmidt import gram_schmidt
 from pymor.core.config import is_scipy_mkl
 from pymor.vectorarrays.list import NumpyListVectorSpace
 from pymor.vectorarrays.numpy import NumpyVectorSpace
@@ -20,6 +15,7 @@ from pymortests.algorithms.qr_test_util import (
     evaluate_qr,
     evaluate_qr_empty,
     evaluate_qr_full_offset,
+    evaluate_qr_offset,
     generate_hilbert_va,
 )
 from pymortests.base import runmodule
@@ -65,37 +61,14 @@ def test_chol_qr_with_product(operator_with_arrays_and_products, recompute_shift
     )
 
 
-@pytest.mark.xfail
-@pyst.given_vector_arrays()
-def test_shifted_chol_qr_with_offset(vector_array):
-    U = vector_array
-
-    assume(len(U) >= 2 and not contains_zero_vector(U))
-
-    # check if the test VectorArray contains linearly dependent vectors
-    # Q and R are later used for comparison
-    onbgs, Rgs = gram_schmidt(U, copy=True, return_R=True)
-    if len(onbgs) < len(U):
-        warnings.warn('Linearly dependent vectors detected! Skipping ...')
-        return
-
-    # orthogonalize first half
-    offset = round(len(U) / 2)
-    onb, Ro = shifted_chol_qr(U[:offset], return_R=True, copy=True)
-    assert np.allclose(onb.inner(onb), np.eye(len(onb)))
-
-    # orthogonalize second half
-    onb.append(U[offset:])
-    _, R = shifted_chol_qr(onb, return_R=True, copy=False)
-
-    # insert R of first orthogonalization step into R of second step
-    # overwritten matrix block only contains a unit matrix
-    R[:offset,:offset] = Ro
-
-    # compare Q and R of shifted Cholesky QR with offset to the gram_schmidt implementation
-    rtol = atol = 1e-13
-    assert np.all(almost_equal(onb, onbgs, rtol=rtol, atol=atol))
-    assert np.allclose(Rgs, R)
+# into how many blocks the matrix should be split; 0 for n blocks/ single vectors
+@pytest.mark.parametrize('num_blocks', [1, 2, 7, 0])
+@pytest.mark.parametrize('recompute_shift', [False, True])
+def test_chol_qr_with_offset(num_blocks, recompute_shift):
+    A = generate_hilbert_va(NumpyVectorSpace, 251)
+    evaluate_qr_offset(shifted_chol_qr, A, num_blocks,
+        {'recompute_shift': recompute_shift, 'maxiter': 10, 'orth_tol': ORTH_TOL}
+    )
 
 
 if __name__ == '__main__':

--- a/src/pymortests/algorithms/gram_schmidt.py
+++ b/src/pymortests/algorithms/gram_schmidt.py
@@ -12,8 +12,12 @@ from pymor.algorithms.gram_schmidt import gram_schmidt, gram_schmidt_biorth
 from pymor.core.logger import log_levels
 from pymor.vectorarrays.list import NumpyListVectorSpace
 from pymor.vectorarrays.numpy import NumpyVectorSpace
-from pymortests.algorithms.qr_test_util import evaluate_qr, generate_hilbert_va
+from pymortests.algorithms.qr_test_util import evaluate_qr, evaluate_qr_empty, generate_hilbert_va
 from pymortests.base import runmodule
+
+
+def test_chol_qr_empty():
+    evaluate_qr_empty(gram_schmidt)
 
 
 @pytest.mark.parametrize('va_space', [NumpyVectorSpace, NumpyListVectorSpace])

--- a/src/pymortests/algorithms/gram_schmidt.py
+++ b/src/pymortests/algorithms/gram_schmidt.py
@@ -4,85 +4,37 @@
 
 import numpy as np
 import pytest
-from hypothesis import assume, settings
+from hypothesis import settings
 
 import pymortests.strategies as pyst
-from pymor.algorithms.basic import almost_equal, contains_zero_vector
+from pymor.algorithms.basic import almost_equal
 from pymor.algorithms.gram_schmidt import gram_schmidt, gram_schmidt_biorth
 from pymor.core.logger import log_levels
+from pymor.vectorarrays.list import NumpyListVectorSpace
+from pymor.vectorarrays.numpy import NumpyVectorSpace
+from pymortests.algorithms.qr_test_util import evaluate_qr, generate_hilbert_va
 from pymortests.base import runmodule
 
 
-@pyst.given_vector_arrays()
-def test_gram_schmidt(vector_array):
-    U = vector_array
-    # TODO: assumption here masks a potential issue with the algorithm
-    #      where it fails in del instead of a proper error
-    assume(len(U) > 1 or not contains_zero_vector(U))
-
-    V = U.copy()
-    onb = gram_schmidt(U, copy=True)
-    assert np.all(almost_equal(U, V))
-    assert np.allclose(onb.inner(onb), np.eye(len(onb)))
-    # TODO: maybe raise tolerances again
-    assert np.all(almost_equal(U, onb.lincomb(onb.inner(U)), atol=1e-13, rtol=1e-13))
-
-    onb2 = gram_schmidt(U, copy=False)
-    assert np.all(almost_equal(onb, onb2))
-    assert np.all(almost_equal(onb, U))
+@pytest.mark.parametrize('va_space', [NumpyVectorSpace, NumpyListVectorSpace])
+@pytest.mark.parametrize('n', [5])
+@pytest.mark.parametrize('return_R', [False, True])
+@pytest.mark.parametrize('copy', [False, True])
+def test_gram_schmidt_parameters(va_space, n, return_R, copy):
+    A = generate_hilbert_va(va_space, n)
+    evaluate_qr(gram_schmidt, A, None, return_R, copy)
 
 
 @pyst.given_vector_arrays()
 @settings(deadline=None)
-def test_gram_schmidt_with_R(vector_array):
-    U = vector_array
-    # TODO: assumption here masks a potential issue with the algorithm
-    #      where it fails in del instead of a proper error
-    assume(len(U) > 1 or not contains_zero_vector(U))
-
-    V = U.copy()
-    onb, R = gram_schmidt(U, return_R=True, copy=True)
-    assert np.all(almost_equal(U, V))
-    assert np.allclose(onb.inner(onb), np.eye(len(onb)))
-    lc = onb.lincomb(onb.inner(U))
-    rtol = atol = 1e-13
-    assert np.all(almost_equal(U, lc, rtol=rtol, atol=atol))
-    assert np.all(almost_equal(V, onb.lincomb(R), rtol=rtol, atol=atol))
-
-    onb2, R2 = gram_schmidt(U, return_R=True, copy=False)
-    assert np.all(almost_equal(onb, onb2))
-    assert np.all(R == R2)
-    assert np.all(almost_equal(onb, U))
+def test_gram_schmidt(vector_array):
+    A = vector_array
+    evaluate_qr(gram_schmidt, A, None, True, True)
 
 
 def test_gram_schmidt_with_product(operator_with_arrays_and_products):
-    _, _, U, _, p, _ = operator_with_arrays_and_products
-
-    V = U.copy()
-    onb = gram_schmidt(U, product=p, copy=True)
-    assert np.all(almost_equal(U, V))
-    assert np.allclose(p.apply2(onb, onb), np.eye(len(onb)))
-    assert np.all(almost_equal(U, onb.lincomb(p.apply2(onb, U)), rtol=1e-13))
-
-    onb2 = gram_schmidt(U, product=p, copy=False)
-    assert np.all(almost_equal(onb, onb2))
-    assert np.all(almost_equal(onb, U))
-
-
-def test_gram_schmidt_with_product_and_R(operator_with_arrays_and_products):
-    _, _, U, _, p, _ = operator_with_arrays_and_products
-
-    V = U.copy()
-    onb, R = gram_schmidt(U, product=p, return_R=True, copy=True)
-    assert np.all(almost_equal(U, V))
-    assert np.allclose(p.apply2(onb, onb), np.eye(len(onb)))
-    assert np.all(almost_equal(U, onb.lincomb(p.apply2(onb, U)), rtol=1e-13))
-    assert np.all(almost_equal(U, onb.lincomb(R)))
-
-    onb2, R2 = gram_schmidt(U, product=p, return_R=True, copy=False)
-    assert np.all(almost_equal(onb, onb2))
-    assert np.all(R == R2)
-    assert np.all(almost_equal(onb, U))
+    _, _, A, _, product, _ = operator_with_arrays_and_products
+    evaluate_qr(gram_schmidt, A, product, True, True)
 
 
 @settings(deadline=None)

--- a/src/pymortests/algorithms/gram_schmidt.py
+++ b/src/pymortests/algorithms/gram_schmidt.py
@@ -16,6 +16,7 @@ from pymortests.algorithms.qr_test_util import (
     evaluate_qr,
     evaluate_qr_empty,
     evaluate_qr_full_offset,
+    evaluate_qr_offset,
     generate_hilbert_va,
 )
 from pymortests.base import runmodule
@@ -48,6 +49,14 @@ def test_gram_schmidt(vector_array):
 def test_gram_schmidt_with_product(operator_with_arrays_and_products):
     _, _, A, _, product, _ = operator_with_arrays_and_products
     evaluate_qr(gram_schmidt, A, product, True, True)
+
+
+# into how many blocks the matrix should be split; 0 for n blocks/ single vectors
+@pytest.mark.parametrize('num_blocks', [1, 2, 7, 0])
+@pyst.given_vector_arrays()
+def test_gram_schmidt_with_offset(vector_array, num_blocks):
+    A = vector_array
+    evaluate_qr_offset(gram_schmidt, A, num_blocks, {})
 
 
 @settings(deadline=None)

--- a/src/pymortests/algorithms/gram_schmidt.py
+++ b/src/pymortests/algorithms/gram_schmidt.py
@@ -12,12 +12,21 @@ from pymor.algorithms.gram_schmidt import gram_schmidt, gram_schmidt_biorth
 from pymor.core.logger import log_levels
 from pymor.vectorarrays.list import NumpyListVectorSpace
 from pymor.vectorarrays.numpy import NumpyVectorSpace
-from pymortests.algorithms.qr_test_util import evaluate_qr, evaluate_qr_empty, generate_hilbert_va
+from pymortests.algorithms.qr_test_util import (
+    evaluate_qr,
+    evaluate_qr_empty,
+    evaluate_qr_full_offset,
+    generate_hilbert_va,
+)
 from pymortests.base import runmodule
 
 
 def test_chol_qr_empty():
     evaluate_qr_empty(gram_schmidt)
+
+
+def test_chol_qr_full_offset():
+    evaluate_qr_full_offset(gram_schmidt)
 
 
 @pytest.mark.parametrize('va_space', [NumpyVectorSpace, NumpyListVectorSpace])

--- a/src/pymortests/algorithms/qr_test_util.py
+++ b/src/pymortests/algorithms/qr_test_util.py
@@ -1,6 +1,19 @@
+from warnings import warn
+
+import numpy as np
+import pytest
 from scipy.linalg import hilbert
 
+from pymor.algorithms.basic import almost_equal
+from pymor.core.config import is_scipy_mkl
+from pymor.operators.interface import Operator
 from pymor.vectorarrays.interface import VectorArray, VectorSpace
+
+# use lower tolerance for MKL
+if is_scipy_mkl():
+    TOL = {'atol': 1e-12, 'rtol': 1e-13}
+else:
+    TOL = {'atol': 1e-13, 'rtol': 1e-13}
 
 
 def generate_hilbert_va(vector_space_type: VectorSpace, n: int) -> VectorArray:
@@ -12,3 +25,63 @@ def generate_hilbert_va(vector_space_type: VectorSpace, n: int) -> VectorArray:
     but are never rank-deficient in exact arithmetic
     """
     return vector_space_type(n).from_numpy(hilbert(n))
+
+
+def evaluate_qr(qr_method, A: VectorArray, product: Operator, return_R: bool, copy: bool, qr_kwargs: dict={}):
+    r"""Tests a `qr_method` for given parameters.
+
+    This test is to ensure that the arguments `product`, `return_R`, `copy`
+    and potential method specific arguments in `qr_kwargs` are working as intended.
+    """
+    # create copy of input matrix and work with it
+    CPY = A.copy()
+
+    tup = qr_method(A=CPY, product=product, return_R=return_R, copy=copy, **qr_kwargs)
+
+    # check number outputs, their types and dimensions
+    if return_R:
+        assert isinstance(tup, tuple)
+        Q, R = tup
+        assert isinstance(R, np.ndarray)
+        assert len(R.shape) == 2
+        assert R.shape == (len(Q), len(A))
+    else:
+        Q = tup
+    assert isinstance(Q, VectorArray)
+    assert Q.space == A.space
+
+    # check if copies work properly, i.e., if we have a copy A should not change and, vise-versa,
+    # if we do not have a copy A should be overwritten by Q
+    if copy:
+        assert np.all(almost_equal(A, CPY, **TOL)), 'Reference copied from might be overwritten.'
+    else:
+        assert np.all(almost_equal(Q, CPY, **TOL)), 'In-place QR decomposition did not modifiy its input completly.'
+
+    # check if solution has low errors
+    # check loss of orthogonality
+    assert np.allclose(Q.inner(Q, product=product), np.eye(len(Q)), **TOL), 'Too high Loss of Orthogonality'
+    if return_R:
+        # check reconstruction error
+        assert np.all(almost_equal(A, Q.lincomb(R), **TOL)), 'Too high Reconstruction error'
+        # check Cholesky error
+        assert np.allclose(A.inner(A, product=product), (R.conj().T) @ R, **TOL),\
+            'Too high Cholesky error ($A^H A - R^H R$)'
+
+    # check if solution is deterministic
+    Q2, R2 = qr_method(A=A, product=product, return_R=True, copy=False, **qr_kwargs)
+    try:
+        assert np.all(almost_equal(Q, Q2, **TOL))
+        if return_R:
+            assert np.allclose(R, R2, **TOL)
+    except AssertionError:
+        precision = np.get_printoptions()['precision']
+        np.set_printoptions(precision=2)
+
+        L = [f'Q\n{Q.to_numpy()}', f'Q2\n{Q2.to_numpy()}']
+        if return_R:
+            L += [f'R\n{R}', f'R2\n{R2}']
+        warn('\n'.join(L))
+
+        np.set_printoptions(precision=precision)
+
+        pytest.xfail('QR method not deterministic.')

--- a/src/pymortests/algorithms/qr_test_util.py
+++ b/src/pymortests/algorithms/qr_test_util.py
@@ -49,6 +49,21 @@ def evaluate_qr_empty(qr_method, qr_kwargs: dict={}):
     assert len(Q2) == 0
 
 
+def evaluate_qr_full_offset(qr_method, qr_kwargs: dict={}):
+    """Test a `qr_method` for a full offset, i.e., no new vectors.
+
+    QR implementations have logic in place to catch this case.
+    Ensure that the logic is correct.
+    """
+    n = 5
+    E = np.eye(n)
+    V = NumpyVectorSpace(n).from_numpy(E)
+    Q, R = qr_method(V, return_R=True, copy=True, offset=n, **qr_kwargs)
+    assert np.all(almost_equal(V, Q, rtol=0, atol=0))
+    assert isinstance(R, np.ndarray)
+    assert np.allclose(R, E)
+
+
 def evaluate_qr(qr_method, A: VectorArray, product: Operator, return_R: bool, copy: bool, qr_kwargs: dict={}):
     r"""Tests a `qr_method` for given parameters.
 

--- a/src/pymortests/algorithms/qr_test_util.py
+++ b/src/pymortests/algorithms/qr_test_util.py
@@ -2,6 +2,7 @@ from warnings import warn
 
 import numpy as np
 import pytest
+from hypothesis import assume
 from scipy.linalg import hilbert
 
 from pymor.algorithms.basic import almost_equal
@@ -122,3 +123,57 @@ def evaluate_qr(qr_method, A: VectorArray, product: Operator, return_R: bool, co
         np.set_printoptions(precision=precision)
 
         pytest.xfail('QR method not deterministic.')
+
+
+def evaluate_qr_offset(qr_method, A: VectorArray, num_blocks: int, qr_kwargs: dict={}):
+    r"""Performs QR-Update using `qr_method` onto `num_blocks` many blocks of matrix `A`.
+
+    Test ensures that the offset is working as intended,
+    and that it does not affect the accuracy.
+    """
+    assume(len(A) > 0 and A.dim > 0)
+
+    n = len(A)
+    if num_blocks <= 0:
+        num_blocks = n
+
+    if num_blocks > n:
+        return # skip
+
+    # create copy of input matrix and work with it
+    CPY = A.copy()
+    Q = CPY.space.empty()
+    off_R = off_Q = 0
+
+    block_size = int(np.ceil(n/num_blocks))
+    R = np.zeros([n,n])
+
+    i = 0
+    while len(CPY) > 0:
+        i += 1
+        min_num = min(len(CPY), block_size)
+        # the way CholQR with offset is implemented in pyMOR,
+        # it deletes and appends vectors in each iteration
+        # therefore, we cannot start with all vectors but have to append them for each call
+        off_Q = len(Q)
+        Q.append(CPY[:min_num])
+        del CPY[:min_num]
+
+        _, R_ = qr_method(Q, offset=off_Q, return_R=True, copy=False, **qr_kwargs)
+        R = R.astype(np.promote_types(R.dtype, R_.dtype), copy=False)
+
+        h, w = R_[:,off_Q:].shape
+        R[:h, off_R:off_R+w] = R_[:,off_Q:]
+        off_R += w
+
+    # vectors might be removed and R therefore not upper-triangular, but upper-trapezoidal
+    R = R[:len(Q),:]
+
+    # check if solution has low errors
+    # check loss of orthogonality
+    assert np.allclose(Q.inner(Q), np.eye(len(Q)), **TOL), 'Too high Loss of Orthogonality'
+    # check reconstruction error
+    assert np.all(almost_equal(A, Q.lincomb(R), **TOL)), 'Too high Reconstruction error'
+    # check Cholesky error
+    assert np.allclose(A.inner(A), (R.conj().T) @ R, **TOL),\
+        'Too high Cholesky error ($A^H A - R^H R$)'

--- a/src/pymortests/algorithms/qr_test_util.py
+++ b/src/pymortests/algorithms/qr_test_util.py
@@ -25,7 +25,7 @@ else:
 def generate_hilbert_va(vector_space_type: VectorSpace, n: int) -> VectorArray:
     """Generates a Hilbert matrix as a VectorArray of the specified VectorSpace type.
 
-    Creates a in exact arithmetic full-rank, potentially ill-conditioned,
+    Creates an in exact arithmetic full-rank, potentially ill-conditioned,
     square Hilbert matrix of the given dimension `n`.
     Larger hilbert matrices are more ill-conditioned,
     but are never rank-deficient in exact arithmetic

--- a/src/pymortests/algorithms/qr_test_util.py
+++ b/src/pymortests/algorithms/qr_test_util.py
@@ -8,6 +8,7 @@ from pymor.algorithms.basic import almost_equal
 from pymor.core.config import is_scipy_mkl
 from pymor.operators.interface import Operator
 from pymor.vectorarrays.interface import VectorArray, VectorSpace
+from pymor.vectorarrays.numpy import NumpyVectorSpace
 
 # use lower tolerance for MKL
 if is_scipy_mkl():
@@ -25,6 +26,27 @@ def generate_hilbert_va(vector_space_type: VectorSpace, n: int) -> VectorArray:
     but are never rank-deficient in exact arithmetic
     """
     return vector_space_type(n).from_numpy(hilbert(n))
+
+
+def evaluate_qr_empty(qr_method, qr_kwargs: dict={}):
+    """Test a `qr_method` for an empty VectorArray.
+
+    QR implementations have logic in place to catch this case.
+    Ensure that the logic is correct.
+    """
+    n = 5
+    V = NumpyVectorSpace(n).empty(0)
+    Q, R = qr_method(V, return_R=True, copy=True, **qr_kwargs)
+    assert isinstance(Q, VectorArray)
+    assert len(Q) == 0
+    assert V.space == Q.space
+    assert isinstance(R, np.ndarray)
+    assert R.shape == (0,0)
+
+    Q2 = qr_method(V, return_R=False, copy=False, **qr_kwargs)
+    assert isinstance(Q2, VectorArray)
+    assert Q2 == V
+    assert len(Q2) == 0
 
 
 def evaluate_qr(qr_method, A: VectorArray, product: Operator, return_R: bool, copy: bool, qr_kwargs: dict={}):

--- a/src/pymortests/algorithms/qr_test_util.py
+++ b/src/pymortests/algorithms/qr_test_util.py
@@ -1,3 +1,7 @@
+# This file is part of the pyMOR project (https://www.pymor.org).
+# Copyright pyMOR developers and contributors. All rights reserved.
+# License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
+
 from warnings import warn
 
 import numpy as np

--- a/src/pymortests/algorithms/qr_test_util.py
+++ b/src/pymortests/algorithms/qr_test_util.py
@@ -1,0 +1,14 @@
+from scipy.linalg import hilbert
+
+from pymor.vectorarrays.interface import VectorArray, VectorSpace
+
+
+def generate_hilbert_va(vector_space_type: VectorSpace, n: int) -> VectorArray:
+    """Generates a Hilbert matrix as a VectorArray of the specified VectorSpace type.
+
+    Creates a in exact arithmetic full-rank, potentially ill-conditioned,
+    square Hilbert matrix of the given dimension `n`.
+    Larger hilbert matrices are more ill-conditioned,
+    but are never rank-deficient in exact arithmetic
+    """
+    return vector_space_type(n).from_numpy(hilbert(n))


### PR DESCRIPTION
PR covers the 3rd point (out of 3) of the PR #2523. 1st point will follow.

It adds a relative tolerance option to the `shifted_chol_qr` algorithm similarly to the existing `gram_schmidt`.

The idea is to filter out zero vectors and vectors that are relatively small (based on `rtol`) compared to the longest vector in $A$ before starting with the shifted Cholesky algorithm. In case of a QR update it can also filter out linearly dependent vectors (compared to the orthonormal basis).

This makes the algorithm slightly more robust against matrices that are almost rank-deficient/contain a bit of noise. However, it cannot handle e.g. an all ones matrix, since all vectors have the same length and are therefore not filtered out.