### PR TITLE
Unify and improve QR tests

### DIFF
--- a/src/pymortests/algorithms/chol_qr.py
+++ b/src/pymortests/algorithms/chol_qr.py
@@ -2,173 +2,72 @@
 # Copyright pyMOR developers and contributors. All rights reserved.
 # License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
 
-import warnings
-
-import numpy as np
 import pytest
-from hypothesis import assume, settings
+from hypothesis import assume
+from hypothesis.errors import UnsatisfiedAssumption
 
-import pymortests.strategies as pyst
-from pymor.algorithms.basic import almost_equal, contains_zero_vector
 from pymor.algorithms.chol_qr import shifted_chol_qr
-from pymor.algorithms.gram_schmidt import gram_schmidt
 from pymor.core.config import is_scipy_mkl
+from pymor.vectorarrays.list import NumpyListVectorSpace
 from pymor.vectorarrays.numpy import NumpyVectorSpace
+from pymortests.algorithms.qr_test_util import (
+    evaluate_qr,
+    evaluate_qr_empty,
+    evaluate_qr_full_offset,
+    evaluate_qr_offset,
+    generate_hilbert_va,
+)
 from pymortests.base import runmodule
 
-
-@pytest.mark.xfail
-@pyst.given_vector_arrays()
-@settings(deadline=None)
-def test_shifted_chol_qr(vector_array):
-    U = vector_array
-
-    assume(len(U) >= 1 and not contains_zero_vector(U))
-
-    V = U.copy()
-
-    onbgs, Rgs = gram_schmidt(U, copy=True, return_R=True)
-    if len(onbgs) < len(V):
-        warnings.warn('Linearly dependent vectors detected! Skipping ...')
-        return
-
-    onb, R = shifted_chol_qr(U, return_R=True, copy=True)
-    assert np.all(almost_equal(U, V))
-    assert np.allclose(onb.inner(onb), np.eye(len(onb)))
-    lc = onb.lincomb(onb.inner(U))
-    rtol = atol = 1e-10
-
-    assert np.all(almost_equal(U, lc, rtol=rtol, atol=atol))
-    try:
-        assert np.all(almost_equal(V, onb.lincomb(R), rtol=rtol, atol=atol))
-    except AssertionError:
-        assert 0
-
-    onb2, R2 = shifted_chol_qr(U, return_R=True, copy=False)
-    assert np.all(almost_equal(onb, onb2))
-    assert np.all(R == R2)
-    assert np.all(almost_equal(onb, U))
+# use lower tolerance for MKL
+ORTH_TOL = 1e-13 if is_scipy_mkl() else 5e-15
 
 
-@pytest.mark.xfail
-def test_shifted_chol_qr_with_product(operator_with_arrays_and_products):
-    if is_scipy_mkl():
-        pytest.xfail('fails with mkl')
-    _, _, U, _, p, _ = operator_with_arrays_and_products
-
-    assume(len(U) >= 1 and not contains_zero_vector(U))
-
-    if U.dim < len(U):
-        return
-
-    V = U.copy()
-
-    onb, R = shifted_chol_qr(U, product=p, return_R=True, copy=True)
-    assert np.all(almost_equal(U, V))
-    # atol increased from 1e-7 to 1e-3 due to failing macos 15 build
-    assert np.allclose(p.apply2(onb, onb), np.eye(len(onb)), atol=1e-3)
-    assert np.all(almost_equal(U, onb.lincomb(p.apply2(onb, U)), rtol=1e-11))
-    assert np.all(almost_equal(U, onb.lincomb(R)))
-
-    onb2, R2 = shifted_chol_qr(U, product=p, return_R=True, copy=False)
-    assert np.all(almost_equal(onb, onb2))
-    assert np.all(R == R2)
-    assert np.all(almost_equal(onb, U))
+def test_chol_qr_empty():
+    evaluate_qr_empty(shifted_chol_qr)
 
 
-@pytest.mark.builtin
+def test_chol_qr_full_offset():
+    evaluate_qr_full_offset(shifted_chol_qr)
+
+
+@pytest.mark.parametrize('va_space', [NumpyVectorSpace, NumpyListVectorSpace])
+@pytest.mark.parametrize('n', [1, 5, 25])
+@pytest.mark.parametrize('return_R', [False, True])
 @pytest.mark.parametrize('copy', [False, True])
-def test_chol_qr_empty(copy):
-    n = 5
-    V = NumpyVectorSpace(n).empty(0)
-    Q, R = shifted_chol_qr(V, return_R=True, copy=copy)
-    assert len(V) == len(Q) == 0
-
-@pytest.mark.xfail
-@pyst.given_vector_arrays()
-def test_shifted_chol_qr_with_offset(vector_array):
-    U = vector_array
-
-    assume(len(U) >= 2 and not contains_zero_vector(U))
-
-    # check if the test VectorArray contains linearly dependent vectors
-    # Q and R are later used for comparison
-    onbgs, Rgs = gram_schmidt(U, copy=True, return_R=True)
-    if len(onbgs) < len(U):
-        warnings.warn('Linearly dependent vectors detected! Skipping ...')
-        return
-
-    # orthogonalize first half
-    offset = round(len(U) / 2)
-    onb, Ro = shifted_chol_qr(U[:offset], return_R=True, copy=True)
-    assert np.allclose(onb.inner(onb), np.eye(len(onb)))
-
-    # orthogonalize second half
-    onb.append(U[offset:])
-    _, R = shifted_chol_qr(onb, return_R=True, copy=False)
-
-    # insert R of first orthogonalization step into R of second step
-    # overwritten matrix block only contains a unit matrix
-    R[:offset,:offset] = Ro
-
-    # compare Q and R of shifted Cholesky QR with offset to the gram_schmidt implementation
-    rtol = atol = 1e-13
-    assert np.all(almost_equal(onb, onbgs, rtol=rtol, atol=atol))
-    assert np.allclose(Rgs, R)
+@pytest.mark.parametrize('recompute_shift', [False, True])
+@pytest.mark.parametrize('orth_tol', [None, ORTH_TOL])
+def test_chol_qr_parameters(va_space, n, return_R, copy, recompute_shift, orth_tol):
+    A = generate_hilbert_va(va_space, n)
+    evaluate_qr(shifted_chol_qr, A, None, return_R, copy,
+        {'recompute_shift': recompute_shift, 'maxiter': 10, 'orth_tol': orth_tol}
+    )
 
 
-@pytest.mark.xfail
-@pyst.given_vector_arrays()
-@settings(deadline=None)
-def test_recalculated_shifted_chol_qr(vector_array):
-    U = vector_array
+@pytest.mark.parametrize('recompute_shift', [False, True])
+def test_chol_qr_with_product(operator_with_arrays_and_products, recompute_shift):
+    _, _, A, _, product, _ = operator_with_arrays_and_products
 
-    assume(len(U) >= 1 and not contains_zero_vector(U))
+    # keeps failing due to restriction; requires more hypothesis examples
+    try:
+        assume(A.dim >= len(A))
+    except UnsatisfiedAssumption:
+        pytest.xfail(f'{UnsatisfiedAssumption.__qualname__} was raised')
 
-    V = U.copy()
-
-    onbgs, Rgs = gram_schmidt(U, copy=True, return_R=True, atol=0, rtol=0)
-    if len(onbgs) < len(V):
-        warnings.warn('Linearly dependent vectors detected! Skipping ...')
-        return
-
-    onb, R = shifted_chol_qr(U, return_R=True, copy=True, recompute_shift=True, maxiter=10, orth_tol=1e-13)
-    assert np.all(almost_equal(U, V))
-    assert np.allclose(onb.inner(onb), np.eye(len(onb)))
-    lc = onb.lincomb(onb.inner(U))
-    rtol = atol = 1e-9
-
-    assert np.all(almost_equal(U, lc, rtol=rtol, atol=atol))
-    assert np.all(almost_equal(V, onb.lincomb(R), rtol=rtol, atol=atol))
-
-    onb2, R2 = shifted_chol_qr(U, return_R=True, copy=False, recompute_shift=True, maxiter=10, orth_tol=1e-13)
-    assert np.all(almost_equal(onb, onb2))
-    assert np.all(R == R2)
-    assert np.all(almost_equal(onb, U))
+    evaluate_qr(shifted_chol_qr, A, product, True, True,
+        {'recompute_shift': recompute_shift, 'maxiter': 10, 'orth_tol': ORTH_TOL}
+    )
 
 
-@pytest.mark.xfail
-def test_recalculated_shifted_chol_qr_with_product(operator_with_arrays_and_products):
-    _, _, U, _, p, _ = operator_with_arrays_and_products
+# into how many blocks the matrix should be split; 0 for n blocks/ single vectors
+@pytest.mark.parametrize('num_blocks', [1, 2, 7, 0])
+@pytest.mark.parametrize('recompute_shift', [False, True])
+def test_chol_qr_with_offset(num_blocks, recompute_shift):
+    A = generate_hilbert_va(NumpyVectorSpace, 251)
+    evaluate_qr_offset(shifted_chol_qr, A, num_blocks,
+        {'recompute_shift': recompute_shift, 'maxiter': 10, 'orth_tol': ORTH_TOL}
+    )
 
-    assume(len(U) >= 1 and not contains_zero_vector(U))
-
-    if U.dim < len(U):
-        return
-
-    V = U.copy()
-
-    onb, R = shifted_chol_qr(U, return_R=True, product=p, copy=True, recompute_shift=True, maxiter=10, orth_tol=1e-13)
-    assert np.all(almost_equal(U, V))
-    assert np.allclose(p.apply2(onb, onb), np.eye(len(onb)))
-    assert np.all(almost_equal(U, onb.lincomb(p.apply2(onb, U)), rtol=1e-11))
-    assert np.all(almost_equal(U, onb.lincomb(R)))
-
-    onb2, R2 = shifted_chol_qr(U, return_R=True, product=p, copy=False,
-                               recompute_shift=True, maxiter=10, orth_tol=1e-13)
-    assert np.all(almost_equal(onb, onb2))
-    assert np.all(R == R2)
-    assert np.all(almost_equal(onb, U))
 
 if __name__ == '__main__':
     runmodule(filename=__file__)

--- a/src/pymortests/algorithms/gram_schmidt.py
+++ b/src/pymortests/algorithms/gram_schmidt.py
@@ -4,85 +4,59 @@
 
 import numpy as np
 import pytest
-from hypothesis import assume, settings
+from hypothesis import settings
 
 import pymortests.strategies as pyst
-from pymor.algorithms.basic import almost_equal, contains_zero_vector
+from pymor.algorithms.basic import almost_equal
 from pymor.algorithms.gram_schmidt import gram_schmidt, gram_schmidt_biorth
 from pymor.core.logger import log_levels
+from pymor.vectorarrays.list import NumpyListVectorSpace
+from pymor.vectorarrays.numpy import NumpyVectorSpace
+from pymortests.algorithms.qr_test_util import (
+    evaluate_qr,
+    evaluate_qr_empty,
+    evaluate_qr_full_offset,
+    evaluate_qr_offset,
+    generate_hilbert_va,
+)
 from pymortests.base import runmodule
 
 
-@pyst.given_vector_arrays()
-def test_gram_schmidt(vector_array):
-    U = vector_array
-    # TODO: assumption here masks a potential issue with the algorithm
-    #      where it fails in del instead of a proper error
-    assume(len(U) > 1 or not contains_zero_vector(U))
+def test_chol_qr_empty():
+    evaluate_qr_empty(gram_schmidt)
 
-    V = U.copy()
-    onb = gram_schmidt(U, copy=True)
-    assert np.all(almost_equal(U, V))
-    assert np.allclose(onb.inner(onb), np.eye(len(onb)))
-    # TODO: maybe raise tolerances again
-    assert np.all(almost_equal(U, onb.lincomb(onb.inner(U)), atol=1e-13, rtol=1e-13))
 
-    onb2 = gram_schmidt(U, copy=False)
-    assert np.all(almost_equal(onb, onb2))
-    assert np.all(almost_equal(onb, U))
+def test_chol_qr_full_offset():
+    evaluate_qr_full_offset(gram_schmidt)
+
+
+@pytest.mark.parametrize('va_space', [NumpyVectorSpace, NumpyListVectorSpace])
+@pytest.mark.parametrize('n', [5])
+@pytest.mark.parametrize('return_R', [False, True])
+@pytest.mark.parametrize('copy', [False, True])
+def test_gram_schmidt_parameters(va_space, n, return_R, copy):
+    A = generate_hilbert_va(va_space, n)
+    evaluate_qr(gram_schmidt, A, None, return_R, copy)
 
 
 @pyst.given_vector_arrays()
 @settings(deadline=None)
-def test_gram_schmidt_with_R(vector_array):
-    U = vector_array
-    # TODO: assumption here masks a potential issue with the algorithm
-    #      where it fails in del instead of a proper error
-    assume(len(U) > 1 or not contains_zero_vector(U))
-
-    V = U.copy()
-    onb, R = gram_schmidt(U, return_R=True, copy=True)
-    assert np.all(almost_equal(U, V))
-    assert np.allclose(onb.inner(onb), np.eye(len(onb)))
-    lc = onb.lincomb(onb.inner(U))
-    rtol = atol = 1e-13
-    assert np.all(almost_equal(U, lc, rtol=rtol, atol=atol))
-    assert np.all(almost_equal(V, onb.lincomb(R), rtol=rtol, atol=atol))
-
-    onb2, R2 = gram_schmidt(U, return_R=True, copy=False)
-    assert np.all(almost_equal(onb, onb2))
-    assert np.all(R == R2)
-    assert np.all(almost_equal(onb, U))
+def test_gram_schmidt(vector_array):
+    A = vector_array
+    evaluate_qr(gram_schmidt, A, None, True, True)
 
 
 def test_gram_schmidt_with_product(operator_with_arrays_and_products):
-    _, _, U, _, p, _ = operator_with_arrays_and_products
-
-    V = U.copy()
-    onb = gram_schmidt(U, product=p, copy=True)
-    assert np.all(almost_equal(U, V))
-    assert np.allclose(p.apply2(onb, onb), np.eye(len(onb)))
-    assert np.all(almost_equal(U, onb.lincomb(p.apply2(onb, U)), rtol=1e-13))
-
-    onb2 = gram_schmidt(U, product=p, copy=False)
-    assert np.all(almost_equal(onb, onb2))
-    assert np.all(almost_equal(onb, U))
+    _, _, A, _, product, _ = operator_with_arrays_and_products
+    evaluate_qr(gram_schmidt, A, product, True, True)
 
 
-def test_gram_schmidt_with_product_and_R(operator_with_arrays_and_products):
-    _, _, U, _, p, _ = operator_with_arrays_and_products
-
-    V = U.copy()
-    onb, R = gram_schmidt(U, product=p, return_R=True, copy=True)
-    assert np.all(almost_equal(U, V))
-    assert np.allclose(p.apply2(onb, onb), np.eye(len(onb)))
-    assert np.all(almost_equal(U, onb.lincomb(p.apply2(onb, U)), rtol=1e-13))
-    assert np.all(almost_equal(U, onb.lincomb(R)))
-
-    onb2, R2 = gram_schmidt(U, product=p, return_R=True, copy=False)
-    assert np.all(almost_equal(onb, onb2))
-    assert np.all(R == R2)
-    assert np.all(almost_equal(onb, U))
+# into how many blocks the matrix should be split; 0 for n blocks/ single vectors
+@pytest.mark.parametrize('num_blocks', [1, 2, 7, 0])
+@pyst.given_vector_arrays()
+def test_gram_schmidt_with_offset(vector_array, num_blocks):
+    A = vector_array
+    evaluate_qr_offset(gram_schmidt, A, num_blocks, {})
 
 
 @settings(deadline=None)

--- a/src/pymortests/algorithms/gram_schmidt.py
+++ b/src/pymortests/algorithms/gram_schmidt.py
@@ -22,11 +22,11 @@ from pymortests.algorithms.qr_test_util import (
 from pymortests.base import runmodule
 
 
-def test_chol_qr_empty():
+def test_gram_schmidt_empty():
     evaluate_qr_empty(gram_schmidt)
 
 
-def test_chol_qr_full_offset():
+def test_gram_schmidt_full_offset():
     evaluate_qr_full_offset(gram_schmidt)
 
 

--- a/src/pymortests/algorithms/qr_test_util.py
+++ b/src/pymortests/algorithms/qr_test_util.py
@@ -1,0 +1,183 @@
+# This file is part of the pyMOR project (https://www.pymor.org).
+# Copyright pyMOR developers and contributors. All rights reserved.
+# License: BSD 2-Clause License (https://opensource.org/licenses/BSD-2-Clause)
+
+from warnings import warn
+
+import numpy as np
+import pytest
+from hypothesis import assume
+from scipy.linalg import hilbert
+
+from pymor.algorithms.basic import almost_equal
+from pymor.core.config import is_scipy_mkl
+from pymor.operators.interface import Operator
+from pymor.vectorarrays.interface import VectorArray, VectorSpace
+from pymor.vectorarrays.numpy import NumpyVectorSpace
+
+# use lower tolerance for MKL
+if is_scipy_mkl():
+    TOL = {'atol': 1e-12, 'rtol': 1e-13}
+else:
+    TOL = {'atol': 1e-13, 'rtol': 1e-13}
+
+
+def generate_hilbert_va(vector_space_type: VectorSpace, n: int) -> VectorArray:
+    """Generates a Hilbert matrix as a VectorArray of the specified VectorSpace type.
+
+    Creates an in exact arithmetic full-rank, potentially ill-conditioned,
+    square Hilbert matrix of the given dimension `n`.
+    Larger hilbert matrices are more ill-conditioned,
+    but are never rank-deficient in exact arithmetic
+    """
+    return vector_space_type(n).from_numpy(hilbert(n))
+
+
+def evaluate_qr_empty(qr_method, qr_kwargs: dict={}):
+    """Test a `qr_method` for an empty VectorArray.
+
+    QR implementations have logic in place to catch this case.
+    Ensure that the logic is correct.
+    """
+    n = 5
+    V = NumpyVectorSpace(n).empty(0)
+    Q, R = qr_method(V, return_R=True, copy=True, **qr_kwargs)
+    assert isinstance(Q, VectorArray)
+    assert len(Q) == 0
+    assert V.space == Q.space
+    assert isinstance(R, np.ndarray)
+    assert R.shape == (0,0)
+
+    Q2 = qr_method(V, return_R=False, copy=False, **qr_kwargs)
+    assert isinstance(Q2, VectorArray)
+    assert Q2 == V
+    assert len(Q2) == 0
+
+
+def evaluate_qr_full_offset(qr_method, qr_kwargs: dict={}):
+    """Test a `qr_method` for a full offset, i.e., no new vectors.
+
+    QR implementations have logic in place to catch this case.
+    Ensure that the logic is correct.
+    """
+    n = 5
+    E = np.eye(n)
+    V = NumpyVectorSpace(n).from_numpy(E)
+    Q, R = qr_method(V, return_R=True, copy=True, offset=n, **qr_kwargs)
+    assert np.all(almost_equal(V, Q, rtol=0, atol=0))
+    assert isinstance(R, np.ndarray)
+    assert np.allclose(R, E)
+
+
+def evaluate_qr(qr_method, A: VectorArray, product: Operator, return_R: bool, copy: bool, qr_kwargs: dict={}):
+    r"""Tests a `qr_method` for given parameters.
+
+    This test is to ensure that the arguments `product`, `return_R`, `copy`
+    and potential method specific arguments in `qr_kwargs` are working as intended.
+    """
+    # create copy of input matrix and work with it
+    CPY = A.copy()
+
+    tup = qr_method(A=CPY, product=product, return_R=return_R, copy=copy, **qr_kwargs)
+
+    # check number outputs, their types and dimensions
+    if return_R:
+        assert isinstance(tup, tuple)
+        Q, R = tup
+        assert isinstance(R, np.ndarray)
+        assert len(R.shape) == 2
+        assert R.shape == (len(Q), len(A))
+    else:
+        Q = tup
+    assert isinstance(Q, VectorArray)
+    assert Q.space == A.space
+
+    # check if copies work properly, i.e., if we have a copy A should not change and, vise-versa,
+    # if we do not have a copy A should be overwritten by Q
+    if copy:
+        assert np.all(almost_equal(A, CPY, **TOL)), 'Reference copied from might be overwritten.'
+    else:
+        assert np.all(almost_equal(Q, CPY, **TOL)), 'In-place QR decomposition did not modifiy its input completly.'
+
+    # check if solution has low errors
+    # check loss of orthogonality
+    assert np.allclose(Q.inner(Q, product=product), np.eye(len(Q)), **TOL), 'Too high Loss of Orthogonality'
+    if return_R:
+        # check reconstruction error
+        assert np.all(almost_equal(A, Q.lincomb(R), **TOL)), 'Too high Reconstruction error'
+        # check Cholesky error
+        assert np.allclose(A.inner(A, product=product), (R.conj().T) @ R, **TOL),\
+            'Too high Cholesky error ($A^H A - R^H R$)'
+
+    # check if solution is deterministic
+    Q2, R2 = qr_method(A=A, product=product, return_R=True, copy=False, **qr_kwargs)
+    try:
+        assert np.all(almost_equal(Q, Q2, **TOL))
+        if return_R:
+            assert np.allclose(R, R2, **TOL)
+    except AssertionError:
+        precision = np.get_printoptions()['precision']
+        np.set_printoptions(precision=2)
+
+        L = [f'Q\n{Q.to_numpy()}', f'Q2\n{Q2.to_numpy()}']
+        if return_R:
+            L += [f'R\n{R}', f'R2\n{R2}']
+        warn('\n'.join(L))
+
+        np.set_printoptions(precision=precision)
+
+        pytest.xfail('QR method not deterministic.')
+
+
+def evaluate_qr_offset(qr_method, A: VectorArray, num_blocks: int, qr_kwargs: dict={}):
+    r"""Performs QR-Update using `qr_method` onto `num_blocks` many blocks of matrix `A`.
+
+    Test ensures that the offset is working as intended,
+    and that it does not affect the accuracy.
+    """
+    assume(len(A) > 0 and A.dim > 0)
+
+    n = len(A)
+    if num_blocks <= 0:
+        num_blocks = n
+
+    if num_blocks > n:
+        return # skip
+
+    # create copy of input matrix and work with it
+    CPY = A.copy()
+    Q = CPY.space.empty()
+    off_R = off_Q = 0
+
+    block_size = int(np.ceil(n/num_blocks))
+    R = np.zeros([n,n])
+
+    i = 0
+    while len(CPY) > 0:
+        i += 1
+        min_num = min(len(CPY), block_size)
+        # the way CholQR with offset is implemented in pyMOR,
+        # it deletes and appends vectors in each iteration
+        # therefore, we cannot start with all vectors but have to append them for each call
+        off_Q = len(Q)
+        Q.append(CPY[:min_num])
+        del CPY[:min_num]
+
+        _, R_ = qr_method(Q, offset=off_Q, return_R=True, copy=False, **qr_kwargs)
+        R = R.astype(np.promote_types(R.dtype, R_.dtype), copy=False)
+
+        h, w = R_[:,off_Q:].shape
+        R[:h, off_R:off_R+w] = R_[:,off_Q:]
+        off_R += w
+
+    # vectors might be removed and R therefore not upper-triangular, but upper-trapezoidal
+    R = R[:len(Q),:]
+
+    # check if solution has low errors
+    # check loss of orthogonality
+    assert np.allclose(Q.inner(Q), np.eye(len(Q)), **TOL), 'Too high Loss of Orthogonality'
+    # check reconstruction error
+    assert np.all(almost_equal(A, Q.lincomb(R), **TOL)), 'Too high Reconstruction error'
+    # check Cholesky error
+    assert np.allclose(A.inner(A), (R.conj().T) @ R, **TOL),\
+        'Too high Cholesky error ($A^H A - R^H R$)'


### PR DESCRIPTION
Currently the QR tests for `gram_schmidt` and `shifted_chol_qr` are basically duplicates. Both of them each have multiple tests for with/without `return_R`, `product`, `copy` and `recompute_shift` (for `shifted_chol_qr`). Furthermore, most `shifted_chol_qr` tests have to be `xfailed` due to unsuitable test inputs.

Added the following QR test helper functions to provide an interfaces for the QR decomposition algorithms to evaluate their results with respect to the parameterization:

`evaluate_qr_empty`:
- checks for correct behaviour for an empty `VectorArray`

`evaluate_qr_full_offset`:
- checks for correct behaviour on `offset=len(A)` for a input `VectorArray` `A`

`evaluate_qr`:
- checks the correct behaviour of the parameters `copy`, `product` and `return_R`
- checks for low numerical errors, hence, it is also suitable for checking other, algorithm specific, parameters

`evaluate_qr_offset`:
- checks for correct behaviour and low numerical errors when using the `offset` parameter
- given a number of blocks (`num_blocks`), performs successive QR-updates with `len(A)/num_blocks` many vectors 

Fixes https://github.com/pymor/pymor/issues/2503.
Fixes https://github.com/pymor/pymor/issues/2392.