### PR TITLE
Fix external_pr_mirror workflow

### DIFF
--- a/.github/workflows/external_pr_mirror.yml
+++ b/.github/workflows/external_pr_mirror.yml
@@ -1,33 +1,68 @@
 ---
 name: external_pr_mirror
 on:
-  pull_request_target:
+  workflow_run:
+    workflows:
+      - external_pr_mirror_trigger
     types:
-      - opened
-      - synchronize
+      - completed
 jobs:
   push:
-    if: github.event.pull_request.head.repo.owner.login != 'pymor'
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      number: ${{ steps.pr.outputs.number }}
     steps:
+      - name: Resolve PR number from trusted payload
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_REPO: ${{ github.event.workflow_run.head_repository.full_name }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          owner="${HEAD_REPO%%/*}"
+          num=$(gh pr list --repo "$GITHUB_REPOSITORY" --state open \
+                 --head "$owner:$HEAD_BRANCH" --json number,headRefOid \
+                 -q ".[] | select(.headRefOid==\"$HEAD_SHA\") | .number")
+          [ -n "$num" ] || { echo "no open PR matching $owner:$HEAD_BRANCH@$HEAD_SHA"; exit 1; }
+          echo "number=$num" >> "$GITHUB_OUTPUT"
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: refs/pull/${{ steps.pr.outputs.number }}/head
       - run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
-          git push --force origin HEAD:refs/heads/external_pr_${{github.event.pull_request.number}}
+          git push --force origin \
+            HEAD:refs/heads/external_pr_${{ steps.pr.outputs.number }}
   comment:
+    needs: push
     runs-on: ubuntu-latest
-    if: github.event.pull_request.head.repo.owner.login != 'pymor' && github.event.action
-      == 'opened'
+    permissions:
+      pull-requests: write
     steps:
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ needs.push.outputs.number }}
         with:
           script: |-
-            await github.rest.issues.createComment({
-              issue_number: context.issue.number,
+            const number = Number(process.env.PR_NUMBER);
+            const marker = '<!-- external-pr-mirror -->';
+            const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `Mirroring external branch in external_pr_${{github.event.pull_request.number}}`
-            })
+              issue_number: number,
+              per_page: 100,
+            });
+            if (comments.some(c => (c.body || '').includes(marker))) {
+              core.info('Mirror comment already present, skipping.');
+              return;
+            }
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: number,
+              body: `${marker}\nMirroring external branch in external_pr_${number}`,
+            });

--- a/.github/workflows/external_pr_mirror_trigger.yml
+++ b/.github/workflows/external_pr_mirror_trigger.yml
@@ -1,0 +1,15 @@
+---
+name: external_pr_mirror_trigger
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+permissions: {}
+jobs:
+  noop:
+    if: github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - run: |-
+          echo "Approval gate for mirroring PR #${{ github.event.pull_request.number }}"

--- a/.github/workflows/external_pr_unmirror.yml
+++ b/.github/workflows/external_pr_unmirror.yml
@@ -12,6 +12,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          allow-unsafe-pr-checkout: true
       - run: |
           git config user.name github-actions
           git config user.email github-actions@github.com


### PR DESCRIPTION
- Make sure branch is only mirrored when external PR has been approved for CI.
- Add "allow-unsafe-pr-checkout: true" to checkout action in external_pr_unmirror to make it run again.