### PR TITLE
Manually bump slycot to 0.7.0 in ci-current image

### DIFF
--- a/requirements-ci-current.txt
+++ b/requirements-ci-current.txt
@@ -492,7 +492,7 @@ six==1.17.0
     # via
     #   python-dateutil
     #   rfc3339-validator
-slycot==0.6.1
+slycot==0.7.0
     # via pymor (./pyproject.toml)
 snowballstemmer==3.0.1
     # via sphinx


### PR DESCRIPTION
Manually bump slycot to isolate potential issues related to the new slycot wheels.