### PR TITLE
Missing E in from_passive_LTIModel

### DIFF
--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -1775,8 +1775,6 @@ class PHLTIModel(LTIModel):
         ----------
         model
             The passive |LTIModel| to convert.
-        generalized
-            If `True`, the resulting |PHLTIModel| will have :math:`Q=I`.
         """
         # Determine solution of KYP inequality
         X = model.gramian('pr_o_dense')

--- a/src/pymor/models/iosys.py
+++ b/src/pymor/models/iosys.py
@@ -1782,17 +1782,18 @@ class PHLTIModel(LTIModel):
         X = model.gramian('pr_o_dense')
         A, B, C, D, E = model.to_matrices()
 
-        XinvAT = np.linalg.solve(X, A.T)
-        AXinv = XinvAT.T # X is symmetric
-        XinvCT = np.linalg.solve(X, C.T)
+        Q = X if E is None else X @ E
 
-        Q = X
-        J = 0.5 * (AXinv - XinvAT)
-        R = -0.5 * (AXinv + XinvAT)
-        G = 0.5 * (XinvCT + B)
-        P = 0.5 * (XinvCT - B)
+        QinvTAT = np.linalg.solve(Q.T, A.T)
+        AQinv = QinvTAT.T
+        QinvTCT = np.linalg.solve(Q.T, C.T)
+
+        J = 0.5 * (AQinv - QinvTAT)
+        R = -0.5 * (AQinv + QinvTAT)
+        G = 0.5 * (QinvTCT + B)
+        P = 0.5 * (QinvTCT - B)
         S = 0.5 * (D + D.T)
-        N = 0.5 * (D - D.T)
+        N = 0.5 * (D.T - D)
 
         return PHLTIModel.from_matrices(J, R, G, P=P, S=S, N=N, E=E, Q=Q, sampling_time=model.sampling_time,
                                         T=model.T, initial_data=model.initial_data, time_stepper=model.time_stepper,

--- a/src/pymordemos/phlti.py
+++ b/src/pymordemos/phlti.py
@@ -9,6 +9,7 @@ import numpy as np
 from cyclopts import App
 from matplotlib import pyplot as plt
 
+from pymor.algorithms.to_matrix import to_matrix
 from pymor.models.examples import msd_example
 from pymor.models.iosys import PHLTIModel
 from pymor.operators.numpy import NumpyMatrixOperator
@@ -18,6 +19,20 @@ from pymor.reductors.ph.ph_irka import PHIRKAReductor
 from pymor.reductors.spectral_factor import SpectralFactorReductor
 
 app = App(help_on_error=True)
+
+def ph_properties(model):
+    """Check the three defining properties of a pH system."""
+    densify = lambda op: to_matrix(op, format='dense')
+    J, R, G, P, S, N, E, Q = map(densify, (model.J, model.R, model.G, model.P, model.S, model.N, model.E, model.Q))
+    H = Q.T @ E
+    Gamma = np.block([[J, G], [-G.T, N]])
+    W = np.block([[R, P], [P.T, S]])
+
+    assert np.allclose(np.abs(H - H.T).max(), 0), 'H is not symmetric'
+    assert np.all(np.linalg.eigvalsh((H + H.T) / 2).min() > -1e-10), 'H is not positive definite'
+    assert np.allclose(np.abs(Gamma + Gamma.T).max(), 0), 'Gamma is not symmetric'
+    assert np.all(np.linalg.eigvalsh((W + W.T) / 2).min() > -1e-4), 'W is not positive semidefinite'
+
 
 @app.default
 def main(n: int = 100, m: int = 2, max_reduced_order: int = 20):
@@ -60,6 +75,9 @@ def main(n: int = 100, m: int = 2, max_reduced_order: int = 20):
         'pH-IRKA_energy_stable': phirka_energy_stable,
         'spectral_factor': spectral_factor_reduce,
     }
+
+    ph_reductors = ['PRBT', 'pH-IRKA', 'spectral_factor']
+
     markers = {
         'BT': '.',
         'PRBT': 'x',
@@ -81,6 +99,10 @@ def main(n: int = 100, m: int = 2, max_reduced_order: int = 20):
             if name in ('PRBT', 'spectral_factor'):
                print('Converting ROM to PHLTIModel.')
                rom = PHLTIModel.from_passive_LTIModel(rom)
+
+            if name in ph_reductors:
+                print(name, r)
+                ph_properties(rom)
 
             h2_errors[i, j] = (rom - fom).h2_norm() / fom.h2_norm()
         t1 = perf_counter()


### PR DESCRIPTION
Fixes #2621. The `E` matrix was missing in the construction of the pH matrices out of the KYP-LMI. The changes I made, resolves this issue. (Edit: I also included an safety Check in the phlti Demo, Not sure if we should keep it there ..) 

There was another bug i believe. Namely, thus far, `S = 0.5 ( D + D.T)` and `N = 0.5 (D - D.T)`. With the construction in the `PHLTIModel`, where we compute `S-N`, this would yields `D.T`, but it should be `D`. Thus, i changed N accordingly. 

Further, there was an argument in the docstring, that is not part of the method nor the arguments in the function anymore. I removed this as well. 
