### PR TITLE
Various docstring fixes

### DIFF
--- a/docs/source/substitutions.py
+++ b/docs/source/substitutions.py
@@ -155,8 +155,6 @@ common = """
 .. |NumPy| replace:: :mod:`NumPy <numpy>`
 .. |NumPy array| replace:: :class:`NumPy array <numpy.ndarray>`
 .. |NumPy arrays| replace:: :class:`NumPy arrays <numpy.ndarray>`
-.. |Numpy array| replace:: :class:`NumPy array <numpy.ndarray>`
-.. |Numpy arrays| replace:: :class:`NumPy arrays <numpy.ndarray>`
 .. |array| replace:: :class:`NumPy array <numpy.ndarray>`
 .. |Array| replace:: :class:`NumPy array <numpy.ndarray>`
 

--- a/src/pymor/algorithms/adaptivegreedy.py
+++ b/src/pymor/algorithms/adaptivegreedy.py
@@ -26,7 +26,7 @@ def adaptive_weak_greedy(surrogate, parameter_space, target_error=None, max_exte
     of the approximation basis to the training set. This is achieved by
     estimating the approximation error on an additional validation set of
     parameters. If the ratio between the estimated errors on the validation
-    set and the validation set is larger than `rho`, the training set
+    set and the training set is larger than `rho`, the training set
     is refined using standard grid refinement techniques.
 
     Parameters

--- a/src/pymor/algorithms/bfgs.py
+++ b/src/pymor/algorithms/bfgs.py
@@ -78,7 +78,7 @@ def error_aware_bfgs(model, parameter_space=None, initial_guess=None, miniter=0,
     Returns
     -------
     mu
-        |Numpy array| containing the computed |parameter values|.
+        |NumPy array| containing the computed |parameter values|.
     data
         Dict containing the following fields:
 

--- a/src/pymor/algorithms/chol_qr.py
+++ b/src/pymor/algorithms/chol_qr.py
@@ -56,7 +56,7 @@ def shifted_chol_qr(A, product=None, return_R=False, maxiter=3, offset=0, orth_t
         Assume that the first `offset` vectors are already orthonormal and apply the
         algorithm for the vectors starting at `offset + 1`.
     orth_tol
-        If not `None`, check if the resulting |VectorArray| is really orthornormal and
+        If not `None`, check if the resulting |VectorArray| is really orthonormal and
         repeat the algorithm until the check passes or `maxiter` is reached.
     recompute_shift
         If `False`, the shift is computed just once if the Cholesky decomposition fails
@@ -64,7 +64,7 @@ def shifted_chol_qr(A, product=None, return_R=False, maxiter=3, offset=0, orth_t
         for further iterations, which would lead to a non-orthonormal basis.
         If `True`, the shift is recomputed in iterations in which the Cholesky decomposition fails.
         Even for an ill-conditioned `A` (at least for matrix condition numbers up to 10^20)
-        is it able to compute an orthonormal basis at the cost of higher runtimes.
+        it is able to compute an orthonormal basis at the cost of higher runtimes.
     check_finite
         This argument is passed down to |SciPy linalg| functions. Disabling may give a
         performance gain, but may result in problems (crashes, non-termination) if the

--- a/src/pymor/algorithms/ei.py
+++ b/src/pymor/algorithms/ei.py
@@ -278,7 +278,7 @@ def qdeim(U, modes=None, pod=True, atol=None, rtol=None, product=None, pod_optio
     The collateral basis is determined by the first :func:`~pymor.algorithms.pod.pod` modes
     of `U`.
 
-    The intperpolation DOFs are computed using the Q-DEIM algorithm from
+    The interpolation DOFs are computed using the Q-DEIM algorithm from
     :cite:`DG16`. It leads to more stable interpolation matrices compared
     to :meth:`ei_greedy`. However, the algorithm only works with |NumPy| data, so the
     basis |VectorArray| needs to support the
@@ -361,7 +361,7 @@ def interpolate_operators(fom, operator_names, parameter_sample, error_norm=None
         A list of |Parameters| for which solution snapshots are calculated.
     error_norm
         See :func:`ei_greedy`.
-        Has no effect if `alg == 'deim' or `alg == 'qdeim'`.
+        Has no effect if `alg == 'deim'` or `alg == 'qdeim'`.
     product
         Inner product for POD computation in :func:`deim`.
         Has no effect if `alg == 'ei_greedy'`.
@@ -446,7 +446,7 @@ def interpolate_function(function, parameter_sample, evaluation_points,
     """Parameter separable approximation of a |Function| using Empirical Interpolation.
 
     This method computes a parameter separated |LincombFunction| approximating
-    the input |Function| using Empirical Interpolation :cite`BMNP04`.
+    the input |Function| using Empirical Interpolation :cite:`BMNP04`.
     The actual EI Greedy algorithm is contained in :func:`ei_greedy`. This function
     acts as a convenience wrapper, which computes the training data and
     constructs an :class:`~pymor.analyticalproblems.functions.EmpiricalInterpolatedFunction`

--- a/src/pymor/algorithms/error.py
+++ b/src/pymor/algorithms/error.py
@@ -293,7 +293,7 @@ def plot_reduction_error_analysis(result, max_basis_size=None, plot_effectivitie
         If `True`, use a logarithmic y-axis to plot the computed custom
         values.
     plot_custom_with_errors
-        It `True`, plot errors and custom values in a single plot (otherwise in separate ones).
+        If `True`, plot errors and custom values in a single plot (otherwise in separate ones).
     """
     error_norms = 'norms' in result
     error_estimator = 'error_estimates' in result

--- a/src/pymor/algorithms/greedy.py
+++ b/src/pymor/algorithms/greedy.py
@@ -25,7 +25,7 @@ def weak_greedy(surrogate, training_set, atol=None, rtol=None, max_extensions=No
 
     In each iteration of the algorithm, a vector :math:`v_{\mu^*}` from
     :math:`\mathcal{M}` is determined which maximizes the estimated
-    best-approxmiation error w.r.t. the current basis. Then, the basis is
+    best-approximation error w.r.t. the current basis. Then, the basis is
     extended with :math:`v_{\mu^*}`.
 
     The algorithm expects a :class:`surrogate <WeakGreedySurrogate>`, which can
@@ -184,7 +184,7 @@ def rb_greedy(fom, reductor, training_set, use_error_estimator=True, error_norm=
     reductor
         Reductor for reducing the given |Model|. This has to be
         an object with a `reduce` method, such that `reductor.reduce()`
-        yields the reduced model, and an `exted_basis` method,
+        yields the reduced model, and an `extend_basis` method,
         such that `reductor.extend_basis(U, copy_U=False, **extension_params)`
         extends the current reduced basis by the vectors contained in `U`.
         For an example see :class:`~pymor.reductors.coercive.CoerciveRBReductor`.

--- a/src/pymor/algorithms/image.py
+++ b/src/pymor/algorithms/image.py
@@ -22,7 +22,7 @@ def estimate_image(operators=(), vectors=(),
     Let `operators` be a list of |Operators| with common source and range, and let
     `vectors` be a list of |VectorArrays| or vector-like |Operators| in the range
     of these operators. Given a |VectorArray| `domain` of vectors in the source of the
-    operators, this algorithms determines a |VectorArray| `image` of range vectors
+    operators, this algorithm determines a |VectorArray| `image` of range vectors
     such that the linear span of `image` contains:
 
     - `op.apply(U, mu=mu)` for all operators `op` in `operators`, for all possible |Parameters|

--- a/src/pymor/algorithms/ml/vkoga/regressor.py
+++ b/src/pymor/algorithms/ml/vkoga/regressor.py
@@ -248,7 +248,7 @@ class VKOGASurrogate(WeakGreedySurrogate):
         Let :math:`K_n` denote the full kernel matrix for the current set of selected
         centers :math:`X_n`. Since :math:`K_n` is a kernel matrix, it is in particular
         positive-definite, so it has a Cholesky decomposition,
-        i.e. :math:`K_n=L_nL_n^\top`. The inverse of the Choleksy decomposition
+        i.e. :math:`K_n=L_nL_n^\top`. The inverse of the Cholesky decomposition
         :math:`C_n := L_{n}^{-1}` will be used to efficiently compute and update the
         coefficients  of the kernel interpolant. The formula for the computation and update of
         :math:`C_n` can be found below.

--- a/src/pymor/algorithms/rand_la.py
+++ b/src/pymor/algorithms/rand_la.py
@@ -35,7 +35,7 @@ class RandomizedRangeFinder(BasicObject):
     A faster alternative is the leave-one-out error estimator from :cite:`ET24` which can be
     activated by setting `error_estimator='loo'`. The leave-one-out error estimator estimates the
     Frobenius norm of the approximation error. Note that while it can be faster and more accurate in
-    practice, this option does only support Euclidian inner products and there are no results on its
+    practice, this option only supports Euclidean inner products and there are no results on its
     failure probability so far.
 
     Parameters
@@ -51,7 +51,7 @@ class RandomizedRangeFinder(BasicObject):
     A_adj
         Adjoint |Operator| to use for power iterations. If `None` the
         adjoint is computed using `A`, `source_product` and `range_product`.
-        Set to `A` for a `self` for a known self-adjoint operator.
+        Set to `A` for a known self-adjoint operator.
     failure_tolerance
         Maximum failure probability. Only needed for error_estimator='bs18'.
     num_testvecs
@@ -254,8 +254,9 @@ class RandomizedRangeFinder(BasicObject):
 class RandomizedSVD(BasicObject):
     r"""Randomized SVD of an |Operator| based on :cite:`SHB21`.
 
-    Viewing the |Operator| :math:`A` as an :math:`m` by :math:`n` matrix, this methods computes and
-    returns the randomized generalized singular value decomposition of `A` according :cite:`SHB21`:
+    Viewing the |Operator| :math:`A` as an :math:`m` by :math:`n` matrix, this method computes and
+    returns the randomized generalized singular value decomposition of `A` according to
+    :cite:`SHB21`:
 
     .. math::
 
@@ -310,7 +311,7 @@ class RandomizedSVD(BasicObject):
         Parameters
         ----------
         n
-            The number of singular values and signular vectors which are to be computed.
+            The number of singular values and singular vectors which are to be computed.
         rtol
             Relative truncation error tolerance for the low-rank SVD.
             See :func:`~pymor.algorithms.svd_va.method_of_snapshots` for a detailed description.
@@ -380,7 +381,7 @@ def randomized_svd(A, n=None, *, rtol=None, atol=None, l2_err=None, rrf_tol=None
                    low_rank_svd_method=None, rrf_args=None):
     r"""Randomized SVD of an |Operator|.
 
-    This is a just a wrapper for :class:`RandomizedSVD`.
+    This is just a wrapper for :class:`RandomizedSVD`.
     """
     svd_alg = RandomizedSVD(A, range_product=range_product, source_product=source_product,
                             power_iterations=power_iterations, low_rank_svd_method=low_rank_svd_method,
@@ -405,7 +406,7 @@ def randomized_ghep(A, E=None, n=6, power_iterations=0, oversampling=20, single_
 
     if `E` is not `None`.
 
-    This method is an implementation of algorithm 6 and 7 in :cite:`SJK16`.
+    This method is an implementation of algorithms 6 and 7 in :cite:`SJK16`.
 
     Parameters
     ----------
@@ -424,7 +425,7 @@ def randomized_ghep(A, E=None, n=6, power_iterations=0, oversampling=20, single_
     single_pass
         If `True`, computes the GHEP where only one set of matvecs Ax is required, but at the
         expense of lower numerical accuracy.
-        If `False`, the methods performs two sets of matvecs Ax (default).
+        If `False`, the method performs two sets of matvecs Ax (default).
     return_evecs
         If `True`, the eigenvectors are computed and returned. Defaults to `False`.
 

--- a/src/pymor/algorithms/rules.py
+++ b/src/pymor/algorithms/rules.py
@@ -375,7 +375,7 @@ class RuleTable(BasicObject, metaclass=RuleTableMeta):
         attributes `a`, for which one of the following is true:
 
             1. `a` is an |Operator|.
-            2. `a` is a dict` and each of its values is either an |Operator| or `None`.
+            2. `a` is a `dict` and each of its values is either an |Operator| or `None`.
             3. `a` is a `list` or `tuple` and each of its elements is either an |Operator|
                or `None`.
             4. `a` is an 'np.ndarray` of `dtype=object` and each of its elements is either

--- a/src/pymor/algorithms/samdp.py
+++ b/src/pymor/algorithms/samdp.py
@@ -20,7 +20,7 @@ def samdp(A, E, B, C, nwanted, init_shifts=None, which='NR', tol=1e-10, imagtol=
     """Compute the dominant pole triplets and residues of the transfer function of an LTI system.
 
     This function uses the subspace accelerated dominant pole (SAMDP) algorithm as described in
-    :cite:`RM06` in Algorithm 2 in order to compute dominant pole triplets and residues of the
+    Algorithm 2 in :cite:`RM06` in order to compute dominant pole triplets and residues of the
     transfer function
 
     .. math::
@@ -393,7 +393,7 @@ def _twosided_rqi(A, E, x, y, theta, init_res, imagtol, rqitol, maxiter, shifted
     rqitol
         Convergence tolerance for the residual of the pole.
     maxiter
-        Maximum number of iteration.
+        Maximum number of iterations.
     shifted_system_solver
         The |Solver| for the shifted systems.
 
@@ -464,9 +464,9 @@ def _select_max_eig(H, G, X, V, B, C, which):
     Parameters
     ----------
     H
-        The |Numpy array| H from the SAMDP algorithm.
+        The |NumPy array| H from the SAMDP algorithm.
     G
-        The |Numpy array| G from the SAMDP algorithm.
+        The |NumPy array| G from the SAMDP algorithm.
     X
         A |VectorArray| describing the orthogonal search space used in the SAMDP algorithm.
     V

--- a/src/pymor/algorithms/scm.py
+++ b/src/pymor/algorithms/scm.py
@@ -127,7 +127,7 @@ class SuccessiveConstraintsSurrogate(WeakGreedySurrogate):
     Parameters
     ----------
     operator
-        |LincombOperator| for which to provide a bounds on the
+        |LincombOperator| for which to provide bounds on the
         coercivity constant.
     initial_parameter
         |Parameter| used to initialize the surrogate for the greedy algorithm.
@@ -190,7 +190,7 @@ def construct_scm_functionals(operator, training_set, initial_parameter, atol=No
     Parameters
     ----------
     operator
-        |LincombOperator| for which to provide a bounds on the
+        |LincombOperator| for which to provide bounds on the
         coercivity constant.
     training_set
         |Parameters| used as training set for the greedy algorithm.

--- a/src/pymor/algorithms/svd_va.py
+++ b/src/pymor/algorithms/svd_va.py
@@ -181,7 +181,7 @@ def scipy_svd(A, product=None, modes=None, rtol=4e-8, atol=0., l2_err=0.):
     and the inner product on R^(`len(A)`) is the Euclidean inner
     product.
 
-    This functions uses :func:`scipy.linalg.svd` by converting the input
+    This function uses :func:`scipy.linalg.svd` by converting the input
     |VectorArray| `A` to a |NumPy array| by calling
     :meth:`~pymor.vectorarrays.interface.VectorArray.to_numpy`.
 

--- a/src/pymor/algorithms/symplectic.py
+++ b/src/pymor/algorithms/symplectic.py
@@ -473,7 +473,9 @@ def symplectic_gram_schmidt(E, F, return_Lambda=False, atol=1e-13, rtol=1e-13, o
 
 
 def esr(E, F, J=None):
-    """Elementary SR factorization. Transforms E and F such that.
+    """Elementary SR factorization.
+
+    Transforms E and F such that
 
         [E, F] = S * diag(r11, r22)
 

--- a/src/pymor/algorithms/timestepping.py
+++ b/src/pymor/algorithms/timestepping.py
@@ -4,7 +4,7 @@
 
 """Generic time-stepping algorithms for the solution of instationary problems.
 
-The algorithms are generic in the sense that each algorithms operates exclusively
+The algorithms are generic in the sense that each algorithm operates exclusively
 on |Operators| and |VectorArrays|. In particular, the algorithms
 can also be used to turn an arbitrary stationary |Model| provided
 by an external library into an instationary |Model|.

--- a/src/pymor/algorithms/tr.py
+++ b/src/pymor/algorithms/tr.py
@@ -34,7 +34,7 @@ def trust_region(fom, surrogate, parameter_space=None, initial_guess=None, beta=
     The main idea for the algorithm can be found in :cite:`YM13`, and an application to
     box-constrained parameters with possible enlarging of the trust radius in :cite:`KMOSV21`.
 
-    This method contrasts itself from :func:`scipy.optimize.minimize` in the computation of the
+    This method differs from :func:`scipy.optimize.minimize` in the computation of the
     trust region: `scipy` TR implementations use a metric distance, whereas this function uses an
     error estimator obtained from the surrogate. Additionally, the cheap model function
     surrogate here is only updated for each outer iteration, not entirely reconstructed.
@@ -94,7 +94,7 @@ def trust_region(fom, surrogate, parameter_space=None, initial_guess=None, beta=
     Returns
     -------
     mu
-        |Numpy array| containing the computed optimal |parameter values|.
+        |NumPy array| containing the computed optimal |parameter values|.
     data
         Dict containing additional information of the optimization call.
 

--- a/src/pymor/analyticalproblems/functions.py
+++ b/src/pymor/analyticalproblems/functions.py
@@ -517,7 +517,7 @@ class EmpiricalInterpolatedFunction(LincombFunction):
         re-evaluation of the snapshot data at the evaluation points can be
         avoided, when this argument is specified together with `basis_evaluations`.
     basis_evaluations
-        Optional |Numpy array| of evaluations of the interpolation basis at
+        Optional |NumPy array| of evaluations of the interpolation basis at
         `evaluation_points`. Corresponds to the `basis` return value of
         :func:`~pymor.algorithms.ei.ei_greedy`.
     """

--- a/src/pymor/bindings/slycot.py
+++ b/src/pymor/bindings/slycot.py
@@ -152,7 +152,7 @@ class SlycotRiccatiSolver(RiccatiSolver):
 
 
 class SlycotRiccatiSolverLR(RiccatiSolverLR):
-    r"""Compute a low-rank factor of a the solution of a |RiccatiEquation| using slycot.
+    r"""Compute a low-rank factor of the solution of a |RiccatiEquation| using slycot.
 
     Computes the dense solution :math:`X` with :class:`SlycotRiccatiSolver` and
     factorizes it.

--- a/src/pymor/core/base.py
+++ b/src/pymor/core/base.py
@@ -298,7 +298,7 @@ class ImmutableObject(BasicObject, metaclass=ImmutableMeta):
     def with_(self, new_type=None, **kwargs):
         """Returns a copy with changed attributes.
 
-        A a new class instance is created with the given keyword arguments as
+        A new class instance is created with the given keyword arguments as
         arguments for `__init__`.  Missing arguments are obtained form instance
         attributes with the
         same name.

--- a/src/pymor/core/cache.py
+++ b/src/pymor/core/cache.py
@@ -44,7 +44,7 @@ the memory cache region can be configured via the
 `pymor.core.cache.default_regions.persistent_max_size` and
 `pymor.core.cache.default_regions.memory_max_keys` |defaults|.
 
-There two ways to disable and enable caching in pyMOR:
+There are two ways to disable and enable caching in pyMOR:
 
     1. Calling :func:`disable_caching` (:func:`enable_caching`), to disable
        (enable) caching globally.

--- a/src/pymor/core/defaults.py
+++ b/src/pymor/core/defaults.py
@@ -375,7 +375,7 @@ def load_defaults_from_file(filename='./pymor_defaults.py'):
 
     Suitable configuration files can be created via :func:`write_defaults_to_file`.
     The file is loaded via Python's :func:`exec` function, so be very careful
-    with configuration files you have not created your own. You have been
+    with configuration files you have not created yourself. You have been
     warned!
 
     Parameters
@@ -450,9 +450,9 @@ def get_defaults(user=True, file=True, code=True):
 
 
 def defaults_changes():
-    """Returns the number of changes made to to pyMOR's global |defaults|.
+    """Returns the number of changes made to pyMOR's global |defaults|.
 
-    This methods returns the number of changes made to the state of
+    This method returns the number of changes made to the state of
     pyMOR's global |defaults| via :func:`set_defaults` or
     :func:`load_defaults_from_file` since the start of program execution.
 

--- a/src/pymor/discretizers/builtin/cg.py
+++ b/src/pymor/discretizers/builtin/cg.py
@@ -981,7 +981,7 @@ def discretize_stationary_cg(analytical_problem, diameter=None, domain_discretiz
         assuming no advection and a symmetric diffusion tensor, `fom.products['energy']`
         is equal to `fom.operator.assemble(mu)`, except for the fact that the former has
         cleared Dirichlet rows and columns, while the latter only
-        has cleared Dirichlet rows).
+        has cleared Dirichlet rows.
     solver
         The |Solver| to be used.
 

--- a/src/pymor/discretizers/builtin/grids/interfaces.py
+++ b/src/pymor/discretizers/builtin/grids/interfaces.py
@@ -52,7 +52,7 @@ class ReferenceElement(CacheableObject):
         Returns a tuple `(A, B)` which defines the embedding of the codim-`subentity_codim`
         subentities into the reference element.
 
-        For `subentity_codim > 1', the embedding is by default given recursively via
+        For `subentity_codim > 1`, the embedding is by default given recursively via
         `subentity_embedding(subentity_codim - 1)` and
         `sub_reference_element(subentity_codim - 1).subentity_embedding(1)` choosing always
         the superentity with smallest index.

--- a/src/pymor/discretizers/builtin/grids/oned.py
+++ b/src/pymor/discretizers/builtin/grids/oned.py
@@ -79,7 +79,7 @@ class OnedGrid(GridWithOrthogonalCenters):
         U
             |NumPy array| of the data to visualize. If `U.dim == 2 and U.shape[1] > 1`, the
             data is visualized as a time series of plots. Alternatively, a tuple of
-            |Numpy arrays| can be provided, in which case a subplot is created for
+            |NumPy arrays| can be provided, in which case a subplot is created for
             each entry of the tuple. The number of time points per array must match.
         codim
             The codimension of the entities the data in `U` is attached to (either 0 or 1).

--- a/src/pymor/discretizers/builtin/grids/rect.py
+++ b/src/pymor/discretizers/builtin/grids/rect.py
@@ -211,7 +211,7 @@ class RectGrid(GridWithOrthogonalCenters):
         U
             |NumPy array| of the data to visualize. If `U.dim == 2 and U.shape[1] > 1`, the
             data is visualized as a time series of plots. Alternatively, a tuple of
-            |Numpy arrays| can be provided, in which case a subplot is created for
+            |NumPy arrays| can be provided, in which case a subplot is created for
             each entry of the tuple. The number of time points per array must match.
         codim
             The codimension of the entities the data in `U` is attached to (either 0 or 2).

--- a/src/pymor/discretizers/builtin/grids/tria.py
+++ b/src/pymor/discretizers/builtin/grids/tria.py
@@ -222,7 +222,7 @@ class TriaGrid(GridWithOrthogonalCenters):
         U
             |NumPy array| of the data to visualize. If `U.dim == 2 and U.shape[1] > 1`, the
             data is visualized as a time series of plots. Alternatively, a tuple of
-            |Numpy arrays| can be provided, in which case a subplot is created for
+            |NumPy arrays| can be provided, in which case a subplot is created for
             each entry of the tuple. The number of time points per array must match.
         codim
             The codimension of the entities the data in `U` is attached to (either 0 or 2).

--- a/src/pymor/discretizers/builtin/grids/unstructured.py
+++ b/src/pymor/discretizers/builtin/grids/unstructured.py
@@ -87,7 +87,7 @@ class UnstructuredTriangleGrid(Grid):
         U
             |NumPy array| of the data to visualize. If `U.dim == 2 and len(U) > 1`, the
             data is visualized as a time series of plots. Alternatively, a tuple of
-            |Numpy arrays| can be provided, in which case a subplot is created for
+            |NumPy arrays| can be provided, in which case a subplot is created for
             each entry of the tuple. The lengths of all arrays have to agree.
         codim
             The codimension of the entities the data in `U` is attached to (either 0 or 2).

--- a/src/pymor/discretizers/builtin/gui/jupyter/kthreed.py
+++ b/src/pymor/discretizers/builtin/gui/jupyter/kthreed.py
@@ -185,7 +185,7 @@ def visualize_k3d(grid, U, bounding_box=None, codim=2, title=None, legend=None,
     grid
         The underlying |Grid|.
     U
-        |VectorArray| of the data to visualize. If `len(U) 1`, the data is visualized
+        |VectorArray| of the data to visualize. If `len(U) > 1`, the data is visualized
         as a time series of plots. Alternatively, a tuple of |VectorArrays| can be
         provided, in which case a subplot is created for each entry of the tuple. The
         lengths of all arrays have to agree.

--- a/src/pymor/discretizers/builtin/gui/qt/gl.py
+++ b/src/pymor/discretizers/builtin/gui/qt/gl.py
@@ -45,7 +45,7 @@ def compile_shader(source, vertex=True):
 
 
 def link_shader_program(shaders):
-    """Create a shader program with from compiled shaders."""
+    """Create a shader program from compiled shaders."""
     program = gl.glCreateProgram()
     for shader in shaders:
         gl.glAttachShader(program, shader)

--- a/src/pymor/discretizers/builtin/inverse.py
+++ b/src/pymor/discretizers/builtin/inverse.py
@@ -29,7 +29,7 @@ def inv_two_by_two(A):
 
 
 def inv_transposed_two_by_two(A):
-    """Efficiently compute the transposed inverses of a |Numpy array| of 2x2-matrices.
+    """Efficiently compute the transposed inverses of a |NumPy array| of 2x2-matrices.
 
     This implements ::
 

--- a/src/pymor/models/data_driven.py
+++ b/src/pymor/models/data_driven.py
@@ -35,7 +35,7 @@ class DataDrivenModel(Model):
     output_scaler
         If not `None`, a scaler object with `fit`, `transform` and
         `inverse_transform` methods similar to the scikit-learn interface can be
-        used to scale the outputs (reduced coeffcients or output quantities)
+        used to scale the outputs (reduced coefficients or output quantities)
         before passing them to the regressor.
     output_functional
         |Operator| mapping a given solution to the model output. In many applications,
@@ -104,7 +104,7 @@ class DataDrivenModel(Model):
 class DataDrivenInstationaryModel(DataDrivenModel):
     """Class for models of instationary problems that use regressors for prediction.
 
-    This class implements a |Model| that uses an regressor for solution
+    This class implements a |Model| that uses a regressor for solution
     or output approximation.
 
     Parameters
@@ -131,7 +131,7 @@ class DataDrivenInstationaryModel(DataDrivenModel):
     output_scaler
         If not `None`, a scaler object with `fit`, `transform` and
         `inverse_transform` methods similar to the scikit-learn interface can be
-        used to scale the outputs (reduced coeffcients or output quantities)
+        used to scale the outputs (reduced coefficients or output quantities)
         before passing them to the regressor.
     time_vectorized
         In the instationary case, determines whether to predict the whole time

--- a/src/pymor/models/examples.py
+++ b/src/pymor/models/examples.py
@@ -86,7 +86,7 @@ def msd_example(n=6, m=2, m_i=4, k_i=4, c_i=1, as_lti=False):
     n
         The order of the model.
     m
-        The number or inputs and outputs of the model.
+        The number of inputs and outputs of the model.
     m_i
         The weight of the masses.
     k_i

--- a/src/pymor/models/interface.py
+++ b/src/pymor/models/interface.py
@@ -60,7 +60,7 @@ class Model(CacheableObject, ParametricObject):
 
     @cached_property
     def computable_quantities(self):
-        """Set of quantities that can be compute via :meth:`compute`."""
+        """Set of quantities that can be computed via :meth:`compute`."""
         return (
             {'solution', 'output', 'output_d_mu', 'solution_error_estimate', 'output_error_estimate'}
             | {('solution_d_mu', param, idx) for param, dim in self.parameters.items() for idx in range(dim)}
@@ -229,7 +229,7 @@ class Model(CacheableObject, ParametricObject):
     def solve(self, mu=None, input=None, return_error_estimate=False):
         """Solve the discrete problem for the |parameter values| `mu`.
 
-        This method returns a |VectorArray| with a internal state
+        This method returns a |VectorArray| with an internal state
         representation of the model's solution for given
         |parameter values|. It is a convenience wrapper around
         :meth:`compute`.
@@ -350,9 +350,9 @@ class Model(CacheableObject, ParametricObject):
         Returns
         -------
         The output sensitivities as a dict `{(parameter, index): sensitivity}` where
-        `sensitivity` is a 2D |NumPy arrays| with axis 0 corresponding to time and axis 1
+        `sensitivity` is a 2D |NumPy array| with axis 0 corresponding to time and axis 1
         corresponding to the output component.
-        The returned :class:`OutputDMuResult` object has a `meth`:~OutputDMuResult.to_numpy`
+        The returned :class:`OutputDMuResult` object has a :meth:`~OutputDMuResult.to_numpy`
         method to convert it into a single NumPy array, e.g., for use in optimization
         libraries.
         """
@@ -461,7 +461,7 @@ class Model(CacheableObject, ParametricObject):
         computing its output or other :attr:`computable_quantities`.
 
         `_compute` is passed a :class:`set` of quantities to compute.
-        If `_compute` knows how to compute a given quantities, the computed value
+        If `_compute` knows how to compute a given quantity, the computed value
         has to be added to the provided `data` dict. After that, the quantity
         should be removed from `quantities` so that a ::
 
@@ -475,7 +475,7 @@ class Model(CacheableObject, ParametricObject):
         obtain the output. `solution_error_estimate` and `output_error_estimate` defer
         the error estimation to the model's :attr:`error_estimator`.
 
-        In case a requested quantity depends on another quantities, implementations should
+        In case a requested quantity depends on other quantities, implementations should
         call ::
 
             self._compute_required_quantities({'quantity_a', 'quantity_b'}, data, mu)

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -937,12 +937,12 @@ class LTIModel(Model):
         """Compute system poles.
 
         .. note::
-            Assumes the systems is small enough to use a dense eigenvalue solver.
+            Assumes the system is small enough to use a dense eigenvalue solver.
 
         Parameters
         ----------
         mu
-            |Parameter values| for which to compute the systems poles.
+            |Parameter values| for which to compute the system's poles.
 
         Returns
         -------
@@ -1210,7 +1210,7 @@ class LTIModel(Model):
         r"""Compute the :math:`\mathcal{H}_\infty`-norm of the |LTIModel|.
 
         .. note::
-            Assumes the system is asymptotically stable. Under this is assumption the
+            Assumes the system is asymptotically stable. Under this assumption, the
             :math:`\mathcal{H}_\infty`-norm is equal to the :math:`\mathcal{L}_\infty`-norm.
             Accordingly, this method calls :meth:`~pymor.models.iosys.LTIModel.linf_norm`.
 
@@ -2484,7 +2484,7 @@ class SecondOrderModel(Model):
         """Compute system poles.
 
         .. note::
-            Assumes the systems is small enough to use a dense eigenvalue solver.
+            Assumes the system is small enough to use a dense eigenvalue solver.
 
         Parameters
         ----------
@@ -2653,7 +2653,7 @@ class SecondOrderModel(Model):
         mu
             |Parameter values|.
         return_fpeak
-            Should the frequency at which the maximum is achieved should be returned.
+            Should the frequency at which the maximum is achieved be returned.
         ab13dd_equilibrate
             Should `slycot.ab13dd` use equilibration.
         tol
@@ -3017,7 +3017,7 @@ class LinearStochasticModel(Model):
         y(k)
         & =
             C x(k)
-            + D u(t),
+            + D u(k),
 
     if discrete-time, where :math:`E`, :math:`A`, :math:`A_i`, :math:`B`, :math:`C`, and :math:`D`
     are linear operators and :math:`\omega_i` are stochastic processes.
@@ -3158,7 +3158,7 @@ class BilinearModel(Model):
         y(k)
         & =
             C x(k)
-            + D u(t),
+            + D u(k),
 
     if discrete-time, where :math:`E`, :math:`A`, :math:`N_i`, :math:`B`, :math:`C`, and :math:`D`
     are linear operators and :math:`m` is the number of inputs.

--- a/src/pymor/models/mpi.py
+++ b/src/pymor/models/mpi.py
@@ -81,7 +81,7 @@ def _MPIVisualizer_visualize(m, U, ind, **kwargs):
 def mpi_wrap_model(local_models, mpi_spaces=None, use_with=True, with_apply2=False,
                    pickle_local_spaces=True, space_type=MPIVectorSpace,
                    base_type=None):
-    """Wrap MPI distributed local |Models| to a global |Model| on rank 0.
+    """Wrap MPI distributed local |Models| as a global |Model| on rank 0.
 
     Given MPI distributed local |Models| referred to by the
     :class:`~pymor.tools.mpi.ObjectId` `local_models`, return a new |Model|

--- a/src/pymor/models/symplectic.py
+++ b/src/pymor/models/symplectic.py
@@ -123,7 +123,7 @@ class QuadraticHamiltonianModel(BaseQuadraticHamiltonianModel):
     nt
         If time_stepper is `None` and nt is specified, the
         :class:`implicit midpoint rule <pymor.algorithms.timestepping.ImplicitMidpointTimeStepper>`
-        as time_stepper.
+        is used as time_stepper.
     num_values
         The number of returned vectors of the solution trajectory. If `None`, each
         intermediate vector that is calculated is returned.

--- a/src/pymor/models/transforms.py
+++ b/src/pymor/models/transforms.py
@@ -16,7 +16,7 @@ class MoebiusTransformation(ImmutableObject):
     A Moebius transformation
 
     .. math::
-        M(s) = \frac{as+b}{cs+b}
+        M(s) = \frac{as+b}{cs+d}
 
     is determined by the coefficients :math:`a,b,c,d\in\mathbb{C}`. The Moebius transformations form
     a group under composition, therefore the `__matmul__` operator is defined to yield a
@@ -59,8 +59,8 @@ class MoebiusTransformation(ImmutableObject):
         z
             A tuple, list or |NumPy array| of three complex numbers that are transformed.
         w
-            A tuple, list or |NumPy array| of three complex numbers represent the images of `z`.
-            Defaults to `(0, 1, np.inf)`.
+            A tuple, list or |NumPy array| of three complex numbers that represent the images of
+            `z`. Defaults to `(0, 1, np.inf)`.
         name
             Name of the transformation.
 

--- a/src/pymor/operators/constructions.py
+++ b/src/pymor/operators/constructions.py
@@ -1104,7 +1104,7 @@ class AdjointOperator(Operator):
 
     Thus, if `( , )_s` and `( , )_r` are the Euclidean inner products,
     `op^*v` is simply given by application of the
-    :attr:adjoint <pymor.operators.interface.Operator.H>`
+    :attr:`adjoint <pymor.operators.interface.Operator.H>`
     |Operator|.
 
     Parameters
@@ -1122,7 +1122,7 @@ class AdjointOperator(Operator):
         and :meth:`~pymor.operators.interface.Operator.apply_inverse_adjoint`
         implementations by calling these methods on the given `operator`.
         (Is set to `False` in the default implementation of
-        and :meth:`~pymor.operators.interface.Operator.apply_inverse_adjoint`.)
+        :meth:`~pymor.operators.interface.Operator.apply_inverse_adjoint`.)
     solver
         The |Solver| for the operator.
     name

--- a/src/pymor/operators/interface.py
+++ b/src/pymor/operators/interface.py
@@ -47,7 +47,7 @@ class Operator(ParametricObject):
     def H(self):
         """Adjoint |Operator|.
 
-        It hold that ::
+        It holds that ::
 
             self.H.apply(V, mu) == self.apply_adjoint(V, mu)
 

--- a/src/pymor/operators/mpi.py
+++ b/src/pymor/operators/mpi.py
@@ -225,7 +225,7 @@ def _MPIOperator_assemble(self, mu):
 
 def mpi_wrap_operator(obj_id, mpi_range, mpi_source, with_apply2=False, pickle_local_spaces=True,
                       space_type=MPIVectorSpace):
-    """Wrap MPI distributed local |Operators| to a global |Operator| on rank 0.
+    """Wrap MPI distributed local |Operators| as a global |Operator| on rank 0.
 
     Given MPI distributed local |Operators| referred to by the
     :class:`~pymor.tools.mpi.ObjectId` `obj_id`, return a new |Operator|

--- a/src/pymor/operators/numpy.py
+++ b/src/pymor/operators/numpy.py
@@ -311,7 +311,7 @@ class NumpyCirculantOperator(Operator, CacheableObject):
                 c_n    & \cdots & \cdots  & c_3    & c_2    & c_1
             \end{bmatrix} \in \mathbb{C}^{n*p \times n*m},
 
-    where the so-called circulant vector :math:`c \in \mathbb{C}^{\times n\times p\times m}` denotes
+    where the so-called circulant vector :math:`c \in \mathbb{C}^{n\times p\times m}` denotes
     the first (matrix-valued) column of the matrix. The matrix :math:`C` as seen above is not
     explicitly constructed, only `c` is stored. Efficient matrix-vector multiplications are realized
     with DFT in the class' `apply` method. See :cite:`GVL13` Chapter 4.8.2. for details.

--- a/src/pymor/parallel/interface.py
+++ b/src/pymor/parallel/interface.py
@@ -128,7 +128,7 @@ class WorkerPool(BasicObject):
     def apply_only(self, function, worker, *args, **kwargs):
         """Apply function on a single worker.
 
-        This calls `function` on on the worker with number `worker`, passing
+        This calls `function` on the worker with number `worker`, passing
         `args` as positional and `kwargs` as keyword arguments. Keyword arguments
         which are |RemoteObjects| are automatically mapped to the
         respective object on the worker. Moreover, keyword arguments which

--- a/src/pymor/parameters/base.py
+++ b/src/pymor/parameters/base.py
@@ -243,7 +243,7 @@ class Parameters(SortedFrozenDict):
     def assert_compatible(self, mu, allow_time_dependent=False):
         """Assert that |parameter values| are compatible with the given |Parameters|.
 
-        Each of the parameter must be contained in  `mu` and the dimensions have to match,
+        Each of the parameters must be contained in  `mu` and the dimensions have to match,
         i.e. ::
 
             mu[parameter].size == self[parameter]
@@ -267,7 +267,7 @@ class Parameters(SortedFrozenDict):
     def is_compatible(self, mu, allow_time_dependent=False):
         """Check if |parameter values| are compatible with the given |Parameters|.
 
-        Each of the parameter must be contained in  `mu` and the dimensions have to match,
+        Each of the parameters must be contained in  `mu` and the dimensions have to match,
         i.e. ::
 
             mu[parameter].size == self[parameter]

--- a/src/pymor/parameters/functionals.py
+++ b/src/pymor/parameters/functionals.py
@@ -25,7 +25,7 @@ class ParameterFunctional(ParametricObject):
         pass
 
     def d_mu(self, parameter, index=0):
-        """Return the functionals's derivative with respect to a given parameter.
+        """Return the functional's derivative with respect to a given parameter.
 
         Parameters
         ----------
@@ -445,7 +445,7 @@ class MinThetaParameterFunctional(ParameterFunctional):
     for Q positive coefficient |ParameterFunctional| theta_1, ..., theta_Q and positive
     semi-definite component bilinear forms a_1, ..., a_Q: V x V -> K. Let mu_bar be a
     parameter with respect to which the coercivity constant
-    of a(., ., mu_bar) is known, i.e. we known alpha_mu_bar > 0, s.t. ::
+    of a(., ., mu_bar) is known, i.e. we know alpha_mu_bar > 0, s.t. ::
 
       alpha_mu_bar |u|_V^2 <= a(u, u, mu=mu_bar).
 
@@ -510,7 +510,7 @@ class BaseMaxThetaParameterFunctional(ParameterFunctional):
     for Q coefficient |ParameterFunctional| theta_1, ..., theta_Q and continuous bilinear forms
     a_1, ..., a_Q: V x V -> K or continuous linear functionals l_q: V -> K. Let mu_bar be a
     parameter with respect to which the continuity constant of a(., ., mu_bar) or l(., mu_bar)
-    is known, i.e. we known gamma_mu_bar > 0, s.t. ::
+    is known, i.e. we know gamma_mu_bar > 0, s.t. ::
 
       a(u, v, mu_bar) <= gamma_mu_bar |u|_V |v|_V
 

--- a/src/pymor/reductors/basic.py
+++ b/src/pymor/reductors/basic.py
@@ -271,7 +271,7 @@ class InstationaryRBReductor(ProjectionBasedReductor):
         The basis of the reduced space onto which to project. If `None` an empty basis is used.
     product
         Inner product |Operator| w.r.t. which `RB` is orthonormalized. If `None`, the
-        the Euclidean inner product is used.
+        Euclidean inner product is used.
     initial_data_product
         Inner product |Operator| w.r.t. which the `initial_data` of `fom` is orthogonally projected.
         If `None`, the Euclidean inner product is used.

--- a/src/pymor/reductors/data_driven.py
+++ b/src/pymor/reductors/data_driven.py
@@ -69,7 +69,7 @@ class DataDrivenReductor(BasicObject):
     output_scaler
         If not `None`, a scaler object with `fit`, `transform` and
         `inverse_transform` methods similar to the scikit-learn interface can be
-        used to scale the outputs (reduced coeffcients or output quantities)
+        used to scale the outputs (reduced coefficients or output quantities)
         before passing them to the regressor.
     input_scaler_fitted
         If `True`, the `input_scaler` is assumed to be already fitted and will

--- a/src/pymor/reductors/era.py
+++ b/src/pymor/reductors/era.py
@@ -18,7 +18,7 @@ from pymor.operators.numpy import NumpyHankelOperator, NumpyMatrixOperator
 class ERAReductorBase(CacheableObject):
     r"""Basic Eigensystem Realization Algorithm reductor.
 
-    This class implements ROM construction from a orthogonal factorization of the Hankel matrix, as
+    This class implements ROM construction from an orthogonal factorization of the Hankel matrix, as
     well as tangential projections of inputs and outputs. The actual factorization and error
     bounds/estimators are implemented by the subclasses.
 
@@ -42,7 +42,7 @@ class ERAReductorBase(CacheableObject):
         Whether the Markov parameters are zero-padded to double the length in order to enforce
         Kung's stability assumption. See :cite:`K78`. Defaults to `True`.
     feedthrough
-        (Optional) |Operator| or |Numpy array| of shape `(p, m)`. The zeroth Markov parameter that
+        (Optional) |Operator| or |NumPy array| of shape `(p, m)`. The zeroth Markov parameter that
         defines the feedthrough of the realization. Defaults to `None`.
     """
 
@@ -148,7 +148,7 @@ class ERAReductor(ERAReductorBase):
         \hat{h}_i = W_L^T h_i W_R,
 
     where :math:`n_L \leq p` and :math:`n_R \leq m` are the number of left and right tangential
-    directions and :math:`W_L \in \mathbb{R}^{p \times n_L}` an
+    directions and :math:`W_L \in \mathbb{R}^{p \times n_L}` and
     :math:`W_R \in \mathbb{R}^{m \times n_R}` are the left and right projectors, respectively.
     See :cite:`KG16`.
 
@@ -172,7 +172,7 @@ class ERAReductor(ERAReductorBase):
         Whether the Markov parameters are zero-padded to double the length in order to enforce
         Kung's stability assumption. See :cite:`K78`. Defaults to `True`.
     feedthrough
-        (Optional) |Operator| or |Numpy array| of shape `(p, m)`. The zeroth Markov parameter that
+        (Optional) |Operator| or |NumPy array| of shape `(p, m)`. The zeroth Markov parameter that
         defines the feedthrough of the realization. Defaults to `None`.
     """
 
@@ -333,7 +333,7 @@ class RandomizedERAReductor(ERAReductorBase):
         Whether the Markov parameters are zero-padded to double the length in order to enforce
         Kung's stability assumption. See :cite:`K78`. Defaults to `True`.
     feedthrough
-        (Optional) |Operator| or |Numpy array| of shape `(p, m)`. The zeroth Markov parameter that
+        (Optional) |Operator| or |NumPy array| of shape `(p, m)`. The zeroth Markov parameter that
         defines the feedthrough of the realization. Defaults to `None`.
     allow_transpose
         Whether to allow the computation of the transposed problem, i.e., the randomized SVD of

--- a/src/pymor/reductors/h2.py
+++ b/src/pymor/reductors/h2.py
@@ -233,7 +233,7 @@ class IRKAReductor(GenericIRKAReductor):
             iteration to. Larger number can avoid occasional cyclic
             behavior of IRKA.
         force_sigma_in_rhp
-            If `False`, new interpolation are reflections of the current
+            If `False`, new interpolation points are reflections of the current
             reduced-order model's poles. Otherwise, only poles in the
             left half-plane are reflected.
         projection
@@ -347,7 +347,7 @@ class OneSidedIRKAReductor(GenericIRKAReductor):
             iteration to. A larger number can avoid occasional cyclic
             behavior.
         force_sigma_in_rhp
-            If `False`, new interpolation are reflections of the current
+            If `False`, new interpolation points are reflections of the current
             reduced-order model's poles. Otherwise, only poles in the
             left half-plane are reflected.
         projection
@@ -602,7 +602,7 @@ class TFIRKAReductor(GenericIRKAReductor):
             iteration to. Larger number can avoid occasional cyclic
             behavior of TF-IRKA.
         force_sigma_in_rhp
-            If `False`, new interpolation are reflections of the current
+            If `False`, new interpolation points are reflections of the current
             reduced-order model's poles. Otherwise, only poles in the
             left half-plane are reflected.
         conv_crit

--- a/src/pymor/reductors/loewner.py
+++ b/src/pymor/reductors/loewner.py
@@ -19,10 +19,10 @@ class LoewnerReductor(CacheableObject):
     Parameters
     ----------
     s
-        |Numpy Array| of shape (n,) containing the frequencies.
+        |NumPy array| of shape (n,) containing the frequencies.
     Hs
-        |Numpy Array| of shape (n, p, m) for MIMO systems with p outputs and m inputs or
-        |Numpy Array| of shape (n,) for SISO systems where the |Numpy Arrays| resemble the transfer
+        |NumPy array| of shape (n, p, m) for MIMO systems with p outputs and m inputs or
+        |NumPy array| of shape (n,) for SISO systems where the |NumPy arrays| represent the transfer
         function samples. Alternatively, |TransferFunction| or `Model` with `transfer_function`
         attribute.
     partitioning

--- a/src/pymor/reductors/sor_irka.py
+++ b/src/pymor/reductors/sor_irka.py
@@ -57,7 +57,7 @@ class SORIRKAReductor(GenericIRKAReductor):
             iteration to. Larger number can avoid occasional cyclic
             behavior of IRKA.
         force_sigma_in_rhp
-            If `False`, new interpolation are reflections of the current
+            If `False`, new interpolation points are reflections of the current
             reduced order model's poles. Otherwise, only the poles in
             the left half-plane are reflected.
         projection

--- a/src/pymor/reductors/stokes.py
+++ b/src/pymor/reductors/stokes.py
@@ -25,7 +25,7 @@ class SupremizerGalerkinStokesReductor(ProjectionBasedReductor):
         The basis of the reduced velocity space onto which to project.
         If `None`, an empty basis is used.
     RB_p
-        The basis of the redcued pressure space onto which to project.
+        The basis of the reduced pressure space onto which to project.
         If `None`, an empty basis is used.
     u_product
         Inner product |Operator| w.r.t. which `RB_u` is orthonormalized.

--- a/src/pymor/solvers/least_squares.py
+++ b/src/pymor/solvers/least_squares.py
@@ -11,7 +11,7 @@ from pymor.solvers.interface import Solver
 class QRLeastSquaresSolver(Solver):
     """Least-squares solver using QR decomposition.
 
-    Convertes `operator` to a |VectorArray| via
+    Converts `operator` to a |VectorArray| via
     :meth:`~pymor.operators.interface.Operator.as_range_array` or
     :meth:`~pymor.operators.interface.Operator.as_source_array`.
     Then uses :func:`~pymor.algorithms.gram_schmidt.gram_schmidt`

--- a/src/pymor/solvers/matrix_equations/equations.py
+++ b/src/pymor/solvers/matrix_equations/equations.py
@@ -446,7 +446,7 @@ class SylvesterEquation(ImmutableObject):
         Returns
         -------
         A
-            The The |NumPy array| or |SciPy spmatrix| A or `None`.
+            The |NumPy array| or |SciPy spmatrix| A or `None`.
         Ar
             The |NumPy array| or |SciPy spmatrix| Ar or `None`.
         E
@@ -496,7 +496,7 @@ class SylvesterEquation(ImmutableObject):
         Br
             The |NumPy array| or |SciPy spmatrix| Br or `None`.
         C
-            The |NumPy array| or |SciPy spmatrix| C `None`.
+            The |NumPy array| or |SciPy spmatrix| C or `None`.
         Cr
             The |NumPy array| or |SciPy spmatrix| Cr or `None`.
         name

--- a/src/pymor/tools/floatcmp.py
+++ b/src/pymor/tools/floatcmp.py
@@ -16,7 +16,7 @@ def float_cmp(x, y, rtol=1e-14, atol=1e-14):
        float_cmp(x,y) <=> |x - y| <= atol + |y|*rtol
 
     .. note::
-       Numpy's :func:`~numpy.allclose` method uses the same definition but
+       NumPy's :func:`~numpy.allclose` method uses the same definition but
        treats arrays containing infinities as close if the infinities are
        at the same places and all other entries are close.
        In our definition, arrays containing infinities can never be close

--- a/src/pymor/tools/progress.py
+++ b/src/pymor/tools/progress.py
@@ -46,7 +46,7 @@ class ProgressDisplay(ABC):
         label
             If not `None`, the label for the corresponding progress bar.
         total
-            If not `None`, the the length of the iterable.
+            If not `None`, the length of the iterable.
         """
         if total is None:
             try:
@@ -233,6 +233,6 @@ def track(iterable, label=None, total=None):
     label
         If not `None`, the label for the corresponding progress bar.
     total
-        If not `None`, the the length of the iterable.
+        If not `None`, the length of the iterable.
     """
     return get_progress_display().track(iterable, label=label, total=total)

--- a/src/pymor/tools/random.py
+++ b/src/pymor/tools/random.py
@@ -84,7 +84,7 @@ class RNG(np.random.Generator):
     Parameters
     ----------
     seed_seq
-        A :class:`~numpy.random.SeedSequence` to initialized the RNG with.
+        A :class:`~numpy.random.SeedSequence` to initialize the RNG with.
     """
 
     def __init__(self, seed_seq):

--- a/src/pymor/tools/weakrefcache.py
+++ b/src/pymor/tools/weakrefcache.py
@@ -10,7 +10,7 @@ class WeakRefCache:
 
     This class allows storing additional data associated with any weakref-able
     object. The data is removed when the corresponding object dies.
-    Compared to WeakKeyDictionary, object do not need to implement hashablel
+    Compared to WeakKeyDictionary, objects do not need to implement hashable
     or comparable.
 
     See https://github.com/python/cpython/issues/88306 for further context.

--- a/src/pymor/vectorarrays/interface.py
+++ b/src/pymor/vectorarrays/interface.py
@@ -32,7 +32,7 @@ class VectorArray(BasicObject):
     of memory' implementations, :meth:`~VectorSpace.zeros` provides a `reserve`
     keyword argument which allows to specify to what size the array is assumed to grow.
 
-    As with |Numpy array|, |VectorArrays| can be indexed with numbers, slices and
+    As with |NumPy array|, |VectorArrays| can be indexed with numbers, slices and
     lists or one-dimensional |NumPy arrays|. Indexing will always return a new
     |VectorArray| which acts as a view into the original data. Thus, if the indexed
     array is modified via :meth:`~VectorArray.scal` or :meth:`~VectorArray.axpy`,
@@ -259,7 +259,7 @@ class VectorArray(BasicObject):
         self._len = len(self.impl)
 
     def to_numpy(self, ensure_copy=False):
-        """Return (self.dim, len(self)) NumPy Array with the data stored in the array.
+        """Return (self.dim, len(self)) NumPy array with the data stored in the array.
 
         Parameters
         ----------
@@ -412,7 +412,7 @@ class VectorArray(BasicObject):
         Complex conjugation is done in the first argument because
         most numerical software in the community handles it this way:
         Numpy, DUNE, FEniCS, Eigen, Matlab and BLAS do complex conjugation
-        in the first argument, only PetSc and deal.ii do complex
+        in the first argument, only PETSc and deal.II do complex
         conjugation in the second argument.
 
         Parameters
@@ -466,7 +466,7 @@ class VectorArray(BasicObject):
         Complex conjugation is done in the first argument because
         most numerical software in the community handles it this way:
         Numpy, DUNE, FEniCS, Eigen, Matlab and BLAS do complex conjugation
-        in the first argument, only PetSc and deal.ii do complex
+        in the first argument, only PETSc and deal.II do complex
         conjugation in the second argument.
 
 
@@ -806,9 +806,9 @@ class VectorSpace(ImmutableObject):
     :meth:`~VectorSpace.zeros`.  The
     :meth:`~VectorSpace.make_array` method builds a new
     |VectorArray| from given raw data of the underlying linear algebra
-    backend (e.g. a |Numpy array| in the case  of |NumpyVectorSpace|).
+    backend (e.g. a |NumPy array| in the case  of |NumpyVectorSpace|).
     Some vector spaces can create new |VectorArrays| from a given
-    |Numpy array| via the :meth:`~VectorSpace.from_numpy`
+    |NumPy array| via the :meth:`~VectorSpace.from_numpy`
     method.
 
     Vector spaces can be compared for equality via the `==` and `!=`

--- a/src/pymordemos/coercivity_estimation_scm.py
+++ b/src/pymordemos/coercivity_estimation_scm.py
@@ -34,7 +34,7 @@ def main(
     Parameters
     ----------
     num_training_parameters
-        Number of test parameters.
+        Number of training parameters.
     num_test_parameters
         Number of test parameters.
     max_extensions

--- a/src/pymordemos/data_driven.py
+++ b/src/pymordemos/data_driven.py
@@ -47,7 +47,7 @@ def main(
     input_scaling
         Scale the input of the regressor (i.e. the parameter).
     output_scaling
-        Scale the output of the regressor (i.e. reduced coefficients or output quantity.
+        Scale the output of the regressor (i.e. reduced coefficients or output quantity).
     """
     if regressor == 'fcnn' and not config.HAVE_TORCH:
         raise TorchMissingError

--- a/src/pymordemos/fenics_nonlinear.py
+++ b/src/pymordemos/fenics_nonlinear.py
@@ -29,7 +29,7 @@ def main(
     order
         Finite element order.
     visualize
-        Visualize solution and reduczed solution.
+        Visualize solution and reduced solution.
     """
     if not config.HAVE_FENICS and not config.HAVE_FENICSX:
         from pymor.core.exceptions import DependencyMissingError

--- a/src/pymordemos/thermalblock_simple.py
+++ b/src/pymordemos/thermalblock_simple.py
@@ -52,7 +52,7 @@ def main(
     test
         Number of parameters for stochastic error estimation.
     visualize
-        Visualize solution and reduczed solution
+        Visualize solution and reduced solution
     """
     # discretize
     ############

--- a/src/pymortests/strategies.py
+++ b/src/pymortests/strategies.py
@@ -197,7 +197,7 @@ def given_vector_arrays(which='all', count=1, dtype=None, length=None, compatibl
 
     The decorated function will be first wrapped in a |hypothesis.given| (with expanded
     `given_args`) and then in |pytest.mark.parametrize| with selected implementation names.
-    The decorated test function must still draw (which a vector_arrays or similar strategy)
+    The decorated test function must still draw (with a vector_arrays or similar strategy)
     from the `data` argument in the default case.
 
     Parameters
@@ -451,7 +451,7 @@ def invalid_indices(draw, array_strategy):
 
 @hyst.composite
 def base_vector_arrays(draw, count=1, dtype=None, max_dim=100):
-    """Strategy to generate linear independent |VectorArray| inputs for test functions.
+    """Strategy to generate linearly independent |VectorArray| inputs for test functions.
 
     Parameters
     ----------


### PR DESCRIPTION
- Various typos fixed in docstrings.
- Removed the `|Numpy array|` and `|Numpy array|` substitutions in favor of `|NumPy array|` and `|NumPy arrays|`.