### PR TITLE
Fix ScipySpSolveSolver factorization cache being defeated by matrix identity churn

### DIFF
--- a/src/pymor/bindings/scipy.py
+++ b/src/pymor/bindings/scipy.py
@@ -152,27 +152,37 @@ class ScipySpSolveSolver(ScipyLinearSolver):
         self.__auto_init(locals())
 
     def _solve_impl(self, matrix, V, initial_guess, promoted_type):
-        # convert to csc
-        if not sps.isspmatrix_csc(matrix):
+        # cache_key keeps a reference to the ORIGINAL matrix object, which stays alive as long
+        # as the caller's operator does. The `_factorizations` cache must be keyed on this, not
+        # on `matrix` after it gets rebound below (`.tocsc()`/`matrix_astype_nocopy()` may return
+        # a brand-new, otherwise-unreferenced object that would be garbage collected -- and thus
+        # evicted from the WeakRefCache -- as soon as this method returns).
+        cache_key = matrix
+
+        def to_csc_if_needed(matrix):
             # csr is also fine when using umfpack
-            if sps.isspmatrix_csr(matrix) and self.use_umfpack and config.HAVE_UMFPACK:
-                pass
-            else:
-                matrix = matrix.tocsc()
+            if sps.isspmatrix_csc(matrix) or \
+                    (sps.isspmatrix_csr(matrix) and self.use_umfpack and config.HAVE_UMFPACK):
+                return matrix
+            return matrix.tocsc()
 
         try:
             if self.keep_factorization:
                 try:
-                    fac, dtype = self._factorizations.get(matrix)
+                    fac, dtype = self._factorizations.get(cache_key)
                     if not np.can_cast(V.dtype, dtype, casting='safe'):
                         raise KeyError
                 except KeyError:
+                    # only convert format/dtype when we actually need to build a new
+                    # factorization -- on a cache hit, the incoming matrix's format never
+                    # matters, so we avoid paying for a `.tocsc()`/astype on every call.
+                    matrix = to_csc_if_needed(matrix)
                     matrix = matrix_astype_nocopy(matrix, promoted_type)
                     if self.use_umfpack and config.HAVE_UMFPACK:
                         fac = scikits.umfpack.splu(matrix)
                     else:
                         fac = splu(matrix, permc_spec=self.permc_spec)
-                    self._factorizations.set(matrix, (fac, promoted_type))
+                    self._factorizations.set(cache_key, (fac, promoted_type))
                 # we may use a complex factorization of a real matrix to
                 # apply it to a real vector. In that case, we downcast
                 # the result here, removing the imaginary part,
@@ -181,6 +191,7 @@ class ScipySpSolveSolver(ScipyLinearSolver):
             else:
                 # the matrix is always converted to the promoted type.
                 # if matrix.dtype == promoted_type, this is a no_op
+                matrix = to_csc_if_needed(matrix)
                 matrix = matrix_astype_nocopy(matrix, promoted_type)
                 if self.use_umfpack and config.HAVE_UMFPACK:
                     R = scikits.umfpack.spsolve(matrix, V)

--- a/src/pymortests/solvers/solvers.py
+++ b/src/pymortests/solvers/solvers.py
@@ -4,7 +4,7 @@
 
 import numpy as np
 import pytest
-from scipy.sparse import diags
+from scipy.sparse import coo_matrix, diags
 
 from pymor.algorithms.basic import almost_equal
 from pymor.bindings.scipy import (
@@ -99,3 +99,36 @@ def test_numpy_sparse_adjoint_solvers(numpy_sparse_solver):
     rhs = op.source.make_array(np.ones(10))
     solution = op.apply_inverse_adjoint(rhs)
     assert ((op.apply_adjoint(solution) - rhs).norm() / rhs.norm())[0] < 1e-8
+
+
+def test_sp_solve_solver_reuses_factorization_for_non_csc_matrix(monkeypatch):
+    # regression test: ScipySpSolveSolver's `_factorizations` cache used to be keyed on the
+    # local `matrix` variable *after* it was rebound by `matrix.tocsc()`. For any matrix that
+    # wasn't already CSC (or CSR with UMFPACK), that rebound object had no other referrers and
+    # was garbage collected as soon as `_solve_impl` returned, evicting the cache entry
+    # immediately and silently defeating `keep_factorization=True` for every subsequent call.
+    import pymor.bindings.scipy as scipy_bindings
+
+    n = 20
+    rng = np.random.default_rng(0)
+    A = rng.standard_normal((n, n))
+    K = coo_matrix(A @ A.T + n * np.eye(n))  # SPD; COO is never CSC and never CSR+UMFPACK-exempt
+
+    splu_calls = []
+    real_splu = scipy_bindings.splu
+
+    def counting_splu(*args, **kwargs):
+        splu_calls.append(None)
+        return real_splu(*args, **kwargs)
+
+    monkeypatch.setattr(scipy_bindings, 'splu', counting_splu)
+
+    solver = ScipySpSolveSolver(keep_factorization=True, use_umfpack=False)
+    op = NumpyMatrixOperator(K, solver=solver)
+    rhs = op.range.make_array(np.ones(n))
+
+    for _ in range(5):
+        solution = op.apply_inverse(rhs)
+        assert ((op.apply(solution) - rhs).norm() / rhs.norm())[0] < 1e-8
+
+    assert len(splu_calls) == 1


### PR DESCRIPTION
#### Reference issue

Fixes #2584

#### What does this implement/fix?

`ScipySpSolveSolver._solve_impl`'s `_factorizations` `WeakRefCache` was keyed on the `matrix` local variable after it got rebound by `matrix.tocsc()`. For any matrix that wasn't already CSC (or CSR with UMFPACK available), that rebound object had no other referrers and was garbage collected as soon as `_solve_impl` returned, evicting the cache entry immediately and silently defeating `keep_factorization=True` for every subsequent call on the "same" matrix. See #2584 for a full reproduction and benchmark numbers.

This PR:
- Captures `cache_key = matrix` before the format-conversion reassignment and keys `_factorizations.get(...)`/`.set(...)` on that instead of the post-conversion local variable.
- Makes the format/dtype conversion lazy -- it only runs inside the `except KeyError:` branch (i.e. only when a new factorization is actually being built), instead of unconditionally on every call, including cache hits where its result was never used.
- Adds a regression test (`test_sp_solve_solver_reuses_factorization_for_non_csc_matrix`) that monkeypatches `splu` to count factorization calls across 5 repeated `apply_inverse` calls on a non-CSC (COO) matrix. Confirmed it fails on unpatched `main` (`assert 5 == 1`) and passes with this fix.

#### Additional information

Verified against the existing `src/pymortests/solvers/solvers.py` suite (all cases pass, results numerically identical to before -- not just faster) and `ruff check` (clean). See #2584 for the standalone reproduction script and measured before/after timings.